### PR TITLE
Avoid creation of registry key when started with command line option to set the AppData location

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -146,7 +146,7 @@ public:
         setProperty("noupgrade", parser.isSet(noupgradeOption));
         if (!parser.value(appDataOption).isEmpty()) {
             appDirArg = parser.value(appDataOption);
-            Settings.setAppDataForSession(appDirArg);
+            ShotcutSettings::setAppDataForSession(appDirArg);
         }
         if (parser.isSet(gpuOption))
             Settings.setPlayerGPU(true);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -29,10 +29,14 @@ static QScopedPointer<ShotcutSettings> instance;
 ShotcutSettings &ShotcutSettings::singleton()
 {
     if (!instance) {
-        instance.reset(new ShotcutSettings);
-        if (instance->settings.value(APP_DATA_DIR_KEY).isValid()
-            && QFile::exists(instance->settings.value(APP_DATA_DIR_KEY).toString() + SHOTCUT_INI_FILENAME) )
-            instance.reset(new ShotcutSettings(instance->settings.value(APP_DATA_DIR_KEY).toString()));
+        if (appDataForSession.isEmpty()) {
+            instance.reset(new ShotcutSettings);
+            if (instance->settings.value(APP_DATA_DIR_KEY).isValid()
+                && QFile::exists(instance->settings.value(APP_DATA_DIR_KEY).toString() + SHOTCUT_INI_FILENAME) )
+                instance.reset(new ShotcutSettings(instance->settings.value(APP_DATA_DIR_KEY).toString()));
+        } else {
+            instance.reset(new ShotcutSettings(appDataForSession));
+        }
         LOG_DEBUG() << "language" << instance->language();
         LOG_DEBUG() << "deinterlacer" << instance->playerDeinterlacer();
         LOG_DEBUG() << "external monitor" << instance->playerExternal();
@@ -531,7 +535,9 @@ void ShotcutSettings::setAppDataForSession(const QString& location)
 {
     // This is intended to be called when using a command line option
     // to set the AppData location.
-    instance.reset(new ShotcutSettings(location));
+    appDataForSession = location;
+    if (instance)
+        instance.reset(new ShotcutSettings(location));
 }
 
 void ShotcutSettings::setAppDataLocally(const QString& location)

--- a/src/settings.h
+++ b/src/settings.h
@@ -153,7 +153,7 @@ public:
 
     void sync();
     QString appDataLocation() const;
-    void setAppDataForSession(const QString& location);
+    static void setAppDataForSession(const QString& location);
     void setAppDataLocally(const QString& location);
 
 signals:
@@ -174,6 +174,7 @@ signals:
 private:
     QSettings settings;
     QString m_appDataLocation;
+    static QString appDataForSession;
 };
 
 #define Settings ShotcutSettings::singleton()


### PR DESCRIPTION
As mentioned in #572: When using the --appdata argument I would prefer that (on Windows) the registry key (HKCU\Software\Meltytech\Shotcut) is not created. Here is my attempt at implementing this, working around that QSettings on windows will always create the registry key on constructing (as described in QTBUG-10851).

Sadly I do not have a working build environment set up, but the change is so small that I am pretty confident it should work (and I am willing to test a pre-release or something if that is possible).