### PR TITLE
Shift keyframes for all filters upon split or trim

### DIFF
--- a/src/commands/undohelper.cpp
+++ b/src/commands/undohelper.cpp
@@ -234,7 +234,7 @@ void UndoHelper::undoChanges()
                 if (clip->get_data("mix_out"))
                     clip->set("mix_out", nullptr, 0);
                 playlist.resize_clip(currentIndex, info.frame_in, info.frame_out);
-                m_model.adjustClipFilters(clip->parent(), filterIn, filterOut, info.in_delta, info.out_delta);
+                MLT.adjustClipFilters(clip->parent(), filterIn, filterOut, info.in_delta, info.out_delta);
             }
 
             QModelIndex modelIndex = m_model.createIndex(currentIndex, 0, info.oldTrackIndex);

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -1288,6 +1288,7 @@ void TimelineDock::splitClip(int trackIndex, int clipIndex)
             if (!m_model.isTransition(playlist, clipIndex)) {
                 QScopedPointer<Mlt::ClipInfo> info(getClipInfo(trackIndex, clipIndex));
                 if (info && m_position > info->start && m_position < info->start + info->frame_count) {
+                    setSelection(); // Avoid filter views becoming out of sync
                     MAIN.undoStack()->push(
                         new Timeline::SplitCommand(m_model, trackIndex, clipIndex, m_position));
                 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -392,8 +392,8 @@ MainWindow::MainWindow()
     connect(m_player, SIGNAL(outChanged(int)), m_filtersDock, SIGNAL(producerOutChanged(int)));
     connect(m_player, SIGNAL(inChanged(int)), m_filterController, SLOT(onServiceInChanged(int)));
     connect(m_player, SIGNAL(outChanged(int)), m_filterController, SLOT(onServiceOutChanged(int)));
-    connect(m_timelineDock->model(), SIGNAL(serviceInChanged(int, Mlt::Service*)), m_filterController, SLOT(onServiceInChanged(int, Mlt::Service*)));
-    connect(m_timelineDock->model(), SIGNAL(serviceOutChanged(int, Mlt::Service*)), m_filterController, SLOT(onServiceOutChanged(int, Mlt::Service*)));
+    connect(this, SIGNAL(serviceInChanged(int, Mlt::Service*)), m_filterController, SLOT(onServiceInChanged(int, Mlt::Service*)));
+    connect(this, SIGNAL(serviceOutChanged(int, Mlt::Service*)), m_filterController, SLOT(onServiceOutChanged(int, Mlt::Service*)));
 
     m_keyframesDock = new KeyframesDock(m_filtersDock->qmlProducer(), this);
     m_keyframesDock->hide();
@@ -2276,7 +2276,7 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
             } else {
                 int i = m_filtersDock->qmlProducer()->position() + m_filtersDock->qmlProducer()->in();
                 if (filterController()->currentFilter()->allowTrim()) {
-                    filterController()->currentFilter()->setIn(i);
+                    m_keyframesDock->model().trimFilterIn(i);
                 }
             }
         }
@@ -2288,7 +2288,7 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
             } else {
                 int i = m_filtersDock->qmlProducer()->position() + m_filtersDock->qmlProducer()->in();
                 if (filterController()->currentFilter()->allowTrim()) {
-                    filterController()->currentFilter()->setOut(i);
+                    m_keyframesDock->model().trimFilterOut(i);
                 }
             }
         }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -109,6 +109,8 @@ signals:
     void openFailed(QString);
     void aboutToShutDown();
     void renameRequested();
+    void serviceInChanged(int delta, Mlt::Service*);
+    void serviceOutChanged(int delta, Mlt::Service*);
 
 protected:
     MainWindow();

