### PR TITLE
Additional GPU checking and clarifications.

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -466,7 +466,10 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>GPU Processing (experimental)</string>
+    <string>GPU Effects (experimental)</string>
+   </property>
+   <property name="toolTip">
+    <string>Use GPU filters</string>
    </property>
   </action>
   <action name="actionChannels1">

--- a/src/mltxmlchecker.cpp
+++ b/src/mltxmlchecker.cpp
@@ -53,6 +53,7 @@ static bool isNumericProperty(const QString& name)
 
 MltXmlChecker::MltXmlChecker()
     : m_needsGPU(false)
+    , m_needsCPU(false)
     , m_hasEffects(false)
     , m_isCorrected(false)
     , m_decimalPoint(QLocale().decimalPoint())
@@ -212,6 +213,7 @@ void MltXmlChecker::processProperties()
 
     if (mlt_class == "filter" || mlt_class == "transition" || mlt_class == "producer") {
         checkGpuEffects(mlt_service);
+        checkCpuEffects(mlt_service);
         checkUnlinkedFile(mlt_service);
 
         // Second pass: amend property values.
@@ -351,6 +353,12 @@ void MltXmlChecker::checkGpuEffects(const QString& mlt_service)
         m_hasEffects = true;
     if (mlt_service.startsWith("movit.") || mlt_service.startsWith("glsl."))
         m_needsGPU = true;
+}
+
+void MltXmlChecker::checkCpuEffects(const QString& mlt_service)
+{
+    if (mlt_service.startsWith("dynamictext") || mlt_service.startsWith("vidstab"))
+        m_needsCPU = true;
 }
 
 void MltXmlChecker::checkUnlinkedFile(const QString& mlt_service)

--- a/src/mltxmlchecker.h
+++ b/src/mltxmlchecker.h
@@ -48,6 +48,7 @@ public:
     bool check(const QString& fileName);
     QString errorString() const;
     bool needsGPU() const { return m_needsGPU; }
+    bool needsCPU() const { return m_needsCPU; }
     bool hasEffects() const { return m_hasEffects; }
     bool isCorrected() const { return m_isCorrected; }
     QString tempFileName() const { return m_tempFile.fileName(); }
@@ -61,6 +62,7 @@ private:
     bool fixWebVfxPath(QString& resource);
     bool readResourceProperty(const QString& name, QString& value);
     void checkGpuEffects(const QString& mlt_service);
+    void checkCpuEffects(const QString& mlt_service);
     void checkUnlinkedFile(const QString& mlt_service);
     bool fixUnlinkedFile(QString& value);
     void fixStreamIndex(QString& value);
@@ -69,6 +71,7 @@ private:
     QXmlStreamReader m_xml;
     QXmlStreamWriter m_newXml;
     bool m_needsGPU;
+    bool m_needsCPU;
     bool m_hasEffects;
     bool m_isCorrected;
     QChar m_decimalPoint;


### PR DESCRIPTION
* Use "GPU Effects" instead of "GPU Processing" so people don't assume
  it refers to encoding.
* Add additional information about the limitations of "GPU Effects"
  and possible side-effects in the information dialog.
* Check for projects that use filters that are incompatible with GPU
  effects when GPU Effects are enabled.