### PR TITLE
Paint playlist items using a custom delegate

### DIFF
--- a/src/docks/playlistdock.h
+++ b/src/docks/playlistdock.h
@@ -27,6 +27,8 @@ namespace Ui {
     class PlaylistDock;
 }
 
+class QAbstractItemView;
+
 class PlaylistDock : public QDockWidget
 {
     Q_OBJECT
@@ -65,9 +67,9 @@ private slots:
 
     void on_actionAppendBlank_triggered();
 
-    void on_tableView_customContextMenuRequested(const QPoint &pos);
+    void viewCustomContextMenuRequested(const QPoint &pos);
 
-    void on_tableView_doubleClicked(const QModelIndex &index);
+    void viewDoubleClicked(const QModelIndex &index);
 
     void on_actionGoto_triggered();
 
@@ -101,8 +103,14 @@ private slots:
 
     void on_updateButton_clicked();
 
+    void updateViewModeFromActions();
+
 private:
+    void setViewMode(PlaylistModel::ViewMode mode);
+
     Ui::PlaylistDock *ui;
+    QAbstractItemView *m_view;
+    QAbstractItemView *m_iconsView;
     PlaylistModel m_model;
     int m_defaultRowHeight;
 };

--- a/src/docks/playlistdock.ui
+++ b/src/docks/playlistdock.ui
@@ -114,6 +114,16 @@ p, li { white-space: pre-wrap; }
           </attribute>
          </widget>
         </item>
+        <item>
+         <widget class="QListView" name="listView">
+          <property name="contextMenuPolicy">
+           <enum>Qt::CustomContextMenu</enum>
+          </property>
+          <property name="movement">
+           <enum>QListView::Static</enum>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </widget>
@@ -313,6 +323,30 @@ p, li { white-space: pre-wrap; }
   <action name="actionAddToTimeline">
    <property name="text">
     <string>Add All to Timeline</string>
+   </property>
+  </action>
+  <action name="actionDetailed">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Detailed</string>
+   </property>
+  </action>
+  <action name="actionTiled">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Tiled</string>
+   </property>
+  </action>
+  <action name="actionIcons">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Icons</string>
    </property>
   </action>
  </widget>

--- a/src/models/playlistmodel.h
+++ b/src/models/playlistmodel.h
@@ -25,10 +25,21 @@
 #include "mltcontroller.h"
 #include "MltPlaylist.h"
 
+#define kDetailedMode "detailed"
+#define kIconsMode "icons"
+#define kTiledMode "tiled"
+
 class PlaylistModel : public QAbstractTableModel
 {
     Q_OBJECT
 public:
+    enum ViewMode {
+        Invalid,
+        Detailed,
+        Tiled,
+        Icons,
+    };
+
     enum Columns {
         COLUMN_INDEX = 0,
         COLUMN_THUMBNAIL,
@@ -37,6 +48,15 @@ public:
         COLUMN_DURATION,
         COLUMN_START,
         COLUMN_COUNT
+    };
+
+    enum Fields {
+        FIELD_INDEX = Qt::UserRole,
+        FIELD_THUMBNAIL,
+        FIELD_RESOURCE,
+        FIELD_IN,
+        FIELD_DURATION,
+        FIELD_START
     };
 
     static const int THUMBNAIL_WIDTH = 80;
@@ -51,6 +71,7 @@ public:
     Qt::DropActions supportedDropActions() const;
     bool insertRows(int row, int count, const QModelIndex & parent = QModelIndex());
     bool removeRows(int row, int count, const QModelIndex & parent = QModelIndex());
+    bool moveRows(const QModelIndex &sourceParent, int sourceRow, int count, const QModelIndex &destinationParent, int destinationChild);
     Qt::ItemFlags flags(const QModelIndex &index) const;
     QStringList mimeTypes() const;
     QMimeData *mimeData(const QModelIndexList &indexes) const;
@@ -63,6 +84,9 @@ public:
     void refreshThumbnails();
     Mlt::Playlist* playlist() { return m_playlist; }
     void setPlaylist(Mlt::Playlist& playlist);
+
+    ViewMode viewMode() const;
+    void setViewMode(ViewMode mode);
 
 signals:
     void created();
@@ -88,6 +112,7 @@ public slots:
 private:
     Mlt::Playlist* m_playlist;
     int m_dropRow;
+    ViewMode m_mode;
 };
 
 #endif // PLAYLISTMODEL_H

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -159,6 +159,17 @@ void ShotcutSettings::setWindowStateDefault(const QByteArray& a)
     settings.setValue("windowStateDefault", a);
 }
 
