### PR TITLE
Fix audio peak scope for > 2 channels.

### DIFF
--- a/src/widgets/audiometerwidget.cpp
+++ b/src/widgets/audiometerwidget.cpp
@@ -200,12 +200,12 @@ void AudioMeterWidget::drawChanLabels(QPainter& p)
             stride++;
         }
 
-        int prevY = height();
+        int prevY = m_graphRect.top();
         for (int i = 0; i < chanLabelCount; i += stride) {
             const QString& label = m_chanLabels[i];
-            y = m_graphRect.bottom() - i * m_barSize.height() - m_barSize.height() / 2 + textHeight / 2;
+            y = m_graphRect.bottom() - (chanLabelCount - 1 - i) * m_barSize.height() - m_barSize.height() / 2 + textHeight / 2;
             x = m_graphRect.left() - fontMetrics().width(label) - TEXT_PAD;
-            if ( prevY - y >= TEXT_PAD) {
+            if ( y - prevY >= TEXT_PAD) {
                 p.drawText(x, y, label);
                 prevY = y - textHeight;
             }
@@ -247,7 +247,7 @@ void AudioMeterWidget::drawBars(QPainter& p)
             double level = IEC_ScaleMax(m_levels[i], m_maxDb);
             bar.setLeft(m_graphRect.left());
             bar.setRight(bar.left() + m_barSize.width() * level);
-            bar.setBottom(m_graphRect.bottom() - i * m_barSize.height() - 1);
+            bar.setBottom(m_graphRect.bottom() - (chanCount - 1 - i) * m_barSize.height() - 1);
             bar.setTop(bar.bottom() - m_barSize.height() + 1);
             p.drawRoundedRect(bar, 3, 3);
         }
@@ -277,8 +277,8 @@ void AudioMeterWidget::drawPeaks(QPainter& p)
             if (bar.left() < m_graphRect.left())
                 continue;
             bar.setRight(bar.left() + 3);
-            bar.setBottom(m_graphRect.bottom() - i * m_barSize.height() + 1);
-            bar.setTop(bar.bottom() - m_barSize.height() + 2);
+            bar.setBottom(m_graphRect.bottom() - (chanCount - 1 - i) * m_barSize.height() - 1);
+            bar.setTop(bar.bottom() - m_barSize.height() + 1);
             p.drawRoundedRect(bar, 3, 3);
         }
     } else {
@@ -307,6 +307,7 @@ void AudioMeterWidget::updateToolTip()
         if (m_orient == Qt::Horizontal) {
             if (mousePos.y() <= m_graphRect.bottom() && mousePos.y() >= m_graphRect.top()) {
                 chan = (int)(m_graphRect.bottom() - mousePos.y()) / (int)m_barSize.height();
+                chan = m_levels.size() - 1 - chan;
             }
         } else {
             if (mousePos.x() >= m_graphRect.left() && mousePos.x() <= m_graphRect.right()) {
@@ -319,7 +320,7 @@ void AudioMeterWidget::updateToolTip()
         if (m_levels[chan] < -90) {
             text = "-inf dB";
         } else {
-            text = QString("%1dB").arg(m_levels[chan], 0, 'f', 1);
+            text = QString("%1dBFS").arg(m_levels[chan], 0, 'f', 1);
         }
 
         if (m_chanLabels.size() > chan) {

--- a/src/widgets/scopes/audiopeakmeterscopewidget.cpp
+++ b/src/widgets/scopes/audiopeakmeterscopewidget.cpp
@@ -29,6 +29,7 @@ AudioPeakMeterScopeWidget::AudioPeakMeterScopeWidget()
   , m_filter(0)
   , m_audioMeter(0)
   , m_orientation((Qt::Orientation)-1)
+  , m_channels( 0 )
 {
     LOG_DEBUG() << "begin";
     m_filter = new Mlt::Filter(MLT.profile(), "audiolevel");
@@ -76,6 +77,10 @@ void AudioPeakMeterScopeWidget::refreshScope(const QSize& /*size*/, bool /*full*
                 }
             }
             QMetaObject::invokeMethod(m_audioMeter, "showAudio", Qt::QueuedConnection, Q_ARG(const QVector<double>&, levels));
+            if (m_channels != channels) {
+                m_channels = channels;
+                QMetaObject::invokeMethod(this, "reconfigureMeter", Qt::QueuedConnection);
+            }
         }
     }
 }
@@ -88,17 +93,32 @@ QString AudioPeakMeterScopeWidget::getTitle()
 void AudioPeakMeterScopeWidget::setOrientation(Qt::Orientation orientation)
 {
     if (orientation != m_orientation) {
-        if (orientation == Qt::Vertical) {
-            m_audioMeter->setMinimumSize(41, 250);
-            setMinimumSize(49, 258);
-            setMaximumSize(49, 508);
-        } else {
-            m_audioMeter->setMinimumSize(250, 41);
-            setMinimumSize(258, 49);
-            setMaximumSize(508, 49);
-        }
-        updateGeometry();
         m_orientation = orientation;
         m_audioMeter->setOrientation(orientation);
+        reconfigureMeter();
     }
+}
+
+void AudioPeakMeterScopeWidget::reconfigureMeter()
+{
+    // Set the bar lables.
+    QStringList channelLabels;
+    if (m_channels == 2 )
+        channelLabels << tr("L") << tr("R");
+    else if (m_channels == 6 )
+        channelLabels << tr("L") << tr("R") << tr("C") << tr("LF") << tr("Ls") << tr("Rs");
+    m_audioMeter->setChannelLabels(channelLabels);
+
+    // Set the size constraints.
+    int spaceNeeded = ( m_channels * 16 ) + 17;
+    if (m_orientation == Qt::Vertical) {
+        m_audioMeter->setMinimumSize(spaceNeeded, 250);
+        setMinimumSize(spaceNeeded + 8, 258);
+        setMaximumSize(spaceNeeded + 8, 508);
+    } else {
+        m_audioMeter->setMinimumSize(250, spaceNeeded);
+        setMinimumSize(258, spaceNeeded + 8);
+        setMaximumSize(508, spaceNeeded + 8);
+    }
+    updateGeometry();
 }

--- a/src/widgets/scopes/audiopeakmeterscopewidget.h
+++ b/src/widgets/scopes/audiopeakmeterscopewidget.h
@@ -47,6 +47,10 @@ private:
     // Members accessed by GUI thread.
     AudioMeterWidget* m_audioMeter;
     Qt::Orientation m_orientation;
+    int m_channels;
+
+private slots:
+    void reconfigureMeter();
 };
 
 #endif // AUDIOPEAKMETERSCOPEWIDGET_H


### PR DESCRIPTION
* Fix size and alignment issues
* Add channel labels to peak meter.
* Order the channels from top to bottom.