### PR TITLE
appdata: fix project_license

### DIFF
--- a/packaging/linux/org.shotcut.Shotcut.appdata.xml.in
+++ b/packaging/linux/org.shotcut.Shotcut.appdata.xml.in
@@ -3,7 +3,7 @@
   <id>org.shotcut.Shotcut</id>
   <launchable type="desktop-id">org.shotcut.Shotcut.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPLv3</project_license>
+  <project_license>GPL-3.0-only</project_license>
   <name>Shotcut</name>
   <summary>Video editor</summary>
   <description>
@@ -48,7 +48,7 @@
   <url type="faq">https://www.shotcut.org/FAQ/</url>
   <url type="help">https://www.shotcut.org/tutorials/</url>
   <url type="translate">https://www.transifex.com/ddennedy/shotcut/</url>
-  <content_rating type="oars-1.1" />
+  <content_rating type="oars-1.1"/>
   <releases>
     <release version="@SHOTCUT_VERSION@" date="@SHOTCUT_DATE@"></release>
   </releases>


### PR DESCRIPTION
This fixes (new check on Flathub):
```
$ appstream-util validate org.shotcut.Shotcut.appdata.xml

org.shotcut.Shotcut.appdata.xml: FAILED:
• tag-invalid           : <project_license> is not valid [GPLv3]SPDX ID 'GPLv3' unknown
```
https://spdx.org/licenses/