### PR TITLE
Limit timeremap input values to the maximum duration of the clip

### DIFF
--- a/src/models/keyframesmodel.cpp
+++ b/src/models/keyframesmodel.cpp
@@ -137,7 +137,7 @@ QVariant KeyframesModel::data(const QModelIndex& index, int role) const
             if (param->rangeType() == QmlKeyframesParameter::MinMax) {
                 return m_metadata->keyframes()->parameter(m_metadataIndex[index.row()])->maximum();
             } else if (param->rangeType() == QmlKeyframesParameter::ClipLength) {
-                int length = m_filter->producer().get_length() - 1;
+                int length = m_filter->producer().get_length() - m_filter->in();
                 return (double)length / MLT.profile().fps();
             }
             return 0.0;

--- a/src/qml/filters/time_remap/ui.qml
+++ b/src/qml/filters/time_remap/ui.qml
@@ -128,31 +128,31 @@ Item {
         }
         onAccepted: {
             var position = getPosition()
+            var maxValue = (producer.length - producer.in) / profile.fps
+            var newValue = filter.getDouble("map", position)
             if (direction == 'after') {
                 var nextPosition = filter.getNextKeyframePosition("map", position)
                 if (nextPosition > position) {
                     var deltaTime = ((nextPosition - position) / profile.fps) * speedSlider.value
                     var nextValue = filter.getDouble("map", nextPosition)
-                    var newValue = nextValue - deltaTime;
-                    if (newValue < 0) {
-                        newValue = 0
-                    }
-                    filter.set('map', newValue, position)
-                    timer.start()
+                    newValue = nextValue - deltaTime;
                 }
             } else { // before
                 var prevPosition = filter.getPrevKeyframePosition("map", position)
                 if (prevPosition < position && prevPosition >= 0) {
                     var deltaTime = ((position - prevPosition) / profile.fps) * speedSlider.value
                     var prevValue = filter.getDouble("map", prevPosition)
-                    var newValue = prevValue + deltaTime;
-                    if (newValue < 0) {
-                        newValue = 0
-                    }
-                    filter.set('map', newValue, position)
-                    timer.start()
+                    newValue = prevValue + deltaTime;
                 }
             }
+            if (newValue < 0) {
+                newValue = 0
+            }
+            if (newValue > maxValue) {
+                newValue = maxValue
+            }
+            filter.set('map', newValue, position)
+            timer.start()
         }
     }
 
@@ -187,7 +187,7 @@ Item {
             Shotcut.TimeSpinner {
                 id: mapSpinner
                 minimumValue: 0
-                maximumValue: 1000000
+                maximumValue: producer.length - producer.in
                 saveButtonVisible: false
                 undoButtonVisible: false
                 onValueChanged: {

--- a/src/qmltypes/qmlfilter.cpp
+++ b/src/qmltypes/qmlfilter.cpp
@@ -676,9 +676,7 @@ int QmlFilter::getNextKeyframePosition(const QString& name, int position)
     int result = -1;
     Mlt::Animation animation = getAnimation(name);
     if (animation.is_valid()) {
-        position -= in();
         result = animation.next_key(animation.is_key(position) ? position + 1: position);
-        result += in();
     }
     return result;
 }
@@ -688,9 +686,7 @@ int QmlFilter::getPrevKeyframePosition(const QString& name, int position)
     int result = -1;
     Mlt::Animation animation = getAnimation(name);
     if (animation.is_valid()) {
-        position -= in();
         result = animation.previous_key(animation.is_key(position) ? position - 1: position);
-        result += in();
     }
     return result;
 }

--- a/src/qmltypes/qmlproducer.cpp
+++ b/src/qmltypes/qmlproducer.cpp
@@ -237,5 +237,6 @@ void QmlProducer::setProducer(Mlt::Producer& producer)
     emit producerChanged();
     emit inChanged(0);
     emit outChanged(0);
+    emit lengthChanged();
 }
 

--- a/src/qmltypes/qmlproducer.h
+++ b/src/qmltypes/qmlproducer.h
@@ -33,6 +33,7 @@ class QmlProducer : public QObject
     Q_PROPERTY(int out READ out() NOTIFY outChanged)
     Q_PROPERTY(int aspectRatio READ aspectRatio() NOTIFY producerChanged)
     Q_PROPERTY(int duration READ duration() NOTIFY durationChanged)
+    Q_PROPERTY(int length READ length() NOTIFY lengthChanged)
     Q_PROPERTY(QString resource READ resource() NOTIFY producerChanged)
     Q_PROPERTY(QString mlt_service READ mlt_service() NOTIFY producerChanged)
     Q_PROPERTY(QString hash READ hash() NOTIFY producerChanged)
@@ -51,6 +52,7 @@ public:
     int out();
     double aspectRatio();
     int duration() { return m_producer.is_valid()? out() - in() + 1 : 0; }
+    int length() { return m_producer.is_valid()? m_producer.get_length() : 0; }
     QString resource();
     QString mlt_service() { return m_producer.is_valid()? m_producer.get("mlt_service") : QString(); }
     QString hash() { return m_producer.is_valid()? m_producer.get(kShotcutHashProperty) : QString(); }
@@ -78,6 +80,7 @@ signals:
     void outChanged(int delta);
     void audioLevelsChanged();
     void durationChanged();
+    void lengthChanged();
 
 public slots:
     void setProducer(Mlt::Producer& producer);


### PR DESCRIPTION
Do not let the user set an input time value beyond the end of the
source file. Also limit the range of the keyframe display to the
maximum duration of the clip

Fixes issue reported here:
https://forum.shotcut.org/t/modify-input-output-time-listings-in-time-remap/27510/14