+QString ShotcutSettings::viewMode() const
+{
+    return settings.value("playlist/viewMode").toString();
+}
+
+void ShotcutSettings::setViewMode(const QString& viewMode)
+{
+    settings.setValue("playlist/viewMode", viewMode);
+    emit viewModeChanged();
+}
+
 QString ShotcutSettings::encodePath() const
 {
     return settings.value("encode/path", QStandardPaths::standardLocations(QStandardPaths::MoviesLocation)).toString();

--- a/src/settings.h
+++ b/src/settings.h
@@ -33,6 +33,7 @@ class ShotcutSettings : public QObject
     Q_PROPERTY(QString openPath READ openPath WRITE setOpenPath NOTIFY openPathChanged)
     Q_PROPERTY(QString savePath READ savePath WRITE setSavePath NOTIFY savePathChanged)
     Q_PROPERTY(QString playlistThumbnails READ playlistThumbnails WRITE setPlaylistThumbnails NOTIFY playlistThumbnailsChanged)
+    Q_PROPERTY(QString viewMode READ viewMode WRITE setViewMode NOTIFY viewModeChanged)
     Q_PROPERTY(bool playerGPU READ playerGPU NOTIFY playerGpuChanged)
     Q_PROPERTY(double audioInDuration READ audioInDuration WRITE setAudioInDuration NOTIFY audioInDurationChanged)
     Q_PROPERTY(double audioOutDuration READ audioOutDuration WRITE setAudioOutDuration NOTIFY audioOutDurationChanged)
@@ -67,6 +68,8 @@ public:
     void setWindowState(const QByteArray&);
     QByteArray windowStateDefault() const;
     void setWindowStateDefault(const QByteArray&);
+    QString viewMode() const;
+    void setViewMode(const QString& viewMode);
 
     QString encodePath() const;
     void setEncodePath(const QString&);
@@ -150,6 +153,7 @@ signals:
     void videoInDurationChanged();
     void videoOutDurationChanged();
     void playlistThumbnailsChanged();
+    void viewModeChanged();
 
 private:
     QSettings settings;

--- a/src/src.pro
+++ b/src/src.pro
@@ -103,6 +103,7 @@ SOURCES += main.cpp\
     sharedframe.cpp \
     widgets/audioscale.cpp \
     widgets/playlisttable.cpp \
+    widgets/playlisticonview.cpp \
     commands/undohelper.cpp \
     models/audiolevelstask.cpp \
     mltxmlchecker.cpp \
@@ -210,6 +211,7 @@ HEADERS  += mainwindow.h \
     sharedframe.h \
     widgets/audioscale.h \
     widgets/playlisttable.h \
+    widgets/playlisticonview.h \
     commands/undohelper.h \
     models/audiolevelstask.h \
     shotcut_mlt_properties.h \

--- a/src/widgets/playlisticonview.cpp
+++ b/src/widgets/playlisticonview.cpp
@@ -1,0 +1,271 @@
+#include "playlisticonview.h"
+
+#include "mainwindow.h"
+#include "models/playlistmodel.h"
+#include "settings.h"
+
+#include <QDebug>
+#include <QPainter>
+#include <QMouseEvent>
+#include <QtMath>
+#include <QScrollBar>
+
+PlaylistIconView::PlaylistIconView(QWidget *parent)
+    : QAbstractItemView(parent)
+    , m_gridSize(170, 100)
+    , m_draggingOverPos(QPoint())
+    , m_itemsPerRow(3)
+{
+    verticalScrollBar()->setSingleStep(100);
+    verticalScrollBar()->setPageStep(400);
+    setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(&Settings, SIGNAL(playlistThumbnailsChanged()), SLOT(updateSizes()));
+}
+
+QRect PlaylistIconView::visualRect(const QModelIndex &index) const
+{
+    int row = index.row() / m_itemsPerRow;
+    int col = index.row() % m_itemsPerRow;
+    return QRect(col * m_gridSize.width(), row * m_gridSize.height(),
+            m_gridSize.width(), m_gridSize.height());
+}
+
+void PlaylistIconView::rowsInserted(const QModelIndex &parent, int start, int end)
+{
+    QAbstractItemView::rowsInserted(parent, start, end);
+    updateSizes();
+    viewport()->update();
+}
+
+void PlaylistIconView::rowsAboutToBeRemoved(const QModelIndex &parent, int start, int end)
+{
+    QAbstractItemView::rowsAboutToBeRemoved(parent, start, end);
+    updateSizes();
+    viewport()->update();
+}
+
+void PlaylistIconView::dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles)
+{
+    QAbstractItemView::dataChanged(topLeft, bottomRight, roles);
+    updateSizes();
+    viewport()->update();
+}
+
+void PlaylistIconView::scrollTo(const QModelIndex &index, ScrollHint hint)
+{
+    Q_UNUSED(index);
+    Q_UNUSED(hint);
+}
+
+QModelIndex PlaylistIconView::indexAt(const QPoint &point) const
+{
+    if (!model())
+        return QModelIndex();
+
+    if (point.x() / m_gridSize.width() >= m_itemsPerRow)
+        return QModelIndex();
+
+    int row = (point.y() + verticalScrollBar()->value()) / m_gridSize.height();
+    int col = (point.x() / m_gridSize.width()) % m_itemsPerRow;
+    return model()->index(row * m_itemsPerRow + col, 0);
+}
+
+QModelIndex PlaylistIconView::moveCursor(CursorAction cursorAction, Qt::KeyboardModifiers modifiers)
+{
+    Q_UNUSED(cursorAction);
+    Q_UNUSED(modifiers);
+    return QModelIndex();
+}
+
+int PlaylistIconView::horizontalOffset() const
+{
+    return 0;
+}
+
+int PlaylistIconView::verticalOffset() const
+{
+    return 0;
+}
+
+bool PlaylistIconView::isIndexHidden(const QModelIndex &index) const
+{
+    Q_UNUSED(index);
+    return false;
+}
+
+void PlaylistIconView::setSelection(const QRect &rect, QItemSelectionModel::SelectionFlags command)
+{
+    QModelIndex i = indexAt(rect.bottomRight());
+    selectionModel()->select(i, command);
+    viewport()->update();
+}
+
+QRegion PlaylistIconView::visualRegionForSelection(const QItemSelection &selection) const
+{
+    Q_UNUSED(selection);
+    return QRegion();
+}
+
+void PlaylistIconView::paintEvent(QPaintEvent*)
+{
+    QPainter painter(viewport());
+    QPalette pal(palette());
+    painter.fillRect(rect(), pal.base());
+
+    if (!model())
+        return;
+
+    QAbstractItemModel * m = model();
+    QRect dragIndicator;
+
+    for (int row = 0; row <= m->rowCount() / m_itemsPerRow; row++) {
+        for (int col = 0; col < m_itemsPerRow; col++) {
+            const int rowIdx = row * m_itemsPerRow + col;
+
+            QModelIndex idx = m->index(rowIdx, 0);
+            if (!idx.isValid())
+                break;
+
+            QRect itemRect(col * m_gridSize.width(), row * m_gridSize.height() - verticalScrollBar()->value(),
+                    m_gridSize.width(), m_gridSize.height());
+
+            if (itemRect.bottom() < 0 || itemRect.top() > this->height())
+                continue;
+
+            const bool selected = selectedIndexes().contains(idx);
+            const QImage thumb = idx.data(Qt::DecorationRole).value<QImage>();
+
+            QRect imageBoundingRect = itemRect;
+            imageBoundingRect.setHeight(0.7 * imageBoundingRect.height());
+            imageBoundingRect.adjust(0, 10, 0, 0);
+
+            QRect imageRect(QPoint(), thumb.size().scaled(imageBoundingRect.size(), Qt::KeepAspectRatio));
+            imageRect.moveCenter(imageBoundingRect.center());
+
+            QRect textRect = itemRect;
+            textRect.setTop(imageBoundingRect.bottom());
+            textRect.adjust(3, 0, -3, 0);
+
+            QRect buttonRect = itemRect.adjusted(2, 2, -2, -2);
+
+            if (selected) {
+                painter.fillRect(buttonRect, pal.highlight());
+            } else {
+                painter.fillRect(buttonRect, pal.button());
+
+                painter.setPen(pal.color(QPalette::Button).lighter());
+                painter.drawLine(buttonRect.topLeft(), buttonRect.topRight());
+                painter.drawLine(buttonRect.topLeft(), buttonRect.bottomLeft());
+
+                painter.setPen(pal.color(QPalette::Button).darker());
+                painter.drawLine(buttonRect.topRight(), buttonRect.bottomRight());
+                painter.drawLine(buttonRect.bottomLeft(), buttonRect.bottomRight());
+            }
+
+            painter.drawImage(imageRect, thumb);
+            painter.setPen(pal.color(QPalette::WindowText));
+            painter.drawText(textRect, Qt::AlignCenter,
+                    painter.fontMetrics().elidedText(idx.data(Qt::DisplayRole).toString(), Qt::ElideMiddle, textRect.width()));
+
+            if (!m_draggingOverPos.isNull() && itemRect.contains(m_draggingOverPos)) {
+                QAbstractItemView::DropIndicatorPosition dropPos =
+                    position(m_draggingOverPos, itemRect, idx);
+                dragIndicator.setSize(QSize(4, itemRect.height()));
+                if (dropPos == QAbstractItemView::AboveItem)
+                    dragIndicator.moveTopLeft(itemRect.topLeft() - QPoint(dragIndicator.width() / 2, 0));
+                else
+                    dragIndicator.moveTopLeft(itemRect.topRight() - QPoint(dragIndicator.width() / 2 - 1, 0));
+            }
+        }
+    }
+    if (!dragIndicator.isNull()) {
+        painter.fillRect(dragIndicator, pal.buttonText());
+    }
+}
+
+void PlaylistIconView::mouseReleaseEvent(QMouseEvent *event)
+{
+    QAbstractItemView::mouseReleaseEvent(event);
+}
+
+void PlaylistIconView::dragMoveEvent(QDragMoveEvent *e)
+{
+    m_draggingOverPos = e->pos();
+    QAbstractItemView::dragMoveEvent(e);
+}
+
+void PlaylistIconView::dragLeaveEvent(QDragLeaveEvent *e)
+{
+    m_draggingOverPos = QPoint();
+    QAbstractItemView::dragLeaveEvent(e);
+}
+
+void PlaylistIconView::dropEvent(QDropEvent *event)
+{
+    m_draggingOverPos = QPoint();
+
+    QModelIndex index = indexAt(event->pos());
+    QRect rectAtDropPoint = visualRect(index);
+
+    QAbstractItemView::DropIndicatorPosition dropPos =
+        position(event->pos(), rectAtDropPoint, index);
+    if (dropPos == QAbstractItemView::BelowItem)
+        index = index.sibling(index.row() + 1, index.column());
+
+    if (true) {
+    //if (d->dropOn(event, &row, &col, &index)) {
+        const Qt::DropAction action = event->dropAction();
+        if (model()->dropMimeData(event->mimeData(), action, index.row(), index.column(), index)) {
+            event->acceptProposedAction();
+        }
+    }
+    stopAutoScroll();
+    setState(NoState);
+    viewport()->update();
+}
+
+void PlaylistIconView::resizeEvent(QResizeEvent *event)
+{
+    updateSizes();
+    QAbstractItemView::resizeEvent(event);
+}
+
+void PlaylistIconView::setModel(QAbstractItemModel* model)
+{
+    QAbstractItemView::setModel(model);
+    updateSizes();
+    viewport()->update();
+}
+
+QAbstractItemView::DropIndicatorPosition PlaylistIconView::position(const QPoint &pos, const QRect &rect, const QModelIndex &index) const
+{
+    Q_UNUSED(index);
+    if (pos.x() < rect.center().x())
+        return QAbstractItemView::AboveItem;
+    else
+        return QAbstractItemView::BelowItem;
+}
+
+void PlaylistIconView::updateSizes()
+{
+    if (!model() || !model()->rowCount())
+    {
+        verticalScrollBar()->setRange(0, 0);
+        return;
+    }
+
+    const bool doubleHeight = Settings.playlistThumbnails() == "tall"
+        || Settings.playlistThumbnails() == "large";
+
+    const int thumbHeight = PlaylistModel::THUMBNAIL_HEIGHT * (doubleHeight ? 2 : 1);
+    const int thumbWidth = thumbHeight * MLT.profile().dar();
+
+    m_itemsPerRow = qMax(1, viewport()->width() / thumbWidth);
+    m_gridSize = QSize(viewport()->width() / m_itemsPerRow, thumbHeight + 20);
+
+    if (!verticalScrollBar())
+        return;
+
+    verticalScrollBar()->setRange(0, m_gridSize.height() * model()->rowCount() / m_itemsPerRow - height() + m_gridSize.height());
+    viewport()->update();
+}

