### PR TITLE
Fix somewhat rare crash when clicking after adding track

### DIFF
--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -690,6 +690,8 @@ bool MultitrackModel::moveClipValid(int fromTrack, int toTrack, int clipIndex, i
             Mlt::Producer* trackFrom = m_tractor->track(m_trackList.at(fromTrack).mlt_index);
             Mlt::Playlist playlistFrom(*trackFrom);
             delete trackFrom;
+            if (clipIndex < 0 || clipIndex >= playlistFrom.count())
+                return false;
             QScopedPointer<Mlt::Producer> clip(playlistFrom.get_clip(clipIndex));
             if (position >= playlist.get_playtime())
                 result = true;


### PR DESCRIPTION
The mousearea handling moves was only getting onReleased, and not onPressed, leaving originalTrackIndex with an old value (0 instead of 1), causing the crash.

Fixes #71