### PR TITLE
Fix shotcut wrapper not supporting relative paths

### DIFF
--- a/scripts/build-shotcut.sh
+++ b/scripts/build-shotcut.sh
@@ -1990,6 +1990,7 @@ End-of-melt-wrapper
 #!/bin/sh
 # Set up environment
 # Run this instead of trying to run bin/shotcut. It runs shotcut with the correct environment.
+RELATIVE_PATH=\$(pwd)
 CURRENT_DIR=\$(readlink -f "\$0")
 INSTALL_DIR=\$(dirname "\$CURRENT_DIR")
 export LD_LIBRARY_PATH="\$INSTALL_DIR/lib":\$LD_LIBRARY_PATH
@@ -2001,7 +2002,7 @@ export MLT_MOVIT_PATH="\$INSTALL_DIR/share/movit"
 cd "\$INSTALL_DIR"
 export QT_PLUGIN_PATH="lib/qt5"
 export QML2_IMPORT_PATH="lib/qml"
-bin/shotcut "\$@"
+bin/shotcut --relativepath \$RELATIVE_PATH "\$@"
 End-of-shotcut-wrapper
   if test 0 != $? ; then
     die "Unable to create wrapper script"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,12 +174,19 @@ public:
         parser.addOption(gpuOption);
         parser.addPositionalArgument("resource",
             QCoreApplication::translate("main", "A file to open."));
+        QCommandLineOption relpathOption("relativepath",
+            QCoreApplication::translate("main", "The relative path of passed filename"), "relativepath");
+        parser.addOption(relpathOption);
         parser.process(arguments());
         isFullScreen = parser.isSet(fullscreenOption);
         if (parser.isSet(gpuOption))
             Settings.setPlayerGPU(true);
         if (!parser.positionalArguments().isEmpty())
+        {
             resourceArg = parser.positionalArguments().first();
+            if (parser.isSet(relpathOption))
+                resourceArg = QDir::cleanPath(parser.value(relpathOption.valueName()) + QDir::separator() + resourceArg);
+        }
     }
 
     ~Application()


### PR DESCRIPTION
This was broken when 'cd $INSTALL_DIR' was added as a workaround for another
bug.

Thus, calling something like Shotcut.app/shotcut ../../Documents/project.mlt wouldn't work.