### PR TITLE
Move canvas painting to QQuickPaintedItem

### DIFF
--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -126,13 +126,11 @@ QVariant MultitrackModel::data(const QModelIndex &index, int role) const
                 return info->fps;
             case IsAudioRole:
                 return m_trackList[index.internalId()].type == AudioTrackType;
-            case AudioLevelsRole: {
-                QVariantList* levels = (QVariantList*) info->producer->get_data(kAudioLevelsProperty);
-                int channels = 2;
-                if (info->producer && info->producer->is_valid() && info->producer->get_data(kAudioLevelsProperty))
-                    return levels->mid(info->frame_in * channels, info->frame_count * channels);
-                break;
-            }
+            case AudioLevelsRole:
+                if (info->producer->get_data(kAudioLevelsProperty))
+                    return QVariant::fromValue(*((QVariantList*) info->producer->get_data(kAudioLevelsProperty)));
+                else
+                    return QVariant();
             case FadeInRole: {
                 QScopedPointer<Mlt::Filter> filter(getFilter("fadeInVolume", info->producer));
                 if (!filter || !filter->is_valid())

--- a/src/qml/timeline/timeline.qml
+++ b/src/qml/timeline/timeline.qml
@@ -19,6 +19,7 @@
 import QtQuick 2.2
 import QtQml.Models 2.1
 import QtQuick.Controls 1.0
+import Shotcut.Controls 1.0
 import QtGraphicalEffects 1.0
 import 'Timeline.js' as Logic
 
@@ -279,32 +280,13 @@ Rectangle {
                 x: timeline.position * multitrack.scaleFactor - scrollView.flickableItem.contentX
                 y: 0
             }
-            Canvas {
+            TimelinePlayhead {
                 id: playhead
-                Component.onCompleted: view.applyQTBUG47714Workaround(playhead);
                 visible: timeline.position > -1
                 x: timeline.position * multitrack.scaleFactor - scrollView.flickableItem.contentX - 5
                 y: 0
                 width: 11
                 height: 5
-                property bool init: true
-                onPaint: {
-                    if (!visible) return;
-                    if (init) {
-                        init = false;
-                        var cx = getContext('2d');
-                        if (cx === null) return
-                        cx.fillStyle = activePalette.windowText;
-                        cx.beginPath();
-                        // Start from the root-left point.
-                        cx.lineTo(width, 0);
-                        cx.lineTo(width / 2.0, height);
-                        cx.lineTo(0, 0);
-                        cx.fill();
-                        cx.closePath();
-                    }
-                }
-                onVisibleChanged: requestPaint()
             }
         }
     }

--- a/src/qmltypes/qmlutilities.cpp
+++ b/src/qmltypes/qmlutilities.cpp
@@ -25,6 +25,7 @@
 #include "qmltypes/qmlfile.h"
 #include "qmltypes/qmlhtmleditor.h"
 #include "qmltypes/qmlmetadata.h"
+#include "qmltypes/timelineitems.h"
 #include "settings.h"
 #include "models/metadatamodel.h"
 #include <QCoreApplication>
@@ -50,6 +51,7 @@ void QmlUtilities::registerCommonTypes()
                                               "You cannot create a MetadataModel from QML.");
     qmlRegisterType<ColorPickerItem>("Shotcut.Controls", 1, 0, "ColorPickerItem");
     qmlRegisterType<ColorWheelItem>("Shotcut.Controls", 1, 0, "ColorWheelItem");
+    registerTimelineItems();
 }
 
 void QmlUtilities::setCommonProperties(QQmlContext* context)

--- a/src/qmltypes/qmlview.h
+++ b/src/qmltypes/qmlview.h
@@ -21,13 +21,8 @@
 
 #include <QObject>
 #include <QPoint>
-#include <QPointer>
-#include <QQuickItem>
-#include <QSGTexture>
 
 class QWindow;
-class QTimerEvent;
-class QSGSimpleTextureNode;
 
 class QmlView : public QObject
 {
@@ -37,28 +32,9 @@ class QmlView : public QObject
 public:
     explicit QmlView(QWindow* qview);
     QPoint pos();
-    Q_INVOKABLE void applyQTBUG47714Workaround(QObject * item);
 
 private:
     QWindow* m_qview;
-};
-
-class QTBUG47714WorkaroundRenderListener : public QObject
-{
-    Q_OBJECT
-
-public:
-    QTBUG47714WorkaroundRenderListener(QQuickItem * item);
-    void timerEvent(QTimerEvent * event);
-    QSGSimpleTextureNode * nodeFromItem();
-
-private slots:
-    void beforeSync();
-    void afterSync();
-
-private:
-    QPointer<QQuickItem> item;
-    QSGTexture * oldTexture;
 };
 
 #endif // QMLVIEW_H

