### PR TITLE
Enable video waveform scope.

### DIFF
--- a/src/controllers/scopecontroller.cpp
+++ b/src/controllers/scopecontroller.cpp
@@ -36,9 +36,9 @@ ScopeController::ScopeController(QMainWindow* mainWindow, QMenu* menu)
     createScopeDock<AudioPeakMeterScopeWidget>(mainWindow, scopeMenu);
     createScopeDock<AudioSpectrumScopeWidget>(mainWindow, scopeMenu);
     createScopeDock<AudioWaveformScopeWidget>(mainWindow, scopeMenu);
-//    if (!Settings.playerGPU()) {
-//        createScopeDock<VideoWaveformScopeWidget>(mainWindow, scopeMenu);
-//    }
+    if (!Settings.playerGPU()) {
+        createScopeDock<VideoWaveformScopeWidget>(mainWindow, scopeMenu);
+    }
     LOG_DEBUG() << "end";
 }
 


### PR DESCRIPTION
Now that the GPU effects mode is a hidden advanced feature, I would propose that we enable the video waveform scope when GPU effects are disabled. I would like to improve the video waveform scope and add more scopes. I think these scopes are important to improve color grading capabilities in Shotcut.