### PR TITLE
Share a common QQmlEngine between all qml components

### DIFF
--- a/src/controllers/filtercontroller.h
+++ b/src/controllers/filtercontroller.h
@@ -41,7 +41,6 @@ public:
 signals:
     void currentFilterAboutToChange();
     void currentFilterChanged(QmlFilter* filter, QmlMetadata* meta, int index);
-    void newMetadataFound(QmlMetadata* meta);
     void statusChanged(QString);
 
 public slots:

--- a/src/docks/filtersdock.cpp
+++ b/src/docks/filtersdock.cpp
@@ -34,7 +34,7 @@
 
 FiltersDock::FiltersDock(MetadataModel* metadataModel, AttachedFiltersModel* attachedModel, QWidget *parent) :
     QDockWidget(tr("Filters"), parent),
-    m_qview(this)
+    m_qview(QmlUtilities::sharedEngine(), this)
 {
     qDebug() << "begin";
     setObjectName("FiltersDock");

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -33,7 +33,7 @@
 TimelineDock::TimelineDock(QWidget *parent) :
     QDockWidget(parent),
     ui(new Ui::TimelineDock),
-    m_quickView(this),
+    m_quickView(QmlUtilities::sharedEngine(), this),
     m_position(-1)
 {
     qDebug() << "begin";

--- a/src/forwardingquickviewworkaround.h
+++ b/src/forwardingquickviewworkaround.h
@@ -25,8 +25,8 @@
 class ForwardingQuickViewWorkaround : public QQuickView
 {
 public:
-    ForwardingQuickViewWorkaround(QObject * receiver)
-        : QQuickView(0)
+    ForwardingQuickViewWorkaround(QQmlEngine * engine, QObject * receiver)
+        : QQuickView(engine, 0)
         , m_receiver(receiver)
     {
     }

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -47,7 +47,7 @@ static ClientWaitSync_fp ClientWaitSync = 0;
 using namespace Mlt;
 
 GLWidget::GLWidget(QObject *parent)
-    : QQuickView((QWindow*) parent)
+    : QQuickView(QmlUtilities::sharedEngine(), (QWindow*) parent)
     , Controller()
     , m_shader(0)
     , m_glslManager(0)

--- a/src/qmltypes/qmlutilities.cpp
+++ b/src/qmltypes/qmlutilities.cpp
@@ -31,6 +31,7 @@
 #include <QSysInfo>
 #include <QCursor>
 #include <QtQml>
+#include <QQmlEngine>
 #include <QQmlContext>
 #include <QQuickView>
 
@@ -71,6 +72,14 @@ QDir QmlUtilities::qmlDir()
     dir.cd("shotcut");
     dir.cd("qml");
     return dir;
+}
+
+QQmlEngine * QmlUtilities::sharedEngine()
+{
+    static QQmlEngine * s_engine = 0;
+    if (!s_engine)
+        s_engine = new QQmlEngine;
+    return s_engine;
 }
 
 QUrl QmlUtilities::blankVui()

--- a/src/qmltypes/qmlutilities.h
+++ b/src/qmltypes/qmlutilities.h
@@ -25,6 +25,7 @@
 #include <QUrl>
 
 class QQuickView;
+class QQmlEngine;
 
 class QmlUtilities : public QObject
 {
@@ -37,6 +38,7 @@ public:
     static void setCommonProperties(QQuickView* qview);
     static QDir qmlDir();
     static QUrl blankVui();
+    static QQmlEngine * sharedEngine();
 };
 
 #endif // QMLUTILITIES_H


### PR DESCRIPTION
Saves us some memory, but more importantly fixes a crash caused by filter
metadata constructed from one qqmlengine being used from another one at a later
point where the original QQmlEngine was deleted.

Not tested with qt 5.2.