### PR TITLE
Save animIn and animOut as time instead of frames

### DIFF
--- a/src/qmltypes/qmlfilter.cpp
+++ b/src/qmltypes/qmlfilter.cpp
@@ -416,15 +416,25 @@ void QmlFilter::setOut(int value)
     set("out", value);
 }
 
+int QmlFilter::animateIn()
+{
+    return m_filter.time_to_frames(m_filter.get(kShotcutAnimInProperty));
+}
+
 void QmlFilter::setAnimateIn(int value)
 {
-    m_filter.set(kShotcutAnimInProperty, value);
+    m_filter.set(kShotcutAnimInProperty, m_filter.frames_to_time(value, mlt_time_clock));
     emit animateInChanged();
+}
+
+int QmlFilter::animateOut()
+{
+    return m_filter.time_to_frames(m_filter.get(kShotcutAnimOutProperty));
 }
 
 void QmlFilter::setAnimateOut(int value)
 {
-    m_filter.set(kShotcutAnimOutProperty, value);
+    m_filter.set(kShotcutAnimOutProperty, m_filter.frames_to_time(value, mlt_time_clock));
     emit animateOutChanged();
 }
 

--- a/src/qmltypes/qmlfilter.h
+++ b/src/qmltypes/qmlfilter.h
@@ -83,9 +83,9 @@ public:
     int out();
     void setOut(int value);
     Mlt::Filter& filter() { return m_filter; }
-    int animateIn() { return m_filter.get_int(kShotcutAnimInProperty); }
+    int animateIn();
     void setAnimateIn(int value);
-    int animateOut() { return m_filter.get_int(kShotcutAnimOutProperty); }
+    int animateOut();
     void setAnimateOut(int value);
     int duration();
     Q_INVOKABLE void resetProperty(const QString& name);


### PR DESCRIPTION
animIn and animOut would be incorrect when changing to a profile with a different frame rate.