### PR TITLE
Keyboard shortcut improvements

### DIFF
--- a/src/docks/filtersdock.cpp
+++ b/src/docks/filtersdock.cpp
@@ -34,7 +34,7 @@
 
 FiltersDock::FiltersDock(MetadataModel* metadataModel, AttachedFiltersModel* attachedModel, QWidget *parent) :
     QDockWidget(tr("Filters"), parent),
-    m_qview()
+    m_qview(this)
 {
     qDebug() << "begin";
     setObjectName("FiltersDock");

--- a/src/docks/filtersdock.h
+++ b/src/docks/filtersdock.h
@@ -23,6 +23,7 @@
 #include <QDockWidget>
 #include <QObject>
 #include <QQuickView>
+#include "forwardingquickviewworkaround.h"
 
 class QmlFilter;
 class QmlMetadata;
@@ -53,7 +54,7 @@ private slots:
     void resetQview();
 
 private:
-    QQuickView m_qview;
+    ForwardingQuickViewWorkaround m_qview;
 };
 
 #endif // FILTERSDOCK_H

--- a/src/docks/playlistdock.ui
+++ b/src/docks/playlistdock.ui
@@ -84,7 +84,7 @@ p, li { white-space: pre-wrap; }
          <number>0</number>
         </property>
         <item>
-         <widget class="QTableView" name="tableView">
+         <widget class="PlaylistTable" name="tableView">
           <property name="contextMenuPolicy">
            <enum>Qt::CustomContextMenu</enum>
           </property>
@@ -327,6 +327,13 @@ p, li { white-space: pre-wrap; }
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PlaylistTable</class>
+   <extends>QTableView</extends>
+   <header>widgets/playlisttable.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../../icons/resources.qrc"/>
  </resources>

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -213,6 +213,11 @@ QList<int> TimelineDock::selection() const
     return ret;
 }
 
+void TimelineDock::selectClipUnderPlayhead()
+{
+    setSelection(QList<int>() << clipIndexAtPlayhead(-1));
+}
+
 void TimelineDock::addAudioTrack()
 {
     m_model.addAudioTrack();

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -173,6 +173,26 @@ void TimelineDock::resetZoom()
     QMetaObject::invokeMethod(m_quickView.rootObject(), "resetZoom");
 }
 
+void TimelineDock::setSelection(QList<int> selection)
+{
+    qDebug() << "Setting selection to" << selection;
+    QVariantList list;
+    foreach (int idx, selection)
+        list << QVariant::fromValue(idx);
+    m_quickView.rootObject()->setProperty("selection", list);
+}
+
+QList<int> TimelineDock::selection() const
+{
+    if (!m_quickView.rootObject())
+        return QList<int>();
+
+    QList<int> ret;
+    foreach (QVariant v, m_quickView.rootObject()->property("selection").toList())
+        ret << v.toInt();
+    return ret;
+}
+
 void TimelineDock::addAudioTrack()
 {
     m_model.addAudioTrack();
@@ -549,6 +569,8 @@ void TimelineDock::onVisibilityChanged(bool visible)
         disconnect(this, SIGNAL(visibilityChanged(bool)), this, SLOT(onVisibilityChanged(bool)));
         connect(m_quickView.rootObject(), SIGNAL(currentTrackChanged()),
                 this, SIGNAL(currentTrackChanged()));
+        connect(m_quickView.rootObject(), SIGNAL(selectionChanged()),
+                this, SIGNAL(selectionChanged()));
     }
 }
 

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -143,6 +143,20 @@ int TimelineDock::dockYOffset() const
 #endif
 }
 
+void TimelineDock::setCurrentTrack(int currentTrack)
+{
+    if (!m_quickView.rootObject())
+        return;
+    m_quickView.rootObject()->setProperty("currentTrack", currentTrack);
+}
+
+int TimelineDock::currentTrack() const
+{
+    if (!m_quickView.rootObject())
+        return 0;
+    return m_quickView.rootObject()->property("currentTrack").toInt();
+}
+
 void TimelineDock::addAudioTrack()
 {
     m_model.addAudioTrack();
@@ -529,6 +543,8 @@ void TimelineDock::onVisibilityChanged(bool visible)
         sourcePath.cd("timeline");
         m_quickView.setSource(QUrl::fromLocalFile(sourcePath.filePath("timeline.qml")));
         disconnect(this, SIGNAL(visibilityChanged(bool)), this, SLOT(onVisibilityChanged(bool)));
+        connect(m_quickView.rootObject(), SIGNAL(currentTrackChanged()),
+                this, SIGNAL(currentTrackChanged()));
     }
 }
 

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -349,9 +349,14 @@ void TimelineDock::openClip(int trackIndex, int clipIndex)
     }
 }
 
