### PR TITLE
Multi-clip selection

### DIFF
--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -30,13 +30,50 @@ namespace Ui {
 class TimelineDock;
 }
 
+class ClipIndex : public QVariant
+{
+public:
+    ClipIndex(const QVariant& copy)
+    {
+        Q_ASSERT(copy.canConvert<QVariantMap>());
+        Q_ASSERT(copy.toMap().contains("trackIndex"));
+        Q_ASSERT(copy.toMap().contains("clipIndex"));
+        *this = static_cast<const ClipIndex&>(copy);
+    }
+
+    ClipIndex(int trackIndex, int clipIndex)
+    {
+        QVariantMap map;
+        map["trackIndex"] = trackIndex;
+        map["clipIndex"] = clipIndex;
+        *this = QVariant::fromValue(map);
+    }
+
+    ClipIndex()
+    {
+        QVariantMap map;
+        map["trackIndex"] = QVariant::fromValue(-1);
+        map["clipIndex"] = QVariant::fromValue(-1);
+        *this = QVariant::fromValue(map);
+    }
+
+    int trackIndex() const
+    {
+        return toMap()["trackIndex"].toInt();
+    }
+    int clipIndex() const
+    {
+        return toMap()["clipIndex"].toInt();
+    }
+};
+
 class TimelineDock : public QDockWidget
 {
     Q_OBJECT
     Q_PROPERTY(int position READ position WRITE setPosition NOTIFY positionChanged)
     Q_PROPERTY(int yoffset READ dockYOffset)
     Q_PROPERTY(int currentTrack READ currentTrack WRITE setCurrentTrack NOTIFY currentTrackChanged)
-    Q_PROPERTY(QList<int> selection READ selection WRITE setSelection NOTIFY selectionChanged)
+    Q_PROPERTY(QVariantList selection READ selection WRITE setSelection NOTIFY selectionChanged)
 
 public:
     explicit TimelineDock(QWidget *parent = 0);
@@ -60,8 +97,13 @@ public:
     void resetZoom();
     void makeTracksShorter();
     void makeTracksTaller();
-    void setSelection(QList<int> selection);
-    QList<int> selection() const;
+    void clearSelection();
+    void setSelection(const QVariantList &selection);
+    void setSelection(const QList<ClipIndex>& selection);
+    void setSelection(const ClipIndex& selection);
+    void setSelection(int trackIndex, int clipIndex);
+    QVariantList selection() const;
+    QVariantList sortedSelection() const;
     void selectClipUnderPlayhead();
     int centerOfClip(int trackIndex, int clipIndex);
     bool isTrackLocked(int trackIndex) const;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -392,7 +392,8 @@ void MainWindow::moveNavigationPositionToCurrentSelection()
     if (t->selection().isEmpty())
         return;
 
-    m_navigationPosition = t->centerOfClip(t->currentTrack(), t->selection().first());
+    ClipIndex clip(t->selection().first());
+    m_navigationPosition = t->centerOfClip(clip.trackIndex(), clip.clipIndex());
 }
 
 MainWindow& MainWindow::singleton()
