### PR TITLE
Export image improvements

### DIFF
--- a/src/dialogs/saveimagedialog.cpp
+++ b/src/dialogs/saveimagedialog.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2021 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "saveimagedialog.h"
+
+#include "mltcontroller.h"
+#include "settings.h"
+#include "util.h"
+
+#include <QDebug>
+#include <QtMath>
+
+static QString suffixFromFilter(const QString& filterText)
+{
+    QString suffix = filterText.section("*", 1, 1).section(")", 0, 0).section(" ", 0, 0);
+    if ( !suffix.startsWith(".") )
+    {
+        suffix.clear();
+    }
+    return suffix;
+}
+
+SaveImageDialog::SaveImageDialog(QWidget *parent, const QString& caption, QImage& image)
+    : QFileDialog(parent, caption)
+    , m_image(image)
+{
+    setModal(true);
+    setAcceptMode(QFileDialog::AcceptSave);
+    setFileMode(QFileDialog::AnyFile);
+    setOptions(Util::getFileDialogOptions());
+    QString path = Settings.savePath();
+    setDirectory(path);
+
+    QString nameFilter = tr("PNG (*.png);;BMP (*.bmp);;JPEG (*.jpg *.jpeg);;PPM (*.ppm);;TIFF (*.tif *.tiff);;WebP (*.webp);;All Files (*)");
+    setNameFilter(nameFilter);
+
+    QStringList nameFilters = nameFilter.split(";;");
+    QString suffix = Settings.exportFrameSuffix();
+    QString selectedNameFilter = nameFilters[0];
+    for (const auto& f : nameFilters) {
+        if (f.contains(suffix)) {
+            selectedNameFilter = f;
+            break;
+        }
+    }
+    selectNameFilter(selectedNameFilter);
+
+    // Use the current player time as a suggested file name
+    QString nameSuggestion = QString("Shotcut_%1").arg(MLT.producer()->frame_time( mlt_time_clock ));
+    nameSuggestion = nameSuggestion.replace(":", "_");
+    nameSuggestion = nameSuggestion.replace(".", "_");
+    nameSuggestion += suffix;
+    selectFile(nameSuggestion);
+
+    if (!connect(this, &QFileDialog::filterSelected, this, &SaveImageDialog::onFilterSelected))
+         connect(this, SIGNAL(filterSelected(const QString &filter)), SLOT(onFilterSelected(const QString &filter)));
+    if (!connect(this, &QFileDialog::fileSelected, this, &SaveImageDialog::onFileSelected))
+         connect(this, SIGNAL(fileSelected(const QString &file)), SLOT(onFileSelected(const QString &file)));
+}
+
+void SaveImageDialog::onFilterSelected(const QString &filter)
+{
+    // When the file type filter is changed, automatically change
+    // the file extension to match.
+    if (filter.isEmpty()) {
+        return;
+    }
+    QString suffix = suffixFromFilter(filter);
+    if (suffix.isEmpty()) {
+        return; // All files
+    }
+    QStringList files = selectedFiles();
+    if (files.size() == 0) {
+        return;
+    }
+    QString filename = files[0];
+    // Strip the suffix from the current file name
+    if (!QFileInfo(filename).suffix().isEmpty()) {
+        filename = filename.section(".", 0, -2);
+    }
+    // Add the new suffix
+    filename += suffix;
+    selectFile(filename);
+}
+
+void SaveImageDialog::onFileSelected(const QString &file)
+{
+    if (file.isEmpty()) {
+        return;
+    }
+    m_saveFile = file;
+    QFileInfo fi(m_saveFile);
+    if (fi.suffix().isEmpty()) {
+        QString suffix = suffixFromFilter(selectedNameFilter());
+        if ( suffix.isEmpty() )
+        {
+            suffix = ".png";
+        }
+        m_saveFile += suffix;
+        fi = QFileInfo(m_saveFile);
+    }
+    if (Util::warnIfNotWritable(m_saveFile, this, windowTitle()))
+        return;
+    // Convert to square pixels if needed.
+    qreal aspectRatio = (qreal) m_image.width() / m_image.height();
+    if (qFloor(aspectRatio * 1000) != qFloor(MLT.profile().dar() * 1000)) {
+        m_image = m_image.scaled(qRound(m_image.height() * MLT.profile().dar()), m_image.height(),
+                             Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+    }
+    m_image.save(m_saveFile, Q_NULLPTR, (fi.suffix() == "webp")? 80 : -1);
+    Settings.setSavePath(fi.path());
+    Settings.setExportFrameSuffix(QString(".") + fi.suffix());
+}

--- a/src/dialogs/saveimagedialog.h
+++ b/src/dialogs/saveimagedialog.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SAVEIMAGEDIALOG_H
+#define SAVEIMAGEDIALOG_H
+
+#include <QFileDialog>
+#include <QImage>
+#include <QString>
+
+class SaveImageDialog : public QFileDialog
+{
+    Q_OBJECT
+
+public:
+    explicit SaveImageDialog(QWidget *parent, const QString& caption, QImage& image);
+    QString saveFile() { return m_saveFile; };
+
+private slots:
+    void onFilterSelected(const QString& filter);
+    void onFileSelected(const QString& file);
+
+private:
+    QImage& m_image;
+    QString m_saveFile;
+};
+
+#endif // SAVEIMAGEDIALOG_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -51,6 +51,7 @@
 #include "controllers/scopecontroller.h"
 #include "docks/filtersdock.h"
 #include "dialogs/customprofiledialog.h"
+#include "dialogs/saveimagedialog.h"
 #include "settings.h"
 #include "leapnetworklistener.h"
 #include "database.h"
@@ -4081,27 +4082,11 @@ void MainWindow::onGLWidgetImageReady()
         MLT.setPreviewScale(Settings.playerPreviewScale());
     }
     if (!image.isNull()) {
-        QString path = Settings.savePath();
-        QString caption = tr("Export Frame");
-        QString nameFilter = tr("PNG (*.png);;BMP (*.bmp);;JPEG (*.jpg *.jpeg);;PPM (*.ppm);;TIFF (*.tif *.tiff);;WebP (*.webp);;All Files (*)");
-        QString saveFileName = QFileDialog::getSaveFileName(this, caption, path, nameFilter,
-            nullptr, Util::getFileDialogOptions());
-        if (!saveFileName.isEmpty()) {
-            QFileInfo fi(saveFileName);
-            if (fi.suffix().isEmpty())
-                saveFileName += ".png";
-            if (Util::warnIfNotWritable(saveFileName, this, caption))
-                return;
-            // Convert to square pixels if needed.
-            qreal aspectRatio = (qreal) image.width() / image.height();
-            if (qFloor(aspectRatio * 1000) != qFloor(MLT.profile().dar() * 1000)) {
-                image = image.scaled(qRound(image.height() * MLT.profile().dar()), image.height(),
-                                     Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
-            }
-            image.save(saveFileName, Q_NULLPTR,
-                (QFileInfo(saveFileName).suffix() == "webp")? 80 : -1);
-            Settings.setSavePath(fi.path());
-            m_recentDock->add(saveFileName);
+        SaveImageDialog dialog(this, tr("Export Frame"), image);
+        dialog.exec();
+        if ( !dialog.saveFile().isEmpty() )
+        {
+            m_recentDock->add(dialog.saveFile());
         }
     } else {
         showStatusMessage(tr("Unable to export frame."));

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -225,6 +225,16 @@ void ShotcutSettings::setViewMode(const QString& viewMode)
     emit viewModeChanged();
 }
 
+QString ShotcutSettings::exportFrameSuffix() const
+{
+    return settings.value("exportFrameSuffix", ".png").toString();
+}
+
+void ShotcutSettings::setExportFrameSuffix(const QString& exportFrameSuffix)
+{
+    settings.setValue("exportFrameSuffix", exportFrameSuffix);
+}
+
 QString ShotcutSettings::encodePath() const
 {
     return settings.value("encode/path", QStandardPaths::standardLocations(QStandardPaths::MoviesLocation)).toString();

--- a/src/settings.h
+++ b/src/settings.h
@@ -85,6 +85,8 @@ public:
     void setWindowStateDefault(const QByteArray&);
     QString viewMode() const;
     void setViewMode(const QString& viewMode);
+    QString exportFrameSuffix() const;
+    void setExportFrameSuffix(const QString& suffix);
 
     // encode
     QString encodePath() const;

--- a/src/src.pro
+++ b/src/src.pro
@@ -57,6 +57,7 @@ SOURCES += main.cpp\
     jobqueue.cpp \
     docks/jobsdock.cpp \
     dialogs/multifileexportdialog.cpp \
+    dialogs/saveimagedialog.cpp \
     dialogs/slideshowgeneratordialog.cpp \
     dialogs/textviewerdialog.cpp \
     models/playlistmodel.cpp \
@@ -189,6 +190,7 @@ HEADERS  += mainwindow.h \
     jobqueue.h \
     docks/jobsdock.h \
     dialogs/multifileexportdialog.h \
+    dialogs/saveimagedialog.h \
     dialogs/slideshowgeneratordialog.h \
     dialogs/textviewerdialog.h \
     models/playlistmodel.h \


### PR DESCRIPTION
In response to this suggestion:
https://forum.shotcut.org/t/suggestion-a-little-enhancement-for-export-frame-option/26920
* Suggest a file name in the file dialog
* Remember the previously used extension and default to it for every
  export request
* Automatically set the file name extension based on the selected
  file filter

With these changes, an image can be exported by typing "Ctl-Shift-E" + "Enter"
without the need to interact with the dialog if the restored defaults are
suitable.