### PR TITLE
Close filtermenu instead of hiding

### DIFF
--- a/src/qml/views/filter/FilterMenu.qml
+++ b/src/qml/views/filter/FilterMenu.qml
@@ -152,7 +152,7 @@ Window {
                     iconName: 'window-close'
                     iconSource: 'qrc:///icons/oxygen/32x32/actions/window-close.png'
                     tooltip: qsTr('Close menu')
-                    onClicked: filterWindow.visible = false
+                    onClicked: filterWindow.close()
                 }
             }
         }


### PR DESCRIPTION
This ensures focus is brought back to the filterview.

Fixes #125