### PR TITLE
Refactor Database to keep sql operations in single thread

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -18,17 +18,162 @@
 
 #include "database.h"
 #include "models/playlistmodel.h"
+#include "mainwindow.h"
 #include <QtSql>
 #include <QStandardPaths>
 #include <QDir>
-#include <QMutexLocker>
 #include <QtDebug>
+
+struct DatabaseJob {
+    enum Type {
+        PutThumbnail,
+        GetThumbnail
+    } type;
+
+    QImage image;
+    QString hash;
+    bool result;
+    bool completed;
+    DatabaseJob()
+        : result(false)
+        , completed(false)
+    {}
+};
 
 static Database* instance = 0;
 
 Database::Database(QObject *parent) :
-    QObject(parent)
+    QThread(parent)
+    , m_commitTimer(0)
 {
+}
+
+Database &Database::singleton(QWidget *parent)
+{
+    if (!instance) {
+        instance = new Database(parent);
+        instance->start();
+    }
+    return *instance;
+}
+
+bool Database::upgradeVersion1()
+{
+    bool success = false;
+    QSqlQuery query;
+    if (query.exec("CREATE TABLE thumbnails (hash TEXT PRIMARY KEY NOT NULL, accessed DATETIME NOT NULL, image BLOB);")) {
+        success = query.exec("UPDATE version SET version = 1;");
+        if (!success)
+            qCritical() << __FUNCTION__ << query.lastError();
+    } else {
+        qCritical() << __PRETTY_FUNCTION__ << "Failed to create thumbnails table.";
+    }
+    return success;
+}
+
+void Database::doJob(DatabaseJob * job)
+{
+    if (!m_commitTimer->isActive())
+        QSqlDatabase::database().transaction();
+    m_commitTimer->start();
+
+    if (job->type == DatabaseJob::PutThumbnail) {
+        QByteArray ba;
+        QBuffer buffer(&ba);
+        buffer.open(QIODevice::WriteOnly);
+        job->image.save(&buffer, "PNG");
+
+        QSqlQuery query;
+        query.prepare("DELETE FROM thumbnails WHERE hash = :hash;");
+        query.bindValue(":hash", job->hash);
+        query.exec();
+        query.prepare("INSERT INTO thumbnails VALUES (:hash, datetime('now'), :image);");
+        query.bindValue(":hash", job->hash);
+        query.bindValue(":image", ba);
+        job->result = query.exec();
+        if (!job->result)
+            qCritical() << __FUNCTION__ << query.lastError();
+    } else if (job->type == DatabaseJob::GetThumbnail) {
+        QImage result;
+        QSqlQuery query;
+        query.prepare("SELECT image FROM thumbnails WHERE hash = :hash;");
+        query.bindValue(":hash", job->hash);
+        if (query.exec() && query.first()) {
+            result.loadFromData(query.value(0).toByteArray(), "PNG");
+            QSqlQuery update;
+            update.prepare("UPDATE thumbnails SET accessed = datetime('now') WHERE hash = :hash ;");
+            update.bindValue(":hash", job->hash);
+            if (!update.exec())
+                qCritical() << __FUNCTION__ << update.lastError();
+        }
+        job->image = result;
+    }
+    deleteOldThumbnails();
+    job->completed = true;
+}
+
+void Database::commitTransaction()
+{
+    QSqlDatabase::database().commit();
+}
+
+bool Database::putThumbnail(const QString& hash, const QImage& image)
+{
+    DatabaseJob job;
+    job.type = DatabaseJob::PutThumbnail;
+    job.hash = hash;
+    job.image = image;
+    submitAndWaitForJob(&job);
+    return job.result;
+}
+
+void Database::submitAndWaitForJob(DatabaseJob * job)
+{
+    job->completed = false;
+    m_mutex.lock();
+    m_jobs.append(job);
+    if (m_jobs.size() == 1) {
+        //worker was idle until now
+        m_waitForNewJob.wakeAll();
+    }
+    while (!job->completed) {
+        m_waitForFinished.wait(&m_mutex);
+    }
+    m_mutex.unlock();
+}
+
+QImage Database::getThumbnail(const QString &hash)
+{
+    DatabaseJob job;
+    job.type = DatabaseJob::GetThumbnail;
+    job.hash = hash;
+    submitAndWaitForJob(&job);
+    return job.image;
+}
+
+void Database::shutdown()
+{
+    requestInterruption();
+    wait();
+    QString connection = QSqlDatabase::database().connectionName();
+    QSqlDatabase::database().close();
+    QSqlDatabase::removeDatabase(connection);
+    instance = 0;
+}
+
+void Database::deleteOldThumbnails()
+{
+    QSqlQuery query;
+    // OFFSET is the numner of thumbnails to cache.
+    if (!query.exec("DELETE FROM thumbnails WHERE hash IN (SELECT hash FROM thumbnails ORDER BY accessed DESC LIMIT -1 OFFSET 10000);"))
+        qCritical() << __FUNCTION__ << query.lastError();
+}
+
+void Database::run()
+{
+    connect(&MAIN, SIGNAL(aboutToShutDown()),
+            this, SLOT(shutdown()), Qt::DirectConnection);
+
     QDir dir(QStandardPaths::standardLocations(QStandardPaths::DataLocation).first());
     if (!dir.exists())
         dir.mkpath(dir.path());
@@ -36,6 +181,12 @@ Database::Database(QObject *parent) :
     QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
     db.setDatabaseName(dir.filePath("db.sqlite3"));
     db.open();
+
+    m_commitTimer = new QTimer();
+    m_commitTimer->setSingleShot(true);
+    m_commitTimer->setInterval(5000);
+    connect(m_commitTimer, SIGNAL(timeout()),
+            this, SLOT(commitTransaction()));
 
     // Initialize version table, if needed.
     int version = 0;
@@ -52,85 +203,25 @@ Database::Database(QObject *parent) :
     if (version < 1 && upgradeVersion1())
         version = 1;
     qDebug() << "Database version is" << version;
-}
 
