### PR TITLE
Fix crash when adding 2 variable frame rate clips

### DIFF
--- a/src/commands/timelinecommands.cpp
+++ b/src/commands/timelinecommands.cpp
@@ -107,7 +107,8 @@ void InsertCommand::redo()
             longTask.reportProgress(QFileInfo(ProxyManager::resource(clip)).fileName(), n - i - 1, n);
             ProxyManager::generateIfNotExists(clip);
             clip.set_in_and_out(info->frame_in, info->frame_out);
-            m_model.insertClip(m_trackIndex, clip, m_position, m_rippleAllTracks, false);
+            bool lastClip = i == 0;
+            m_model.insertClip(m_trackIndex, clip, m_position, m_rippleAllTracks, false, lastClip);
         }
     } else {
         ProxyManager::generateIfNotExists(clip);
@@ -151,7 +152,8 @@ void OverwriteCommand::redo()
             longTask.reportProgress(QFileInfo(ProxyManager::resource(clip)).fileName(), i, n);
             ProxyManager::generateIfNotExists(clip);
             clip.set_in_and_out(info->frame_in, info->frame_out);
-            m_model.overwrite(m_trackIndex, clip, position, false);
+            bool lastClip = i == (n - 1);
+            m_model.overwrite(m_trackIndex, clip, position, false, lastClip);
             position += info->frame_count;
         }
     } else {

--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -889,7 +889,7 @@ int MultitrackModel::overwriteClip(int trackIndex, Mlt::Producer& clip, int posi
     return result;
 }
 
-QString MultitrackModel::overwrite(int trackIndex, Mlt::Producer& clip, int position, bool seek)
+QString MultitrackModel::overwrite(int trackIndex, Mlt::Producer& clip, int position, bool seek, bool notify)
 {
     createIfNeeded();
     Mlt::Playlist result;
@@ -976,14 +976,16 @@ QString MultitrackModel::overwrite(int trackIndex, Mlt::Producer& clip, int posi
         }
         QModelIndex index = createIndex(targetIndex, 0, trackIndex);
         AudioLevelsTask::start(clip.parent(), this, index);
-        emit overWritten(trackIndex, targetIndex);
-        emit modified();
-        emit seeked(playlist.clip_start(targetIndex) + playlist.clip_length(targetIndex), seek);
+        if (notify) {
+            emit overWritten(trackIndex, targetIndex);
+            emit modified();
+            emit seeked(playlist.clip_start(targetIndex) + playlist.clip_length(targetIndex), seek);
+        }
     }
     return MLT.XML(&result);
 }
 
-int MultitrackModel::insertClip(int trackIndex, Mlt::Producer &clip, int position, bool rippleAllTracks, bool seek)
+int MultitrackModel::insertClip(int trackIndex, Mlt::Producer &clip, int position, bool rippleAllTracks, bool seek, bool notify)
 {
     createIfNeeded();
     int result = -1;
@@ -1077,9 +1079,11 @@ int MultitrackModel::insertClip(int trackIndex, Mlt::Producer &clip, int positio
 
             QModelIndex index = createIndex(result, 0, trackIndex);
             AudioLevelsTask::start(clip.parent(), this, index);
-            emit inserted(trackIndex, result);
-            emit modified();
-            emit seeked(playlist.clip_start(result) + playlist.clip_length(result), seek);
+            if (notify) {
+                emit inserted(trackIndex, result);
+                emit modified();
+                emit seeked(playlist.clip_start(result) + playlist.clip_length(result), seek);
+            }
         }
     }
     return result;

--- a/src/models/multitrackmodel.h
+++ b/src/models/multitrackmodel.h
@@ -139,8 +139,8 @@ public slots:
     void notifyClipOut(int trackIndex, int clipIndex);
     bool moveClip(int fromTrack, int toTrack, int clipIndex, int position, bool ripple, bool rippleAllTracks);
     int overwriteClip(int trackIndex, Mlt::Producer& clip, int position, bool seek = true);
-    QString overwrite(int trackIndex, Mlt::Producer& clip, int position, bool seek = true);
-    int insertClip(int trackIndex, Mlt::Producer& clip, int position, bool rippleAllTracks, bool seek = true);
+    QString overwrite(int trackIndex, Mlt::Producer& clip, int position, bool seek = true, bool notify = true);
+    int insertClip(int trackIndex, Mlt::Producer& clip, int position, bool rippleAllTracks, bool seek = true, bool notify = true);
     int appendClip(int trackIndex, Mlt::Producer &clip);
     void removeClip(int trackIndex, int clipIndex, bool rippleAllTracks);
     void liftClip(int trackIndex, int clipIndex);


### PR DESCRIPTION
As reported here:
https://forum.shotcut.org/t/adding-at-least-2-variable-framerate-clips-from-playlist-to-timeline-crashes-shotcut/29411

The "convert" dialog is created on the stack in the avformat producer
panel. When adding items from the playlist to the timeline, each item
triggers the panel to load. When a new clip loads in the panel, the
previous panel is deleted and tries to delete the dialog if it was
created. Attempting to delete a dialog that was created on the stack
causes a crash.

This change only triggers events on the last item so that the panel
will not open and delete for each item being added.