### PR TITLE
fix #1004 Toolbar buttons are different sizes

### DIFF
--- a/src/qml/modules/Shotcut/Controls/ToolButton.qml
+++ b/src/qml/modules/Shotcut/Controls/ToolButton.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Meltytech, LLC
+ * Copyright (c) 2020-2021 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,21 +21,11 @@ import Shotcut.Controls 1.0 as Shotcut
 
 ToolButton {
     id: control
-    property string iconName
-    property url iconSource
-    property alias tooltip: tooltip.text
 
-    background: Rectangle {
-        id: rect
-        radius: 3
-        width: control.width
-        height: control.height
-        SystemPalette { id: activePalette }
-        color: control.checked? activePalette.highlight : activePalette.button
-    }
-    action: Action {
-        icon.name: iconName
-        icon.source: iconSource
-    }
-    Shotcut.HoverTip { id: tooltip }
+    icon.height: control.height - (verticalPadding * 2)
+    icon.width: control.height -  (horizontalPadding * 2)
+    padding: 3
+
+    SystemPalette { id: activePalette }
+    palette.button: checked ? activePalette.highlight : activePalette.button
 }

--- a/src/qml/modules/Shotcut/Controls/qmldir
+++ b/src/qml/modules/Shotcut/Controls/qmldir
@@ -17,6 +17,6 @@ TextFilterVui 1.0 TextFilterVui.qml
 ToggleButton 1.0 ToggleButton.qml
 VuiBase 1.0 VuiBase.qml
 KeyframableFilter 1.0 KeyframableFilter.qml
-ToolBarToggle 1.0 ToolBarToggle.qml
+ToolButton 1.0 ToolButton.qml
 HoverTip 1.0 HoverTip.qml
 ComboBox 1.0 ComboBox.qml

