### PR TITLE
Fix buggy UndoHelper+transitions

### DIFF
--- a/src/commands/undohelper.cpp
+++ b/src/commands/undohelper.cpp
@@ -228,6 +228,8 @@ void UndoHelper::undoChanges()
             if (m_clipsAdded.removeOne(uid)) {
                 UNDOLOG << "Removing clip at" << i;
                 m_model.beginRemoveRows(m_model.index(trackIndex), i, i);
+                if (clip->parent().get_data("mlt_mix"))
+                    clip->parent().set("mlt_mix", NULL, 0);
                 playlist.remove(i);
                 m_model.endRemoveRows();
             }


### PR DESCRIPTION
When removing a clip, the adjacent clips would also have their trim points
adjusted, which is not desirable when UndoHelper is working to restore the
exact state.