### PR TITLE
qmake: check Qt version

### DIFF
--- a/shotcut.pri
+++ b/shotcut.pri
@@ -1,0 +1,22 @@
+defineTest(minQtVersion) {
+    maj = $$1
+    min = $$2
+    patch = $$3
+    isEqual(QT_MAJOR_VERSION, $$maj) {
+        isEqual(QT_MINOR_VERSION, $$min) {
+            isEqual(QT_PATCH_VERSION, $$patch) {
+                return(true)
+            }
+            greaterThan(QT_PATCH_VERSION, $$patch) {
+                return(true)
+            }
+        }
+        greaterThan(QT_MINOR_VERSION, $$min) {
+            return(true)
+        }
+    }
+    greaterThan(QT_MAJOR_VERSION, $$maj) {
+        return(true)
+    }
+    return(false)
+}

--- a/shotcut.pro
+++ b/shotcut.pro
@@ -1,3 +1,10 @@
+include(shotcut.pri)
+
+!minQtVersion(5, 9, 0) {
+    message("Cannot build Shotcut with Qt version $${QT_VERSION}.")
+    error("Use at least Qt 5.9.0.")
+}
+
 TEMPLATE = subdirs
 SUBDIRS = CuteLogger src translations
 cache()


### PR DESCRIPTION
copied from:
https://code.qt.io/cgit/qt-creator/qt-creator.git/tree/qtcreator.pri
https://code.qt.io/cgit/qt-creator/qt-creator.git/tree/qtcreator.pro

fixes:
* prevents issues like: https://github.com/mltframework/shotcut/issues/696
* `setDesktopFileName` needs Qt 5.7 (https://github.com/mltframework/shotcut/pull/699)