### PR TITLE
add External Monitor "NDI Output" feature

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -601,6 +601,14 @@ void MainWindow::setupSettingsMenu()
         action->setData(QString("sdi"));
         m_externalGroup->addAction(action);
     }
+    
+    Mlt::Consumer ndi(MLT.profile(), "ndi");
+    if (ndi.is_valid()) {
+        QAction* action = new QAction("NDI Output", this);
+        action->setCheckable(true);
+        action->setData(QString("ndi:Shotcut Output"));
+        m_externalGroup->addAction(action);
+    }
 #endif
 
     Mlt::Profile profile;


### PR DESCRIPTION
This feature will make the Shotcut "External Monitor" output (pause/playback/scrubing) available as a NewTek NDI video&audio stream using the mlt/melt consumer. Other NDI capable programs like "OBS Studio" or "CasparCG server" may than be able to use "hostname (Shotcut Output)" as a valid NDI source.

This requires building mlt/melt with the NewTek NDI sdk "include" files and NDI "lib" files before building Shotcut. Tested using Shotcut 20.04.18 on ubuntu-mate 18.4.4 LTS amd64 with libndi 4.5 in obs-studio(ppa) 25.04 with obs-ndi from Palakis see https://github.com/Palakis/obs-ndi/releases.

Shotcut forum topic:
https://forum.shotcut.org/t/please-could-you-add-newtek-ndi-support/5209/5