### PR TITLE
Fix FreeBSD segfault.

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -480,6 +480,19 @@ bool Util::isMemoryLow()
         }
     }
     return false;
+#elif defined(__FreeBSD__)
+    QProcess p;
+    p.start("sysctl -n hw.usermem");
+    p.waitForFinished();
+    auto lines = p.readAllStandardOutput();
+    p.close();
+    bool ok = false;
+    auto availableKB = lines.toUInt(&ok);
+    if (ok) {
+	    return availableKB < kLowMemoryThresholdKB;
+    }
+
+    return false;
 #elif defined(Q_OS_LINUX)
     unsigned int availableKB = UINT_MAX;
     QFile meminfo("/proc/meminfo");


### PR DESCRIPTION
Implement a way to get an idea of the free memory available on FreeBSD.

It can be argued how accurate this is, but we apply this patch in out ports infrastructure. Without it, shotcut segfaults.

fernape@FreeBSD.org