### PR TITLE
Fix build on big-endian FreeBSD

### DIFF
--- a/src/spatialmedia/constants.h
+++ b/src/spatialmedia/constants.h
@@ -36,6 +36,8 @@
 #  define le64toh(x) qFromLittleEndian(x)
 #elif !defined(__FreeBSD__)
 #  include <endian.h>
+#elif defined(__FreeBSD__)
+#  include <sys/endian.h>
 #endif
 
 struct AudioMetadata {


### PR DESCRIPTION
Without this, build on powerpc64 fails. This is because there's no endian.h header, but there is sys/endian.h.