### PR TITLE
Warn about proxy frame export when timeline is active.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4112,10 +4112,13 @@ void MainWindow::onGLWidgetImageReady()
     if (Settings.playerGPU() || Settings.playerPreviewScale()) {
         MLT.setPreviewScale(Settings.playerPreviewScale());
     }
-    if (glw->imageIsProxy() && !image.isNull()) {
+    if (!image.isNull() &&
+        (glw->imageIsProxy() || (MLT.isMultitrack() && Settings.proxyEnabled()))
+
+    ) {
         QMessageBox dialog(QMessageBox::Question,
                            tr("Export frame from proxy?"),
-                           tr("This frame is from a lower resolution proxy instead of the original source.\n\n"
+                           tr("This frame may be from a lower resolution proxy instead of the original source.\n\n"
                               "Do you still want to continue?"),
                            QMessageBox::No | QMessageBox::Yes,
                            this);


### PR DESCRIPTION
It is not practical to detect if a frame has been degraded by a proxy
source file when exporting a frame from the timeline. This change
will always warn the user if they export a frame when proxy is
enabled and the timeline is the source.

As suggested here:
https://forum.shotcut.org/t/add-warning-when-exporting-frame-with-proxy-on/28185