### PR TITLE
Lower job priority on Windows.

### DIFF
--- a/src/jobs/abstractjob.h
+++ b/src/jobs/abstractjob.h
@@ -63,6 +63,7 @@ protected:
 protected slots:
     virtual void onFinished(int exitCode, QProcess::ExitStatus exitStatus);
     virtual void onReadyRead();
+    virtual void onStarted();
 
 private:
     bool m_ran;


### PR DESCRIPTION
Discussion here:
https://forum.shotcut.org/t/limit-cpu-core-threads-used-at-export/4073
This improves system responsiveness on my PC when export jobs are running.