### PR TITLE
Get CuteLogger to use INSTALL_ROOT

### DIFF
--- a/CuteLogger/CuteLogger.pro
+++ b/CuteLogger/CuteLogger.pro
@@ -42,7 +42,7 @@ unix:!symbian {
     maemo5 {
         target.path = /opt/usr/lib
     } else {
-        target.path = /usr/lib
+        target.path = $(INSTALL_ROOT)/usr/lib
     }
     INSTALLS += target
 }


### PR DESCRIPTION
This was required to package shotcut for NixOS