--- a/src/qml/views/keyframes/KeyframesToolbar.qml
+++ b/src/qml/views/keyframes/KeyframesToolbar.qml
@@ -27,12 +27,19 @@ ToolBar {
 
     id: toolbar
     width: 200
-    height: 36
+    height: settings.smallIcons ? 28 : hiddenButton.implicitHeight + 3
 
     RowLayout {
         y: 2
         ToolButton {
-            id: menuButton
+            id: hiddenButton
+            visible: false
+            icon.name: 'show-menu'
+            icon.source: 'qrc:///icons/oxygen/32x32/actions/show-menu.png'
+        }
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             Shotcut.HoverTip { text: qsTr('Display a menu of additional actions') }
             focusPolicy: Qt.NoFocus
             action: Action {
@@ -47,7 +54,9 @@ ToolBar {
             implicitWidth: 2
             implicitHeight: toolbar.height / 2
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             Shotcut.HoverTip { text: qsTr('Set the filter start') }
             focusPolicy: Qt.NoFocus
             action: Action {
@@ -56,7 +65,9 @@ ToolBar {
                 onTriggered: filter.in = producer.position + producer.in
             }
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             Shotcut.HoverTip { text: qsTr('Set the filter end') }
             focusPolicy: Qt.NoFocus
             action: Action {
@@ -65,7 +76,9 @@ ToolBar {
                 onTriggered: filter.out = producer.position + producer.in
             }
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             Shotcut.HoverTip { text: qsTr('Set the first simple keyframe') }
             focusPolicy: Qt.NoFocus
             action: Action {
@@ -74,7 +87,9 @@ ToolBar {
                 onTriggered: filter.animateIn = producer.position + producer.in - filter.in
             }
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             Shotcut.HoverTip { text: qsTr('Set the second simple keyframe') }
             focusPolicy: Qt.NoFocus
             action: Action {
@@ -88,7 +103,9 @@ ToolBar {
             implicitWidth: 2
             implicitHeight: toolbar.height / 2
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             Shotcut.HoverTip { text: qsTr('Zoom keyframes out (Alt+-)') }
             focusPolicy: Qt.NoFocus
             action: Action {
@@ -101,7 +118,9 @@ ToolBar {
         ZoomSlider {
             id: scaleSlider
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             Shotcut.HoverTip { text: qsTr('Zoom keyframes in (Alt++)') }
             focusPolicy: Qt.NoFocus
             action: Action {
@@ -111,7 +130,9 @@ ToolBar {
                 onTriggered: root.zoomIn()
             }
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             Shotcut.HoverTip { text: qsTr('Zoom keyframes to fit (Alt+0)') }
             focusPolicy: Qt.NoFocus
             action: Action {

--- a/src/qml/views/timeline/TimelineToolbar.qml
+++ b/src/qml/views/timeline/TimelineToolbar.qml
@@ -29,15 +29,19 @@ ToolBar {
 
     id: toolbar
     width: 200
-    height: 32
+    height: settings.smallIcons ? 28 : hiddenButton.implicitHeight + 3
 
     RowLayout {
         y: 2
         ToolButton {
             id: hiddenButton
             visible: false
+            icon.name: 'show-menu'
+            icon.source: 'qrc:///icons/oxygen/32x32/actions/show-menu.png'
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             action: menuAction
             Shotcut.HoverTip { text: qsTr('Display a menu of additional actions') }
             focusPolicy: Qt.NoFocus
@@ -47,17 +51,23 @@ ToolBar {
             implicitWidth: 2
             implicitHeight: toolbar.height / 2
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             action: cutAction
             Shotcut.HoverTip { text: qsTr('Cut - Copy the current clip to the Source\nplayer and ripple delete it') }
             focusPolicy: Qt.NoFocus
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             action: copyAction
             Shotcut.HoverTip { text: qsTr('Copy - Copy the current clip to the Source player (C)') }
             focusPolicy: Qt.NoFocus
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             action: insertAction
             Shotcut.HoverTip { text: qsTr('Paste - Insert clip into the current track\nshifting following clips to the right (V)') }
             focusPolicy: Qt.NoFocus
@@ -67,27 +77,37 @@ ToolBar {
             implicitWidth: 2
             implicitHeight: toolbar.height / 2
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             action: appendAction
             Shotcut.HoverTip { text: qsTr('Append to the current track (A)') }
             focusPolicy: Qt.NoFocus
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             action: deleteAction
             Shotcut.HoverTip { text: qsTr('Ripple Delete - Remove current clip\nshifting following clips to the left (X)') }
             focusPolicy: Qt.NoFocus
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             action: liftAction
             Shotcut.HoverTip { text: qsTr('Lift - Remove current clip without\naffecting position of other clips (Z)') }
             focusPolicy: Qt.NoFocus
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             action: overwriteAction
             Shotcut.HoverTip { text: qsTr('Overwrite clip onto the current track (B)') }
             focusPolicy: Qt.NoFocus
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             action: splitAction
             Shotcut.HoverTip { text: qsTr('Split At Playhead (S)') }
             focusPolicy: Qt.NoFocus
@@ -97,40 +117,48 @@ ToolBar {
             implicitWidth: 2
             implicitHeight: toolbar.height / 2
         }
-        Shotcut.ToolBarToggle {
+        Shotcut.ToolButton {
             id: snapButton
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             checked: settings.timelineSnap
-            iconName: 'snap'
-            iconSource: 'qrc:///icons/oxygen/32x32/actions/snap.png'
+            icon.name: 'snap'
+            icon.source: 'qrc:///icons/oxygen/32x32/actions/snap.png'
             focusPolicy: Qt.NoFocus
-            tooltip: qsTr('Toggle snapping')
+            Shotcut.HoverTip { text: qsTr('Toggle snapping') }
             onClicked: settings.timelineSnap = !settings.timelineSnap
         }
-        Shotcut.ToolBarToggle {
+        Shotcut.ToolButton {
             id: scrubButton
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             checked: settings.timelineDragScrub
-            iconName: 'scrub_drag'
-            iconSource: 'qrc:///icons/oxygen/32x32/actions/scrub_drag.png'
+            icon.name: 'scrub_drag'
+            icon.source: 'qrc:///icons/oxygen/32x32/actions/scrub_drag.png'
             focusPolicy: Qt.NoFocus
-            tooltip: qsTr('Scrub while dragging')
+            Shotcut.HoverTip { text: qsTr('Scrub while dragging') }
             onClicked: settings.timelineDragScrub = !settings.timelineDragScrub
         }
-        Shotcut.ToolBarToggle {
+        Shotcut.ToolButton {
             id: rippleButton
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             checked: settings.timelineRipple
-            iconName: 'target'
-            iconSource: 'qrc:///icons/oxygen/32x32/actions/target.png'
+            icon.name: 'target'
+            icon.source: 'qrc:///icons/oxygen/32x32/actions/target.png'
             focusPolicy: Qt.NoFocus
-            tooltip: qsTr('Ripple trim and drop')
+            Shotcut.HoverTip { text: qsTr('Ripple trim and drop') }
             onClicked: settings.timelineRipple = !settings.timelineRipple
         }
-        Shotcut.ToolBarToggle {
+        Shotcut.ToolButton {
             id: rippleAllButton
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             checked: settings.timelineRippleAllTracks
-            iconName: 'ripple-all'
-            iconSource: 'qrc:///icons/oxygen/32x32/actions/ripple-all.png'
+            icon.name: 'ripple-all'
+            icon.source: 'qrc:///icons/oxygen/32x32/actions/ripple-all.png'
             focusPolicy: Qt.NoFocus
-            tooltip: qsTr('Ripple edits across all tracks')
+            Shotcut.HoverTip { text: qsTr('Ripple edits across all tracks') }
             onClicked: settings.timelineRippleAllTracks = !settings.timelineRippleAllTracks
         }
         Button { // separator
@@ -138,7 +166,9 @@ ToolBar {
             implicitWidth: 2
             implicitHeight: toolbar.height / 2
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             action: zoomOutAction
             Shotcut.HoverTip { text: qsTr("Zoom timeline out (-)") }
             focusPolicy: Qt.NoFocus
@@ -146,12 +176,16 @@ ToolBar {
         ZoomSlider {
             id: scaleSlider
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             action: zoomInAction
             Shotcut.HoverTip { text: qsTr("Zoom timeline in (+)") }
             focusPolicy: Qt.NoFocus
         }
-        ToolButton {
+        Shotcut.ToolButton {
+            implicitHeight: toolbar.height - 3
+            implicitWidth: implicitHeight
             action: zoomFitAction
             Shotcut.HoverTip { text: qsTr('Zoom timeline to fit (0)') }
             focusPolicy: Qt.NoFocus


### PR DESCRIPTION
20.11.28 using Controls 1:
![image](https://user-images.githubusercontent.com/821968/105645208-b23a4780-5e5f-11eb-9fcf-f46051886c48.png)

Master using Controls 2:
![image](https://user-images.githubusercontent.com/821968/105645240-fe858780-5e5f-11eb-8c7b-db983f2f0a53.png)

This proposal using Controls 2 and explicit sizing:
![image](https://user-images.githubusercontent.com/821968/105645222-d8f87e00-5e5f-11eb-89b8-ab47ba1d8d59.png)

The relative icon size can be easily changed by increasing or decreasing the button padding if you want to try larger or smaller. Lower padding results in larger icons.
https://github.com/mltframework/shotcut/compare/master...bmatherly:toolbar_icon?expand=1#diff-be25bb78c0bd5398a778f928cf7ffbec62fff56a373d6720a39fe86e4fff3ccdR27