### PR TITLE
Decrease speed muliplication on fastForward

### DIFF
--- a/src/mltcontroller.cpp
+++ b/src/mltcontroller.cpp
@@ -700,7 +700,7 @@ void Controller::fastForward(bool forceChangeDirection)
         if (forceChangeDirection && speed < 0.0)
             speed = 0.5;
         if (speed > 0.0)
-            m_producer->set_speed(speed * 2.0);
+            m_producer->set_speed(speed * 1.25);
         else
             m_producer->set_speed(::ceil(speed * 0.5));
         if (m_consumer && m_consumer->is_valid())


### PR DESCRIPTION
In addition to your change "Improved the playback speeds of fast forward and rewind to not be so fast and more usable."
I think you should reduce the speed increase of fastforward button since it can be accelerated by pressing on the button again.
This will permit for instance to still understand people talking in the video. Since it is quite imposible at the double speed.