### PR TITLE
Improve MIME type definition.

### DIFF
--- a/packaging/linux/org.shotcut.Shotcut.xml
+++ b/packaging/linux/org.shotcut.Shotcut.xml
@@ -3,6 +3,8 @@
   <mime-type type="application/vnd.mlt+xml">
     <comment>MLT XML</comment>
     <glob pattern="*.mlt"/>
+    <sub-class-of type="application/xml"/>
+    <icon name="org.shotcut.Shotcut"/>
   </mime-type>
 </mime-info>
 


### PR DESCRIPTION
- MLT files must be in XML format.
- Use app icon to represent MLT file.