### PR TITLE
Fix rare case of snapping not working when moving a clip cross tracks

### DIFF
--- a/src/qml/views/timeline/Track.js
+++ b/src/qml/views/timeline/Track.js
@@ -29,7 +29,7 @@ function snapClip(clip, repeater) {
         // Snap to other clips on the same track.
         for (var i = 0; i < repeater.count; i++) {
             // Do not snap to self.
-            if (i === clip.DelegateModel.itemsIndex && clip.trackIndex === repeater.itemAt(i).trackIndex)
+            if (i === clip.DelegateModel.itemsIndex && clip.originalTrackIndex === repeater.itemAt(i).originalTrackIndex)
                 continue
             var itemLeft = repeater.itemAt(i).x
             var itemRight = itemLeft + repeater.itemAt(i).width


### PR DESCRIPTION
A clip's `trackIndex` changes to the target track's index as soon as it's dragged to that track. 
`clip.trackIndex === repeater.itemAt(i).trackIndex` becomes less restrictive, and `if` clause will look for any clip that satisfy `i === clip.DelegateModel.itemsIndex` and prevents snapping to that clip.

A clip's `originalTrackIndex` doesn't change to the target track's index as soon as it's dragged to that track, so `if` clause will only prevents snapping to self.

For some reason, only changing `clip.trackIndex` to `originalTrackIndex` broke snapping when multiple clips are dragged across tracks. Changing `repeater.itemAt(i).trackIndex` to `originalTrackIndex` fixed it.