### PR TITLE
Improve reliability of 20 and 10 pixels grids

### DIFF
--- a/src/qml/modules/Shotcut/Controls/RectangleControl.qml
+++ b/src/qml/modules/Shotcut/Controls/RectangleControl.qml
@@ -89,7 +89,7 @@ Item {
             return x
         }
         if (video.grid !== 95 && video.grid !== 8090) {
-            var n = (video.grid > 10000) ? video.grid - 10000 : parent.width / video.grid
+            var n = (video.grid > 10000) ? parent.width / (profile.width / (video.grid - 10000)) : parent.width / video.grid
             return snapGrid(x, n)
         } else {
             var deltas = null
@@ -116,7 +116,7 @@ Item {
             return y
         }
         if (video.grid !== 95 && video.grid !== 8090) {
-            var n = (video.grid > 10000) ? video.grid - 10000 : parent.height / video.grid
+            var n = (video.grid > 10000) ? parent.height / (profile.height / (video.grid - 10000)) : parent.height / video.grid
             return snapGrid(y, n)
         } else {
             var deltas = null

--- a/src/qml/modules/Shotcut/Controls/VuiBase.qml
+++ b/src/qml/modules/Shotcut/Controls/VuiBase.qml
@@ -18,8 +18,8 @@ DropArea {
                 var zoomOffsetY = ( video.rect.height - rectH ) / 2
                 var rectX = video.rect.x - video.offset.x + zoomOffsetX
                 var rectY = video.rect.y - video.offset.y + zoomOffsetY
-                var gridSizeX = (video.grid > 10000) ? (video.grid - 10000) * zoom : rectW / video.grid
-                var gridSizeY = (video.grid > 10000) ? (video.grid - 10000) * zoom : rectH / video.grid
+                var gridSizeX = (video.grid > 10000) ? rectW / (profile.width / (video.grid - 10000)) : rectW / video.grid
+                var gridSizeY = (video.grid > 10000) ? rectH / (profile.height / (video.grid - 10000)) : rectH / video.grid
                 var gridOffsetX = rectX % gridSizeX
                 var gridOffsetY = rectY % gridSizeY
 


### PR DESCRIPTION
@bmatherly made changes for me about VUI not aligning with 20 and 10 pixel grids after my forum post.
https://github.com/mltframework/shotcut/commit/f1067d585a836752c8925570b6bb98002ba0bd74
But this fix introduced a new bug. Space between 20 and 10 grid lines changes as I change the application window size. 
This is because `video.zoom` becomes large as `m_rect.width()` becomes small in response to `GLWidget::resizeEvent` while `MLT.profile().width()` remains the same.

Reverting that commit and making changes to `snapX` and `snapY` in `RectangleControl.qml` doesn't look good because the grid lines won't respond to user's zoom change input.

I made changes to `VuiBase.qml` and `RectangleControl.qml` so that grid and handle alignment will be kept intact after application window size change or even profile change due to a user choosing another Video Mode.

The only down side is that there will a lot of lines drawn if a high resolution video or image is zoomed out like 10% for example.