-void TimelineDock::selectClip(int trackIndex, int clipIndex)
+void TimelineDock::emitClipSelectedFromSelection()
 {
-    Mlt::ClipInfo* info = getClipInfo(trackIndex, clipIndex);
+    if (selection().isEmpty() || currentTrack() == -1) {
+        emit clipSelected(0);
+        return;
+    }
+
+    Mlt::ClipInfo* info = getClipInfo(currentTrack(), selection().first());
     if (info && info->producer && info->producer->is_valid()) {
         // We need to set these special properties so time-based filters
         // can get information about the cut while still applying filters

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -238,10 +238,7 @@ void TimelineDock::append(int trackIndex)
 
 void TimelineDock::remove(int trackIndex, int clipIndex)
 {
-    if (trackIndex < 0)
-        trackIndex = currentTrack();
-    if (clipIndex < 0)
-        clipIndex = m_quickView.rootObject()->property("currentClip").toInt();
+    Q_ASSERT(trackIndex >= 0 && clipIndex >= 0);
     Mlt::Producer* clip = getClip(trackIndex, clipIndex);
     if (clip) {
         QString xml = MLT.XML(clip);
@@ -255,10 +252,7 @@ void TimelineDock::remove(int trackIndex, int clipIndex)
 
 void TimelineDock::lift(int trackIndex, int clipIndex)
 {
-    if (trackIndex < 0)
-        trackIndex = currentTrack();
-    if (clipIndex < 0)
-        clipIndex = m_quickView.rootObject()->property("currentClip").toInt();
+    Q_ASSERT(trackIndex >= 0 && clipIndex >= 0);
     Mlt::Producer* clip = getClip(trackIndex, clipIndex);
     if (clip) {
         QString xml = MLT.XML(clip);
@@ -268,6 +262,22 @@ void TimelineDock::lift(int trackIndex, int clipIndex)
         MAIN.undoStack()->push(
             new Timeline::LiftCommand(m_model, trackIndex, clipIndex, position, xml));
     }
+}
+
+void TimelineDock::removeSelection()
+{
+    if (selection().isEmpty())
+        return;
+    foreach (int index, selection())
+        remove(currentTrack(), index);
+}
+
+void TimelineDock::liftSelection()
+{
+    if (selection().isEmpty())
+        return;
+    foreach (int index, selection())
+        lift(currentTrack(), index);
 }
 
 void TimelineDock::selectTrack(int by)
@@ -293,10 +303,7 @@ void TimelineDock::selectTrackHead(int trackIndex)
 
 void TimelineDock::openClip(int trackIndex, int clipIndex)
 {
-    if (trackIndex < 0)
-        trackIndex = currentTrack();
-    if (clipIndex < 0)
-        clipIndex = m_quickView.rootObject()->property("currentClip").toInt();
+    Q_ASSERT(trackIndex >= 0 && clipIndex >= 0);
     QScopedPointer<Mlt::ClipInfo> info(getClipInfo(trackIndex, clipIndex));
     if (info) {
         QString xml = MLT.XML(info->producer);
@@ -457,10 +464,7 @@ void TimelineDock::splitClip(int trackIndex, int clipIndex)
 void TimelineDock::fadeIn(int trackIndex, int clipIndex, int duration)
 {
     if (duration < 0) return;
-    if (trackIndex < 0)
-        trackIndex = currentTrack();
-    if (clipIndex < 0)
-        clipIndex = m_quickView.rootObject()->property("currentClip").toInt();
+    Q_ASSERT(trackIndex >= 0 && clipIndex >= 0);
     MAIN.undoStack()->push(
         new Timeline::FadeInCommand(m_model, trackIndex, clipIndex, duration));
     emit fadeInChanged(duration);
@@ -469,10 +473,7 @@ void TimelineDock::fadeIn(int trackIndex, int clipIndex, int duration)
 void TimelineDock::fadeOut(int trackIndex, int clipIndex, int duration)
 {
     if (duration < 0) return;
-    if (trackIndex < 0)
-        trackIndex = currentTrack();
-    if (clipIndex < 0)
-        clipIndex = m_quickView.rootObject()->property("currentClip").toInt();
+    Q_ASSERT(trackIndex >= 0 && clipIndex >= 0);
     MAIN.undoStack()->push(
         new Timeline::FadeOutCommand(m_model, trackIndex, clipIndex, duration));
     emit fadeOutChanged(duration);

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -158,6 +158,21 @@ int TimelineDock::currentTrack() const
     return m_quickView.rootObject()->property("currentTrack").toInt();
 }
 
+void TimelineDock::zoomIn()
+{
+    QMetaObject::invokeMethod(m_quickView.rootObject(), "zoomIn");
+}
+
+void TimelineDock::zoomOut()
+{
+    QMetaObject::invokeMethod(m_quickView.rootObject(), "zoomOut");
+}
+
+void TimelineDock::resetZoom()
+{
+    QMetaObject::invokeMethod(m_quickView.rootObject(), "resetZoom");
+}
+
 void TimelineDock::addAudioTrack()
 {
     m_model.addAudioTrack();
@@ -233,18 +248,6 @@ void TimelineDock::lift(int trackIndex, int clipIndex)
         MAIN.undoStack()->push(
             new Timeline::LiftCommand(m_model, trackIndex, clipIndex, position, xml));
     }
-}
-
-void TimelineDock::pressKey(int key, Qt::KeyboardModifiers modifiers)
-{
-    QKeyEvent event(QEvent::KeyPress, key, modifiers);
-    MAIN.keyPressEvent(&event);
-}
-
-void TimelineDock::releaseKey(int key, Qt::KeyboardModifiers modifiers)
-{
-    QKeyEvent event(QEvent::KeyRelease, key, modifiers);
-    MAIN.keyReleaseEvent(&event);
 }
 
 void TimelineDock::selectTrack(int by)

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -119,6 +119,11 @@ Mlt::Producer *TimelineDock::getClip(int trackIndex, int clipIndex)
 
 int TimelineDock::clipIndexAtPlayhead(int trackIndex)
 {
+    return clipIndexAtPosition(trackIndex, m_position);
+}
+
+int TimelineDock::clipIndexAtPosition(int trackIndex, int position)
+{
     int result = -1;
     if (trackIndex < 0)
         trackIndex = currentTrack();
@@ -127,7 +132,7 @@ int TimelineDock::clipIndexAtPlayhead(int trackIndex)
         QScopedPointer<Mlt::Producer> track(m_model.tractor()->track(i));
         if (track) {
             Mlt::Playlist playlist(*track);
-            result = playlist.get_clip_index_at(m_position);
+            result = playlist.get_clip_index_at(position);
         }
     }
     return result;

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -34,6 +34,7 @@ static const char* kFilterOutProperty = "_shotcut:filter_out";
 TimelineDock::TimelineDock(QWidget *parent) :
     QDockWidget(parent),
     ui(new Ui::TimelineDock),
+    m_quickView(this),
     m_position(-1)
 {
     qDebug() << "begin";

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -138,6 +138,21 @@ int TimelineDock::clipIndexAtPosition(int trackIndex, int position)
     return result;
 }
 
+int TimelineDock::clipCount(int trackIndex) const
+{
+    if (trackIndex < 0)
+        trackIndex = currentTrack();
+    if (trackIndex >= 0 && trackIndex < m_model.trackList().size()) {
+        int i = m_model.trackList().at(trackIndex).mlt_index;
+        QScopedPointer<Mlt::Producer> track(m_model.tractor()->track(i));
+        if (track) {
+            Mlt::Playlist playlist(*track);
+            return playlist.count();
+        }
+    }
+    return 0;
+}
+
 int TimelineDock::dockYOffset() const
 {
     // XXX This is a workaround for menus appearing in wrong location in a Quick

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -121,7 +121,7 @@ int TimelineDock::clipIndexAtPlayhead(int trackIndex)
 {
     int result = -1;
     if (trackIndex < 0)
-        trackIndex = m_quickView.rootObject()->property("currentTrack").toInt();
+        trackIndex = currentTrack();
     if (trackIndex >= 0 && trackIndex < m_model.trackList().size()) {
         int i = m_model.trackList().at(trackIndex).mlt_index;
         QScopedPointer<Mlt::Producer> track(m_model.tractor()->track(i));
@@ -194,7 +194,7 @@ void TimelineDock::append(int trackIndex)
 {
     if (MLT.isSeekableClip() || MLT.savedProducer()) {
         if (trackIndex < 0)
-            trackIndex = m_quickView.rootObject()->property("currentTrack").toInt();
+            trackIndex = currentTrack();
         MAIN.undoStack()->push(
             new Timeline::AppendCommand(m_model, trackIndex,
                 MLT.XML(MLT.isClip()? 0 : MLT.savedProducer())));
@@ -204,7 +204,7 @@ void TimelineDock::append(int trackIndex)
 void TimelineDock::remove(int trackIndex, int clipIndex)
 {
     if (trackIndex < 0)
-        trackIndex = m_quickView.rootObject()->property("currentTrack").toInt();
+        trackIndex = currentTrack();
     if (clipIndex < 0)
         clipIndex = m_quickView.rootObject()->property("currentClip").toInt();
     Mlt::Producer* clip = getClip(trackIndex, clipIndex);
@@ -221,7 +221,7 @@ void TimelineDock::remove(int trackIndex, int clipIndex)
 void TimelineDock::lift(int trackIndex, int clipIndex)
 {
     if (trackIndex < 0)
-        trackIndex = m_quickView.rootObject()->property("currentTrack").toInt();
+        trackIndex = currentTrack();
     if (clipIndex < 0)
         clipIndex = m_quickView.rootObject()->property("currentClip").toInt();
     Mlt::Producer* clip = getClip(trackIndex, clipIndex);
@@ -249,12 +249,12 @@ void TimelineDock::releaseKey(int key, Qt::KeyboardModifiers modifiers)
 
 void TimelineDock::selectTrack(int by)
 {
-    int currentTrack = m_quickView.rootObject()->property("currentTrack").toInt();
+    int newTrack = currentTrack();
     if (by < 0)
-        currentTrack = qMax(0, currentTrack + by);
+        newTrack = qMax(0, newTrack + by);
     else
-        currentTrack = qMin(m_model.trackList().size() - 1, currentTrack + by);
-    m_quickView.rootObject()->setProperty("currentTrack", currentTrack);
+        newTrack = qMin(m_model.trackList().size() - 1, newTrack + by);
+    setCurrentTrack(newTrack);
 }
 
 void TimelineDock::selectTrackHead(int trackIndex)
@@ -271,7 +271,7 @@ void TimelineDock::selectTrackHead(int trackIndex)
 void TimelineDock::openClip(int trackIndex, int clipIndex)
 {
     if (trackIndex < 0)
-        trackIndex = m_quickView.rootObject()->property("currentTrack").toInt();
+        trackIndex = currentTrack();
     if (clipIndex < 0)
         clipIndex = m_quickView.rootObject()->property("currentClip").toInt();
     QScopedPointer<Mlt::ClipInfo> info(getClipInfo(trackIndex, clipIndex));
@@ -379,7 +379,7 @@ void TimelineDock::insert(int trackIndex, int position, const QString &xml)
         QString xmlToUse = !xml.isEmpty()? xml
             : MLT.XML(MLT.isClip()? 0 : MLT.savedProducer());
         if (trackIndex < 0)
-            trackIndex = m_quickView.rootObject()->property("currentTrack").toInt();
+            trackIndex = currentTrack();
         if (position < 0)
             position = m_position;
         MAIN.undoStack()->push(
@@ -393,7 +393,7 @@ void TimelineDock::overwrite(int trackIndex, int position, const QString &xml)
         QString xmlToUse = !xml.isEmpty()? xml
             : MLT.XML(MLT.isClip()? 0 : MLT.savedProducer());
         if (trackIndex < 0)
-            trackIndex = m_quickView.rootObject()->property("currentTrack").toInt();
+            trackIndex = currentTrack();
         if (position < 0)
             position = m_position;
         MAIN.undoStack()->push(
@@ -403,14 +403,14 @@ void TimelineDock::overwrite(int trackIndex, int position, const QString &xml)
 
 void TimelineDock::appendFromPlaylist(Mlt::Playlist *playlist)
 {
-    int trackIndex = m_quickView.rootObject()->property("currentTrack").toInt();
+    int trackIndex = currentTrack();
     m_model.appendFromPlaylist(playlist, trackIndex);
 }
 
 void TimelineDock::splitClip(int trackIndex, int clipIndex)
 {
     if (trackIndex < 0)
-        trackIndex = m_quickView.rootObject()->property("currentTrack").toInt();
+        trackIndex = currentTrack();
     if (clipIndex < 0)
         clipIndex = clipIndexAtPlayhead(trackIndex);
     if (clipIndex >= 0 && trackIndex >= 0) {
@@ -435,7 +435,7 @@ void TimelineDock::fadeIn(int trackIndex, int clipIndex, int duration)
 {
     if (duration < 0) return;
     if (trackIndex < 0)
-        trackIndex = m_quickView.rootObject()->property("currentTrack").toInt();
+        trackIndex = currentTrack();
     if (clipIndex < 0)
         clipIndex = m_quickView.rootObject()->property("currentClip").toInt();
     MAIN.undoStack()->push(
@@ -447,7 +447,7 @@ void TimelineDock::fadeOut(int trackIndex, int clipIndex, int duration)
 {
     if (duration < 0) return;
     if (trackIndex < 0)
-        trackIndex = m_quickView.rootObject()->property("currentTrack").toInt();
+        trackIndex = currentTrack();
     if (clipIndex < 0)
         clipIndex = m_quickView.rootObject()->property("currentClip").toInt();
     MAIN.undoStack()->push(
@@ -520,7 +520,7 @@ void TimelineDock::dragLeaveEvent(QDragLeaveEvent *event)
 void TimelineDock::dropEvent(QDropEvent *event)
 {
     if (event->mimeData()->hasFormat(Mlt::XmlMimeType)) {
-        int trackIndex = m_quickView.rootObject()->property("currentTrack").toInt();
+        int trackIndex = currentTrack();
         if (trackIndex >= 0) {
             emit dropAccepted(QString::fromUtf8(event->mimeData()->data(Mlt::XmlMimeType)));
             event->acceptProposedAction();

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -253,10 +253,11 @@ void TimelineDock::remove(int trackIndex, int clipIndex)
 void TimelineDock::lift(int trackIndex, int clipIndex)
 {
     Q_ASSERT(trackIndex >= 0 && clipIndex >= 0);
-    Mlt::Producer* clip = getClip(trackIndex, clipIndex);
+    QScopedPointer<Mlt::Producer> clip(getClip(trackIndex, clipIndex));
     if (clip) {
-        QString xml = MLT.XML(clip);
-        delete clip;
+        if (clip->is_blank())
+            return;
+        QString xml = MLT.XML(clip.data());
         QModelIndex idx = m_model.index(clipIndex, 0, m_model.index(trackIndex));
         int position = m_model.data(idx, MultitrackModel::StartRole).toInt();
         MAIN.undoStack()->push(

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -218,6 +218,16 @@ void TimelineDock::selectClipUnderPlayhead()
     setSelection(QList<int>() << clipIndexAtPlayhead(-1));
 }
 
+int TimelineDock::centerOfClip(int trackIndex, int clipIndex)
+{
+    Mlt::ClipInfo * clip = getClipInfo(trackIndex, clipIndex);
+    Q_ASSERT(clip);
+    int centerOfClip = clip->start + clip->frame_count / 2;
+    delete clip;
+    clip = 0;
+    return centerOfClip;
+}
+
 void TimelineDock::addAudioTrack()
 {
     m_model.addAudioTrack();
@@ -598,6 +608,10 @@ void TimelineDock::onVisibilityChanged(bool visible)
                 this, SIGNAL(currentTrackChanged()));
         connect(m_quickView.rootObject(), SIGNAL(selectionChanged()),
                 this, SIGNAL(selectionChanged()));
+        connect(m_quickView.rootObject(), SIGNAL(selectionChanged()),
+                this, SLOT(emitClipSelectedFromSelection()));
+        connect(m_quickView.rootObject(), SIGNAL(clipClicked()),
+                this, SIGNAL(clipClicked()));
     }
 }
 

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -91,7 +91,6 @@ public slots:
     void selectTrack(int by);
     void selectTrackHead(int trackIndex);
     void openClip(int trackIndex, int clipIndex);
-    void selectClip(int trackIndex, int clipIndex);
     void setTrackName(int trackIndex, const QString& value);
     void toggleTrackMute(int trackIndex);
     void toggleTrackHidden(int trackIndex);
@@ -123,6 +122,7 @@ private:
 
 private slots:
     void onVisibilityChanged(bool visible);
+    void emitClipSelectedFromSelection();
 };
 
 #endif // TIMELINEDOCK_H

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -60,6 +60,7 @@ public:
     void setSelection(QList<int> selection);
     QList<int> selection() const;
     void selectClipUnderPlayhead();
+    int centerOfClip(int trackIndex, int clipIndex);
 
 signals:
     void currentTrackChanged();
@@ -74,6 +75,7 @@ signals:
     void fadeOutChanged(int duration);
     void trackSelected(Mlt::Producer* producer);
     void clipSelected(Mlt::Producer* producer);
+    void clipClicked();
 
 public slots:
     void addAudioTrack();

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -106,6 +106,7 @@ public slots:
     void fadeOut(int trackIndex, int clipIndex = -1, int duration = -1);
     void seekPreviousEdit();
     void seekNextEdit();
+    void clearSelectionIfInvalid();
 
 protected:
     void dragEnterEvent(QDragEnterEvent* event);

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -36,6 +36,7 @@ class TimelineDock : public QDockWidget
     Q_PROPERTY(int position READ position WRITE setPosition NOTIFY positionChanged)
     Q_PROPERTY(int yoffset READ dockYOffset)
     Q_PROPERTY(int currentTrack READ currentTrack WRITE setCurrentTrack NOTIFY currentTrackChanged)
+    Q_PROPERTY(QList<int> selection READ selection WRITE setSelection NOTIFY selectionChanged)
 
 public:
     explicit TimelineDock(QWidget *parent = 0);
@@ -54,9 +55,12 @@ public:
     void zoomIn();
     void zoomOut();
     void resetZoom();
+    void setSelection(QList<int> selection);
+    QList<int> selection() const;
 
 signals:
     void currentTrackChanged();
+    void selectionChanged();
     void seeked(int position);
     void positionChanged();
     void clipOpened(void* producer);

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -34,6 +34,7 @@ class TimelineDock : public QDockWidget
     Q_OBJECT
     Q_PROPERTY(int position READ position WRITE setPosition NOTIFY positionChanged)
     Q_PROPERTY(int yoffset READ dockYOffset)
+    Q_PROPERTY(int currentTrack READ currentTrack WRITE setCurrentTrack NOTIFY currentTrackChanged)
 
 public:
     explicit TimelineDock(QWidget *parent = 0);
@@ -47,8 +48,11 @@ public:
     Mlt::Producer* getClip(int trackIndex, int clipIndex);
     int clipIndexAtPlayhead(int trackIndex = -1);
     int dockYOffset() const;
+    void setCurrentTrack(int currentTrack);
+    int currentTrack() const;
 
 signals:
+    void currentTrackChanged();
     void seeked(int position);
     void positionChanged();
     void clipOpened(void* producer);

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -81,6 +81,8 @@ public slots:
     void append(int trackIndex);
     void remove(int trackIndex, int clipIndex);
     void lift(int trackIndex, int clipIndex);
+    void removeSelection();
+    void liftSelection();
     void selectTrack(int by);
     void selectTrackHead(int trackIndex);
     void openClip(int trackIndex, int clipIndex);

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -51,6 +51,9 @@ public:
     int dockYOffset() const;
     void setCurrentTrack(int currentTrack);
     int currentTrack() const;
+    void zoomIn();
+    void zoomOut();
+    void resetZoom();
 
 signals:
     void currentTrackChanged();
@@ -74,8 +77,6 @@ public slots:
     void append(int trackIndex);
     void remove(int trackIndex, int clipIndex);
     void lift(int trackIndex, int clipIndex);
-    void pressKey(int key, Qt::KeyboardModifiers modifiers);
-    void releaseKey(int key, Qt::KeyboardModifiers modifiers);
     void selectTrack(int by);
     void selectTrackHead(int trackIndex);
     void openClip(int trackIndex, int clipIndex);

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -53,6 +53,7 @@ public:
     int dockYOffset() const;
     void setCurrentTrack(int currentTrack);
     int currentTrack() const;
+    int clipCount(int trackIndex) const;
     void zoomIn();
     void zoomOut();
     void resetZoom();

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -59,6 +59,7 @@ public:
     void resetZoom();
     void setSelection(QList<int> selection);
     QList<int> selection() const;
+    void selectClipUnderPlayhead();
 
 signals:
     void currentTrackChanged();

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -24,6 +24,7 @@
 #include <QApplication>
 #include "models/multitrackmodel.h"
 #include "sharedframe.h"
+#include "forwardingquickviewworkaround.h"
 
 namespace Ui {
 class TimelineDock;
@@ -104,7 +105,7 @@ protected:
 
 private:
     Ui::TimelineDock *ui;
-    QQuickView m_quickView;
+    ForwardingQuickViewWorkaround m_quickView;
     MultitrackModel m_model;
     int m_position;
 

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -49,6 +49,7 @@ public:
     Mlt::ClipInfo* getClipInfo(int trackIndex, int clipIndex);
     Mlt::Producer* getClip(int trackIndex, int clipIndex);
     int clipIndexAtPlayhead(int trackIndex = -1);
+    int clipIndexAtPosition(int trackIndex, int position);
     int dockYOffset() const;
     void setCurrentTrack(int currentTrack);
     int currentTrack() const;

--- a/src/forwardingquickviewworkaround.h
+++ b/src/forwardingquickviewworkaround.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2015 Meltytech, LLC
+ * Author: Harald Hvaal <harald.hvaal@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _FORWARDINGQUICKVIEWWORKAROUND_H
+#define _FORWARDINGQUICKVIEWWORKAROUND_H
+
+#include <QQuickView>
+#include <QCoreApplication>
+
+class ForwardingQuickViewWorkaround : public QQuickView
+{
+public:
+    ForwardingQuickViewWorkaround(QObject * receiver)
+        : QQuickView(0)
+        , m_receiver(receiver)
+    {
+    }
+
+protected:
+    QObject * m_receiver;
+
+    void keyPressEvent(QKeyEvent* e) {
+        QQuickView::keyPressEvent(e);
+        if (!e->isAccepted())
+            qApp->sendEvent(m_receiver, e);
+    }
+};
+
+
+#endif

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1007,6 +1007,7 @@ void MainWindow::on_actionAbout_Shotcut_triggered()
 
 void MainWindow::keyPressEvent(QKeyEvent* event)
 {
+
     switch (event->key()) {
     case Qt::Key_Home:
         m_player->seek(0);
@@ -1182,6 +1183,9 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
             m_playlistDock->raise();
             m_playlistDock->setIndex(9);
         }
+        else if (m_timelineDock->isVisible()) {
+            m_timelineDock->zoomIn();
+        }
         break;
     case Qt::Key_X: // Avid Extract
         if (event->modifiers() == Qt::ShiftModifier) {
@@ -1219,6 +1223,14 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
             m_timelineDock->raise();
             m_timelineDock->lift(-1, -1);
         }
+        break;
+    case Qt::Key_Minus:
+        if (m_timelineDock->isVisible())
+            m_timelineDock->zoomOut();
+        break;
+    case Qt::Key_Equal:
+        if (m_timelineDock->isVisible())
+            m_timelineDock->zoomIn();
         break;
     case Qt::Key_Enter: // Seek to current playlist item
     case Qt::Key_Return:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1195,7 +1195,7 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
         } else {
             m_timelineDock->show();
             m_timelineDock->raise();
-            m_timelineDock->remove(-1, -1);
+            m_timelineDock->removeSelection();
         }
         break;
     case Qt::Key_Backspace:
@@ -1204,9 +1204,9 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
             m_timelineDock->show();
             m_timelineDock->raise();
             if (event->modifiers() == Qt::ShiftModifier)
-                m_timelineDock->remove(-1, -1);
+                m_timelineDock->removeSelection();
             else
-                m_timelineDock->lift(-1, -1);
+                m_timelineDock->liftSelection();
         } else {
             m_playlistDock->show();
             m_playlistDock->raise();
@@ -1221,7 +1221,7 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
         } else if (multitrack()) {
             m_timelineDock->show();
             m_timelineDock->raise();
-            m_timelineDock->lift(-1, -1);
+            m_timelineDock->liftSelection();
         }
         break;
     case Qt::Key_Minus:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1208,6 +1208,7 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
             m_playlistDock->raise();
             m_playlistDock->on_removeButton_clicked();
         }
+        break;
     case Qt::Key_Z: // Avid Lift
         if (event->modifiers() == Qt::ShiftModifier) {
             m_playlistDock->show();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -106,6 +106,10 @@ MainWindow::MainWindow()
     }
 #endif
 
+    if (!qgetenv("OBSERVE_FOCUS").isEmpty())
+        connect(qApp, &QApplication::focusChanged,
+                this, &MainWindow::onFocusChanged);
+
     qDebug() << "begin";
     new GLTestWidget(this);
     Database::singleton(this);
@@ -2273,4 +2277,9 @@ void MainWindow::on_actionGammaRec709_triggered(bool checked)
     Settings.setPlayerGamma("bt709");
     MLT.restart();
     MLT.refreshConsumer();
+}
+
+void MainWindow::onFocusChanged(QWidget *, QWidget * now) const
+{
+    qDebug() << "Focuswidget changed to" << now;
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1083,6 +1083,12 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
             m_timelineDock->append(-1);
         }
         break;
+    case Qt::Key_D:
+        if (event->modifiers() == Qt::ControlModifier)
+            m_timelineDock->setSelection(QList<int>());
+        else
+            handled = false;
+        break;
     case Qt::Key_J:
         if (m_isKKeyPressed)
             m_player->seek(m_player->position() - 1);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1231,6 +1231,9 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
     case Qt::Key_F5:
         m_timelineDock->model()->reload();
         break;
+    case Qt::Key_F1:
+        qDebug() << "Current focusWidget:" << QApplication::focusWidget();
+        break;
     default:
         QMainWindow::keyPressEvent(event);
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1195,6 +1195,8 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
         } else {
             m_timelineDock->show();
             m_timelineDock->raise();
+            if (m_timelineDock->selection().isEmpty())
+                m_timelineDock->setSelection(QList<int>() << m_timelineDock->clipIndexAtPlayhead());
             m_timelineDock->removeSelection();
         }
         break;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1314,7 +1314,10 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
         break;
     case Qt::Key_Enter: // Seek to current playlist item
     case Qt::Key_Return:
-        if (m_playlistDock->position() >= 0) {
+        if (!m_timelineDock->selection().isEmpty()) {
+            m_timelineDock->openClip(m_timelineDock->currentTrack(), m_timelineDock->selection().first());
+        }
+        else if (m_playlistDock->position() >= 0) {
             if (event->modifiers() == Qt::ShiftModifier)
                 seekPlaylist(m_playlistDock->position());
             else

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -216,6 +216,7 @@ private slots:
     void onAutosaveTimeout();
     void on_actionGammaSRGB_triggered(bool checked);
     void on_actionGammaRec709_triggered(bool checked);
+    void onFocusChanged(QWidget *old, QWidget * now) const;
 };
 
 #define MAIN MainWindow::singleton()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -124,6 +124,7 @@ private:
     QMutex m_autosaveMutex;
     QTimer m_autosaveTimer;
     int m_exitCode;
+    int m_navigationPosition;
 
 #ifdef WITH_LIBLEAP
     LeapListener m_leapListener;
@@ -217,6 +218,7 @@ private slots:
     void on_actionGammaSRGB_triggered(bool checked);
     void on_actionGammaRec709_triggered(bool checked);
     void onFocusChanged(QWidget *old, QWidget * now) const;
+    void moveNavigationPositionToCurrentSelection();
 };
 
 #define MAIN MainWindow::singleton()

--- a/src/mltcontroller.cpp
+++ b/src/mltcontroller.cpp
@@ -195,8 +195,8 @@ void Controller::play(double speed)
             m_consumer->set("buffer", 25);
             m_consumer->set("prefill", 1);
             // Changes to real_time require a consumer restart if running.
-            if (!m_consumer->is_stopped())
-                m_consumer->stop();
+            /* if (!m_consumer->is_stopped()) */
+            /*     m_consumer->stop(); */
         }
         m_consumer->start();
         refreshConsumer();

--- a/src/models/playlistmodel.cpp
+++ b/src/models/playlistmodel.cpp
@@ -566,8 +566,10 @@ void PlaylistModel::setPlaylist(Mlt::Playlist& playlist)
             m_playlist = 0;
             return;
         }
-        beginInsertRows(QModelIndex(), 0, m_playlist->count() - 1);
-        endInsertRows();
+        if (m_playlist->count()) {
+            beginInsertRows(QModelIndex(), 0, m_playlist->count() - 1);
+            endInsertRows();
+        }
         // do not let opening a clip change the profile!
         MLT.profile().set_explicit(true);
         if (Settings.playerGPU() && Settings.playlistThumbnails() != "hidden")

--- a/src/qml/timeline/Clip.qml
+++ b/src/qml/timeline/Clip.qml
@@ -38,8 +38,9 @@ Rectangle {
     property int originalTrackIndex: trackIndex
     property int originalClipIndex: index
     property int originalX: x
+    property bool selected: false
 
-    signal selected(var clip)
+    signal clicked(var clip)
     signal moved(var clip)
     signal dragged(var clip, var mouse)
     signal dropped(var clip)
@@ -64,7 +65,6 @@ Rectangle {
     border.color: 'black'
     border.width: isBlank? 0 : 1
     clip: true
-    state: 'normal'
     Drag.active: mouseArea.drag.active
     Drag.proposedAction: Qt.MoveAction
     opacity: Drag.active? 0.5 : 1.0
@@ -146,7 +146,7 @@ Rectangle {
             cx.closePath()
             var grad = cx.createLinearGradient(0, 0, 0, height)
             var color = isAudio? 'darkseagreen' : root.shotcutBlue
-            grad.addColorStop(0, parent.state === 'selected'? Qt.darker(color) : Qt.lighter(color))
+            grad.addColorStop(0, clipRoot.selected ? Qt.darker(color) : Qt.lighter(color))
             grad.addColorStop(1, color)
             cx.fillStyle = grad
             cx.fill()
@@ -209,6 +209,7 @@ Rectangle {
     states: [
         State {
             name: 'normal'
+            when: !clipRoot.selected
             PropertyChanges {
                 target: clipRoot
                 z: 0
@@ -216,6 +217,7 @@ Rectangle {
         },
         State {
             name: 'selected'
+            when: clipRoot.selected
             PropertyChanges {
                 target: clipRoot
                 z: 1
@@ -262,10 +264,10 @@ Rectangle {
             originalTrackIndex = trackIndex
             originalClipIndex = index
             startX = parent.x
-            parent.state = 'selected'
-            parent.selected(clipRoot)
             if (mouse.button === Qt.RightButton)
                 menu.popup()
+            else
+                clipRoot.clicked(clipRoot)
         }
         onPositionChanged: {
             if (mouse.y < 0 && trackIndex > 0)

--- a/src/qml/timeline/Clip.qml
+++ b/src/qml/timeline/Clip.qml
@@ -58,10 +58,12 @@ Rectangle {
             color: Qt.lighter(getColor())
         }
         GradientStop {
+            id: gradientStop2
             position: 1.0
             color: getColor()
         }
     }
+
     border.color: 'black'
     border.width: isBlank? 0 : 1
     clip: true
@@ -216,6 +218,18 @@ Rectangle {
             }
         },
         State {
+            name: 'selectedBlank'
+            when: clipRoot.selected && clipRoot.isBlank
+            PropertyChanges {
+                target: gradientStop2
+                color: '#77ffffff'
+            }
+            PropertyChanges {
+                target: gradientStop
+                color: 'transparent'
+            }
+        },
+        State {
             name: 'selected'
             when: clipRoot.selected
             PropertyChanges {
@@ -229,13 +243,6 @@ Rectangle {
         }
     ]
 
-    transitions: [
-        Transition {
-            to: '*'
-            ColorAnimation { target: gradientStop; duration: 100 }
-
-        }
-    ]
     onStateChanged: if (isTransition) transitionCanvas.requestPaint()
 
     MouseArea {

--- a/src/qml/timeline/Clip.qml
+++ b/src/qml/timeline/Clip.qml
@@ -346,7 +346,7 @@ Rectangle {
                 parent.anchors.left = undefined
                 parent.anchors.horizontalCenter = undefined
                 parent.opacity = 1
-                trackRoot.clipSelected(clipRoot, trackRoot)
+                // trackRoot.clipSelected(clipRoot, trackRoot) TODO
             }
             onReleased: {
                 root.stopScrolling = false

--- a/src/qml/timeline/CornerSelectionShadow.qml
+++ b/src/qml/timeline/CornerSelectionShadow.qml
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2015 Meltytech, LLC
+ * Author: Harald Hvaal <harald.hvaal@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.2
+
+Item {
+    id: root
+
+    property Item clip
+    property bool mirrorGradient: false
+
+    width: 100
+    height: clip ? clip.height : 0
+    Behavior on opacity { NumberAnimation { duration: 100 } }
+
+    Rectangle {
+        id: shadowGradient
+        width: parent.height
+        height: parent.width
+        anchors.centerIn: parent
+        rotation: mirrorGradient ? -90 : 90
+        gradient: Gradient {
+            GradientStop { position: 0.0; color: "transparent" }
+            GradientStop { position: 1.0; color: "white" }
+        }
+        PulsingAnimation {
+            target: shadowGradient
+            running: root.opacity
+        }
+    }
+}

--- a/src/qml/timeline/PulsingAnimation.qml
+++ b/src/qml/timeline/PulsingAnimation.qml
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2015 Meltytech, LLC
+ * Author: Harald Hvaal <harald.hvaal@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.2
+
+SequentialAnimation {
+    property alias target: firstAnim.target
+
+    loops: Animation.Infinite
+    NumberAnimation {
+        id: firstAnim
+        property: "opacity"
+        from: 0.3
+        to: 0
+        duration: 800
+    }
+    NumberAnimation {
+        target: firstAnim.target
+        property: "opacity"
+        from: 0
+        to: 0.3
+        duration: 800
+    }
+    PauseAnimation { duration: 300 }
+}
+

--- a/src/qml/timeline/Track.qml
+++ b/src/qml/timeline/Track.qml
@@ -49,6 +49,10 @@ Rectangle {
         Logic.snapDrop(clip, repeater)
     }
 
+    function clipAt(index) {
+        return repeater.itemAt(index)
+    }
+
     color: 'transparent'
 
     DelegateModel {

--- a/src/qml/timeline/Track.qml
+++ b/src/qml/timeline/Track.qml
@@ -27,17 +27,14 @@ Rectangle {
     property bool isAudio
     property real timeScale: 1.0
     property bool placeHolderAdded: false
+    property bool isCurrentTrack: false
+    property var selection
 
-    signal clipSelected(var clip, var track)
+    signal clipClicked(var clip, var track)
     signal clipDragged(var clip, int x, int y)
     signal clipDropped(var clip)
     signal clipDraggedToTrack(var clip, int direction)
     signal checkSnap(var clip)
-
-    function resetStates(index) {
-        for (var i = 0; i < repeater.count; i++)
-            if (i !== index) repeater.itemAt(i).state = ''
-    }
 
     function redrawWaveforms() {
         for (var i = 0; i < repeater.count; i++)
@@ -72,11 +69,9 @@ Rectangle {
             trackIndex: trackRoot.DelegateModel.itemsIndex
             fadeIn: model.fadeIn
             fadeOut: model.fadeOut
+            selected: trackRoot.isCurrentTrack && trackRoot.selection.indexOf(index) !== -1
 
-            onSelected: {
-                resetStates(clip.DelegateModel.itemsIndex);
-                trackRoot.clipSelected(clip, trackRoot);
-            }
+            onClicked: trackRoot.clipClicked(clip, trackRoot);
             onMoved: {
                 var fromTrack = clip.originalTrackIndex
                 var toTrack = clip.trackIndex

--- a/src/qml/timeline/TrackHead.qml
+++ b/src/qml/timeline/TrackHead.qml
@@ -23,25 +23,43 @@ import QtQuick.Layouts 1.0
 import Shotcut.Controls 1.0 as Shotcut
 
 Rectangle {
+    id: trackHeadRoot
     property string trackName: ''
     property bool isMute
     property bool isHidden
     property int isComposite
     property bool isVideo
+    property bool selected: false
+    property bool current: false
     signal clicked()
 
-    id: trackHeadRoot
     SystemPalette { id: activePalette }
-    color: activePalette.window
+    color: selected ? selectedTrackColor : (index % 2)? activePalette.alternateBase : activePalette.base
     clip: true
     state: 'normal'
     states: [
-        State { name: 'normal' },
         State {
             name: 'selected'
+            when: trackHeadRoot.selected
             PropertyChanges {
                 target: trackHeadRoot
                 color: isVideo? root.shotcutBlue : 'darkseagreen'
+            }
+        },
+        State {
+            name: 'current'
+            when: trackHeadRoot.current
+            PropertyChanges {
+                target: trackHeadRoot
+                color: selectedTrackColor
+            }
+        },
+        State {
+            when: !trackHeadRoot.selected && !trackHeadRoot.current
+            name: 'normal'
+            PropertyChanges {
+                target: trackHeadRoot
+                color: (index % 2)? activePalette.alternateBase : activePalette.base
             }
         }
     ]

--- a/src/qml/timeline/timeline.qml
+++ b/src/qml/timeline/timeline.qml
@@ -27,6 +27,8 @@ Rectangle {
     SystemPalette { id: activePalette }
     color: activePalette.window
 
+    signal clipClicked()
+
     function zoomIn() {
         scaleSlider.value += 0.0625
         for (var i = 0; i < tracksRepeater.count; i++)
@@ -61,6 +63,7 @@ Rectangle {
                 trackHeaderRepeater.itemAt(i).selected = false
         }
     }
+    onCurrentTrackChanged: selection = [];
 
     MouseArea {
         anchors.fill: parent
@@ -429,6 +432,7 @@ Rectangle {
             onClipClicked: {
                 currentTrack = track.DelegateModel.itemsIndex
                 root.selection = [ clip.DelegateModel.itemsIndex ];
+                root.clipClicked()
             }
             onClipDragged: {
                 // This provides continuous scrolling at the left/right edges.

--- a/src/qml/timeline/timeline.qml
+++ b/src/qml/timeline/timeline.qml
@@ -237,6 +237,23 @@ Rectangle {
                     }
                 }
             }
+
+            CornerSelectionShadow {
+                y: tracksRepeater.count ? tracksRepeater.itemAt(currentTrack).y + ruler.height - scrollView.flickableItem.contentY : 0
+                clip: root.selection.length ?
+                        tracksRepeater.itemAt(currentTrack).clipAt(root.selection[0]) : null
+                opacity: clip && clip.x + clip.width < scrollView.flickableItem.contentX ? 1 : 0
+            }
+
+            CornerSelectionShadow {
+                y: tracksRepeater.count ? tracksRepeater.itemAt(currentTrack).y + ruler.height - scrollView.flickableItem.contentY : 0
+                clip: root.selection.length ?
+                        tracksRepeater.itemAt(currentTrack).clipAt(root.selection[root.selection.length - 1]) : null
+                opacity: clip && clip.x > scrollView.flickableItem.contentX + scrollView.width ? 1 : 0
+                anchors.right: parent.right
+                mirrorGradient: true
+            }
+
             Rectangle {
                 id: cursor
                 visible: timeline.position > -1

--- a/src/qml/timeline/timeline.qml
+++ b/src/qml/timeline/timeline.qml
@@ -53,6 +53,14 @@ Rectangle {
     property alias trackCount: tracksRepeater.count
     property bool stopScrolling: false
     property color shotcutBlue: Qt.rgba(23/255, 92/255, 118/255, 1.0)
+    property var selection: []
+
+    onSelectionChanged: {
+        if (selection.length) {
+            for (var i = 0; i < trackHeaderRepeater.count; i++)
+                trackHeaderRepeater.itemAt(i).selected = false
+        }
+    }
 
     MouseArea {
         anchors.fill: parent
@@ -120,18 +128,17 @@ Rectangle {
                             isHidden: model.hidden
                             isComposite: model.composite
                             isVideo: !model.audio
-                            color: (index === currentTrack)? selectedTrackColor : (index % 2)? activePalette.alternateBase : activePalette.base
                             width: headerWidth
                             height: model.audio? multitrack.trackHeight : multitrack.trackHeight * 2
+                            selected: false
+                            current: index === currentTrack
                             onClicked: {
+                                root.selection = []
                                 currentTrack = index
                                 timeline.selectTrackHead(currentTrack)
-                                currentClip = -1
-                                for (var i = 0; i < tracksRepeater.count; i++)
-                                    tracksRepeater.itemAt(i).resetStates();
                                 for (var i = 0; i < trackHeaderRepeater.count; i++)
-                                    trackHeaderRepeater.itemAt(i).state = 'normal'
-                                state = 'selected'
+                                    trackHeaderRepeater.itemAt(i).selected = false
+                                selected = true
                             }
                         }
                     }
@@ -399,15 +406,12 @@ Rectangle {
             height: audio? multitrack.trackHeight : multitrack.trackHeight * 2
             width: childrenRect.width
             isAudio: audio
+            isCurrentTrack: currentTrack === index
             timeScale: multitrack.scaleFactor
-            onClipSelected: {
-                currentClip = clip.DelegateModel.itemsIndex
-                currentClipTrack = track.DelegateModel.itemsIndex
-                for (var i = 0; i < tracksRepeater.count; i++)
-                    if (i !== track.DelegateModel.itemsIndex) tracksRepeater.itemAt(i).resetStates();
-                for (var i = 0; i < trackHeaderRepeater.count; i++)
-                    trackHeaderRepeater.itemAt(i).state = 'normal'
-                timeline.selectClip(currentClipTrack, currentClip)
+            selection: root.selection
+            onClipClicked: {
+                currentTrack = track.DelegateModel.itemsIndex
+                root.selection = [ clip.DelegateModel.itemsIndex ];
             }
             onClipDragged: {
                 // This provides continuous scrolling at the left/right edges.

--- a/src/src.pro
+++ b/src/src.pro
@@ -189,7 +189,8 @@ HEADERS  += mainwindow.h \
     widgets/scopes/videowaveformscopewidget.h \
     dataqueue.h \
     sharedframe.h \
-    widgets/audioscale.h
+    widgets/audioscale.h \
+    forwardingquickviewworkaround.h \
 
 FORMS    += mainwindow.ui \
     openotherdialog.ui \

--- a/src/src.pro
+++ b/src/src.pro
@@ -98,7 +98,9 @@ SOURCES += main.cpp\
     widgets/scopes/audiowaveformscopewidget.cpp \
     widgets/scopes/videowaveformscopewidget.cpp \
     sharedframe.cpp \
-    widgets/audioscale.cpp
+    widgets/audioscale.cpp \
+    widgets/playlisttable.cpp \
+
 
 HEADERS  += mainwindow.h \
     mltcontroller.h \
@@ -191,6 +193,7 @@ HEADERS  += mainwindow.h \
     sharedframe.h \
     widgets/audioscale.h \
     forwardingquickviewworkaround.h \
+    widgets/playlisttable.h \
 
 FORMS    += mainwindow.ui \
     openotherdialog.ui \

--- a/src/widgets/playlisttable.cpp
+++ b/src/widgets/playlisttable.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2015 Meltytech, LLC
+ * Author: Harald Hvaal <harald.hvaal@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "playlisttable.h"
+
+#include <QKeyEvent>
+
+PlaylistTable::PlaylistTable(QWidget *parent)
+    : QTableView(parent)
+{
+
+}
+
+void PlaylistTable::keyPressEvent(QKeyEvent* event)
+{
+    if (event->key() == Qt::Key_Left || event->key() == Qt::Key_Right)
+    {
+        /* make sure we ignore left/right keypresses here so it can bubble its way up to the top
+         * level where it's handled as a global keyboard shortcut. There's seemingly no way to keep
+         * QTableView from using left/right for moving between cells, so this is a slight hack to
+         * prevent that behavior. */
+        event->ignore();
+        return;
+    }
+    QTableView::keyPressEvent(event);
+}

--- a/src/widgets/playlisttable.h
+++ b/src/widgets/playlisttable.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2015 Meltytech, LLC
+ * Author: Harald Hvaal <harald.hvaal@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _PLAYLISTTABLE_H
+#define _PLAYLISTTABLE_H
+
+#include <QTableView>
+
+class PlaylistTable : public QTableView
+{
+public:
+    PlaylistTable(QWidget *parent = 0);
+    void keyPressEvent(QKeyEvent*);
+};
+
+#endif


### PR DESCRIPTION
This branch has many improvements centered around keyboard control in shotcut.

- selecting multiple clips is now possible, due to selection being stored in an index array (ie [0,2,3])
   - this functionality is not yet exposed in the UI
- global keyboard shortcut code is moved to MainWindow
- the playlist eating some keypresses is fixed
- the current selection can now be moved with Shift+Arrow keys
     - As a part of this, empty spaces can now also be selected, so that they may be removed with X without reaching for the mouse. This might be the most risky change, and I know of at least one unfixed bug so far (the blank clip may be opened by pressing Enter, and then appending that clip does weird stuff)
- clips may be removed using X without selecting them first
- pressing Esc clears selection