### PR TITLE
Ctl s w

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -188,6 +188,7 @@ MainWindow::MainWindow()
     connect(ui->actionAbout_Qt, SIGNAL(triggered()), qApp, SLOT(aboutQt()));
     connect(this, &MainWindow::producerOpened, this, &MainWindow::onProducerOpened);
     connect(ui->mainToolBar, SIGNAL(visibilityChanged(bool)), SLOT(onToolbarVisibilityChanged(bool)));
+    ui->actionSave->setEnabled(false);
 
     // Accept drag-n-drop of files.
     this->setAcceptDrops(true);
@@ -2687,6 +2688,7 @@ void MainWindow::onProducerOpened(bool withReopen)
         Util::getHash(*MLT.producer());
         ui->actionPaste->setEnabled(true);
     }
+    ui->actionSave->setEnabled(true);
     QMutexLocker locker(&m_autosaveMutex);
     if (m_autosaveFile)
         setCurrentFile(m_autosaveFile->managedFileName());
@@ -3966,6 +3968,7 @@ void MainWindow::on_actionClose_triggered()
         setCurrentFile("");
         MLT.resetURL();
         MLT.setProjectFolder(QString());
+        ui->actionSave->setEnabled(false);
         MLT.stop();
         if (multitrack())
             m_timelineDock->model()->close();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3960,6 +3960,11 @@ void MainWindow::on_actionClose_triggered()
 {
     if (continueModified()) {
         LOG_DEBUG() << "";
+        QMutexLocker locker(&m_autosaveMutex);
+        m_autosaveFile.reset();
+        locker.unlock();
+        setCurrentFile("");
+        MLT.resetURL();
         MLT.setProjectFolder(QString());
         MLT.stop();
         if (multitrack())


### PR DESCRIPTION
Improvements for:
https://forum.shotcut.org/t/entire-project-wiped-after-accidentally-hitting-ctrl-w-and-ctrl-s-at-the-same-time/29786

Now, when CTL + WS occurs, the project still closes, but the "save as" dialog pops up instead of saving an empty project into the previous project file.