### PR TITLE
Clean up shared frame use.

### DIFF
--- a/src/sharedframe.h
+++ b/src/sharedframe.h
@@ -63,7 +63,7 @@ public:
     mlt_image_format get_image_format() const;
     int get_image_width() const;
     int get_image_height() const;
-    const uint8_t* get_image(mlt_image_format format = mlt_image_none) const;
+    const uint8_t* get_image(mlt_image_format format) const;
     mlt_audio_format get_audio_format() const;
     int get_audio_channels() const;
     int get_audio_frequency() const;


### PR DESCRIPTION
* Keep the rendered 4:2:2 image as the native image so that converted
  images keep higher quality.
* Require the programmer to specify the requested image format so
  that the native image can be changed without consequence
* Avoid unnecessary conversions.