### PR TITLE
Show "Now loading" message in statusbar

### DIFF
--- a/src/mltcontroller.cpp
+++ b/src/mltcontroller.cpp
@@ -27,6 +27,7 @@
 #include "glwidget.h"
 #include "settings.h"
 #include "shotcut_mlt_properties.h"
+#include "mainwindow.h"
 
 namespace Mlt {
 
@@ -97,6 +98,9 @@ int Controller::open(const QString &url)
     int error = 0;
 
     close();
+
+    MAIN.showStatusMessage(QObject::tr("Now loading %1...").arg(url));
+
     if (Settings.playerGPU() && !profile().is_explicit())
         // Prevent loading normalizing filters, which might be Movit ones that
         // may not have a proper OpenGL context when requesting a sample frame.
@@ -131,6 +135,7 @@ int Controller::open(const QString &url)
         m_producer = 0;
         error = 1;
     }
+    MAIN.showStatusMessage(QString());
     return error;
 }
 


### PR DESCRIPTION
My most ambitious attempt was to get a QProgressDialog showing the files loading, but that proved to be very hard with the loading happening in the GUI thread and almost exclusively inside libmlt (ie. no easy way to sneak in some calls to QApplication::processEvents(), unless you know of a callback mechanism?).

I tried showing a QLabel but that simply didn't very good so I ended up just setting the status bar message to at least show some hint about why shotcut is frozen (I have had it freeze for up to 20 seconds on my larger projects).