### PR TITLE
WIP: Support multi selection in cut copy paste

### DIFF
--- a/src/commands/timelinecommands.h
+++ b/src/commands/timelinecommands.h
@@ -56,6 +56,23 @@ private:
     bool m_skipProxy;
 };
 
+class InsertSelectionCommand : public QUndoCommand
+{
+public:
+    InsertSelectionCommand(MultitrackModel& model, QVector<Mlt::Producer> producers, int trackIndex, int position, bool seek = true, QUndoCommand * parent = 0);
+    void redo();
+    void undo();
+private:
+    MultitrackModel& m_model;
+    int m_trackIndex;
+    int m_position;
+    QStringList m_oldTracks;
+    UndoHelper m_undoHelper;
+    bool m_seek;
+    bool m_rippleAllTracks;
+    QVector<Mlt::Producer> m_producers;
+};
+
 class InsertCommand : public QUndoCommand
 {
 public:

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -120,7 +120,7 @@ public slots:
     void incrementCurrentTrack(int by);
     void selectTrackHead(int trackIndex);
     void selectMultitrack();
-    void copyClip(int trackIndex, int clipIndex);
+    void copyClip();
     void setTrackName(int trackIndex, const QString& value);
     void toggleTrackMute(int trackIndex);
     void toggleTrackHidden(int trackIndex);
@@ -179,6 +179,7 @@ private:
         int selectedTrack;
         bool isMultitrackSelected;
     };
+    QVector<Mlt::Producer> m_producers;
     Selection m_selection;
     Selection m_savedSelection;
     QScopedPointer<Timeline::TrimCommand> m_trimCommand;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1890,11 +1890,8 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
         } else if (isMultitrackValid()) {
             m_timelineDock->show();
             m_timelineDock->raise();
-            if (m_timelineDock->selection().isEmpty()) {
-                m_timelineDock->copyClip(-1, -1);
-            } else {
-                auto& selected = m_timelineDock->selection().first();
-                m_timelineDock->copyClip(selected.y(), selected.x());
+            if (!m_timelineDock->selection().isEmpty()) {
+                m_timelineDock->copyClip();
             }
         }
         break;
@@ -3452,8 +3449,8 @@ void MainWindow::processMultipleFiles()
                     continue;
                 }
                 Util::getHash(p);
+                ProxyManager::generateIfNotExists(p);
                 Mlt::Producer* producer = MLT.setupNewProducer(&p);
-                ProxyManager::generateIfNotExists(*producer);
                 undoStack()->push(new Playlist::AppendCommand(*m_playlistDock->model(), MLT.XML(producer), false));
                 m_recentDock->add(filename.toUtf8().constData());
                 delete producer;
@@ -4024,7 +4021,7 @@ void MainWindow::on_actionCopy_triggered()
     m_timelineDock->show();
     m_timelineDock->raise();
     if (!m_timelineDock->selection().isEmpty())
-        m_timelineDock->copyClip(m_timelineDock->selection().first().y(), m_timelineDock->selection().first().x());
+        m_timelineDock->copyClip();
 }
 
 void MainWindow::on_actionPaste_triggered()


### PR DESCRIPTION
## A little Of My Background
So this is me really tinkering with the code trying to understand how it works. The best way I find to get a better understanding of its inner workings is to play with the code. 
I don't have any prior experience working with video editing software and never had heard about MTL framework for that matter, I am just learning as I go through the code. As I haven't yet gone through the MLT doc (planning to do it soon), I have little to none knowledge of how it is working in the code.

## Development Thought Process
First I went on to try to know where in the copy/paste was happening. I noticed that only the first element of selected clip was being copied so I created a `QVector<Mlt::Producer>` where I would use it insert the element into the timeline.
At first I had each element of `QVector<Mlt::Producer>` being inserted into the timeline using the `Timeline::InsertCommand` in the `TimelineDock::insert` method. Even though that worked I had a problem where the undo would remove the just pasted  clips one by one instead of all at once. That is when I  tried instead working with `TimelineDock::appendFromPlaylist` but that would just pasted clips in the end of the timeline. So when I went to the timeline commands, getting a very basic understanding of  how they work, I was able to create a new working command.

I have done the basic tests and the multi copy/cut/paste seems to working but as I don't don't have the full understanding of the code I don't know the full implications of the changes I made so I am requesting a review in order to give me a better idea of everything. I want to know about the solution I came up with, how they affect the app, what the ideal solution would be etc... as I believe this will help me greatly in the future when working with Shotcut. I would like to be set in the right track to have this functionality working.

## Known Bugs
-  Broke the copy from playlist to timeline
Because of the changes I made I am not able anymore to copy the clip from the playlist into the timeline, I tried coming up with a fix but the app crashed every time so I discarded it for the time being, I am hoping to have a light shined on this issue.

- Able to paste the clip even though the project is closed.
If I close a project (through File -> Close) and then click in the paste icon in the timeline toolbar the last clips copied will be pasted into the timeline. If no clips were copied nothing happens as opposed to what happens in #1109. I didn't try to fix because I haven't explored that part of the code yet.
