### PR TITLE
Fix clip trim in redo on timeline

### DIFF
--- a/src/commands/timelinecommands.cpp
+++ b/src/commands/timelinecommands.cpp
@@ -481,8 +481,11 @@ void TrimClipInCommand::redo()
     if (m_redo) {
         LOG_DEBUG() << "trackIndex" << m_trackIndex << "clipIndex" << m_clipIndex << "delta" << m_delta;
         m_undoHelper.reset(new UndoHelper(m_model));
-        if (!m_ripple)
+        if (m_ripple) {
             m_undoHelper->setHints(UndoHelper::SkipXML);
+        } else {
+            m_undoHelper->setHints(UndoHelper::RestoreTracks);
+        }
         m_undoHelper->recordBeforeState();
         m_model.trimClipIn(m_trackIndex, m_clipIndex, m_delta, m_ripple, m_rippleAllTracks);
         m_undoHelper->recordAfterState();


### PR DESCRIPTION
As reported here:
https://forum.shotcut.org/t/undo-trim-clip-in-may-shift-clips-bug-hasnt-been-completely-fixed/28487