### PR TITLE
remove private qt headers

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -2,7 +2,6 @@ CONFIG   += link_prl
 
 QT       += widgets opengl xml network printsupport qml quick sql
 QT       += multimedia websockets quickwidgets quickcontrols2
-QT       += qml-private core-private quick-private gui-private
 
 TARGET = shotcut
 TEMPLATE = app


### PR DESCRIPTION
Not neccesary as no `#include <private/*>` in the source files.

Remove qmake warning:
```
Project MESSAGE: This project is using private headers and will therefore be tied to this specific Qt module build version.
Project MESSAGE: Running this project against other versions of the Qt modules may crash at any arbitrary point.
Project MESSAGE: This is not a bug, but a result of using Qt internals. You have been warned!
```