@@ -1061,10 +1062,10 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
             if (m_timelineDock->selection().isEmpty()) {
                 m_timelineDock->selectClipUnderPlayhead();
             } else if (m_timelineDock->selection().size() == 1) {
-                int newIndex = m_timelineDock->selection().first() - 1;
+                int newIndex = ClipIndex(m_timelineDock->selection().first()).clipIndex() - 1;
                 if (newIndex < 0)
                     break;
-                m_timelineDock->setSelection(QList<int>() << newIndex);
+                m_timelineDock->setSelection(m_timelineDock->currentTrack(), newIndex);
                 m_navigationPosition = m_timelineDock->centerOfClip(m_timelineDock->currentTrack(), newIndex);
             }
         } else {
@@ -1076,10 +1077,10 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
             if (m_timelineDock->selection().isEmpty()) {
                 m_timelineDock->selectClipUnderPlayhead();
             } else if (m_timelineDock->selection().size() == 1) {
-                int newIndex = m_timelineDock->selection().first() + 1;
+                int newIndex = ClipIndex(m_timelineDock->selection().first()).clipIndex() + 1;
                 if (newIndex >= m_timelineDock->clipCount(-1))
                     break;
-                m_timelineDock->setSelection(QList<int>() << newIndex);
+                m_timelineDock->setSelection(m_timelineDock->currentTrack(), newIndex);
                 m_navigationPosition = m_timelineDock->centerOfClip(m_timelineDock->currentTrack(), newIndex);
             }
         } else {
@@ -1122,7 +1123,7 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
         break;
     case Qt::Key_D:
         if (event->modifiers() & Qt::ControlModifier)
-            m_timelineDock->setSelection(QList<int>());
+            m_timelineDock->clearSelection();
         else
             handled = false;
         break;
@@ -1240,7 +1241,7 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
 
             if (newClipIndex >= 0) {
                 newClipIndex = qMin(newClipIndex, m_timelineDock->clipCount(m_timelineDock->currentTrack()) - 1);
-                m_timelineDock->setSelection(QList<int>() << newClipIndex);
+                m_timelineDock->setSelection(m_timelineDock->currentTrack(), newClipIndex);
             }
 
         } else if (m_playlistDock->isVisible()) {
@@ -1264,7 +1265,7 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
 
             if (newClipIndex >= 0) {
                 newClipIndex = qMin(newClipIndex, m_timelineDock->clipCount(m_timelineDock->currentTrack()) - 1);
-                m_timelineDock->setSelection(QList<int>() << newClipIndex);
+                m_timelineDock->setSelection(m_timelineDock->currentTrack(), newClipIndex);
             }
 
         } else if (m_playlistDock->isVisible()) {
@@ -1371,7 +1372,8 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
     case Qt::Key_Enter: // Seek to current playlist item
     case Qt::Key_Return:
         if (!m_timelineDock->selection().isEmpty()) {
-            m_timelineDock->openClip(m_timelineDock->currentTrack(), m_timelineDock->selection().first());
+            ClipIndex clip(m_timelineDock->selection().first());
+            m_timelineDock->openClip(clip.trackIndex(), clip.clipIndex());
         }
         else if (m_playlistDock->position() >= 0) {
             if (event->modifiers() == Qt::ShiftModifier)

--- a/src/qml/timeline/Clip.qml
+++ b/src/qml/timeline/Clip.qml
@@ -40,6 +40,7 @@ Rectangle {
     property int originalX: x
     property bool selected: false
 
+    signal ctrlClicked(var clip)
     signal clicked(var clip)
     signal moved(var clip)
     signal dragged(var clip, var mouse)
@@ -274,6 +275,8 @@ Rectangle {
             startX = parent.x
             if (mouse.button === Qt.RightButton)
                 menu.popup()
+            else if (mouse.modifiers & Qt.ControlModifier)
+                clipRoot.ctrlClicked(clipRoot)
             else
                 clipRoot.clicked(clipRoot)
         }

--- a/src/qml/timeline/Track.qml
+++ b/src/qml/timeline/Track.qml
@@ -29,8 +29,9 @@ Rectangle {
     property bool placeHolderAdded: false
     property bool isCurrentTrack: false
     property bool isLocked: false
-    property var selection
+    property var selectedClipsOnThisTrack
 
+    signal clipCtrlClicked(var clip, var track)
     signal clipClicked(var clip, var track)
     signal clipDragged(var clip, int x, int y)
     signal clipDropped(var clip)
@@ -75,9 +76,10 @@ Rectangle {
             trackIndex: trackRoot.DelegateModel.itemsIndex
             fadeIn: model.fadeIn
             fadeOut: model.fadeOut
-            selected: trackRoot.isCurrentTrack && trackRoot.selection.indexOf(index) !== -1
+            selected: trackRoot.selectedClipsOnThisTrack.indexOf(index) !== -1
 
             onClicked: trackRoot.clipClicked(clip, trackRoot);
+            onCtrlClicked: trackRoot.clipCtrlClicked(clip, trackRoot);
             onMoved: {
                 var fromTrack = clip.originalTrackIndex
                 var toTrack = clip.trackIndex

--- a/src/qml/timeline/timeline.qml
+++ b/src/qml/timeline/timeline.qml
@@ -73,7 +73,6 @@ Rectangle {
                 trackHeaderRepeater.itemAt(i).selected = false
         }
     }
-    onCurrentTrackChanged: selection = [];
 
     MouseArea {
         anchors.fill: parent
@@ -257,14 +256,14 @@ Rectangle {
             CornerSelectionShadow {
                 y: tracksRepeater.count ? tracksRepeater.itemAt(currentTrack).y + ruler.height - scrollView.flickableItem.contentY : 0
                 clip: root.selection.length ?
-                        tracksRepeater.itemAt(currentTrack).clipAt(root.selection[0]) : null
+                        tracksRepeater.itemAt(currentTrack).clipAt(root.selection[0].clipIndex) : null
                 opacity: clip && clip.x + clip.width < scrollView.flickableItem.contentX ? 1 : 0
             }
 
             CornerSelectionShadow {
                 y: tracksRepeater.count ? tracksRepeater.itemAt(currentTrack).y + ruler.height - scrollView.flickableItem.contentY : 0
                 clip: root.selection.length ?
-                        tracksRepeater.itemAt(currentTrack).clipAt(root.selection[root.selection.length - 1]) : null
+                        tracksRepeater.itemAt(currentTrack).clipAt(root.selection[root.selection.length - 1].clipIndex) : null
                 opacity: clip && clip.x > scrollView.flickableItem.contentX + scrollView.width ? 1 : 0
                 anchors.right: parent.right
                 mirrorGradient: true
@@ -440,10 +439,40 @@ Rectangle {
             isAudio: audio
             isCurrentTrack: currentTrack === index
             timeScale: multitrack.scaleFactor
-            selection: root.selection
+            selectedClipsOnThisTrack: {
+                var selectedList = [];
+                for (var idx in root.selection) {
+                    if (root.selection[idx].trackIndex === index)
+                        selectedList.push(root.selection[idx].clipIndex);
+                }
+                return selectedList;
+            }
+            onClipCtrlClicked: {
+                currentTrack = track.DelegateModel.itemsIndex
+                var newSelection = root.selection;
+                if (selectedClipsOnThisTrack.indexOf(clip.DelegateModel.itemsIndex) == -1) {
+                    newSelection.push({
+                        trackIndex: index,
+                        clipIndex: clip.DelegateModel.itemsIndex
+                    });
+                } else {
+                    for (var i = 0; i < newSelection.length; i++) {
+                        if (newSelection[i].trackIndex === index &&
+                                newSelection[i].clipIndex === clip.DelegateModel.itemsIndex) {
+                            newSelection.splice(i, 1);
+                            break;
+                        }
+                    }
+                }
+                root.selection = newSelection;
+                root.clipClicked()
+            }
             onClipClicked: {
                 currentTrack = track.DelegateModel.itemsIndex
-                root.selection = [ clip.DelegateModel.itemsIndex ];
+                root.selection = [{
+                    trackIndex: index,
+                    clipIndex: clip.DelegateModel.itemsIndex
+                }];
                 root.clipClicked()
             }
             onClipDragged: {


### PR DESCRIPTION
Ctrl-clicking a clip while another is selected will append the clip to the
current selection.

- Selections are no longer just a clipIndex, but a variantmap containing both
  trackIndex and clipIndex.
- A clipindex helper class is provided for setting and getting the trackIndex
  and clipIndex properties from the variant
- Functions operating on the selection will now have to consider multiple clips
  and multiple tracks. You can no longer make any assumptions about current
  track and current selection.
- The first clip in the selection list will always be the first clip that was
  clicked on, and if the operation only operates on a single clip, the first
  item in this list should be chosen.

Shift-clicking for selecting ranges is on my TODO list.