-Database &Database::singleton(QWidget *parent)
-{
-    if (!instance)
-        instance = new Database(parent);
-    return *instance;
-}
-
-Database::~Database()
-{
-    QString connection = QSqlDatabase::database().connectionName();
-    QSqlDatabase::database().close();
-    QSqlDatabase::removeDatabase(connection);
-    instance = 0;
-}
-
-bool Database::upgradeVersion1()
-{
-    QMutexLocker lock(&m_mutex);
-    bool success = false;
-    QSqlQuery query;
-    if (query.exec("CREATE TABLE thumbnails (hash TEXT PRIMARY KEY NOT NULL, accessed DATETIME NOT NULL, image BLOB);")) {
-        success = query.exec("UPDATE version SET version = 1;");
-        if (!success)
-            qCritical() << __FUNCTION__ << query.lastError();
-    } else {
-        qCritical() << __PRETTY_FUNCTION__ << "Failed to create thumbnails table.";
+    while (true) {
+        DatabaseJob * newJob = 0;
+        m_mutex.lock();
+        if (m_jobs.isEmpty())
+            m_waitForNewJob.wait(&m_mutex, 1000);
+        else
+            newJob = m_jobs.takeFirst();
+        m_mutex.unlock();
+        QCoreApplication::processEvents();
+        if (newJob) {
+            doJob(newJob);
+            m_waitForFinished.wakeAll();
+        }
+        if (isInterruptionRequested())
+            break;
     }
-    return success;
-}
-
-bool Database::putThumbnail(const QString& hash, const QImage& image)
-{
-    QMutexLocker lock(&m_mutex);
-    QByteArray ba;
-    QBuffer buffer(&ba);
-    buffer.open(QIODevice::WriteOnly);
-    image.save(&buffer, "PNG");
-
-    QSqlQuery query;
-    query.prepare("DELETE FROM thumbnails WHERE hash = :hash;");
-    query.bindValue(":hash", hash);
-    query.exec();
-    query.prepare("INSERT INTO thumbnails VALUES (:hash, datetime('now'), :image);");
-    query.bindValue(":hash", hash);
-    query.bindValue(":image", ba);
-    bool result = query.exec();
-    if (!result)
-        qCritical() << __FUNCTION__ << query.lastError();
-    deleteOldThumbnails();
-    return result;
-}
-
-QImage Database::getThumbnail(const QString &hash)
-{
-    QMutexLocker lock(&m_mutex);
-    QImage result;
-    QSqlQuery query;
-    query.prepare("SELECT image FROM thumbnails WHERE hash = :hash;");
-    query.bindValue(":hash", hash);
-    if (query.exec() && query.first()) {
-        result.loadFromData(query.value(0).toByteArray(), "PNG");
-        QSqlQuery update;
-        update.prepare("UPDATE thumbnails SET accessed = datetime('now') WHERE hash = :hash ;");
-        update.bindValue(":hash", hash);
-        if (!update.exec())
-            qCritical() << __FUNCTION__ << update.lastError();
-    }
-//    qDebug() << __FUNCTION__ << result.byteCount();
-    deleteOldThumbnails();
-    return result;
-}
-
-void Database::deleteOldThumbnails()
-{
-    QSqlQuery query;
-    // OFFSET is the numner of thumbnails to cache.
-    if (!query.exec("DELETE FROM thumbnails WHERE hash IN (SELECT hash FROM thumbnails ORDER BY accessed DESC LIMIT -1 OFFSET 10000);"))
-        qCritical() << __FUNCTION__ << query.lastError();
+    if (m_commitTimer->isActive())
+        commitTransaction();
+    delete m_commitTimer;
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1599,6 +1599,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
         if (!m_htmlEditor || m_htmlEditor->close()) {
             writeSettings();
             event->accept();
+            emit aboutToShutDown();
             QApplication::exit(m_exitCode);
             return;
         }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -77,6 +77,7 @@ signals:
     void producerOpened();
     void profileChanged();
     void openFailed(QString);
+    void aboutToShutDown();
 
 protected:
     MainWindow();


### PR DESCRIPTION
All database operations will now post a job request for the database thread,
then block until it is completed. Testing shows that in practice there is
rarely waiting going on due to multiple jobs in the queue.
The most expensive operation of all: writing to disk, has been delayed until 5
secs after the last database request, and all operations are grouped in an
implicit transactions. This improves thumbnail loading time greatly as the disk
is not written to before thumbnails are ready and on screen, and more
importantly, only written to once (not one time for every thumbnail in the
timeline).

Fixes #120