### PR TITLE
Make the build reproducible

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -325,7 +325,7 @@ debug_and_release {
 LIBS += -lCuteLogger
 
 isEmpty(SHOTCUT_VERSION) {
-    !win32:SHOTCUT_VERSION = $$system(date "+%y.%m.%d")
+    !win32:SHOTCUT_VERSION = $$system(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%y.%m.%d" 2>/dev/null || date -u -r "${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%y.%m.%d")
      win32:SHOTCUT_VERSION = adhoc
 }
 DEFINES += SHOTCUT_VERSION=\\\"$$SHOTCUT_VERSION\\\"


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort we noticed that `shotcut` could not be built reproducibly.

This is because it uses the current build date for the `SHOTCUT_VERSION` variable. This PR bases this value on [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/) instead if available.

This was originally filed in Debian as [#949817](https://bugs.debian.org/949817).