### PR TITLE
Warn the user before exporting a frame from proxy file

### DIFF
--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -761,6 +761,21 @@ QImage GLWidget::image() const
     return QImage();
 }
 
+bool GLWidget::imageIsProxy() const
+{
+    bool isProxy = false;
+    SharedFrame frame = m_frameRenderer->getDisplayFrame();
+    if (frame.is_valid()) {
+        Mlt::Producer* frameProducer = frame.get_original_producer();
+        if (frameProducer && frameProducer->is_valid() && frameProducer->get_int(kIsProxyProperty))
+        {
+            isProxy = true;
+        }
+        delete frameProducer;
+    }
+    return isProxy;
+}
+
 void GLWidget::requestImage() const
 {
     m_frameRenderer->requestImage();

--- a/src/glwidget.h
+++ b/src/glwidget.h
@@ -88,6 +88,7 @@ public:
     float zoom() const { return m_zoom * MLT.profile().width() / m_rect.width(); }
     QPoint offset() const;
     QImage image() const;
+    bool imageIsProxy() const;
     void requestImage() const;
     bool snapToGrid() const { return m_snapToGrid; }
     int maxTextureSize() const { return m_maxTextureSize; }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4112,6 +4112,20 @@ void MainWindow::onGLWidgetImageReady()
     if (Settings.playerGPU() || Settings.playerPreviewScale()) {
         MLT.setPreviewScale(Settings.playerPreviewScale());
     }
+    if (glw->imageIsProxy() && !image.isNull()) {
+        QMessageBox dialog(QMessageBox::Question,
+                           tr("Export frame from proxy?"),
+                           tr("This frame is from a lower resolution proxy instead of the original source.\n\n"
+                              "Do you still want to continue?"),
+                           QMessageBox::No | QMessageBox::Yes,
+                           this);
+        dialog.setDefaultButton(QMessageBox::Yes);
+        dialog.setEscapeButton(QMessageBox::No);
+        dialog.setWindowModality(QmlApplication::dialogModality());
+        if (dialog.exec() != QMessageBox::Yes) {
+            return;
+        }
+    }
     if (!image.isNull()) {
         SaveImageDialog dialog(this, tr("Export Frame"), image);
         dialog.exec();

--- a/src/sharedframe.cpp
+++ b/src/sharedframe.cpp
@@ -252,3 +252,8 @@ const int16_t* SharedFrame::get_audio() const
     int samples = get_audio_samples();
     return (int16_t*)d->f.get_audio(format, frequency, channels, samples);
 }
+
+Mlt::Producer* SharedFrame::get_original_producer()
+{
+    return d->f.get_original_producer();
+}

--- a/src/sharedframe.h
+++ b/src/sharedframe.h
@@ -69,6 +69,7 @@ public:
     int get_audio_frequency() const;
     int get_audio_samples() const;
     const int16_t* get_audio() const;
+    Mlt::Producer* get_original_producer();
 private:
     QExplicitlySharedDataPointer<FrameData> d;
 };


### PR DESCRIPTION
As suggested here:
https://forum.shotcut.org/t/add-warning-when-exporting-frame-with-proxy-on/28185