### PR TITLE
Store git version info in Shotcut.app/versions

### DIFF
--- a/scripts/build-shotcut.sh
+++ b/scripts/build-shotcut.sh
@@ -1994,6 +1994,14 @@ End-of-desktop-file
 
   cmd pushd "$INSTALL_DIR"
 
+  VERSION_INFO=Shotcut/Shotcut.app/versions
+  rm -f $VERSION_INFO
+  for DIR in $SUBDIRS; do
+    if [ -d $SOURCE_DIR/$DIR/.git ]; then
+      echo $DIR $(git -C $SOURCE_DIR/$DIR rev-parse HEAD) $(git -C $SOURCE_DIR/$DIR describe HEAD) >> $VERSION_INFO
+    fi
+  done
+
   if [ "$ARCHIVE" = "1" ]; then
     log Creating archive
     tarball="$INSTALL_DIR/shotcut.tar.bz2"

--- a/scripts/versiondiff.sh
+++ b/scripts/versiondiff.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -eu
+
+catIfValid() {
+    cat $1 2>/dev/null
+}
+
+printVersions() {
+    VERSIONFILEPATH=$1
+    if [ $(basename $VERSIONFILEPATH) = "versions" ]; then
+        cat $VERSIONFILEPATH
+    elif catIfValid $VERSIONFILEPATH/Shotcut.app/versions; then
+        return 0
+    elif catIfValid $VERSIONFILEPATH/Shotcut/Shotcut.app/versions; then
+        return 0
+    elif file $VERSIONFILEPATH | grep -q "compressed data"; then
+        >&2 echo "Reading version from $VERSIONFILEPATH"...
+        tar xOf $VERSIONFILEPATH Shotcut/Shotcut.app/versions
+        if [ "$?" -ne "0" ]; then
+            >&2 echo No versions file found in $VERSIONFILEPATH
+            return 1
+        fi
+    else
+        return 1
+    fi
+}
+
+oldVersion=$(mktemp)
+newVersion=$(mktemp)
+trap "rm -f $oldVersion $newVersion" EXIT
+
+printVersions $1 > $oldVersion
+printVersions $2 > $newVersion
+
+cd $(dirname $0)/../../
+
+cat $oldVersion | while read dir sha; do
+    pushd $dir > /dev/null
+
+    oldsha=$sha
+    newsha=$(egrep "^$dir" $newVersion | cut -f2 -d' ')
+    if [ "$oldsha" = "$newsha" ]; then
+        echo $dir: No new commits
+        popd > /dev/null
+        continue
+    fi
+    sharange=$oldsha..$newsha
+    commitcount=$(git rev-list $sharange | wc -l)
+
+    echo
+    echo ---- $dir: $commitcount new commits
+    git log --oneline $sharange
+
+    popd > /dev/null
+done


### PR DESCRIPTION
versiondiff.sh can give a nice readable list over new commits introduced in a
new release.

versiondiff.sh accepts two parameters, in the same order as a git range:
$ versiondiff.sh [old] [new]

These parameters can either be
- a compressed shotcut release (tar.bz2 file)
- a Shotcut.app folder
- or the versions file directly

Example output:

```
$ ./versiondiff.sh ~/tmp/shotcut.tar.bzip2  ~/shotcut/Shotcut/Shotcut.app
Reading version from /home/harald/tmp/shotcut.tar.bzip2...

---- FFmpeg: 2 new commits
db27f50 avformat/mov: Fix mixed declaration and statement warning
8327bef Update for 2.3.6

---- frei0r: 2 new commits
baa08d2 Fix memory leaks in cairoblend and cairoaffineblend.
75e8940 Fix possible divide by zero.

---- libepoxy: 3 new commits
20062c2 Merge branch 'khronos-registry'
e9ce388 Import registry from SVN 29350
135f7bf wgl: Fix an extra break statement.

---- libvpx: 0 new commits

---- mlt: 0 new commits

---- movit: 2 new commits
b757b4f Release Movit 1.1.3.
0cea318 Make read_file() thread-safe.

---- opus: 2 new commits
36e0445 Ogg Opus draft: Address chair review comments.
6814b2c Avoiding the term "mode" in opus_demo

---- shotcut: 3 new commits
a80d205 Store git version info in Shotcut.app/versions
4535b19 Reject timeline modifications to locked tracks
231462e Do not auto-select clips on locked tracks

---- vid.stab: 7 new commits
4ec5be1 Merge branch 'master' of github.com:georgmartius/vid.stab
b002aac Merge pull request #23 from govindnh4cl/DocUpdate
859ddff Updated spaces
326f76f renamed README.md after updating it
2c52016 Merge pull request #21 from al42and/transcode-plugin-compilation
3c09ff2 Minor issues with transcode filter
07693de version to 1.0 because of API actually changed between 0.96 and 0.98

---- webvfx: 2 new commits
a54b093 Change nokia.com links in documentation to qt-project.org.
e5c01d4 Change all nokia.com links to qt-project.org.

---- x264: 2 new commits
121396c Cosmetic changes
8e71b43 Update configure for auto detection of system libx264 configuration

---- x265: 0 new commits

```