### PR TITLE
Show in the filterdock what is currently selected

### DIFF
--- a/src/models/attachedfiltersmodel.cpp
+++ b/src/models/attachedfiltersmodel.cpp
@@ -80,6 +80,19 @@ void AttachedFiltersModel::setProducer(Mlt::Producer* producer)
     }
 }
 
+QString AttachedFiltersModel::trackTitle() const
+{
+    if (m_producer.isNull())
+        return QString();
+
+    return QString::fromUtf8(m_producer->get("shotcut:name"));
+}
+
+bool AttachedFiltersModel::isProducerSelected() const
+{
+    return !m_producer.isNull();
+}
+
 int AttachedFiltersModel::rowCount(const QModelIndex &parent) const
 {
     if (m_producer && m_producer->is_valid())
@@ -373,6 +386,8 @@ void AttachedFiltersModel::reset(Mlt::Producer* producer)
     }
 
     endResetModel();
+    emit trackTitleChanged();
+    emit isProducerSelectedChanged();
     emit readyChanged();
 }
 

--- a/src/models/attachedfiltersmodel.h
+++ b/src/models/attachedfiltersmodel.h
@@ -30,6 +30,8 @@ class AttachedFiltersModel : public QAbstractListModel
 {
     Q_OBJECT
     Q_PROPERTY(bool ready READ isReady NOTIFY readyChanged)
+    Q_PROPERTY(QString trackTitle READ trackTitle NOTIFY trackTitleChanged)
+    Q_PROPERTY(bool isProducerSelected READ isProducerSelected NOTIFY isProducerSelectedChanged)
 public:
     enum ModelRoles {
         TypeDisplayRole = Qt::UserRole + 1
@@ -41,6 +43,8 @@ public:
     Mlt::Filter* getFilter(int row) const;
     QmlMetadata* getMetadata(int row) const;
     void setProducer(Mlt::Producer* producer = 0);
+    QString trackTitle() const;
+    bool isProducerSelected() const;
 
     // QAbstractListModel Implementation
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
@@ -57,6 +61,8 @@ signals:
     void changed();
     void readyChanged();
     void duplicateAddFailed(int index);
+    void trackTitleChanged();
+    void isProducerSelectedChanged();
 
 public slots:
     void add(QmlMetadata* meta);

--- a/src/qml/views/filter/filterview.qml
+++ b/src/qml/views/filter/filterview.qml
@@ -64,6 +64,16 @@ Rectangle {
         columns: 3
         anchors.top: parent.top
         anchors.left: parent.left
+
+        Text {
+            text: qsTr("Track: %1").arg(attachedfiltersmodel.trackTitle)
+            height: visible ? implicitHeight : 0
+            visible: attachedfiltersmodel.trackTitle != ""
+            wrapMode: Text.Wrap
+            color: activePalette.text
+            Layout.columnSpan: 3
+            Layout.fillWidth: true
+        }
         
         AttachedFilters {
             id: attachedFilters
@@ -72,6 +82,12 @@ Rectangle {
             Layout.fillHeight: true
             onFilterClicked: {
                 root.currentFilterRequested(index)
+            }
+            Text {
+                anchors.centerIn: parent
+                text: qsTr("Nothing selected")
+                color: activePalette.text
+                visible: !attachedfiltersmodel.isProducerSelected
             }
         }
 


### PR DESCRIPTION
This is shown in a label directly above the list of filters.

If nothing is selected, "Nothing selected" is shown on top of the filters list.
This makes it less obvious why there is an opaque black box with two disabled
buttons.

Clips just show "Anonymous submission" so far, and I'm not sure what would be the best thing to show.