### PR TITLE
Implicitly choose clip

### DIFF
--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -257,7 +257,19 @@ QList<int> TimelineDock::selection() const
 
 void TimelineDock::selectClipUnderPlayhead()
 {
-    setSelection(QList<int>() << clipIndexAtPlayhead(-1));
+    int track = -1, clip = -1;
+    chooseClipAtPosition(m_position, &track, &clip);
+    if (clip == -1) {
+        int idx = clipIndexAtPlayhead(-1);
+        if (idx == -1)
+            setSelection(QList<int>());
+        else
+            setSelection(QList<int>() << clipIndexAtPlayhead(-1));
+        return;
+    }
+
+    setCurrentTrack(track);
+    setSelection(QList<int>() << clip);
 }
 
 int TimelineDock::centerOfClip(int trackIndex, int clipIndex)

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -548,10 +548,9 @@ void TimelineDock::appendFromPlaylist(Mlt::Playlist *playlist)
 
 void TimelineDock::splitClip(int trackIndex, int clipIndex)
 {
-    if (trackIndex < 0)
-        trackIndex = currentTrack();
-    if (clipIndex < 0)
-        clipIndex = clipIndexAtPlayhead(trackIndex);
+    if (trackIndex < 0 || clipIndex < 0)
+        chooseClipAtPosition(m_position, &trackIndex, &clipIndex);
+    setCurrentTrack(trackIndex);
     if (clipIndex >= 0 && trackIndex >= 0) {
         int i = m_model.trackList().at(trackIndex).mlt_index;
         QScopedPointer<Mlt::Producer> track(m_model.tractor()->track(i));

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -50,6 +50,7 @@ public:
     Mlt::Producer* getClip(int trackIndex, int clipIndex);
     int clipIndexAtPlayhead(int trackIndex = -1);
     int clipIndexAtPosition(int trackIndex, int position);
+    void chooseClipAtPosition(int position, int * trackIndex, int * clipIndex);
     int dockYOffset() const;
     void setCurrentTrack(int currentTrack);
     int currentTrack() const;
@@ -116,6 +117,7 @@ protected:
     bool event(QEvent *event);
 
 private:
+    bool isBlank(int trackIndex, int clipIndex);
     Ui::TimelineDock *ui;
     ForwardingQuickViewWorkaround m_quickView;
     MultitrackModel m_model;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1274,7 +1274,7 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
             m_timelineDock->show();
             m_timelineDock->raise();
             if (m_timelineDock->selection().isEmpty())
-                m_timelineDock->setSelection(QList<int>() << m_timelineDock->clipIndexAtPlayhead());
+                m_timelineDock->selectClipUnderPlayhead();
             m_timelineDock->removeSelection();
         }
         break;
@@ -1301,6 +1301,8 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
         } else if (multitrack()) {
             m_timelineDock->show();
             m_timelineDock->raise();
+            if (m_timelineDock->selection().isEmpty())
+                m_timelineDock->selectClipUnderPlayhead();
             m_timelineDock->liftSelection();
         }
         break;


### PR DESCRIPTION
Commonly used commands will implicitly select clips under playhead on any track if there is no selection already. The priority should always be:
1. Current selection
2. Clip under playhead on current track
3. Clip under playhead on any track
4. (when it makes sense) blank clip under playhead on current track