### PR TITLE
snap build expose more shipped binaries "untested pull"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,16 @@ confinement: classic
 apps:
   shotcut:
     command: bin/desktop-launch $SNAP/Shotcut.app/shotcut
+  ffmpeg:
+    command: $SNAP/Shotcut.app/ffmpeg
+  ffplay:
+    command: $SNAP/Shotcut.app/ffplay
+  ffprobe:
+    command: $SNAP/Shotcut.app/ffprobe
+  melt:
+    command: $SNAP/Shotcut.app/melt
+  qmelt:
+    command: $SNAP/Shotcut.app/qmelt
 
 parts:
   shotcut:


### PR DESCRIPTION
Shotcut snap comes with its own melt/ffmpeg/ffprobe/etc binaries, I’d like these to become available as a global bash command to the whole system instead of only snap shotcut gui for ease in testing a current/different melt/ffmpeg version. For example:

$ shotcut #runs shotcut gui version which is already working
$ shotcut.melt #runs the melt version shipped with shotcut snap
$ shotcut.ffmpeg #runs the ffmpeg version shipped with shotcut snap

I think its not that hard to add, however I don’t know if others would like this feature?

https://forum.shotcut.org/t/shotcut-snap-could-include-commands-for-shipped-melt-ffmpeg-ffprobe-binaries/4054