### PR TITLE
WIP Markers

### DIFF
--- a/src/commands/markercommands.cpp
+++ b/src/commands/markercommands.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2021 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "markercommands.h"
+#include <Logger.h>
+
+namespace Markers
+{
+
+DeleteCommand::DeleteCommand(MarkersModel& model, const Marker& delMarker, int index)
+    : QUndoCommand(0)
+    , m_model(model)
+    , m_delMarker(delMarker)
+    , m_index(index)
+{
+    setText(QObject::tr("Delete Marker: %1").arg(m_delMarker.text));
+}
+
+void DeleteCommand::redo()
+{
+    m_model.doRemove(m_index);
+}
+
+void DeleteCommand::undo()
+{
+    m_model.doInsert(m_index, m_delMarker);
+}
+
+InsertCommand::InsertCommand(MarkersModel& model, const Marker& newMarker, int index)
+    : QUndoCommand(0)
+    , m_model(model)
+    , m_newMarker(newMarker)
+    , m_index(index)
+{
+    setText(QObject::tr("Insert Marker: %1").arg(newMarker.text));
+}
+
+void InsertCommand::redo()
+{
+    m_model.doInsert(m_index, m_newMarker);
+}
+
+void InsertCommand::undo()
+{
+    m_model.doRemove(m_index);
+}
+
+AppendCommand::AppendCommand(MarkersModel& model, const Marker& newMarker, int index)
+    : QUndoCommand(0)
+    , m_model(model)
+    , m_newMarker(newMarker)
+    , m_index(index)
+{
+    setText(QObject::tr("Append Marker: %1").arg(m_newMarker.text));
+}
+
+void AppendCommand::redo()
+{
+    m_model.doAppend(m_newMarker);
+}
+
+void AppendCommand::undo()
+{
+    m_model.doRemove(m_index);
+}
+
+
+UpdateCommand::UpdateCommand(MarkersModel& model, const Marker& newMarker, const Marker& oldMarker, int index)
+    : QUndoCommand(0)
+    , m_model(model)
+    , m_newMarker(newMarker)
+    , m_oldMarker(oldMarker)
+    , m_index(index)
+{
+    if (m_newMarker.text == m_oldMarker.text && m_newMarker.color == m_oldMarker.color )
+    {
+        setText(QObject::tr("Move Marker: %1").arg(m_oldMarker.text));
+    }
+    else
+    {
+        setText(QObject::tr("Edit Marker: %1").arg(m_oldMarker.text));
+    }
+}
+
+void UpdateCommand::redo()
+{
+    m_model.doUpdate(m_index, m_newMarker);
+}
+
+void UpdateCommand::undo()
+{
+    m_model.doUpdate(m_index, m_oldMarker);
+}
+
+
+} // namespace Markers

--- a/src/commands/markercommands.h
+++ b/src/commands/markercommands.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MARKERCOMMANDS_H
+#define MARKERCOMMANDS_H
+
+#include "models/markersmodel.h"
+#include <QUndoCommand>
+
+namespace Markers
+{
+
+class DeleteCommand : public QUndoCommand
+{
+public:
+    DeleteCommand(MarkersModel& model, const Marker& delMarker, int index);
+    void redo();
+    void undo();
+private:
+    MarkersModel& m_model;
+    Marker m_delMarker;
+    int m_index;
+};
+
+class InsertCommand : public QUndoCommand
+{
+public:
+    InsertCommand(MarkersModel& model, const Marker& newMarker, int index);
+    void redo();
+    void undo();
+private:
+    MarkersModel& m_model;
+    Marker m_newMarker;
+    int m_index;
+};
+
+class AppendCommand : public QUndoCommand
+{
+public:
+    AppendCommand(MarkersModel& model, const Marker& newMarker, int index);
+    void redo();
+    void undo();
+private:
+    MarkersModel& m_model;
+    Marker m_newMarker;
+    int m_index;
+};
+
+class UpdateCommand : public QUndoCommand
+{
+public:
+    UpdateCommand(MarkersModel& model, const Marker& newMarker, const Marker& oldMarker, int index);
+    void redo();
+    void undo();
+private:
+    MarkersModel& m_model;
+    Marker m_newMarker;
+    Marker m_oldMarker;
+    int m_index;
+};
+
+}
+
+#endif // MARKERCOMMANDS_H

--- a/src/dialogs/editmarkerdialog.cpp
+++ b/src/dialogs/editmarkerdialog.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "editmarkerdialog.h"
+
+#include "Logger.h"
+#include "widgets/editmarkerwidget.h"
+
+#include <QDebug>
+#include <QDialogButtonBox>
+#include <QVBoxLayout>
+
+EditMarkerDialog::EditMarkerDialog(QWidget *parent, const QString& text, const QColor& color, int start, int end)
+    : QDialog(parent)
+{
+    setWindowTitle(tr("Edit Marker"));
+
+    QVBoxLayout* VLayout = new QVBoxLayout(this);
+
+    m_sWidget = new EditMarkerWidget(this, text, color, start, end);
+    VLayout->addWidget(m_sWidget);
+
+    m_buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Close);
+    VLayout->addWidget(m_buttonBox);
+    connect(m_buttonBox, SIGNAL(clicked(QAbstractButton*)), this, SLOT(clicked(QAbstractButton*)));
+
+    setLayout(VLayout);
+    setModal(true);
+    layout()->setSizeConstraint(QLayout::SetFixedSize);
+}
+
+QString EditMarkerDialog::getText()
+{
+    return m_sWidget->getText();
+}
+
+QColor EditMarkerDialog::getColor()
+{
+    return m_sWidget->getColor();
+}
+
+int EditMarkerDialog::getStart()
+{
+    return m_sWidget->getStart();
+}
+
+int EditMarkerDialog::getEnd()
+{
+    return m_sWidget->getEnd();
+}
+
+void EditMarkerDialog::clicked(QAbstractButton* button)
+{
+    QDialogButtonBox::ButtonRole role = m_buttonBox->buttonRole(button);
+    if (role == QDialogButtonBox::AcceptRole)
+    {
+        accept();
+    }
+    else if (role == QDialogButtonBox::RejectRole)
+    {
+        reject();
+    }
+    else
+    {
+        LOG_DEBUG() << "Unknown role" << role;
+    }
+}

