### PR TITLE
Improve accuracy of delta portion of bubblehelp while trimming on Timeline and Keyframes

### DIFF
--- a/src/qml/views/keyframes/Clip.qml
+++ b/src/qml/views/keyframes/Clip.qml
@@ -476,8 +476,7 @@ Rectangle {
                     var newDuration = Math.round((parent.x + parent.width) / timeScale)
                     var delta = duration - newDuration
                     if (Math.abs(delta) > 0) {
-                        if (clipDuration - originalX - delta > 0)
-                            originalX += delta
+                        originalX += delta
                         clipRoot.trimmingOut(clipRoot, delta, mouse)
                         duration = newDuration
                     }

--- a/src/qml/views/keyframes/keyframes.qml
+++ b/src/qml/views/keyframes/keyframes.qml
@@ -355,6 +355,8 @@ Rectangle {
                                                                .arg(s.substring(3))
                                                                .arg(application.timecode(n))
                                                 bubbleHelp.show(clip.x, trackRoot.y + trackRoot.height, s)
+                                            } else {
+                                                clip.originalX -= delta
                                             }
                                         }
                                         onTrimmedIn: bubbleHelp.hide()
@@ -368,6 +370,8 @@ Rectangle {
                                                                .arg(s.substring(3))
                                                                .arg(application.timecode(n))
                                                 bubbleHelp.show(clip.x + clip.width, trackRoot.y + trackRoot.height, s)
+                                            } else {
+                                                clip.originalX -= delta
                                             }
                                         }
                                         onTrimmedOut: bubbleHelp.hide()

--- a/src/qml/views/timeline/Clip.qml
+++ b/src/qml/views/timeline/Clip.qml
@@ -610,8 +610,7 @@ Rectangle {
                     var newDuration = Math.round((parent.x + parent.width) / timeScale)
                     var delta = duration - newDuration
                     if (Math.abs(delta) > 0) {
-                        if (clipDuration - originalX - delta > 0)
-                            originalX += delta
+                        originalX += delta
                         clipRoot.trimmingOut(clipRoot, delta, mouse)
                         duration = newDuration
                     }

--- a/src/qml/views/timeline/Track.qml
+++ b/src/qml/views/timeline/Track.qml
@@ -188,7 +188,7 @@ Rectangle {
                     } else {
                         clip.originalX -= originalDelta
                     }
-                } else
+                } else {
                     clip.originalX -= originalDelta
                 }
             }

--- a/src/qml/views/timeline/Track.qml
+++ b/src/qml/views/timeline/Track.qml
@@ -160,6 +160,8 @@ Rectangle {
                     } else {
                         clip.originalX -= originalDelta
                     }
+                } else {
+                    clip.originalX -= originalDelta
                 }
             }
             onTrimmedIn: {
@@ -186,6 +188,8 @@ Rectangle {
                     } else {
                         clip.originalX -= originalDelta
                     }
+                } else
+                    clip.originalX -= originalDelta
                 }
             }
             onTrimmedOut: {


### PR DESCRIPTION
timeline/Track.qml
- `else` clause for `if (delta != 0)` means the trim handle is being stuck due to snapping enabled. Accumulated delta `clip.originalX` needs to be adjusted in the same manner as when `timeline.trimClipIn` or `timeline.trimClipOut` returns `false`.

keyframes/keyframes.qml
- `else` clauses in `onTrimmingIn` and `onTrimmingOut` are equivalent to when `timeline.trimClipIn` or `timeline.trimClipOut` returns `false` in the Timeline.

Clip.qml
- Somehow `- originalX - delta` is double-counting or something. `delta` accumulation stops half way trimming. I feel like this `if` statement check of a clip becoming very thin is taken care of by `clip.originalX -= originalDelta` or `clip.originalX -= delta` in the files above.
