### PR TITLE
Fix Shotcut hangs when changing speed on clip

### DIFF
--- a/src/mltcontroller.cpp
+++ b/src/mltcontroller.cpp
@@ -200,9 +200,7 @@ bool Controller::openXML(const QString &filename)
 
 void Controller::close()
 {
-    if (m_profile.is_explicit()) {
-        pause();
-    } else if (m_consumer && !m_consumer->is_stopped()) {
+    if (m_consumer && !m_consumer->is_stopped()) {
         m_consumer->stop();
     }
     if (isSeekableClip()) {


### PR DESCRIPTION
Steps to reproduce:
1) Set profile to a manual profile (not automatic)
2) Open a clip
3) Change the clip speed parameter
Shotcut will hang

The problem does not occur for clips on the timeline