### PR TITLE
Webvfx filter ui: custom properties

### DIFF
--- a/src/qml/filters/webvfx/ui.qml
+++ b/src/qml/filters/webvfx/ui.qml
@@ -31,6 +31,21 @@ Rectangle {
 
     SystemPalette { id: activePalette; colorGroup: SystemPalette.Active }
     Shotcut.File { id: htmlFile }
+    Shotcut.File {
+        id: customUiFile
+        url: {
+            if (!htmlFile.url || !htmlFile.exists())
+                return "";
+            var uiFile = htmlFile.url.toString();
+            return uiFile.substr(0, uiFile.lastIndexOf(".")) + "_ui.qml";
+        }
+        onUrlChanged: {
+            if (exists())
+                customUILoader.source = url;
+            else
+                customUILoader.source = "";
+        }
+    }
 
     Component.onCompleted: {
         var resource = filter.get('resource')
@@ -214,6 +229,12 @@ Rectangle {
             Layout.columnSpan: 2
             Layout.fillWidth: true
             visible: editButton.visible
+        }
+
+        Loader {
+            id: customUILoader
+            Layout.columnSpan: 4
+            Layout.fillWidth: true
         }
 
         Item {

--- a/src/qml/modules/Shotcut/Controls/SimplePropertyUI.qml
+++ b/src/qml/modules/Shotcut/Controls/SimplePropertyUI.qml
@@ -1,0 +1,40 @@
+import QtQuick 2.1
+import QtQuick.Layouts 1.0
+import QtQuick.Controls 1.1
+
+Column {
+    id: root
+    Layout.columnSpan: 4
+    Layout.fillWidth: true
+    spacing: 4
+
+    property var properties: []
+
+    Label {
+        text: qsTr("Custom Properties")
+        font.bold: true
+    }
+
+    Repeater {
+        model: root.properties
+
+        RowLayout {
+            width: parent.width
+            height: propField.height
+            Label {
+                Layout.preferredWidth: editButton.width
+                Layout.minimumWidth: implicitWidth
+                anchors {
+                    verticalCenter: propField.verticalCenter
+                }
+                text: modelData
+            }
+            TextField {
+                id: propField
+                Layout.fillWidth: true
+                text: filter.get(modelData)
+                onTextChanged: filter.set(modelData, text)
+            }
+        }
+    }
+}

--- a/src/qml/modules/Shotcut/Controls/qmldir
+++ b/src/qml/modules/Shotcut/Controls/qmldir
@@ -7,3 +7,4 @@ TimeSpinner 1.0 TimeSpinner.qml
 SaveDefaultButton 1.0 SaveDefaultButton.qml
 SliderSpinner 1.0 SliderSpinner.qml
 RectangleControl 1.0 RectangleControl.qml
+SimplePropertyUI 1.0 SimplePropertyUI.qml

--- a/src/src.pro
+++ b/src/src.pro
@@ -353,6 +353,7 @@ OTHER_FILES += \
     qml/filters/white/ui.qml \
     qml/modules/Shotcut/Controls/SliderSpinner.qml \
     qml/modules/Shotcut/Controls/RectangleControl.qml \
+    qml/modules/Shotcut/Controls/SimplePropertyUI.qml \
     qml/filters/size_position/SizePositionUI.qml \
     qml/filters/size_position/SizePositionVUI.qml \
     qml/filters/size_position/meta_affine.qml \


### PR DESCRIPTION
This adds a new part to the html overlay filter ui that lets the user set custom
properties, accessible from a webvfx enabled html filter. The new UI is only
visible when the webvfx javascript extension checkbox is enabled.
The list of property names is stored in a special property called
"customPropertynames", which is a comma-separated list of names.

Here's a short youtube video that shows how it may be used:

[![IMAGE ALT TEXT HERE](http://img.youtube.com/vi/KYyXdFfYsas/0.jpg)](https://youtu.be/KYyXdFfYsas)