--- a/src/dialogs/editmarkerdialog.h
+++ b/src/dialogs/editmarkerdialog.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EDITMARKERDIALOG_H
+#define EDITMARKERDIALOG_H
+
+#include <QDialog>
+
+class EditMarkerWidget;
+class QAbstractButton;
+class QDialogButtonBox;
+
+class EditMarkerDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit EditMarkerDialog(QWidget *parent, const QString& text, const QColor& color, int start, int end);
+    QString getText();
+    QColor getColor();
+    int getStart();
+    int getEnd();
+
+private slots:
+    void clicked(QAbstractButton* button);
+
+private:
+    EditMarkerWidget* m_sWidget;
+    QDialogButtonBox* m_buttonBox;
+};
+
+#endif // EDITMARKERDIALOG_H

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -21,6 +21,7 @@
 #include <QDockWidget>
 #include <QQuickWidget>
 #include <QApplication>
+#include "models/markersmodel.h"
 #include "models/multitrackmodel.h"
 #include "sharedframe.h"
 
@@ -155,6 +156,9 @@ public slots:
     bool blockSelection(bool block);
     void onProducerModified();
     void replace(int trackIndex, int clipIndex, const QString& xml = QString());
+    void createMarker();
+    void editMarker(int markerIndex);
+    void deleteMarker(int markerIndex);
 
 protected:
     void dragEnterEvent(QDragEnterEvent* event);
@@ -173,6 +177,7 @@ private:
     Ui::TimelineDock *ui;
     QQuickWidget m_quickView;
     MultitrackModel m_model;
+    MarkersModel m_markersModel;
     int m_position;
     QScopedPointer<Timeline::UpdateCommand> m_updateCommand;
     bool m_ignoreNextPositionChange;
@@ -195,6 +200,7 @@ private slots:
     void onTransitionAdded(int trackIndex, int clipIndex, int position, bool ripple);
     void selectClip(int trackIndex, int clipIndex);
     void onMultitrackClosed();
+    void reloadTimelineMarkers();
 };
 
 class TimelineSelectionBlocker

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1988,6 +1988,8 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
         if (event->modifiers() & Qt::ControlModifier && isMultitrackValid())
 #endif
             m_timelineDock->toggleTrackMute(m_timelineDock->currentTrack());
