### PR TITLE
Build Shotcut with Travis, also build shotcut appimage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+sudo: required
+language: generic
+dist: trusty
+addons:
+  apt:
+    packages:
+    - squashfs-tools
+    - desktop-file-utils
+
+services:
+  - docker
+
+before_install:
+- wget --no-check-certificate https://raw.githubusercontent.com/mltframework/mlt-scripts/master/docker/shotcut-build/Dockerfile
+- mkdir shotcut-build
+- mv Dockerfile shotcut-build/
+- docker build --rm -t ddennedy/shotcut-build shotcut-build
+- mkdir work; cd work
+- wget --no-check-certificate https://raw.githubusercontent.com/mltframework/shotcut/master/scripts/build-shotcut.sh
+- wget --no-check-certificate https://raw.githubusercontent.com/mltframework/shotcut/master/scripts/shotcut.nsi
+- wget --no-check-certificate https://raw.githubusercontent.com/AppImage/AppImages/master/pkg2appimage
+
+script:
+- docker run -it --rm -v $PWD:/root/shotcut ddennedy/shotcut-build
+- bash -ex pkg2appimage ../scripts/shotcut-recipe.yml
+- mv shotcut.tar.bz2 shotcut-${TRAVIS_TAG}.tar.bz2
+- mv out/Shotcut-.glibc2.14-x86_64.AppImage Shotcut-${TRAVIS_TAG}.glibc2.14-x86_64.AppImage
+
+deploy:
+  provider: releases
+  api_key: "$GITHUB_TOKEN"
+  file_glob: true
+  file:
+    - "*.AppImage"
+    - "*.tar.bz2"
+  skip_cleanup: true
+  on:
+    branch: master
+    tags: true

--- a/scripts/shotcut-recipe.yml
+++ b/scripts/shotcut-recipe.yml
@@ -1,0 +1,31 @@
+app: Shotcut
+verbose: true
+
+ingredients:
+  packages:
+    - libsdl1.2debian
+    - libxkbcommon-x11-0
+  dist: trusty
+  sources: 
+    - deb http://us.archive.ubuntu.com/ubuntu/ trusty main universe
+  script:
+    - echo "multiarch-support" >> excludedeblist                                                                                         
+                                                                                                                                         
+script:
+  - ls -la
+  - tar xf ../../shotcut.tar.bz2 -C usr/bin --strip=2
+  - wget "https://github.com/mltframework/shotcut/raw/master/icons/shotcut-logo-64.png" -O shotcut.png
+  - cat > shotcut.desktop <<\EOF
+  - [Desktop Entry]
+  - Type=Application
+  - Name=Shotcut
+  - Name[de]=Shotcut
+  - GenericName=Video Editor
+  - GenericName[de]=Video Bearbeitungsprogramm
+  - Comment=Video Editor
+  - Comment[de]=Programm zum Bearbeiten und Abspielen von Videodateien.
+  - Terminal=false
+  - Exec=shotcut
+  - Icon=shotcut
+  - EOF
+


### PR DESCRIPTION
This pull request automates the build of Shotcut from the docker image.

It builds both the default .tar.bz2-archive plus an additional AppImage which is very similar to the tar.bz2 but with added functionality. It uses a squash-filesystem internally and does not need to be unpacked. Just set the exectuable bit and double-click. Very convinient. :)
More info here [AppImage](https://appimage.org/)

When a new release is tagged on Github, Travis automatically uploads the .tar.bz2 and .AppImage to the corresponding releases section on Github.

What is needed for this to work:
* A token needs to be created on github and uploaded to travis-ci.org to allow the upload.

Further work:
* Initially I tried to automate also automatically build snap package and push to snap repo but I have decided to leave that out of the scope for now. I think this could be added quite easily but I don't have the time right now to do the research.
* Right now Travis builds from the docker image, however there is no correlation between the git commit that Travis started the build from and the actual commit used in the build. The docker image pulls shotcut from github ~3 minutes after the build has started. This means that if there are several commits in a row there is a possibility that Travis builds a later commit. This could be fixed if the dockerimage was set to build the local source that is automatically pulled by Travis instead of pulling the source in the docker image.
* Windows build files could also be built and uploaded to the tagged release.
* You could possible split the build load between AppVeyor Circle-CI and Travis.
    * AppVeyor can be used to build in a windows environment.
    * Circle CI can build in a MacOS environment.
* Consider to use Qt 5.6.2 instead of 5.6.1 then you could use prebuilt libraries from the above providers.

See, https://www.appveyor.com/docs/build-environment/#qt
