### PR TITLE
Linux/Wayland: make window title bar icon work

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,7 +113,7 @@ public:
 #endif
         addLibraryPath(dir.absolutePath());
         setOrganizationName("Meltytech");
-        setOrganizationDomain("meltytech.com");
+        setOrganizationDomain("shotcut.org");
         setApplicationName("Shotcut");
         setApplicationVersion(SHOTCUT_VERSION);
         setAttribute(Qt::AA_UseHighDpiPixmaps);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,8 +113,9 @@ public:
 #endif
         addLibraryPath(dir.absolutePath());
         setOrganizationName("Meltytech");
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
         setOrganizationDomain("shotcut.org");
+        setDesktopFileName("org.shotcut.Shotcut");
 #else
         setOrganizationDomain("meltytech.com");
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,7 +113,11 @@ public:
 #endif
         addLibraryPath(dir.absolutePath());
         setOrganizationName("Meltytech");
+#ifdef Q_OS_LINUX
         setOrganizationDomain("shotcut.org");
+#else
+        setOrganizationDomain("meltytech.com");
+#endif
         setApplicationName("Shotcut");
         setApplicationVersion(SHOTCUT_VERSION);
         setAttribute(Qt::AA_UseHighDpiPixmaps);


### PR DESCRIPTION
Otherwise, only a generic icon is shown.

This must match the naming scheme of `packaging/linux/org.shotcut.Shotcut.desktop`.

Also `QGuiApplication::setDesktopFileName("org.shotcut.Shotcut");` needs to be added somewhere in `main`.