### PR TITLE
qmake: check for qmelt

### DIFF
--- a/shotcut.pro
+++ b/shotcut.pro
@@ -5,6 +5,13 @@ include(shotcut.pri)
     error("Use at least Qt 5.9.0.")
 }
 
+QMELT_OUTPUT = $$system(qmelt -version, blob)
+QMELT_STRING = $$find(QMELT_OUTPUT, "qmelt qmelt")
+isEmpty(QMELT_STRING) {
+    message("You need qmelt [https://github.com/mltframework/webvfx] for a fully functional Shotcut.")
+    error("Cannot find qmelt binary.")
+}
+
 TEMPLATE = subdirs
 SUBDIRS = CuteLogger src translations
 cache()


### PR DESCRIPTION
Apparently, Arch Linux offers a Shotcut build without qmelt:

patch to rename qmelt:
https://git.archlinux.org/svntogit/community.git/tree/trunk/melt.patch?h=packages/shotcut

no webvfx in `depends`:
https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/shotcut