--- a/src/widgets/playlisticonview.h
+++ b/src/widgets/playlisticonview.h
@@ -1,0 +1,46 @@
+#ifndef SRC_WIDGETS_PLAYLISTICONVIEW_H
+#define SRC_WIDGETS_PLAYLISTICONVIEW_H
+
+#include <QAbstractItemView>
+
+class PlaylistIconView : public QAbstractItemView
+{
+    Q_OBJECT
+public:
+    PlaylistIconView(QWidget *parent);
+
+    QRect visualRect(const QModelIndex &index) const Q_DECL_OVERRIDE;
+    void scrollTo(const QModelIndex &index, ScrollHint hint = EnsureVisible) Q_DECL_OVERRIDE;
+    QModelIndex indexAt(const QPoint &point) const Q_DECL_OVERRIDE;
+    QModelIndex moveCursor(CursorAction cursorAction, Qt::KeyboardModifiers modifiers) Q_DECL_OVERRIDE;
+    int horizontalOffset() const Q_DECL_OVERRIDE;
+    int verticalOffset() const Q_DECL_OVERRIDE;
+    bool isIndexHidden(const QModelIndex &index) const Q_DECL_OVERRIDE;
+    void setSelection(const QRect &rect, QItemSelectionModel::SelectionFlags command) Q_DECL_OVERRIDE;
+    QRegion visualRegionForSelection(const QItemSelection &selection) const Q_DECL_OVERRIDE;
+
+    void paintEvent(QPaintEvent*) Q_DECL_OVERRIDE;
+    void mouseReleaseEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
+    void dragMoveEvent(QDragMoveEvent *e) Q_DECL_OVERRIDE;
+    void dragLeaveEvent(QDragLeaveEvent *e) Q_DECL_OVERRIDE;
+    void dropEvent(QDropEvent *e) Q_DECL_OVERRIDE;
+    void resizeEvent(QResizeEvent *event) Q_DECL_OVERRIDE;
+    void setModel(QAbstractItemModel* model) Q_DECL_OVERRIDE;
+
+    void rowsInserted(const QModelIndex &parent, int start, int end) Q_DECL_OVERRIDE;
+    void rowsAboutToBeRemoved(const QModelIndex &parent, int start, int end) Q_DECL_OVERRIDE;
+    void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles = QVector<int>()) Q_DECL_OVERRIDE;
+
+private slots:
+    void updateSizes();
+
+private:
+    int rowWidth() const;
+    QAbstractItemView::DropIndicatorPosition position(const QPoint &pos, const QRect &rect, const QModelIndex &index) const;
+
+    QSize m_gridSize;
+    QPoint m_draggingOverPos;
+    int m_itemsPerRow;
+};
+
+#endif


