### PR TITLE
Fix build for systems that have an unsupported version of QT5 installed

### DIFF
--- a/scripts/build-shotcut.sh
+++ b/scripts/build-shotcut.sh
@@ -584,9 +584,6 @@ function set_globals {
   elif [ "$TARGET_OS" = "Win32" ]; then
     # DEFINES+=QT_STATIC is for QWebSockets
     CONFIG[7]="$QMAKE -r -spec mingw CONFIG+=link_pkgconfig PKGCONFIG+=mlt++ LIBS+=-L${QTDIR}/lib SHOTCUT_VERSION=$(date '+%y.%m.%d') DEFINES+=QT_STATIC"
-  elif [ "$(which qmake-qt5)" != "" ]; then
-    CONFIG[7]="qmake-qt5 -r"
-    LD_LIBRARY_PATH_[7]="/usr/local/lib"
   else
     CONFIG[7]="$QTDIR/bin/qmake -r"
     LD_LIBRARY_PATH_[7]="/usr/local/lib"
@@ -606,8 +603,6 @@ function set_globals {
     CONFIG[9]="$QTDIR/bin/qmake -r -spec macx-g++ MLT_PREFIX=$FINAL_INSTALL_DIR"
   elif [ "$TARGET_OS" = "Win32" ]; then
     CONFIG[9]="$QMAKE -r -spec mingw LIBS+=-L${QTDIR}/lib INCLUDEPATH+=$FINAL_INSTALL_DIR/include"
-  elif [ "$(which qmake-qt5)" != "" ]; then
-    CONFIG[9]="qmake-qt5 -r"
   else
     CONFIG[9]="$QTDIR/bin/qmake -r"
   fi


### PR DESCRIPTION
This is a proposed solution for this issue:
https://plus.google.com/u/0/102032883547463415401/posts/dFiKM9Nc6Px?cfem=1

The user has Qt 5.3.0 installed. The script detects the installed version and does not use the version installed in his home directory.

I feel that this is a valid solution because we maintain Shotcut in a way that it requires a very specific version of Qt. Alternately, we could check if the supported version of QT is installed in the system path and only use the installed QT if it is the supported QT version.

The reason I haven't seen this problem in Ubuntu is because Ubuntu installs QT 5.2.1with qmake named "qmake" not "qmake-qt5". So the script does not detect the installed version of QT in my ubuntu installation.
