### PR TITLE
Small fixes

### DIFF
--- a/src/docks/encodedock.cpp
+++ b/src/docks/encodedock.cpp
@@ -153,22 +153,18 @@ void EncodeDock::loadPresetFromProperties(Mlt::Properties& preset)
             ui->bFramesSpinner->setValue(preset.get_int("bf"));
         else if (name == "deinterlace") {
             ui->scanModeCombo->setCurrentIndex(preset.get_int("deinterlace"));
-            ui->scanModeCombo->setEnabled(false);
         }
         else if (name == "progressive") {
             ui->scanModeCombo->setCurrentIndex(preset.get_int("progressive"));
-            ui->scanModeCombo->setEnabled(false);
         }
         else if (name == "top_field_first") {
             ui->fieldOrderCombo->setCurrentIndex(preset.get_int("top_field_first"));
         }
         else if (name == "width") {
             ui->widthSpinner->setValue(preset.get_int("width"));
-            ui->widthSpinner->setEnabled(false);
         }
         else if (name == "height") {
             ui->heightSpinner->setValue(preset.get_int("height"));
-            ui->heightSpinner->setEnabled(false);
         }
         else if (name == "aspect") {
             double dar = preset.get_double("aspect");
@@ -190,12 +186,9 @@ void EncodeDock::loadPresetFromProperties(Mlt::Properties& preset)
                 ui->aspectDenSpinner->setValue(1000);
                 break;
             }
-            ui->aspectNumSpinner->setEnabled(false);
-            ui->aspectDenSpinner->setEnabled(false);
         }
         else if (name == "r") {
             ui->fpsSpinner->setValue(preset.get_double("r"));
-            ui->fpsSpinner->setEnabled(false);
         }
         else if (name == "pix_fmt") {
             QString pix_fmt(preset.get("pix_fmt"));
@@ -269,7 +262,6 @@ void EncodeDock::loadPresetFromProperties(Mlt::Properties& preset)
                 ui->deinterlacerCombo->setCurrentIndex(2);
             else if (name == "yadif")
                 ui->deinterlacerCombo->setCurrentIndex(3);
-            ui->deinterlacerCombo->setDisabled(true);
         }
         else if (name == "rescale") {
             name = preset.get("rescale");
@@ -281,7 +273,6 @@ void EncodeDock::loadPresetFromProperties(Mlt::Properties& preset)
                 ui->interpolationCombo->setCurrentIndex(2);
             else if (name == "hyper" || name == "lanczos")
                 ui->interpolationCombo->setCurrentIndex(3);
-            ui->interpolationCombo->setDisabled(true);
         }
         else if (name != "an" && name != "vn" && name != "threads"
                  && !name.startsWith('_') && !name.startsWith("meta.preset.")) {
@@ -763,15 +754,7 @@ void EncodeDock::resetOptions()
     // Reset all controls to default values.
     ui->formatCombo->setCurrentIndex(0);
 
-    ui->widthSpinner->setEnabled(true);
-    ui->heightSpinner->setEnabled(true);
-    ui->aspectNumSpinner->setEnabled(true);
-    ui->aspectDenSpinner->setEnabled(true);
-    ui->scanModeCombo->setEnabled(true);
-    ui->fpsSpinner->setEnabled(true);
-    ui->deinterlacerCombo->setEnabled(true);
     ui->deinterlacerCombo->setCurrentIndex(3);
-    ui->interpolationCombo->setEnabled(true);
     ui->interpolationCombo->setCurrentIndex(1);
 
     ui->videoBitrateCombo->lineEdit()->setText("2M");
@@ -860,13 +843,6 @@ void EncodeDock::on_presetsTree_clicked(const QModelIndex &index)
                     ui->aspectDenSpinner->setValue(p.display_aspect_den());
                     ui->scanModeCombo->setCurrentIndex(p.progressive());
                     ui->fpsSpinner->setValue(p.fps());
-
-                    ui->widthSpinner->setEnabled(false);
-                    ui->heightSpinner->setEnabled(false);
-                    ui->aspectNumSpinner->setEnabled(false);
-                    ui->aspectDenSpinner->setEnabled(false);
-                    ui->scanModeCombo->setEnabled(false);
-                    ui->fpsSpinner->setEnabled(false);
                 }
             }
             loadPresetFromProperties(*preset);

--- a/src/mltxmlchecker.cpp
+++ b/src/mltxmlchecker.cpp
@@ -54,8 +54,6 @@ MltXmlChecker::MltXmlChecker()
     , m_isCorrected(false)
     , m_decimalPoint(QLocale::system().decimalPoint())
     , m_tempFile(QDir::tempPath().append("/shotcut-XXXXXX.mlt"))
-    , m_hasComma(false)
-    , m_hasPeriod(false)
     , m_numericValueChanged(false)
 {
     LOG_DEBUG() << "decimal point" << m_decimalPoint;
@@ -87,7 +85,7 @@ bool MltXmlChecker::check(const QString& fileName)
                 readMlt();
                 m_newXml.writeEndElement();
                 m_newXml.writeEndDocument();
-                m_isCorrected = m_isCorrected || (m_hasPeriod && m_hasComma && m_numericValueChanged);
+                m_isCorrected = m_isCorrected || m_numericValueChanged;
             } else {
                 m_xml.raiseError(QObject::tr("The file is not a MLT XML file."));
             }
@@ -248,12 +246,6 @@ void MltXmlChecker::checkInAndOutPoints()
 
 bool MltXmlChecker::checkNumericString(QString& value)
 {
-    // See which delimiters are being used.
-    if (!m_hasComma)
-        m_hasComma = value.contains(',');
-    if (!m_hasPeriod)
-        m_hasPeriod = value.contains('.');
-
     // Determine if there is a decimal point inconsistent with locale.
     if (!value.contains(m_decimalPoint) &&
             (value.contains('.') || value.contains(','))) {

--- a/src/mltxmlchecker.h
+++ b/src/mltxmlchecker.h
@@ -72,8 +72,6 @@ private:
     bool m_isCorrected;
     QChar m_decimalPoint;
     QTemporaryFile m_tempFile;
-    bool m_hasComma;
-    bool m_hasPeriod;
     bool m_numericValueChanged;
     QString m_basePath;
     QStandardItemModel m_unlinkedFilesModel;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -697,6 +697,10 @@ void Player::enableTab(TabIndex index, bool enabled)
 
 void Player::onTabBarClicked(int index)
 {
+    // Do nothing if requested tab is already selected.
+    if (m_tabs->currentIndex() == index)
+        return;
+
     switch (index) {
     case SourceTabIndex:
         if (MLT.savedProducer() && MLT.savedProducer()->is_valid() && MLT.producer()


### PR DESCRIPTION
9cc7cdb avoids the situation where the player would switch back and forth between two producers after having opened at least two media files and successively clicking on the "Source" tab.
19b9cfb enables repairing of MLT XMLs which were produced by an instance running on a system with another locale (in my case Windows with German locale and Linux with English locale). In this case the whole file would have decimal points which are inconsistent with the locale everywhere. Previously, repairing would only be offered if both commas and periods were found within the XML.