### PR TITLE
Noticed an error in the French translation

### DIFF
--- a/translations/shotcut_fr.ts
+++ b/translations/shotcut_fr.ts
@@ -3473,7 +3473,7 @@ coupe sélectionnée.</translation>
     <message>
         <location filename="../src/docks/playlistdock.ui" line="227"/>
         <source>Update</source>
-        <translation>Mis à jour</translation>
+        <translation>Mettre à jour</translation>
     </message>
     <message>
         <location filename="../src/docks/playlistdock.ui" line="232"/>


### PR DESCRIPTION
"Mis à jour" means "Updated"
"Mettre à jour" means "Update"
Changed the verb from past tense to present tense.
