### PR TITLE
Fix behavior of previous/next keyframe button

### DIFF
--- a/src/qml/views/keyframes/ParameterHead.qml
+++ b/src/qml/views/keyframes/ParameterHead.qml
@@ -109,8 +109,8 @@ Rectangle {
                 iconSource: 'qrc:///icons/oxygen/32x32/actions/media-skip-backward.png'
                 onClicked: {
                     if (delegateIndex >= 0) {
-                        root.selection = [keyframes.seekPrevious()]
                         root.currentTrack = delegateIndex
+                        root.selection = [keyframes.seekPrevious()]
                     } else {
                         Logic.seekPreviousSimple()
                     }
@@ -166,8 +166,8 @@ Rectangle {
                 iconSource: 'qrc:///icons/oxygen/32x32/actions/media-skip-forward.png'
                 onClicked: {
                     if (delegateIndex >= 0) {
-                        root.selection = [keyframes.seekNext()]
                         root.currentTrack = delegateIndex
+                        root.selection = [keyframes.seekNext()]
                     } else {
                         Logic.seekNextSimple()
                     }


### PR DESCRIPTION
Currently when seeking the previous/next keyframe button, no matter which button
is pressed, it is always the previous/next keyframe corresponding to
the currently selected parameter that is selected and the current track is changed
to the track corresponding to the button only after that, i.e. for two tracks

--o1----o2----|----o3-----
--o4---------------o5-----

where `o*` is a keyframe and `|` is the cursor and the current track, pressing previous keyframe
button on the second parameter will jump to `o2` instead of `o4`.
I don't think this is the correct/expected behavior especially since `o2` isn't even a
keyframe for the second parameter at all.

This commit changed the behavior to change the current track first before selecting the keyframe.

This behavior was first introduced in 417a2f8c06907d658d3fc12a115eb097300eeb27.