+        else if (event->modifiers() == Qt::NoModifier && isMultitrackValid())
+            m_timelineDock->createMarker();
         break;
     case Qt::Key_I:
         if (event->modifiers() == Qt::ControlModifier) {

--- a/src/models/markersmodel.cpp
+++ b/src/models/markersmodel.cpp
@@ -1,0 +1,420 @@
+/*
+ * Copyright (c) 2021 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "markersmodel.h"
+
+#include "commands/markercommands.h"
+#include "mainwindow.h"
+#include "shotcut_mlt_properties.h"
+
+#include <Logger.h>
+
+static void markerToProperties(const Markers::Marker& marker, Mlt::Properties* properties, Mlt::Producer* producer)
+{
+    properties->set("text", qPrintable(marker.text));
+    properties->set("start", producer->frames_to_time(marker.start, mlt_time_clock));
+    properties->set("end", producer->frames_to_time(marker.end, mlt_time_clock));
+    mlt_color color;
+    color.r = marker.color.red();
+    color.g = marker.color.green();
+    color.b = marker.color.blue();
+    color.a = 0xFF;
+    properties->set("color", color);
+}
+
+static void propertiesToMarker(Mlt::Properties* properties, Markers::Marker& marker, Mlt::Producer* producer)
+{
+    marker.text = properties->get("text");
+    marker.start = producer->time_to_frames(properties->get("start"));
+    marker.end = producer->time_to_frames(properties->get("end"));
+    mlt_color color = properties->get_color("color");
+    marker.color = QColor::fromRgb(color.r, color.g, color.b, 0xFF);
+}
+
+MarkersModel::MarkersModel(QObject* parent)
+    : QAbstractItemModel(parent)
+    , m_producer(nullptr)
+{
+}
+
+MarkersModel::~MarkersModel()
+{
+}
+
+void MarkersModel::load(Mlt::Producer* producer)
+{
+    beginResetModel();
+    m_producer = producer;
+    m_keys.clear();
+    if (m_producer) {
+        Mlt::Properties* markerList = m_producer->get_props(kShotcutMarkersProperty);
+        if (markerList &&  markerList->is_valid()) {
+            int count = markerList->count();
+            for (int i = 0; i < count; i++) {
+                Mlt::Properties* marker = markerList->get_props_at(i);
+                if (marker && marker->is_valid()) {
+                    char* key = markerList->get_name(i);
+                    int intKey = QString(key).toInt();
+                    m_keys << intKey;
+                }
+                delete marker;
+            }
+        }
+        delete markerList;
+    }
+
+    endResetModel();
+}
+
+Markers::Marker MarkersModel::getMarker(int markerIndex)
+{
+    Markers::Marker retMarker;
+    Mlt::Properties* markerProperties = getMarkerProperties(markerIndex);
+    if (!markerProperties || !markerProperties->is_valid()) {
+        LOG_ERROR() << "Marker does not exist" << markerIndex;
+        delete markerProperties;
+    } else {
+        propertiesToMarker(markerProperties, retMarker, m_producer);
+    }
+    return retMarker;
+}
+
+void MarkersModel::remove(int markerIndex)
+{
+    Mlt::Properties* markerProperties = getMarkerProperties(markerIndex);
+    if (!markerProperties || !markerProperties->is_valid()) {
+        LOG_ERROR() << "Marker does not exist" << markerIndex;
+        delete markerProperties;
+        return;
+    }
+    Markers::Marker oldMarker;
+    propertiesToMarker(markerProperties, oldMarker, m_producer);
+    Markers::DeleteCommand* command = new Markers::DeleteCommand(*this, oldMarker, markerIndex);
+    MAIN.undoStack()->push(command);
+    delete markerProperties;
+}
+
+void MarkersModel::doRemove(int markerIndex)
+{
+    if (!m_producer) {
+        LOG_ERROR() << "No producer";
+        return;
+    }
+    QModelIndex modelIndex = index(markerIndex, 0);
+    if (!modelIndex.isValid()) {
+        LOG_ERROR() << "Invalid Index: " << markerIndex;
+        return;
+    }
+    if (modelIndex.row() >= m_keys.count()) {
+        LOG_ERROR() << "Index out of bounds: " << modelIndex.row() << m_keys.count();
+        return;
+    }
+    Mlt::Properties* markersListProperties = m_producer->get_props(kShotcutMarkersProperty);
+    if (!markersListProperties || !markersListProperties->is_valid()) {
+        LOG_ERROR() << "No Markers";
+        delete markersListProperties;
+        return;
+    }
+    beginRemoveRows(QModelIndex(), modelIndex.row(), modelIndex.row());
+    markersListProperties->clear(qPrintable(QString::number(m_keys[modelIndex.row()])));
+    m_keys.removeAt(modelIndex.row());
+    endRemoveRows();
+
+    delete markersListProperties;
+}
+
+void MarkersModel::insert( int markerIndex, const Markers::Marker& marker )
+{
+    if (!m_producer) {
+        LOG_ERROR() << "No producer";
+        return;
+    }
+    QModelIndex modelIndex = index(markerIndex, 0);
+    if (!modelIndex.isValid()) {
+        LOG_ERROR() << "Invalid Index: " << markerIndex;
+        return;
+    }
+    Markers::InsertCommand* command = new Markers::InsertCommand(*this, marker, modelIndex.row());
+    MAIN.undoStack()->push(command);
+}
+
+void MarkersModel::doInsert(int markerIndex,  const Markers::Marker& marker )
+{
+    if (!m_producer) {
+        LOG_ERROR() << "No producer";
+        return;
+    }
+
+    QModelIndex modelIndex = index(markerIndex, 0);
+    if (!modelIndex.isValid()) {
+        LOG_ERROR() << "Invalid Index: " << markerIndex;
+        return;
+    }
+
+    Mlt::Properties* markersListProperties = m_producer->get_props(kShotcutMarkersProperty);
+    if (!markersListProperties || !markersListProperties->is_valid()) {
+        delete markersListProperties;
+        markersListProperties = new Mlt::Properties;
+        m_producer->set(kShotcutMarkersProperty, *markersListProperties);
+    }
+
+    Mlt::Properties markerProperties;
+    markerToProperties(marker, &markerProperties, m_producer);
+
+    beginInsertRows(QModelIndex(), modelIndex.row(), modelIndex.row());
+    int key = uniqueKey();
+    markersListProperties->set(qPrintable(QString::number(key)), markerProperties);
+    m_keys.insert(modelIndex.row(), key);
+    endInsertRows();
+
+    delete markersListProperties;
+}
+
+void MarkersModel::append( const Markers::Marker& marker )
+{
+    if (!m_producer) {
+        LOG_ERROR() << "No producer";
+        return;
+    }
+    Markers::AppendCommand* command = new Markers::AppendCommand(*this, marker, markerCount());
+    MAIN.undoStack()->push(command);
+}
+
+void MarkersModel::doAppend( const Markers::Marker& marker )
+{
+    if (!m_producer) {
+        LOG_ERROR() << "No producer";
+        return;
+    }
+
+    Mlt::Properties* markersListProperties = m_producer->get_props(kShotcutMarkersProperty);
+    if (!markersListProperties || !markersListProperties->is_valid()) {
+        delete markersListProperties;
+        markersListProperties = new Mlt::Properties;
+        m_producer->set(kShotcutMarkersProperty, *markersListProperties);
+    }
+
+    Mlt::Properties markerProperties;
+    markerToProperties(marker, &markerProperties, m_producer);
+
+    int count = markerCount();
+    beginInsertRows(QModelIndex(), count, count);
+    int key = uniqueKey();
+    markersListProperties->set(qPrintable(QString::number(key)), markerProperties);
+    m_keys.append(key);
+    endInsertRows();
+
+    delete markersListProperties;
+}
+
+void MarkersModel::update(int markerIndex,  const Markers::Marker& marker)
+{
+    Mlt::Properties* markerProperties = getMarkerProperties(markerIndex);
+    if (!markerProperties || !markerProperties->is_valid()) {
+        LOG_ERROR() << "Marker does not exist" << markerIndex;
+        delete markerProperties;
+        return;
+    }
+    Markers::Marker oldMarker;
+    propertiesToMarker(markerProperties, oldMarker, m_producer);
+
+    Markers::UpdateCommand* command = new Markers::UpdateCommand(*this, marker, oldMarker, markerIndex);
+    MAIN.undoStack()->push(command);
+    delete markerProperties;
+}
+
+void MarkersModel::doUpdate(int markerIndex,  const Markers::Marker& marker)
+{
+    QModelIndex modelIndex = index(markerIndex, 0);
+    if (!modelIndex.isValid()) {
+        LOG_ERROR() << "Invalid Index: " << markerIndex;
+        return;
+    }
+    Mlt::Properties* markerProperties = getMarkerProperties(markerIndex);
+    if (!markerProperties || !markerProperties->is_valid()) {
+        LOG_ERROR() << "Marker does not exist" << markerIndex;
+        delete markerProperties;
+        return;
+    }
+    markerToProperties(marker, markerProperties, m_producer);
+    delete markerProperties;
+
+    emit dataChanged(modelIndex, modelIndex, QVector<int>() << TextRole << StartRole << EndRole << ColorRole);
+}
+
+void MarkersModel::move(int markerIndex, int start, int end)
+{
+    Mlt::Properties* markerProperties = getMarkerProperties(markerIndex);
+    if (!markerProperties || !markerProperties->is_valid()) {
+        LOG_ERROR() << "Marker does not exist" << markerIndex;
+        delete markerProperties;
+        return;
+    }
+    Markers::Marker oldMarker;
+    propertiesToMarker(markerProperties, oldMarker, m_producer);
+    Markers::Marker newMarker = oldMarker;
+    newMarker.start = start;
+    newMarker.end = end;
+
+    Markers::UpdateCommand* command = new Markers::UpdateCommand(*this, newMarker, oldMarker, markerIndex);
+    MAIN.undoStack()->push(command);
+}
+
+int MarkersModel::markerCount() const
+{
+    if (!m_producer) {
+        return 0;
+    }
+    return m_keys.count();
+}
+
+int MarkersModel::keyIndex(int key) const
+{
+    int index = -1;
+    for (int i = 0; i < m_keys.size(); i++) {
+        if (m_keys[i] == key) {
+            index = i;
+            break;
+        }
+    }
+    return index;
+}
+
+int MarkersModel::uniqueKey() const
+{
+    int key = 0;
+    while (keyIndex(key) >= 0) {
+        key++;
+    }
+    return key;
+}
+
+Mlt::Properties* MarkersModel::getMarkerProperties(int markerIndex)
+{
+    Mlt::Properties* markerProperties = nullptr;
+    if (!m_producer) {
+        LOG_ERROR() << "No producer";
+        return markerProperties;
+    }
+    QModelIndex modelIndex = index(markerIndex, 0);
+    if (!modelIndex.isValid()) {
+        LOG_ERROR() << "Invalid Index: " << markerIndex;
+        return markerProperties;
+    }
+    Mlt::Properties* markersListProperties = m_producer->get_props(kShotcutMarkersProperty);
+    if (!markersListProperties || !markersListProperties->is_valid()) {
+        LOG_ERROR() << "No Markers";
+    }
+    else
+    {
+        markerProperties = markersListProperties->get_props(qPrintable(QString::number(m_keys[modelIndex.row()])));
+        if (!markerProperties || !markerProperties->is_valid()) {
+            LOG_ERROR() << "Marker does not exist" << modelIndex.row();
+            delete markerProperties;
+            markerProperties = nullptr;
+        }
+    }
+    delete markersListProperties;
+    return markerProperties;
+}
+
+int MarkersModel::rowCount(const QModelIndex& parent) const
+{
+    Q_UNUSED(parent)
+    return markerCount();
+}
+
+int MarkersModel::columnCount(const QModelIndex& parent) const
+{
+    Q_UNUSED(parent)
+    return 1;
+}
+
+QVariant MarkersModel::data(const QModelIndex& index, int role) const
+{
+    QVariant result;
+    if (!m_producer) {
+        LOG_DEBUG() << "No Producer: " << index.row() << index.column() << role;
+        return result;
+    }
+    if (!index.isValid() || index.column() != 0 || index.row() < 0 || index.row() >= markerCount()) {
+        LOG_ERROR() << "Invalid Index: " << index.row() << index.column() << role;
+        return result;
+    }
+    Mlt::Properties* markersListProperties = m_producer->get_props(kShotcutMarkersProperty);
+    if (!markersListProperties || !markersListProperties->is_valid()) {
+        LOG_DEBUG() << "No Markers: " << index.row() << index.column() << role;
+        delete markersListProperties;
+        return result;
+    }
+    Mlt::Properties* markerProperties = markersListProperties->get_props(qPrintable(QString::number(m_keys[index.row()])));
+    if (!markerProperties || !markerProperties->is_valid()) {
+        LOG_DEBUG() << "Marker does not exist: " << index.row() << index.column() << role << m_keys[index.row()];
+        delete markerProperties;
+        delete markersListProperties;
+        return result;
+    }
+
+    Markers::Marker marker;
+    propertiesToMarker(markerProperties, marker, m_producer);
+
+    switch (role) {
+        case Qt::DisplayRole:
+        case TextRole:
+            result = marker.text;
+            break;
+        case StartRole:
+            result = marker.start;
+            break;
+        case EndRole:
+            result = marker.end;
+            break;
+        case ColorRole:
+            result = marker.color;
+            break;
+        default:
+            LOG_ERROR() << "Invalid Role" << index.row() << role;
+            break;
+    }
+    delete markersListProperties;
+    delete markerProperties;
+    return result;
+}
+
+QModelIndex MarkersModel::index(int row, int column, const QModelIndex& parent) const
+{
+    Q_UNUSED(parent)
+    if (column != 0 || row < 0 || row >= markerCount())
+        return QModelIndex();
+    return createIndex(row, column, (int)0);
+}
+
+QModelIndex MarkersModel::parent(const QModelIndex& index) const
+{
+    Q_UNUSED(index)
+    return QModelIndex();
+}
+
+QHash<int, QByteArray> MarkersModel::roleNames() const
+{
+    QHash<int, QByteArray> roles;
+    roles[TextRole]        = "text";
+    roles[StartRole]       = "start";
+    roles[EndRole]         = "end";
+    roles[ColorRole]       = "color";
+    return roles;
+}

--- a/src/models/markersmodel.h
+++ b/src/models/markersmodel.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MARKERSMODEL_H
+#define MARKERSMODEL_H
+
+#include <MltProducer.h>
+
+#include <QAbstractItemModel>
+#include <QColor>
+#include <QString>
+
+namespace Markers
+{
+
+class Marker
+{
+public:
+    QString text;
+    int start;
+    int end;
+    QColor color;
+};
+
+}
+
+class MarkersModel : public QAbstractItemModel
+{
+    Q_OBJECT
+
+public:
+
+    enum Roles {
+        TextRole = Qt::UserRole + 1,
+        StartRole,
+        EndRole,
+        ColorRole,
+    };
+
+    explicit MarkersModel(QObject* parent = 0);
+    virtual ~MarkersModel();
+
+    void load(Mlt::Producer* producer);
+    Markers::Marker getMarker(int markerIndex);
+    int uniqueKey() const;
+
+    // These should only be called by the marker commands
+    void doRemove(int markerIndex);
+    void doInsert(int markerIndex, const Markers::Marker& marker);
+    void doAppend(const Markers::Marker& marker);
+    void doUpdate(int markerIndex,  const Markers::Marker& marker);
+
+public slots:
+    void remove(int markerIndex);
+    void insert(int markerIndex, const Markers::Marker& marker);
+    void append(const Markers::Marker& marker);
+    void update(int markerIndex, const Markers::Marker& marker);
+    void move(int markerIndex, int start, int end);
+
+protected:
+    // Implement QAbstractItemModel
+    int rowCount(const QModelIndex& parent) const;
+    int columnCount(const QModelIndex& parent) const;
+    QVariant data(const QModelIndex& index, int role) const;
+    QModelIndex index(int row, int column = 0, const QModelIndex& parent = QModelIndex()) const;
+    QModelIndex parent(const QModelIndex& index) const;
+    QHash<int, QByteArray> roleNames() const;
+
+private:
+    int markerCount() const;
+    int keyIndex(int key) const;
+    Mlt::Properties* getMarkerProperties(int markerIndex);
+
+    Mlt::Producer* m_producer;
+    QList<int> m_keys;
+};
+
+#endif // MARKERSMODEL_H

--- a/src/qml/filters/levels/ui.qml
+++ b/src/qml/filters/levels/ui.qml
@@ -258,7 +258,7 @@ Item {
         Shotcut.SliderSpinner {
             id: gammaSlider
             minimumValue: 0.01
-            maximumValue: 4
+            maximumValue: 4.0
             decimals: 2
             onValueChanged: updateFilter(gammaParam, value / maximumValue, getPosition(), gammaKeyframesButton)
         }

--- a/src/qml/modules/Shotcut/Controls/Marker.qml
+++ b/src/qml/modules/Shotcut/Controls/Marker.qml
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2021 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Shapes 1.12
+
+Item {
+    id: root
+    property real timeScale: 1.0;
+    property var start: 0
+    property var end: 0
+    property var markerColor: 'black'
+    property var text: ""
+    property var index: 0
+    signal editRequested(int index)
+    signal deleteRequested(int index)
+    x: 0
+    width: parent.width
+    height: 17
+
+    SystemPalette { id: activePalette }
+
+    onTimeScaleChanged: {
+        updatePosition()
+    }
+    onStartChanged: {
+        updatePosition()
+    }
+    onEndChanged: {
+        updatePosition()
+    }
+
+    function updatePosition() {
+        markerStart.x = (start * timeScale) - 7
+        markerEnd.x = end * timeScale
+    }
+
+    Menu {
+        id: menu
+        title: qsTr('Marker Operations')
+        MenuItem {
+            text: qsTr('Edit...')
+            onTriggered: root.editRequested(root.index)
+        }
+        MenuItem {
+            text: qsTr('Delete')
+            onTriggered: root.deleteRequested(root.index)
+        }
+    }
+
+    Shape {
+        id: markerStart
+        width: 7
+        height: 17
+        x: (start * timeScale) - 7
+        antialiasing: true
+        ShapePath {
+            strokeWidth: 1
+            strokeColor: 'transparent'
+            fillColor: root.markerColor
+            startX: 0
+            startY: 0
+            PathLine { x: 0; y: 10 }
+            PathLine { x: 7; y: 17 }
+            PathLine { x: 7; y: 0 }
+            PathLine { x: 0; y: 0 }
+        }
+
+        MouseArea {
+            id: startMouseArea
+            anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            cursorShape: Qt.PointingHandCursor
+            property int lockWidth: 0
+            property var dragStartX: 0
+            drag {
+                target: pressedButtons & Qt.LeftButton ? parent : undefined
+                axis: Drag.XAxis
+                threshold: 0
+                minimumX: 0
+                maximumX: startMouseArea.lockWidth == -1 ? markerEnd.x - 7 : root.width
+            }
+            onPressed: {
+               dragStartX = markerStart.x
+               if (mouse.modifiers & Qt.ControlModifier)
+                   lockWidth = -1
+               else
+                   lockWidth = markerEnd.x - markerStart.x
+            }
+            onPositionChanged: {
+                if (lockWidth != -1) {
+                    markerEnd.x = markerStart.x + lockWidth
+                }
+            }
+            onReleased: {
+                if (mouse.button == Qt.LeftButton && markerStart.x != dragStartX) {
+                    markers.move(index, Math.round((markerStart.x + 7) / timeScale), Math.round(markerEnd.x / timeScale))
+                }
+            }
+            onClicked: {
+                if (mouse.button == Qt.RightButton)
+                    menu.popup()
+            }
+        }
+    }
+
+    Shape {
+        id: markerEnd
+        width: 7
+        height: 17
+        x: end * timeScale
+        antialiasing: true
+        ShapePath {
+            strokeWidth: 1
+            strokeColor: 'transparent'
+            fillColor: root.markerColor
+            startX: 0
+            startY: 0
+            PathLine { x: 0; y: 17 }
+            PathLine { x: 7; y: 10 }
+            PathLine { x: 7; y: 0 }
+            PathLine { x: 0; y: 0 }
+        }
+
+        MouseArea {
+            id: endMouseArea
+            anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            cursorShape: Qt.PointingHandCursor
+            property int lockWidth: 0
+            property var dragStartX: 0
+            drag {
+                target: pressedButtons & Qt.LeftButton ? parent : undefined
+                axis: Drag.XAxis
+                threshold: 0
+                minimumX: endMouseArea.lockWidth == -1 ? markerStart.x + 7 : 0
+                maximumX: root.width
+            }
+            onPressed: {
+               dragStartX = markerEnd.x
+               if (mouse.modifiers & Qt.ControlModifier)
+                   lockWidth = -1
+               else
+                   lockWidth = markerEnd.x - markerStart.x
+            }
+            onPositionChanged: {
+                if (lockWidth != -1) {
+                    markerStart.x = markerEnd.x - lockWidth
+                }
+            }
+            onReleased: {
+                if (mouse.button == Qt.LeftButton && markerEnd.x != dragStartX) {
+                    markers.move(index, Math.round((markerStart.x + 7) / timeScale), Math.round(markerEnd.x / timeScale))
+                }
+            }
+            onClicked: {
+                if (mouse.button == Qt.RightButton)
+                    menu.popup()
+            }
+        }
+    }
+
+    Rectangle {
+        id: markerLink
+        anchors.left: markerStart.right
+        anchors.right: markerEnd.left
+        height: 7
+        color: root.markerColor
+
+        MouseArea {
+            id: linkMouseArea
+            anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            cursorShape: Qt.PointingHandCursor
+            property var dragStartX
+            property int startDragStartX
+            property int endDragStartX
+            drag {
+                target: pressedButtons & Qt.LeftButton ? parent : undefined
+                axis: Drag.XAxis
+                threshold: 0
+                minimumX: 0
+                maximumX: root.width
+            }
+            onPressed: {
+                markerLink.anchors.left = undefined
+                markerLink.anchors.right = undefined
+                dragStartX = markerLink.x
+                startDragStartX = markerStart.x
+                endDragStartX = markerEnd.x
+            }
+            onPositionChanged: {
+                var delta = dragStartX - markerLink.x
+                markerStart.x = startDragStartX - delta
+                markerEnd.x = endDragStartX - delta
+            }
+            onReleased: {
+                markerLink.anchors.left = markerStart.right
+                markerLink.anchors.right = markerEnd.left
+                if (mouse.button == Qt.LeftButton && dragStartX != markerLink.x) {
+                    markers.move(index, (markerStart.x + 7) / timeScale, markerEnd.x / timeScale)
+                }
+            }
+            onClicked: {
+                if (mouse.button == Qt.RightButton)
+                    menu.popup()
+            }
+        }
+    }
+}

--- a/src/qml/modules/Shotcut/Controls/MarkerBar.qml
+++ b/src/qml/modules/Shotcut/Controls/MarkerBar.qml
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.12
+
+Repeater {
+    id: markerbar
+    property real timeScale: 1.0
+    signal editRequested(int index)
+    signal deleteRequested(int index)
+    Marker {
+        timeScale: parent.timeScale
+        start: model.start
+        end: model.end
+        markerColor: model.color
+        text: model.text
+        index: model.index
+        onEditRequested: markerbar.editRequested(index)
+        onDeleteRequested: markerbar.deleteRequested(index)
+    }
+}

--- a/src/qml/modules/Shotcut/Controls/qmldir
+++ b/src/qml/modules/Shotcut/Controls/qmldir
@@ -22,3 +22,5 @@ HoverTip 1.0 HoverTip.qml
 ComboBox 1.0 ComboBox.qml
 EditMenu 1.0 EditMenu.qml
 TipBox 1.0 TipBox.qml
+Marker 1.0 Marker.qml
+MarkerBar 1.0 MarkerBar.qml

--- a/src/qml/views/timeline/Ruler.qml
+++ b/src/qml/views/timeline/Ruler.qml
@@ -17,11 +17,14 @@
 
 import QtQuick 2.12
 import QtQuick.Controls 2.12
+import Shotcut.Controls 1.0 as Shotcut
 
 Rectangle {
     property real timeScale: 1.0
     property int adjustment: 0
     property real intervalSeconds: ((timeScale > 5)? 1 : (5 * Math.max(1, Math.floor(1.5 / timeScale)))) + adjustment
+    signal editMarkerRequested(int index)
+    signal deleteMarkerRequested(int index)
 
     SystemPalette { id: activePalette }
 
@@ -48,6 +51,20 @@ Rectangle {
                 color: activePalette.windowText
                 text: application.timecode(index * intervalSeconds * profile.fps + 2).substr(0, 8)
             }
+        }
+    }
+
+    Shotcut.MarkerBar {
+        anchors.top: rulerTop.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        timeScale: root.timeScale
+        model: markers
+        onEditRequested: {
+            parent.editMarkerRequested(index)
+        }
+        onDeleteRequested: {
+            parent.deleteMarkerRequested(index)
         }
     }
 

--- a/src/qml/views/timeline/timeline.qml
+++ b/src/qml/views/timeline/timeline.qml
@@ -298,6 +298,12 @@ Rectangle {
                         id: ruler
                         width: tracksContainer.width
                         timeScale: multitrack.scaleFactor
+                        onEditMarkerRequested: {
+                            timeline.editMarker(index)
+                        }
+                        onDeleteMarkerRequested: {
+                            timeline.deleteMarker(index)
+                        }
                     }
                 }
                 Flickable {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "settings.h"
+#include <QColor>
 #include <QLocale>
 #include <QStandardPaths>
 #include <QFile>
@@ -296,6 +297,16 @@ bool ShotcutSettings::convertAdvanced() const
 void ShotcutSettings::setConvertAdvanced(bool b)
 {
     settings.setValue("convertAdvanced", b);
+}
+
+void ShotcutSettings::setMarkerColor(const QColor& color)
+{
+    settings.setValue("markerColor", color.name());
+}
+
+QColor ShotcutSettings::markerColor()
+{
+    return QColor(settings.value("markerColor", "green").toString());
 }
 
 bool ShotcutSettings::showConvertClipDialog() const

--- a/src/settings.h
+++ b/src/settings.h
@@ -89,6 +89,8 @@ public:
     void setExportFrameSuffix(const QString& suffix);
     bool convertAdvanced() const;
     void setConvertAdvanced(bool);
+    void setMarkerColor(const QColor& color);
+    QColor markerColor();
 
     // encode
     QString encodePath() const;

--- a/src/shotcut_mlt_properties.h
+++ b/src/shotcut_mlt_properties.h
@@ -47,6 +47,7 @@
 #define kShotcutSkipConvertProperty "shotcut:skipConvert"
 #define kShotcutAnimInProperty "shotcut:animIn"
 #define kShotcutAnimOutProperty "shotcut:animOut"
+#define kShotcutMarkersProperty "shotcut:markers"
 // Shotcut's VUI (video user interface) components set this so that glwidget can
 // hide the VUI when the play head is not over the clip with the current filter.
 #define kShotcutVuiMetaProperty "meta.shotcut.vui"

--- a/src/src.pro
+++ b/src/src.pro
@@ -58,6 +58,7 @@ SOURCES += main.cpp\
     docks/jobsdock.cpp \
     dialogs/multifileexportdialog.cpp \
     dialogs/saveimagedialog.cpp \
+    dialogs/editMarkerdialog.cpp \
     dialogs/slideshowgeneratordialog.cpp \
     dialogs/textviewerdialog.cpp \
     models/playlistmodel.cpp \
@@ -86,6 +87,7 @@ SOURCES += main.cpp\
     qmltypes/qmlutilities.cpp \
     qmltypes/qmlview.cpp \
     qmltypes/thumbnailprovider.cpp \
+    commands/markercommands.cpp \
     commands/timelinecommands.cpp \
     util.cpp \
     widgets/lumamixtransition.cpp \
@@ -130,6 +132,8 @@ SOURCES += main.cpp\
     docks/keyframesdock.cpp \
     qmltypes/qmlproducer.cpp \
     models/keyframesmodel.cpp \
+    models/markersmodel.cpp \
+    widgets/editmarkerwidget.cpp \
     widgets/slideshowgeneratorwidget.cpp \
     widgets/textproducerwidget.cpp \
     dialogs/listselectiondialog.cpp \
@@ -191,6 +195,7 @@ HEADERS  += mainwindow.h \
     docks/jobsdock.h \
     dialogs/multifileexportdialog.h \
     dialogs/saveimagedialog.h \
+    dialogs/editmarkerdialog.h \
     dialogs/slideshowgeneratordialog.h \
     dialogs/textviewerdialog.h \
     models/playlistmodel.h \
@@ -220,6 +225,7 @@ HEADERS  += mainwindow.h \
     qmltypes/qmlutilities.h \
     qmltypes/qmlview.h \
     qmltypes/thumbnailprovider.h \
+    commands/markercommands.h \
     commands/timelinecommands.h \
     util.h \
     widgets/lumamixtransition.h \
@@ -266,6 +272,8 @@ HEADERS  += mainwindow.h \
     docks/keyframesdock.h \
     qmltypes/qmlproducer.h \
     models/keyframesmodel.h \
+    models/markersmodel.h \
+    widgets/editmarkerwidget.h \
     widgets/slideshowgeneratorwidget.h \
     widgets/textproducerwidget.h \
     dialogs/listselectiondialog.h \

--- a/src/widgets/editmarkerwidget.cpp
+++ b/src/widgets/editmarkerwidget.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "editmarkerwidget.h"
+
+#include "Logger.h"
+#include "qmltypes/qmlapplication.h"
+#include "widgets/timespinbox.h"
+
+#include <QColorDialog>
+#include <QDebug>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+
+EditMarkerWidget::EditMarkerWidget(QWidget *parent, const QString& text, const QColor& color, int start, int end)
+    : QWidget(parent)
+{
+    QGridLayout* grid = new QGridLayout();
+    setLayout(grid);
+
+    grid->addWidget(new QLabel(tr("Text")), 0, 0, Qt::AlignRight);
+    m_textField = new QLineEdit(text);
+    m_textField->setToolTip(tr("Set the text for this marker."));
+    grid->addWidget(m_textField, 0, 1);
+
+    grid->addWidget(new QLabel(""), 1, 0, Qt::AlignRight);
+    m_colorButton = new QPushButton(tr("Color..."));
+    connect(m_colorButton, SIGNAL(clicked()), SLOT(on_colorButton_clicked()));
+    m_colorLabel = new QLabel(color.name(QColor::HexRgb));
+    m_colorLabel->setStyleSheet(QString("color: %1; background-color: %2")
+            .arg((color.value() < 150)? "white":"black")
+            .arg(color.name()));
+    QHBoxLayout* colorHbox = new QHBoxLayout();
+    colorHbox->addWidget(m_colorButton);
+    colorHbox->addWidget(m_colorLabel);
+    grid->addLayout(colorHbox, 1, 1);
+
+    grid->addWidget(new QLabel(tr("Start")), 2, 0, Qt::AlignRight);
+    m_startSpinner = new TimeSpinBox();
+    m_startSpinner->setValue(start);
+    m_startSpinner->setToolTip(tr("Set the start time for this marker."));
+    grid->addWidget(m_startSpinner, 2, 1);
+
+    grid->addWidget(new QLabel(tr("End")), 3, 0, Qt::AlignRight);
+    m_endSpinner = new TimeSpinBox();
+    m_endSpinner->setValue(end);
+    m_endSpinner->setToolTip(tr("Set the end time for this marker."));
+    grid->addWidget(m_endSpinner, 3, 1);
+}
+
+EditMarkerWidget::~EditMarkerWidget()
+{
+}
+
+QString EditMarkerWidget::getText()
+{
+    return m_textField->text();
+}
+
+QColor EditMarkerWidget::getColor()
+{
+    return QColor(m_colorLabel->text());
+}
+
+int EditMarkerWidget::getStart()
+{
+    return m_startSpinner->value();
+}
+
+int EditMarkerWidget::getEnd()
+{
+    return m_endSpinner->value();
+}
+
+void EditMarkerWidget::on_colorButton_clicked()
+{
+    QColor color = QColor(m_colorLabel->text());
+    QColorDialog dialog(color);
+    dialog.setModal(QmlApplication::dialogModality());
+    if (dialog.exec() == QDialog::Accepted) {
+        auto newColor = dialog.currentColor();
+        m_colorLabel->setText(newColor.name(QColor::HexRgb));
+        m_colorLabel->setStyleSheet(QString("color: %1; background-color: %2")
+                                      .arg((newColor.value() < 150)? "white":"black")
+                                      .arg(newColor.name()));
+    }
+}

--- a/src/widgets/editmarkerwidget.h
+++ b/src/widgets/editmarkerwidget.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EDITMARKERWIDGET_H
+#define EDITMARKERWIDGET_H
+
+#include <QWidget>
+
+class QLabel;
+class QLineEdit;
+class QPushButton;
+class TimeSpinBox;
+
+class EditMarkerWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    EditMarkerWidget(QWidget *parent, const QString& text, const QColor& color, int start, int end);
+    virtual ~EditMarkerWidget();
+    QString getText();
+    QColor getColor();
+    int getStart();
+    int getEnd();
+
+private slots:
+    void on_colorButton_clicked();
+
+private:
+    QLineEdit* m_textField;
+    QPushButton* m_colorButton;
+    QLabel* m_colorLabel;
+    TimeSpinBox* m_startSpinner;
+    TimeSpinBox* m_endSpinner;
+};
+
+#endif // EDITMARKERWIDGET_H


### PR DESCRIPTION
Instructions:

* Press <kbd>M</kbd> to create a marker on the timeline at the current playhead position
* Click and drag to move markers
* <kbd>Ctrl</kbd>+click and drag to change the range of a marker (default is 1 frame)
* Right-click a marker to edit

TODO:

- [ ] Display marker information in the bubble status (in progress)
- [x] Click to seek to it
- [x] Edit keyboard shortcut (<kbd>M</kbd>)
- [x] Toolbar button
- [x] Delete keyboard shortcut (<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>M</kbd>)
- [x] Export marker range

Out-of-scope but desired:

* Snap or skip to markers
* Create chapters from markers
* Ripple with timeline operations
* Display all markers in a **Markers** panel

Comments welcome on size, location, usability. I personally wonder if the marker handles are too small. Maybe the ruler height should be increased to allow the markers to be bigger.