### PR TITLE
stabilize filter ui: Move the 'Analyze' button up under the 'Analyze …

### DIFF
--- a/src/qml/filters/stabilize/ui.qml
+++ b/src/qml/filters/stabilize/ui.qml
@@ -28,18 +28,28 @@ Item {
     height: 150
     property string settingsSavePath: settings.savePath
 
+    function hasFilterCompleted() {
+        return (filter.get("results").length > 0 &&
+                filter.get("filename").indexOf(filter.get("results")) !== -1)
+    }
+
     function setStatus( inProgress ) {
         if (inProgress) {
             status.text = qsTr('Analyzing...')
         }
-        else if (filter.get("results").length > 0 && 
-                 filter.get("filename").indexOf(filter.get("results")) !== -1) {
+        else if (hasFilterCompleted()) {
             status.text = qsTr('Analysis complete.')
         }
         else
         {
             status.text = qsTr('Click Analyze to use this filter.')
         }
+    }
+
+    function analyzeValueChanged() {
+        button.enabled = true
+        status.text = qsTr('Analysis required')
+        filter.set("results", '')
     }
 
     // This signal is used to workaround context properties not available in
@@ -57,7 +67,6 @@ Item {
         onAnalyzeFinished: {
             filter.set("reload", 1);
             setStatus(false)
-            button.enabled = true
         }
     }
     
@@ -118,7 +127,10 @@ Item {
             tickmarksEnabled: true
             stepSize: 1
             value: filter.getDouble('shakiness')
-            onValueChanged: filter.set('shakiness', value)
+            onValueChanged: {
+                filter.set('shakiness', value)
+                analyzeValueChanged()
+            }
         }
         UndoButton {
             onClicked: shakinessSlider.value = 4
@@ -135,7 +147,10 @@ Item {
             tickmarksEnabled: true
             stepSize: 1
             value: filter.getDouble('accuracy')
-            onValueChanged: filter.set('accuracy', value)
+            onValueChanged: {
+                filter.set('accuracy', value)
+                analyzeValueChanged()
+            }
         }
         UndoButton {
             onClicked: accuracySlider.value = 4
@@ -145,6 +160,7 @@ Item {
             id: button
             text: qsTr('Analyze')
             Layout.alignment: Qt.AlignRight
+            enabled: !hasFilterCompleted()
             onClicked: {
                 button.enabled = false
                 fileDialog.folder = settings.savePath

--- a/src/qml/filters/stabilize/ui.qml
+++ b/src/qml/filters/stabilize/ui.qml
@@ -141,6 +141,24 @@ Item {
             onClicked: accuracySlider.value = 4
         }
 
+        Button {
+            id: button
+            text: qsTr('Analyze')
+            Layout.alignment: Qt.AlignRight
+            onClicked: {
+                button.enabled = false
+                fileDialog.folder = settings.savePath
+                fileDialog.open()
+            }
+        }
+        Label {
+            id: status
+            Layout.columnSpan: 2
+            Component.onCompleted: {
+                setStatus(false)
+            }
+        }
+
         Label {
             text: qsTr('<b>Filter Options</b>')
             Layout.columnSpan: 3
@@ -183,24 +201,6 @@ Item {
         }
         UndoButton {
             onClicked: smoothingSlider.value = 15
-        }
-
-        Button {
-            id: button
-            text: qsTr('Analyze')
-            Layout.alignment: Qt.AlignRight
-            onClicked: {
-                button.enabled = false
-                fileDialog.folder = settings.savePath
-                fileDialog.open()
-            }
-        }
-        Label {
-            id: status
-            Layout.columnSpan: 2
-            Component.onCompleted: {
-                setStatus(false)
-            }
         }
 
         Item {


### PR DESCRIPTION
…Options' to make it clearer that this button is only related to the analyze properties


Imo this makes it clearer to the user that the analyze goes with the analyze settings and that the other settings don't require you to press the analyze button again.

It would be even neater if we could auto-analyze when the user enabled the filter, but that would require some hysteresis and would have to handle the case where the user didn't wait for the analysis to complete etc.

Another idea is tracking what settings were used to indicate to the user when analyze had to be run again. That might be a simpler change that better fits with how the current filter uis are designed.