### PR TITLE
Fix zoom button has no icon on startup.

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -232,6 +232,7 @@ Player::Player(QWidget *parent)
     m_zoomButton->setCheckable(true);
     m_zoomButton->setToolTip(tr("Toggle zoom"));
     toolbar->addWidget(m_zoomButton);
+    toggleZoom(false);
 
     // Add grid display button to toolbar.
     m_gridButton = new QToolButton;


### PR DESCRIPTION
The zoom button in the player does not have an icon until you open something. This change forces the icon to appear when the application is first started.