### PR TITLE
Select first filter if none selected

### DIFF
--- a/src/qml/views/filter/AttachedFilters.qml
+++ b/src/qml/views/filter/AttachedFilters.qml
@@ -154,6 +154,12 @@ Rectangle {
             }
             
             onCurrentIndexChanged: positionViewAtIndex(currentIndex, ListView.Contain)
+            onCountChanged: {
+                if (count > 0 && currentIndex == -1) {
+                    currentIndex = 0;
+                    filterClicked(currentIndex);
+                }
+            }
 
             MouseArea {
                 property int oldIndex: -1


### PR DESCRIPTION
If there are filters available, and no filters are currently selected,
automatically select the first one in the list. With this, you only need to
click a clip in the timeline in order to have the filter ui show.