### PR TITLE
stabilize filter: Add a SliderSpinner to enable adjusting the 'smooth…

### DIFF
--- a/src/qml/filters/stabilize/ui.qml
+++ b/src/qml/filters/stabilize/ui.qml
@@ -166,6 +166,25 @@ Item {
             onClicked: zoomSlider.value = 0
         }
 
+        Label {
+            text: qsTr('Smoothing')
+            Layout.alignment: Qt.AlignRight
+        }
+        SliderSpinner {
+            id: smoothingSlider
+            minimumValue: 0
+            maximumValue: 100
+            tickmarksEnabled: true
+            stepSize: 1
+            value: filter.get('smoothing')
+            onValueChanged: {
+                filter.set('smoothing', value)
+            }
+        }
+        UndoButton {
+            onClicked: smoothingSlider.value = 15
+        }
+
         Button {
             id: button
             text: qsTr('Analyze')


### PR DESCRIPTION
…ing' property of the stabilize filter

The smoothing property controls how many frames are used for the low pass filtering of motion. A
larger value means that more camera movement is transformed away.

The 'smoothing' property is an integer. Add QmlFilter::getInt() to match the type of the property.