--- a/src/mltcontroller.cpp
+++ b/src/mltcontroller.cpp
@@ -736,94 +736,26 @@ void Controller::next(int currentPosition)
 void Controller::setIn(int in)
 {
     if (m_producer && m_producer->is_valid()) {
-        // Adjust filters.
-        bool changed = false;
-        int n = m_producer->filter_count();
-        for (int i = 0; i < n; i++) {
-            QScopedPointer<Filter> filter(m_producer->filter(i));
-            if (filter && filter->is_valid()) {
-                if (QString(filter->get(kShotcutFilterProperty)).startsWith("fadeIn")) {
-                    if (!filter->get(kShotcutAnimInProperty)) {
-                        // Convert legacy fadeIn filters.
-                        filter->set(kShotcutAnimInProperty, filter->get_length());
-                    }
-                    filter->set_in_and_out(in, filter->get_out());
-                    changed = true;
-                } else if (!filter->get_int("_loader") && filter->get_in() == m_producer->get_in()) {
-                    filter->set_in_and_out(in, filter->get_out());
-                    changed = true;
-                }
-            }
+        int delta = in - m_producer->get_in();
+        if (!delta) {
+            return;
         }
-        if (changed)
-            Controller::refreshConsumer();
+        adjustClipFilters(*m_producer, m_producer->get_in(), m_producer->get_out(), delta, 0);
         m_producer->set("in", in);
+        Controller::refreshConsumer();
     }
 }
 
 void Controller::setOut(int out)
 {
     if (m_producer && m_producer->is_valid()) {
-        // Adjust all filters that have an explicit duration.
-        bool changed = false;
-        int n = m_producer->filter_count();
-        for (int i = 0; i < n; i++) {
-            QScopedPointer<Filter> filter(m_producer->filter(i));
-            if (filter && filter->is_valid()) {
-                QString filterName = filter->get(kShotcutFilterProperty);
-                if (filterName.startsWith("fadeOut")) {
-                    if (!filter->get(kShotcutAnimOutProperty)) {
-                        // Convert legacy fadeOut filters.
-                        filter->set(kShotcutAnimOutProperty, filter->get_length());
-                    }
-                    filter->set_in_and_out(filter->get_in(), out);
-                    changed = true;
-                    if (filterName == "fadeOutBrightness") {
-                        const char* key = filter->get_int("alpha") != 1? "alpha" : "level";
-                        filter->clear(key);
-                        filter->anim_set(key, 1, filter->get_length() - filter->get_int(kShotcutAnimOutProperty));
-                        filter->anim_set(key, 0, filter->get_length() - 1);
-                    } else if (filterName == "fadeOutMovit") {
-                        filter->clear("opacity");
-                        filter->anim_set("opacity", 1, filter->get_length() - filter->get_int(kShotcutAnimOutProperty), 0, mlt_keyframe_smooth);
-                        filter->anim_set("opacity", 0, filter->get_length() - 1);
-                    } else if (filterName == "fadeOutVolume") {
-                        filter->clear("level");
-                        filter->anim_set("level", 0, filter->get_length() - filter->get_int(kShotcutAnimOutProperty));
-                        filter->anim_set("level", -60, filter->get_length() - 1);
-                    }
-                } else if (!filter->get_int("_loader") && filter->get_out() == m_producer->get_out()) {
-                    filter->set_in_and_out(filter->get_in(), out);
-                    changed = true;
-
-                    // Update simple keyframes of non-current filters.
-                    if (filter->get_int(kShotcutAnimOutProperty) > 0
-                        && MAIN.filterController()->currentFilter()
-                        && MAIN.filterController()->currentFilter()->service().get_service() != filter.data()->get_service()) {
-                        QmlMetadata* meta = MAIN.filterController()->metadataForService(filter.data());
-                        if (meta && meta->keyframes()) {
-                            foreach (QString name, meta->keyframes()->simpleProperties()) {
-                                if (!filter->get_animation(name.toUtf8().constData()))
-                                    // Cause a string property to be interpreted as animated value.
-                                    filter->anim_get_double(name.toUtf8().constData(), 0, filter->get_length());
-                                Mlt::Animation animation = filter->get_animation(name.toUtf8().constData());
-                                if (animation.is_valid()) {
-                                    int n = animation.key_count();
-                                    if (n > 1) {
-                                        animation.set_length(filter->get_length());
-                                        animation.key_set_frame(n - 2, filter->get_length() - filter->get_int(kShotcutAnimOutProperty));
-                                        animation.key_set_frame(n - 1, filter->get_length() - 1);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            if (changed)
-                Controller::refreshConsumer();
+        int delta = out - m_producer->get_out();
+        if (!delta) {
+            return;
         }
+        adjustClipFilters(*m_producer, m_producer->get_in(), m_producer->get_out(), 0, -delta);
         m_producer->set("out", out);
+        Controller::refreshConsumer();
     }
 }
 
@@ -1159,6 +1091,181 @@ void Controller::adjustFilters(Producer& producer, int index)
     }
     if (changed)
         MLT.refreshConsumer();
+}
+
+static void shiftKeyframes(Mlt::Service* service, QmlMetadata* meta, int delta)
+{
+    if (!meta || !meta->keyframes() || meta->keyframes()->parameterCount() < 1) {
+        return;
+    }
+    QmlKeyframesMetadata* keyMeta = meta->keyframes();
+    for (int parameterIndex = 0; parameterIndex < keyMeta->parameterCount(); parameterIndex++) {
+        QmlKeyframesParameter* paramMeta = keyMeta->parameter(parameterIndex);
+        QString name = paramMeta->property();
+        Mlt::Animation animation = service->get_animation(qUtf8Printable(name));
+        if (animation.is_valid()) {
+            // Keyframes are not allowed to have negative positions because
+            // there is no way for the user to interact with them.
+            // Handle keyframes that will become negative by deleting them.
+            if (animation.key_get_frame(0) < delta)
+            {
+                // Create a new keyframe at position that will become 0 based on interpolated value
+                int previous = animation.previous_key(delta);
+                mlt_keyframe_type existingType = animation.keyframe_type(previous);
+                if (paramMeta->isRectangle()) {
+                    auto value = service->anim_get_rect(qUtf8Printable(name), delta);
+                    service->anim_set(qUtf8Printable(name), value, delta, 0, existingType);
+                } else {
+                    double value = service->anim_get_double(qUtf8Printable(name), delta);
+                    service->anim_set(qUtf8Printable(name), value, delta, 0, existingType);
+                    foreach (QString gangName, paramMeta->gangedProperties()) {
+                        Mlt::Animation gangAnim = service->get_animation(qUtf8Printable(gangName));
+                        double gangValue = service->anim_get_double(qUtf8Printable(gangName), delta);
+                        service->anim_set(qUtf8Printable(gangName), gangValue, delta, existingType);
+                    }
+                }
+                // Remove all keyframes that will be negative position
+                int count = animation.key_count();
+                for (int keyframeIndex = 0; keyframeIndex < count;) {
+                    int frame = animation.key_get_frame(keyframeIndex);
+                    if (frame < delta) {
+                        animation.remove(frame);
+                        animation.interpolate();
+                        --count;
+                    } else {
+                        break;
+                    }
+                }
+                foreach (QString gangName, paramMeta->gangedProperties()) {
+                    Mlt::Animation gangAnim = service->get_animation(qUtf8Printable(gangName));
+                    int gangKeyCount = gangAnim.key_count();
+                    for (int keyframeIndex = 0; keyframeIndex < gangKeyCount;) {
+                        int frame = gangAnim.key_get_frame(keyframeIndex);
+                        if (frame < delta) {
+                            gangAnim.remove(frame);
+                            gangAnim.interpolate();
+                            gangKeyCount -= 1;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            }
+            // Shift all the keyframes proportional to the delta
+            animation.shift_frames(-delta);
+            foreach (QString gangName, paramMeta->gangedProperties()) {
+                Mlt::Animation gangAnim = service->get_animation(qUtf8Printable(gangName));
+                gangAnim.shift_frames(-delta);
+            }
+        }
+    }
+}
+
+void Controller::adjustFilter(Mlt::Filter* filter, int in, int out, int inDelta, int outDelta)
+{
+    if (!filter || !filter->is_valid()) {
+        return;
+    }
+
+    QString filterName = filter->get(kShotcutFilterProperty);
+    QmlMetadata* meta = MAIN.filterController()->metadataForService(filter);
+    if (inDelta) {
+        if (in + inDelta < 0) {
+            inDelta = -in;
+        }
+        if (filter->get_int(kShotcutAnimInProperty) == filter->get_int(kShotcutAnimOutProperty)) {
+            // Shift all keyframes proportional to the in delta if they are not simple keyframes
+            shiftKeyframes(filter,  meta, inDelta);
+        }
+        if (filterName.startsWith("fadeIn")) {
+            if (!filter->get(kShotcutAnimInProperty)) {
+                // Convert legacy fadeIn filters.
+                filter->set(kShotcutAnimInProperty, filter->get_length());
+            }
+            filter->set_in_and_out(in + inDelta, filter->get_out());
+            emit MAIN.serviceInChanged(inDelta, filter);
+        } else if (!filter->get_int("_loader") && filter->get_in() <= in) {
+            filter->set_in_and_out(in + inDelta, filter->get_out());
+            emit MAIN.serviceInChanged(inDelta, filter);
+        }
+    }
+
+    if (outDelta) {
+        if (filterName.startsWith("fadeOut")) {
+            if (!filter->get(kShotcutAnimOutProperty)) {
+                // Convert legacy fadeOut filters.
+                filter->set(kShotcutAnimOutProperty, filter->get_length());
+            }
+            filter->set_in_and_out(filter->get_in(), out - outDelta);
+            if (filterName == "fadeOutBrightness") {
+                const char* key = filter->get_int("alpha") != 1? "alpha" : "level";
+                filter->clear(key);
+                filter->anim_set(key, 1, filter->get_length() - filter->get_int(kShotcutAnimOutProperty));
+                filter->anim_set(key, 0, filter->get_length() - 1);
+            } else if (filterName == "fadeOutMovit") {
+                filter->clear("opacity");
+                filter->anim_set("opacity", 1, filter->get_length() - filter->get_int(kShotcutAnimOutProperty), 0, mlt_keyframe_smooth);
+                filter->anim_set("opacity", 0, filter->get_length() - 1);
+            } else if (filterName == "fadeOutVolume") {
+                filter->clear("level");
+                filter->anim_set("level", 0, filter->get_length() - filter->get_int(kShotcutAnimOutProperty));
+                filter->anim_set("level", -60, filter->get_length() - 1);
+            }
+            emit MAIN.serviceOutChanged(outDelta, filter);
+        } else if (!filter->get_int("_loader")  && filter->get_out() >= out) {
+            filter->set_in_and_out(filter->get_in(), out - outDelta);
+            emit MAIN.serviceOutChanged(outDelta, filter);
+
+            // Update simple keyframes
+            if (filter->get_int(kShotcutAnimOutProperty) && meta && meta->keyframes()) {
+                foreach (QString name, meta->keyframes()->simpleProperties()) {
+                    if (!filter->get_animation(name.toUtf8().constData()))
+                        // Cause a string property to be interpreted as animated value.
+                        filter->anim_get_double(name.toUtf8().constData(), 0, filter->get_length());
+                    Mlt::Animation animation = filter->get_animation(name.toUtf8().constData());
+                    if (animation.is_valid()) {
+                        int n = animation.key_count();
+                        if (n > 1) {
+                            animation.set_length(filter->get_length());
+                            animation.key_set_frame(n - 2, filter->get_length() - filter->get_int(kShotcutAnimOutProperty));
+                            animation.key_set_frame(n - 1, filter->get_length() - 1);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+void Controller::adjustClipFilters(Mlt::Producer& producer, int in, int out, int inDelta, int outDelta)
+{
+    for (int j = 0; j < producer.filter_count(); j++) {
+        QScopedPointer<Mlt::Filter> filter(producer.filter(j));
+        adjustFilter(filter.data(), in, out, inDelta, outDelta);
+    }
+
+    // Adjust link in/out
+    if (producer.type() == mlt_service_chain_type) {
+        Mlt::Chain chain(producer);
+        int link_count = chain.link_count();
+        for (int j = 0; j < chain.link_count(); j++) {
+            QScopedPointer<Mlt::Link> link(chain.link(j));
+            QmlMetadata* meta = MAIN.filterController()->metadataForService(link.data());
+            if (link && link->is_valid()) {
+                if (inDelta) {
+                    shiftKeyframes(link.data(),  meta, inDelta);
+                }
+                if (link->get_out() >= out) {
+                    link->set_in_and_out(link->get_in(), out - outDelta);
+                    emit MAIN.serviceOutChanged(outDelta, link.data());
+                }
+                if (link->get_in() <= in) {
+                    link->set_in_and_out(in + inDelta, link->get_out());
+                    emit MAIN.serviceInChanged(inDelta, link.data());
+                }
+            }
+        }
+    }
 }
 
 void Controller::setSavedProducer(Mlt::Producer* producer)

--- a/src/mltcontroller.h
+++ b/src/mltcontroller.h
@@ -127,6 +127,8 @@ public:
     void copyFilters(Mlt::Producer* producer = nullptr);
     void pasteFilters(Mlt::Producer* producer = nullptr);
     static void adjustFilters(Mlt::Producer& producer, int startIndex = 0);
+    static void adjustFilter(Mlt::Filter* filter, int in, int out, int inDelta, int outDelta);
+    static void adjustClipFilters(Mlt::Producer& producer, int in, int out, int inDelta, int outDelta);
     bool hasFiltersOnClipboard() const {
         return m_filtersClipboard->is_valid() && m_filtersClipboard->filter_count() > 0;
     }

--- a/src/models/keyframesmodel.h
+++ b/src/models/keyframesmodel.h
@@ -86,6 +86,8 @@ public slots:
     void reload();
     void onFilterChanged(const QString& property);
     void onFilterInChanged(int delta);
+    void trimFilterIn(int in);
+    void trimFilterOut(int out);
 
 private:
     QList<QString> m_propertyNames;

--- a/src/models/multitrackmodel.h
+++ b/src/models/multitrackmodel.h
@@ -108,7 +108,6 @@ public:
     void insertTrack(int trackIndex, TrackType type = VideoTrackType);
     void insertOrAdjustBlankAt(QList<int> tracks, int position, int length);
     bool mergeClipWithNext(int trackIndex, int clipIndex, bool dryrun);
-    void adjustClipFilters(Mlt::Producer& producer, int in, int out, int inDelta, int outDelta);
     Mlt::ClipInfo *findClipByUuid(const QUuid& uuid, int& trackIndex, int& clipIndex);
 
 signals:
@@ -122,8 +121,6 @@ signals:
     void showStatusMessage(QString);
     void durationChanged();
     void filteredChanged();
-    void serviceInChanged(int delta, Mlt::Service*);
-    void serviceOutChanged(int delta, Mlt::Service*);
     void reloadRequested();
     void appended(int trackIndex, int clipIndex);
     void inserted(int trackIndex, int clipIndex);

--- a/src/qml/filters/audio_fadein/ui.qml
+++ b/src/qml/filters/audio_fadein/ui.qml
@@ -32,8 +32,8 @@ Item {
         } else if (filter.animateIn === 0) {
             // Convert legacy filter.
             duration = filter.duration
-            filter.in = producer.in
-            filter.out = producer.out
+            filter.set('in', producer.in )
+            filter.set('out', producer.out )
         } else {
             duration = filter.animateIn
         }

--- a/src/qml/filters/audio_fadeout/ui.qml
+++ b/src/qml/filters/audio_fadeout/ui.qml
@@ -32,8 +32,8 @@ Item {
         } else if (filter.animateOut === 0) {
             // Convert legacy filter.
             duration = filter.duration
-            filter.in = producer.in
-            filter.out = producer.out
+            filter.set('in', producer.in )
+            filter.set('out', producer.out )
         } else {
             duration = filter.animateOut
         }

--- a/src/qml/filters/fadein_brightness/ui.qml
+++ b/src/qml/filters/fadein_brightness/ui.qml
@@ -34,8 +34,8 @@ Item {
         } else if (filter.animateIn === 0) {
             // Convert legacy filter.
             duration = filter.duration
-            filter.in = producer.in
-            filter.out = producer.out
+            filter.set('in', producer.in )
+            filter.set('out', producer.out )
         } else {
             duration = filter.animateIn
         }

--- a/src/qml/filters/fadein_movit/ui.qml
+++ b/src/qml/filters/fadein_movit/ui.qml
@@ -33,8 +33,8 @@ Item {
         } else if (filter.animateIn === 0) {
             // Convert legacy filter.
             duration = filter.duration
-            filter.in = producer.in
-            filter.out = producer.out
+            filter.set('in', producer.in )
+            filter.set('out', producer.out )
         } else {
             duration = filter.animateIn
         }

--- a/src/qml/filters/fadeout_brightness/ui.qml
+++ b/src/qml/filters/fadeout_brightness/ui.qml
@@ -34,8 +34,8 @@ Item {
         } else if (filter.animateOut === 0) {
             // Convert legacy filter.
             duration = filter.duration
-            filter.in = producer.in
-            filter.out = producer.out
+            filter.set('in', producer.in )
+            filter.set('out', producer.out )
         } else {
             duration = filter.animateOut
         }

--- a/src/qml/filters/fadeout_movit/ui.qml
+++ b/src/qml/filters/fadeout_movit/ui.qml
@@ -34,8 +34,8 @@ Item {
         } else if (filter.animateOut === 0) {
             // Convert legacy filter.
             duration = filter.duration
-            filter.in = producer.in
-            filter.out = producer.out
+            filter.set('in', producer.in )
+            filter.set('out', producer.out )
         } else {
             duration = filter.animateOut
         }

--- a/src/qml/views/keyframes/KeyframesToolbar.qml
+++ b/src/qml/views/keyframes/KeyframesToolbar.qml
@@ -58,7 +58,7 @@ ToolBar {
             action: Action {
                 icon.name: 'keyframes-filter-in'
                 icon.source: 'qrc:///icons/oxygen/32x32/actions/keyframes-filter-in.png'
-                onTriggered: filter.in = producer.position + producer.in
+                onTriggered: parameters.trimFilterIn( producer.position + producer.in )
             }
         }
         Shotcut.ToolButton {
@@ -70,7 +70,7 @@ ToolBar {
             action: Action {
                 icon.name: 'keyframes-filter-out'
                 icon.source: 'qrc:///icons/oxygen/32x32/actions/keyframes-filter-out.png'
-                onTriggered: filter.out = producer.position + producer.in
+                onTriggered: parameters.trimFilterOut( producer.position + producer.in )
             }
         }
         Shotcut.ToolButton {

--- a/src/qml/views/keyframes/keyframes.qml
+++ b/src/qml/views/keyframes/keyframes.qml
@@ -348,7 +348,7 @@ Rectangle {
                                         onTrimmingIn: {
                                             var n = filter.in + delta
                                             if (delta != 0 && n >= producer.in && n <= filter.out) {
-                                                filter.in = n
+                                                parameters.trimFilterIn(n)
                                                 // Show amount trimmed as a time in a "bubble" help.
                                                 var s = application.timecode(Math.abs(clip.originalX))
                                                 s = '%1%2 = %3'.arg((clip.originalX < 0)? '-' : (clip.originalX > 0)? '+' : '')
@@ -361,7 +361,7 @@ Rectangle {
                                         onTrimmingOut: {
                                             var n = filter.out - delta
                                             if (delta != 0 && n >= filter.in && n <= producer.out) {
-                                                filter.out = n
+                                                parameters.trimFilterOut(n)
                                                 // Show amount trimmed as a time in a "bubble" help.
                                                 var s = application.timecode(Math.abs(clip.originalX))
                                                 s = '%1%2 = %3'.arg((clip.originalX < 0)? '+' : (clip.originalX > 0)? '-' : '')

--- a/src/qmltypes/qmlfilter.cpp
+++ b/src/qmltypes/qmlfilter.cpp
@@ -498,11 +498,6 @@ int QmlFilter::in()
     return result;
 }
 
-void QmlFilter::setIn(int value)
-{
-    set("in", value);
-}
-
 int QmlFilter::out()
 {
     int result = 0;
@@ -524,11 +519,6 @@ int QmlFilter::out()
         }
     }
     return result;
-}
-
-void QmlFilter::setOut(int value)
-{
-    set("out", value);
 }
 
 int QmlFilter::animateIn()

--- a/src/qmltypes/qmlfilter.h
+++ b/src/qmltypes/qmlfilter.h
@@ -39,8 +39,8 @@ class QmlFilter : public QObject
     Q_PROPERTY(bool isNew READ isNew)
     Q_PROPERTY(QString path READ path)
     Q_PROPERTY(QStringList presets READ presets NOTIFY presetsChanged)
-    Q_PROPERTY(int in READ in WRITE setIn NOTIFY inChanged)
-    Q_PROPERTY(int out READ out WRITE setOut NOTIFY outChanged)
+    Q_PROPERTY(int in READ in NOTIFY inChanged)
+    Q_PROPERTY(int out READ out NOTIFY outChanged)
     Q_PROPERTY(int animateIn READ animateIn WRITE setAnimateIn NOTIFY animateInChanged)
     Q_PROPERTY(int animateOut READ animateOut WRITE setAnimateOut NOTIFY animateOutChanged)
     Q_PROPERTY(int duration READ duration NOTIFY durationChanged)
@@ -98,9 +98,7 @@ public:
     Q_INVOKABLE void getHash();
     Mlt::Producer& producer() { return m_producer; }
     int in();
-    void setIn(int value);
     int out();
-    void setOut(int value);
     Mlt::Service& service() { return m_service; }
     int animateIn();
     void setAnimateIn(int value);


### PR DESCRIPTION
When the in point of a producer is changed due to split or trim,
adjust the keyframes for all filters attached to that producer.

For simple keyframes, keyframes are always relative to the start and
end of the filter. So the 3rd and 4th keyframe need to be moved if
the out point changes.

For advanced keyframes, all keyframes are relative to the start of
the producer. So all keyframes need to be moved if the in point
changes.

Issue reported here:
https://forum.shotcut.org/t/inconsistent-handling-of-keyframes-when-splitting-a-clip/27404

This passed my inspection and testing, but it changes many things and will need more inspection and testing.