### PR TITLE
Misc. doxy and source comment typos

### DIFF
--- a/mvcp/mvcp_response.c
+++ b/mvcp/mvcp_response.c
@@ -154,7 +154,7 @@ int mvcp_response_printf( mvcp_response response, size_t size, const char *forma
 	return length;
 }
 
-/** Write text to the reponse.
+/** Write text to the response.
 */
 
 int mvcp_response_write( mvcp_response response, const char *text, int size )

--- a/scripts/build-shotcut.sh
+++ b/scripts/build-shotcut.sh
@@ -73,7 +73,7 @@ QT_LIB_DIR=${QTDIR:+${QTDIR}/lib}
 MLT_DISABLE_SOX=0
 
 ################################################################################
-# Location of config file - if not overriden on command line
+# Location of config file - if not overridden on command line
 CONFIGFILE=build-shotcut.conf
 
 # If defined to 1, outputs trace log lines
@@ -285,7 +285,7 @@ function die {
   else
     echo "ERROR: $@"
   fi
-  feedback_result FAILURE "Some kind of error occured: $@"
+  feedback_result FAILURE "Some kind of error occurred: $@"
   exit -1
 }
 
@@ -931,7 +931,7 @@ function prepare_feedback {
 #################################################################
 # check_abort
 # Function that checks if the user wanted to cancel what we are doing.
-# returns "stop" or "cont" as appropiate
+# returns "stop" or "cont" as appropriate
 function check_abort {
   # log "$ARG"
   echo
@@ -1209,7 +1209,7 @@ function get_subproject {
           REPOLOCURL=`svn --non-interactive info | grep URL | awk '{print $2}'`
           # Now, we have to be a bit clever here, because if the user originally checked it out using
           # https, we can not change to http. So, we check for https in the current URL
-          # Note, that beeing clever almost always fails at some point. But, at least we give it a try...
+          # Note, that being clever almost always fails at some point. But, at least we give it a try...
           if test "${REPOLOCURL:0:5}" = "https" ; then
               REPOLOC=${REPOLOC/http/https}
           fi

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -164,7 +164,7 @@ void Database::shutdown()
 void Database::deleteOldThumbnails()
 {
     QSqlQuery query;
-    // OFFSET is the numner of thumbnails to cache.
+    // OFFSET is the number of thumbnails to cache.
     if (!query.exec("DELETE FROM thumbnails WHERE hash IN (SELECT hash FROM thumbnails ORDER BY accessed DESC LIMIT -1 OFFSET 10000);"))
         LOG_ERROR() << query.lastError();
 }

--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -1852,7 +1852,7 @@ bool MultitrackModel::addTransitionByTrimInValid(int trackIndex, int clipIndex, 
     if (track) {
         Mlt::Playlist playlist(*track);
         if (clipIndex > 0) {
-            // Check if preceeding clip is not blank, not already a transition,
+            // Check if preceding clip is not blank, not already a transition,
             // and there is enough frames before in point of current clip.
             if (!m_isMakingTransition && delta < 0 && !playlist.is_blank(clipIndex - 1) && !isTransition(playlist, clipIndex - 1)) {
                 Mlt::ClipInfo info;

--- a/src/mvcp/qconsole.cpp
+++ b/src/mvcp/qconsole.cpp
@@ -513,7 +513,7 @@ void QConsole::keyPressEvent( QKeyEvent *e )
 			else 
 			{ //no selection
 				//when typing normal characters,
-				//make sure the cursor is positionned in the
+				//make sure the cursor is positioned in the
 				//edition zone
 				if ( !isInEditionZone() )
 				{
@@ -798,7 +798,7 @@ void QConsole::contextMenuEvent ( QContextMenuEvent * event)
 void QConsole::cut()
 {
 		//Cut only in the editing zone,
-		//perfom a copy otherwise
+		//perform a copy otherwise
 		if(isInEditionZone())
 		{
 				QTextEdit::cut();


### PR DESCRIPTION
Found via `codespell -q 3 --skip="*.ts" -I ../shotcut-word-whitelist.txt` where whitelist consist of:
```
lod
ot
seeked
```