### PR TITLE
Show job progress in Windows taskbar button

### DIFF
--- a/src/jobqueue.cpp
+++ b/src/jobqueue.cpp
@@ -19,6 +19,9 @@
 #include <QtWidgets>
 #include <Logger.h>
 #include "settings.h"
+#ifdef Q_OS_WIN
+#include "windowstools.h"
+#endif
 
 JobQueue::JobQueue(QObject *parent) :
     QStandardItemModel(0, COLUMN_COUNT, parent),
@@ -86,6 +89,9 @@ void JobQueue::onProgressUpdated(QStandardItem* standardItem, int percent)
             standardItem->setText(QString("%1% (%2)").arg(percent).arg(remaining));
         }
     }
+#ifdef Q_OS_WIN
+    WindowsTaskbarButton::getInstance().setProgress(percent);
+#endif
 }
 
 void JobQueue::onFinished(AbstractJob* job, bool isSuccess, QString time)
@@ -116,6 +122,10 @@ void JobQueue::onFinished(AbstractJob* job, bool isSuccess, QString time)
         if (item)
             item->setIcon(icon);
     }
+#ifdef Q_OS_WIN
+    WindowsTaskbarButton::getInstance().resetProgress();
+#endif
+
     startNextJob();
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -80,6 +80,9 @@
 #include "dialogs/longuitask.h"
 #include "dialogs/systemsyncdialog.h"
 #include "proxymanager.h"
+#ifdef Q_OS_WIN
+#include "windowstools.h"
+#endif
 
 #include <QtWidgets>
 #include <Logger.h>
@@ -2537,6 +2540,10 @@ void MainWindow::showEvent(QShowEvent* event)
 #ifndef SHOTCUT_NOUPGRADE
     if (!Settings.noUpgrade() && !qApp->property("noupgrade").toBool())
         QTimer::singleShot(0, this, SLOT(showUpgradePrompt()));
+#endif
+
+#ifdef Q_OS_WIN
+    WindowsTaskbarButton::getInstance().setParentWindow(this);
 #endif
 }
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -398,6 +398,11 @@ win32 {
         LIBS += -L$$PWD/../drmingw/x64/lib -lexchndl
     }
     RC_FILE = ../packaging/windows/shotcut.rc
+    QT += winextras
+    HEADERS += \
+    windowstools.h
+    SOURCES += \
+    windowstools.cpp
 }
 unix:!mac {
     QT += x11extras

--- a/src/windowstools.cpp
+++ b/src/windowstools.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2012-2020 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "windowstools.h"
+
+WindowsTaskbarButton::WindowsTaskbarButton()
+{
+}
+
+WindowsTaskbarButton& WindowsTaskbarButton::getInstance()
+{
+    static WindowsTaskbarButton* instance = 0;
+    if (!instance)
+        instance = new WindowsTaskbarButton();
+    return *instance;
+}
+
+void WindowsTaskbarButton::setParentWindow(QWidget* parent)
+{
+    m_taskbarButton = new QWinTaskbarButton(parent);
+    m_taskbarButton->setWindow(parent->windowHandle());
+    m_taskbarProgress = m_taskbarButton->progress();
+}
+
+void WindowsTaskbarButton::setProgress(int progress)
+{
+    if (m_taskbarProgress != NULL)
+    {
+        m_taskbarProgress->setVisible(true);
+        m_taskbarProgress->setValue(progress);
+    }
+}
+
+void WindowsTaskbarButton::resetProgress()
+{
+    if (m_taskbarProgress != NULL)
+    {
+        m_taskbarProgress->setVisible(false);
+        m_taskbarProgress->reset();
+    }
+}

--- a/src/windowstools.h
+++ b/src/windowstools.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2012-2020 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <QWinTaskbarButton>
+#include <QWinTaskbarProgress>
+#include <QWidget>
+
+class WindowsTaskbarButton
+{
+public:
+    static WindowsTaskbarButton& getInstance();
+
+    void setParentWindow(QWidget* parent);
+    void setProgress(int progress);
+    void resetProgress();
+private:
+    WindowsTaskbarButton();
+
+    QWinTaskbarButton* m_taskbarButton;
+    QWinTaskbarProgress* m_taskbarProgress;
+};


### PR DESCRIPTION
Use `QWinTaskbarProgress` to show a progress of a running job in the Windows taskbar (see [forum](https://forum.shotcut.org/t/progress-bar-for-windows-taskbar-icon/21308) for feature proposal).

I tried to separate the Windows stuff out to a different file (similar to macOS). If you have a simpler/better concept to realize this please let me know, I'll try to change it.