### PR TITLE
Fix video waveform scope

### DIFF
--- a/src/widgets/scopes/videowaveformscopewidget.cpp
+++ b/src/widgets/scopes/videowaveformscopewidget.cpp
@@ -57,7 +57,7 @@ void VideoWaveformScopeWidget::refreshScope(const QSize& size, bool full)
         QColor bgColor( 0, 0, 0 ,0 );
         m_renderImg.fill(bgColor);
 
-        const uint8_t* yData = m_frame.get_image();
+        const uint8_t* yData = m_frame.get_image(mlt_image_yuv420p);
 
         for (int x = 0; x < columns; x++) {
             int pixels = m_frame.get_image_height();


### PR DESCRIPTION
The scope assumed that the shared frame had been preconverted to
yuv420. But the default format has been changed to rgb24a. So
the scope must request yuv420 explicitly.