### PR DESCRIPTION
This uses the screen space more efficiently because we are no longer
constrained to a tabular layout with one cell for each piece of information.

Short summary of the changes so far:

- A class inheriting from QStyledItemDelegate is introduced, which handles painting of items
- PlaylistModel is modified so the different pieces of information are available as different roles, and not columns. This lets the delegate painter retrieve all it wants even though it's just painting a single cell.

This pull request is not ready for merge, because there is still one issue remaining that will affect how to proceed: compact playlists without thumbnails.
For the thumbnail case, there is enough space next to the thumbnail to present clip in/duration/start, like this:

![](http://i.imgur.com/PUzt0cV.png)

But, when choosing the compact style AKA "hidden", the row height is too small to fit all of this. For reference, here's how it looks in the latest release:

![](http://i.imgur.com/6DwLY6L.png)

Here's two suggested solutions:

(1) We set the row height to font lineheight * 2, and wrap the time fields into two lines. Pros: still no horizontal scrollbars. Cons: Less compact than before

(2) When choosing "hidden", the model goes back to COLUMN_COUNT like today, and shows the in/duration/start fields in columns. For thumbnail modes, there is only one column and painting is done with the delegate painter. Pros: Rows are just as compact as today. Cons: more code complexity, horizontal scroll bars

I'm leaning towards (1), but I'd like your opinion before I do any more because going for (2) would need more refactoring.