### PR TITLE
Copy file date when converting files.

### DIFF
--- a/src/jobs/abstractjob.h
+++ b/src/jobs/abstractjob.h
@@ -19,6 +19,7 @@
 #ifndef ABSTRACTJOB_H
 #define ABSTRACTJOB_H
 
+#include "postjobaction.h"
 #include <QProcess>
 #include <QModelIndex>
 #include <QList>
@@ -46,6 +47,7 @@ public:
     QList<QAction*> successActions() const { return m_successActions; }
     QTime estimateRemaining(int percent);
     QTime time() const { return m_time; }
+    void setPostJobAction(PostJobAction* action);
 
 public slots:
     virtual void start();
@@ -71,6 +73,7 @@ private:
     QString m_log;
     QString m_label;
     QTime m_time;
+    QScopedPointer<PostJobAction> m_postJobAction;
 };
 
 #endif // ABSTRACTJOB_H

--- a/src/jobs/postjobaction.cpp
+++ b/src/jobs/postjobaction.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "postjobaction.h"
+
+// For file time functions in FilePropertiesPostJobAction::doAction();
+#include <utime.h>
+#include <sys/stat.h>
+
+void FilePropertiesPostJobAction::doAction()
+{
+    // TODO: When QT 5.10 is available, use QFileDevice functions
+#ifdef Q_OS_WIN
+    struct _stat srcTime;
+    struct _utimbuf dstTime;
+    _stat(m_srcFile.toUtf8().constData(), &srcTime);
+    dstTime.actime = srcTime.st_atime;
+    dstTime.modtime = srcTime.st_mtime;
+    _utime(m_dstFile.toUtf8().constData(), &dstTime);
+#else
+    struct stat srcTime;
+    struct utimbuf dstTime;
+    stat(m_srcFile.toUtf8().constData(), &srcTime);
+    dstTime.actime = srcTime.st_atime;
+    dstTime.modtime = srcTime.st_mtime;
+    utime(m_dstFile.toUtf8().constData(), &dstTime);
+#endif
+}

--- a/src/jobs/postjobaction.h
+++ b/src/jobs/postjobaction.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef POSTJOBACTION_H
+#define POSTJOBACTION_H
+
+#include <QString>
+
+class PostJobAction
+{
+public:
+    virtual ~PostJobAction() {}
+    virtual void doAction() = 0;
+};
+
+class FilePropertiesPostJobAction : public PostJobAction
+{
+public:
+    FilePropertiesPostJobAction(QString srcFile, QString dstFile)
+        : m_srcFile(srcFile)
+        , m_dstFile(dstFile) {};
+    void doAction();
+
+private:
+    QString m_srcFile;
+    QString m_dstFile;
+};
+
+#endif // POSTJOBACTION_H

--- a/src/src.pro
+++ b/src/src.pro
@@ -90,6 +90,7 @@ SOURCES += main.cpp\
     jobs/abstractjob.cpp \
     jobs/meltjob.cpp \
     jobs/encodejob.cpp \
+    jobs/postjobaction.cpp \
     jobs/videoqualityjob.cpp \
     commands/playlistcommands.cpp \
     docks/scopedock.cpp \
@@ -201,6 +202,7 @@ HEADERS  += mainwindow.h \
     jobs/abstractjob.h \
     jobs/meltjob.h \
     jobs/encodejob.h \
+    jobs/postjobaction.h \
     jobs/videoqualityjob.h \
     commands/playlistcommands.h \
     docks/scopedock.h \

--- a/src/widgets/avformatproducerwidget.cpp
+++ b/src/widgets/avformatproducerwidget.cpp
@@ -25,6 +25,7 @@
 #include "jobs/ffprobejob.h"
 #include "jobs/ffmpegjob.h"
 #include "jobs/meltjob.h"
+#include "jobs/postjobaction.h"
 #include "settings.h"
 #include "util.h"
 #include "Logger.h"
@@ -646,7 +647,9 @@ void AvformatProducerWidget::convert(TranscodeDialog& dialog)
 
             Settings.setSavePath(QFileInfo(filename).path());
             args << filename;
-            JOBS.add(new FfmpegJob(filename, args, false));
+            FfmpegJob* job = new FfmpegJob(filename, args, false);
+            job->setPostJobAction(new FilePropertiesPostJobAction(resource, filename));
+            JOBS.add(job);
         }
     }
 }
@@ -715,7 +718,9 @@ void AvformatProducerWidget::on_actionReverse_triggered()
 
             Settings.setSavePath(QFileInfo(filename).path());
             args << QString("target=").append(filename);
-            JOBS.add(new MeltJob(filename, args));
+            MeltJob* job = new MeltJob(filename, args);
+            job->setPostJobAction(new FilePropertiesPostJobAction(resource, filename));
+            JOBS.add(job);
         }
     }
 }


### PR DESCRIPTION
This will allow the text "filedate" keyword to work when they are
converted to edit friendly formats.

See the request here on the forum:
https://forum.shotcut.org/t/preserve-file-creation-date-when-transcoding/5561

Tested in Windows and Linux.