--- a/src/qmltypes/timelineitems.cpp
+++ b/src/qmltypes/timelineitems.cpp
@@ -1,0 +1,133 @@
+#include "timelineitems.h"
+
+#include <QQuickPaintedItem>
+#include <QPainter>
+#include <QPalette>
+#include <QPainterPath>
+#include <QLinearGradient>
+
+class TimelineTransition : public QQuickPaintedItem
+{
+    Q_OBJECT
+    Q_PROPERTY(QColor colorA MEMBER m_colorA NOTIFY propertyChanged)
+    Q_PROPERTY(QColor colorB MEMBER m_colorB NOTIFY propertyChanged)
+
+public:
+    TimelineTransition()
+    {
+        setAntialiasing(QPainter::Antialiasing);
+        connect(this, SIGNAL(propertyChanged()), this, SLOT(update()));
+    }
+
+    void paint(QPainter *painter)
+    {
+        QLinearGradient gradient(0, 0, 0, height());
+        gradient.setColorAt(0, m_colorA);
+        gradient.setColorAt(1, m_colorB);
+
+        QPainterPath path;
+        path.moveTo(0,0);
+        path.lineTo(width(), height());
+        path.lineTo(width(), 0);
+        path.lineTo(0, height());
+        painter->fillPath(path, gradient);
+        painter->strokePath(path, painter->pen());
+    }
+signals:
+    void propertyChanged();
+
+private:
+    QColor m_colorA;
+    QColor m_colorB;
+};
+
+class TimelinePlayhead : public QQuickPaintedItem
+{
+    void paint(QPainter *painter)
+    {
+        QPainterPath path;
+        path.moveTo(width(), 0);
+        path.lineTo(width() / 2.0, height());
+        path.lineTo(0, 0);
+        QPalette p;
+        painter->fillPath(path, p.color(QPalette::WindowText));
+    }
+};
+
+class TimelineTriangle : public QQuickPaintedItem
+{
+public:
+    TimelineTriangle()
+    {
+        setAntialiasing(QPainter::Antialiasing);
+    }
+    void paint(QPainter *painter)
+    {
+        QPainterPath path;
+        path.moveTo(0, 0);
+        path.lineTo(width(), 0);
+        path.lineTo(0, height());
+        painter->fillPath(path, Qt::black);
+    }
+};
+
+class TimelineWaveform : public QQuickPaintedItem
+{
+    Q_OBJECT
+    Q_PROPERTY(QVariant levels MEMBER m_audioLevels NOTIFY propertyChanged)
+    Q_PROPERTY(QColor fillColor MEMBER m_color NOTIFY propertyChanged)
+    Q_PROPERTY(int inPoint MEMBER m_inPoint NOTIFY inPointChanged)
+    Q_PROPERTY(int outPoint MEMBER m_outPoint NOTIFY outPointChanged)
+
+public:
+    TimelineWaveform()
+    {
+        setAntialiasing(QPainter::Antialiasing);
+        connect(this, SIGNAL(propertyChanged()), this, SLOT(update()));
+    }
+
+    void paint(QPainter *painter)
+    {
+        QVariantList data = m_audioLevels.toList();
+        if (data.isEmpty())
+            return;
+
+        const qreal indicesPrPixel = qreal(m_outPoint - m_inPoint) / width();
+
+        QPainterPath path;
+        path.moveTo(-1, height());
+        for (int i = 0; i < width(); ++i)
+        {
+            int idx = qMin(m_inPoint + int(i * indicesPrPixel), data.length() - 2);
+            qreal level = qMax(data.at(idx).toReal(), data.at(idx + 1).toReal()) / 256;
+            path.lineTo(i, height() - level * height());
+        }
+        path.lineTo(width(), height());
+        painter->fillPath(path, m_color.lighter());
+
+        QPen pen(painter->pen());
+        pen.setColor(m_color.darker());
+        painter->strokePath(path, pen);
+    }
+
+signals:
+    void propertyChanged();
+    void inPointChanged();
+    void outPointChanged();
+
+private:
+    QVariant m_audioLevels;
+    int m_inPoint;
+    int m_outPoint;
+    QColor m_color;
+};
+
+void registerTimelineItems()
+{
+    qmlRegisterType<TimelineTransition>("Shotcut.Controls", 1, 0, "TimelineTransition");
+    qmlRegisterType<TimelinePlayhead>("Shotcut.Controls", 1, 0, "TimelinePlayhead");
+    qmlRegisterType<TimelineTriangle>("Shotcut.Controls", 1, 0, "TimelineTriangle");
+    qmlRegisterType<TimelineWaveform>("Shotcut.Controls", 1, 0, "TimelineWaveform");
+}
+
+#include "timelineitems.moc"

--- a/src/qmltypes/timelineitems.h
+++ b/src/qmltypes/timelineitems.h
@@ -1,0 +1,6 @@
+#ifndef _TIMELINEITEMS_H
+#define _TIMELINEITEMS_H
+
+void registerTimelineItems();
+
+#endif

--- a/src/src.pro
+++ b/src/src.pro
@@ -66,6 +66,7 @@ SOURCES += main.cpp\
     qmltypes/qmlfilter.cpp \
     qmltypes/qmlhtmleditor.cpp \
     qmltypes/qmlmetadata.cpp \
+    qmltypes/timelineitems.cpp \
     qmltypes/qmlprofile.cpp \
     htmleditor/htmleditor.cpp \
     htmleditor/highlighter.cpp \
@@ -164,6 +165,7 @@ HEADERS  += mainwindow.h \
     qmltypes/qmlfilter.h \
     qmltypes/qmlhtmleditor.h \
     qmltypes/qmlmetadata.h \
+    qmltypes/timelineitems.h \
     qmltypes/qmlprofile.h \
     htmleditor/htmleditor.h \
     htmleditor/highlighter.h \


### PR DESCRIPTION

    This commit takes a different approach on the qt >=5.5.0 canvas item bug
    that has proven very hard to workaround reliably. Instead of doing the drawing
    in canvas with javascript, the drawing code is moved to a small set of
    QQuickPaintedItem classes that do the same drawing with QPainter (which
    provides a very similar api).
    
    In order to speed up and avoid detaching, this commit also includes a change to
    how audio levels are passed along - now the pointer to the levels data is made
    available through a QVariant, and the waveform painter will access it using
    in/out points and read directly from that data without deep copying.

It wasn't my intention initially to touch the audio levels part, but I quickly realized how inefficient it was to do a subcopy of the array, send it to javascript, do data processing there, then send it back to c++ for drawing.

This addresses #151 