### PR TITLE
Negative keyframes 1

### DIFF
--- a/src/docks/keyframesdock.cpp
+++ b/src/docks/keyframesdock.cpp
@@ -103,7 +103,6 @@ void KeyframesDock::setCurrentFilter(QmlFilter* filter, QmlMetadata* meta)
     connect(filter, SIGNAL(animateInChanged()), &m_model, SLOT(reload()));
     connect(filter, SIGNAL(animateOutChanged()), &m_model, SLOT(reload()));
     connect(filter, SIGNAL(inChanged(int)), &m_model, SLOT(onFilterInChanged(int)));
-    connect(filter, SIGNAL(outChanged(int)), &m_model, SLOT(onFilterOutChanged(int)));
 }
 
 bool KeyframesDock::event(QEvent *event)

--- a/src/models/keyframesmodel.cpp
+++ b/src/models/keyframesmodel.cpp
@@ -497,20 +497,8 @@ void KeyframesModel::onFilterInChanged(int delta)
         if (count > 0) {
             Mlt::Animation animation = m_filter->getAnimation(m_propertyNames[parameterIndex]);
             if (animation.is_valid()) {
-                for (int keyframeIndex = 0; keyframeIndex < count;) {
-                    int newFrame = animation.key_get_frame(keyframeIndex) - delta;
-                    if (animation.is_key(newFrame)) {
-                        beginRemoveRows(index(parameterIndex), keyframeIndex, keyframeIndex);
-                        animation.remove(animation.key_get_frame(keyframeIndex));
-                        animation.interpolate();
-                        m_keyframeCounts[parameterIndex] -= 1;
-                        endRemoveRows();
-                        --count;
-                    } else {
-                        animation.key_set_frame(keyframeIndex, newFrame);
-                        ++keyframeIndex;
-                    }
-                }
+                // Shift all the keyframes proportional to the delta
+                animation.shift_frames(-delta);
                 QModelIndex parentIndex = index(parameterIndex);
                 emit dataChanged(index(0, 0, parentIndex), index(count - 1, 0, parentIndex), QVector<int>() << FrameNumberRole);
             }

--- a/src/models/keyframesmodel.cpp
+++ b/src/models/keyframesmodel.cpp
@@ -98,7 +98,7 @@ QVariant KeyframesModel::data(const QModelIndex& index, int role) const
                     case MaximumFrameRole: {
                         int minimum = animation.previous_key(qMax(0, position - 1)) + 1;
                         int result = animation.next_key(position + 1) - 1;
-                        result = (result < minimum) ? m_filter->duration() : result;
+                        result = (result < minimum) ? std::numeric_limits<int>::max() : result;
 //                        LOG_DEBUG() << "keyframeIndex" << index.row() << "maximumFrame" << result;
                         return result - 1;
                     }
@@ -470,6 +470,11 @@ void KeyframesModel::reload()
 void KeyframesModel::onFilterChanged(const QString& property)
 {
 //    LOG_DEBUG() << property;
+    if (property == "in") {
+        // Handled by onFilterInChanged()
+        return;
+    }
+
     int i = m_propertyNames.indexOf(property);
     if (i > -1) {
         int count = m_keyframeCounts[i];
@@ -495,41 +500,73 @@ void KeyframesModel::onFilterInChanged(int delta)
     for (int parameterIndex = 0; parameterIndex < m_propertyNames.count(); parameterIndex++) {
         int count = m_keyframeCounts[parameterIndex];
         if (count > 0) {
-            Mlt::Animation animation = m_filter->getAnimation(m_propertyNames[parameterIndex]);
+            QString name = m_propertyNames[parameterIndex];
+            Mlt::Animation animation = m_filter->getAnimation(name);
             if (animation.is_valid()) {
                 // Shift all the keyframes proportional to the delta
                 animation.shift_frames(-delta);
-                QModelIndex parentIndex = index(parameterIndex);
-                emit dataChanged(index(0, 0, parentIndex), index(count - 1, 0, parentIndex), QVector<int>() << FrameNumberRole);
-            }
-        }
-    }
-}
-
-void KeyframesModel::onFilterOutChanged(int delta)
-{
-    Q_UNUSED(delta)
-    for (int parameterIndex = 0; parameterIndex < m_propertyNames.count(); parameterIndex++) {
-        int count = m_keyframeCounts[parameterIndex];
-        if (count > 0) {
-            Mlt::Animation animation = m_filter->getAnimation(m_propertyNames[parameterIndex]);
-            if (animation.is_valid()) {
-                for (int keyframeIndex = 0; keyframeIndex < count;) {
-                    int frame = animation.key_get_frame(keyframeIndex);
-                    if (frame < 0) {
-                        beginRemoveRows(index(parameterIndex), keyframeIndex, keyframeIndex);
-                        animation.remove(animation.key_get_frame(keyframeIndex));
-                        animation.interpolate();
-                        m_keyframeCounts[parameterIndex] -= 1;
-                        endRemoveRows();
-                        --count;
+                foreach (QString gangName, m_metadata->keyframes()->parameter(m_metadataIndex[parameterIndex])->gangedProperties()) {
+                    Mlt::Animation gangAnim = m_filter->getAnimation(gangName);
+                    if (gangAnim.is_valid())
+                        gangAnim.shift_frames(-delta);
+                }
+                // Keyframes are not allowed to have negative positions because
+                // there is no way for the user to interact with them.
+                if (animation.key_get_frame(0) < 0)
+                {
+                    // Create a new keyframe at position 0 based on interpolated value
+                    auto parameter = m_metadata->keyframes()->parameter(m_metadataIndex[parameterIndex]);
+                    m_filter->blockSignals(true);
+                    if (parameter->isRectangle()) {
+                        auto value = m_filter->getRect(name, 0);
+                        mlt_keyframe_type keyframeType = m_filter->getKeyframeType(animation, 0, mlt_keyframe_type(-1));
+                        m_filter->set(name, value, 1.0, 0, keyframeType);
                     } else {
-                        ++keyframeIndex;
+                        double value = m_filter->getDouble(name, 0);
+                        mlt_keyframe_type keyframeType = m_filter->getKeyframeType(animation, 0, mlt_keyframe_type(-1));
+                        m_filter->set(name, value, 0, keyframeType);
+                        foreach (QString gangName, m_metadata->keyframes()->parameter(m_metadataIndex[parameterIndex])->gangedProperties()) {
+                            Mlt::Animation gangAnim = m_filter->getAnimation(gangName);
+                            double gangValue = m_filter->getDouble(gangName, 0);
+                            if (gangAnim.is_valid()) {
+                                keyframeType = m_filter->getKeyframeType(gangAnim, 0, mlt_keyframe_type(-1));
+                                m_filter->set(gangName, gangValue, 0, keyframeType);
+                            }
+                        }
+                    }
+                    m_filter->blockSignals(false);
+
+                    // Remove all negative position keyframes
+                    for (int keyframeIndex = 0; keyframeIndex < count;) {
+                        int frame = animation.key_get_frame(keyframeIndex);
+                        if (frame < 0) {
+                            animation.remove(frame);
+                            animation.interpolate();
+                            m_keyframeCounts[parameterIndex] -= 1;
+                            --count;
+                        } else {
+                            break;
+                        }
+                    }
+                    foreach (QString gangName, m_metadata->keyframes()->parameter(m_metadataIndex[parameterIndex])->gangedProperties()) {
+                        Mlt::Animation gangAnim = m_filter->getAnimation(gangName);
+                        int gangKeyCount = gangAnim.key_count();
+                        for (int keyframeIndex = 0; keyframeIndex < gangKeyCount;) {
+                            int frame = gangAnim.key_get_frame(keyframeIndex);
+                            if (frame < 0) {
+                                gangAnim.remove(frame);
+                                gangAnim.interpolate();
+                                gangKeyCount -= 1;
+                            } else {
+                                break;
+                            }
+                        }
                     }
                 }
             }
         }
     }
+    reload();
 }
 
 int KeyframesModel::keyframeCount(int index) const

--- a/src/models/keyframesmodel.h
+++ b/src/models/keyframesmodel.h
@@ -83,7 +83,6 @@ public slots:
     void reload();
     void onFilterChanged(const QString& property);
     void onFilterInChanged(int delta);
-    void onFilterOutChanged(int delta);
 
 private:
     QList<QString> m_propertyNames;

--- a/src/qml/views/keyframes/Keyframe.qml
+++ b/src/qml/views/keyframes/Keyframe.qml
@@ -22,7 +22,7 @@ import 'Keyframes.js' as Logic
 
 Rectangle {
     id: keyframeRoot
-    property int position: 0
+    property int position
     property int interpolation: KeyframesModel.DiscreteInterpolation // rectangle for discrete
     property bool isSelected: false
     property string name: ''
@@ -37,6 +37,7 @@ Rectangle {
     property double maxDragX: activeClip.x + activeClip.width - width/2
     property double minDragY: activeClip.y - width/2
     property double maxDragY: activeClip.y + activeClip.height - width/2
+    property bool inRange: position >= (filter.in - producer.in) && position <= (filter.out - producer.in)
 
     signal clicked(var keyframe)
 
@@ -47,8 +48,9 @@ Rectangle {
     anchors.verticalCenterOffset: isCurve ? trackValue : 0
     height: 10
     width: height
-    color: isSelected? 'red' : activePalette.buttonText
+    color: isSelected ? 'red' : activePalette.buttonText
     border.color: activePalette.button
+    opacity: inRange ? 1.0 : 0.3
     border.width: 1
     radius: (interpolation === KeyframesModel.SmoothInterpolation)? height/2 : 0 // circle for smooth
     rotation: (interpolation === KeyframesModel.LinearInterpolation)? 45 : 0    // diamond for linear

--- a/src/qml/views/keyframes/Parameter.qml
+++ b/src/qml/views/keyframes/Parameter.qml
@@ -78,8 +78,7 @@ Item {
                 var widthOffset = keyframesRepeater.itemAt(0).width / 2
                 var heightOffset = keyframesRepeater.itemAt(0).height / 2
                 // Draw extent before first keyframe.
-                var startX = (filter.in - producer.in) * timeScale
-                ctx.moveTo(startX, keyframesRepeater.itemAt(0).y + heightOffset)
+                ctx.moveTo(0, keyframesRepeater.itemAt(0).y + heightOffset)
                 ctx.lineTo(keyframesRepeater.itemAt(0).x + widthOffset, keyframesRepeater.itemAt(0).y + heightOffset)
                 // Draw lines between keyframes.
                 for (var i = 1; i < keyframesRepeater.count; i++) {
@@ -98,9 +97,7 @@ Item {
                     }
                 }
                 // Draw extent after last keyframe.
-                var x = (filter.out - producer.in + 1) * timeScale
-                if (x > keyframesRepeater.itemAt(i - 1).x)
-                    ctx.lineTo(x, keyframesRepeater.itemAt(i - 1).y + heightOffset)
+                ctx.lineTo(width, keyframesRepeater.itemAt(i - 1).y + heightOffset)
             }
             ctx.stroke()
         }
@@ -110,7 +107,7 @@ Item {
         id: keyframeDelegateModel
         model: parameters
         Keyframe {
-            position: (filter.in - producer.in) + model.frame
+            property int frame: model.frame
             interpolation: model.interpolation
             name: model.name
             value: model.value
@@ -123,6 +120,12 @@ Item {
             parameterIndex: parameterRoot.DelegateModel.itemsIndex
             onClicked: parameterRoot.clicked(keyframe, parameterRoot)
             onInterpolationChanged: canvas.requestPaint()
+            Component.onCompleted: {
+                position = (filter.in - producer.in) + model.frame
+            }
+            onFrameChanged: {
+                position = (filter.in - producer.in) + model.frame
+            }
             onPositionChanged: canvas.requestPaint()
             onValueChanged: {
                 if (isCurve && (value > maximum || value < minimum)) {


### PR DESCRIPTION
Depends on https://github.com/mltframework/mlt/pull/659

Here is a change for your consideration:
* Do not allow negative keyframes.
* If the user changes the in point to cause a negative keyframe, create a keyframe at position 0 and delete negative keyframes
* Allow keyframes greater than the out point
* Keyframes after the out point are "dimmed" visually to indicate that they are inactive
* If the out point is changed back so that keyframes are in range again, they will still be at the original position
* Remove some redundant interactions. For example, sometimes multiple signals trigger the same function to be called multiple times unnecessarily

There is still some interaction between the timeline and the keyframe in/out points that I have not figured out. Trimming filter in/out in the keyframe dock seems reliable. But trimming clip in/out in the timeline still causes keyframe corruption. I might need help with that.