### PR TITLE
Fix erratic keyframe parameter height zoom function

### DIFF
--- a/src/qml/views/keyframes/Parameter.qml
+++ b/src/qml/views/keyframes/Parameter.qml
@@ -30,6 +30,11 @@ Item {
 
     signal clicked(var keyframe, var parameter)
 
+    function setLowestHighest(lh) {
+        minimum = lh ? model.lowest : model.minimum
+        maximum = lh ? model.highest : model.maximum
+    }
+
     function getKeyframeCount() {
         return keyframesRepeater.count
     }

--- a/src/qml/views/keyframes/Parameter.qml
+++ b/src/qml/views/keyframes/Parameter.qml
@@ -30,9 +30,9 @@ Item {
 
     signal clicked(var keyframe, var parameter)
 
-    function setLowestHighest(lh) {
-        minimum = lh ? model.lowest : model.minimum
-        maximum = lh ? model.highest : model.maximum
+    function setMinMax(zoomHeight) {
+        minimum = zoomHeight ? model.lowest : model.minimum
+        maximum = zoomHeight ? model.highest : model.maximum
     }
 
     function getKeyframeCount() {

--- a/src/qml/views/keyframes/ParameterHead.qml
+++ b/src/qml/views/keyframes/ParameterHead.qml
@@ -28,6 +28,7 @@ Rectangle {
     property bool selected: false
     property bool current: false
     property bool isCurve: false
+    property bool zoomHeight: false
     property int delegateIndex: -1
     signal clicked()
 
@@ -208,11 +209,15 @@ Rectangle {
                 focusPolicy: Qt.NoFocus
                 visible: delegateIndex >= 0 && paramHeadRoot.isCurve
                 checkable: true
+                checked: zoomHeight
                 action: Action {
                     id: zoomFitKeyframeAction
                     icon.name: 'zoom-fit-best'
                     icon.source: 'qrc:///icons/oxygen/32x32/actions/zoom-fit-best.png'
-                    onTriggered: root.paramRepeater.itemAt(delegateIndex).zoomHeight = checked
+                    onTriggered: {
+                        zoomHeight = !zoomHeight
+                        root.paramRepeater.itemAt(delegateIndex).setLowestHighest(zoomHeight)
+                    }
                 }
             }
         }

--- a/src/qml/views/keyframes/ParameterHead.qml
+++ b/src/qml/views/keyframes/ParameterHead.qml
@@ -216,7 +216,7 @@ Rectangle {
                     icon.source: 'qrc:///icons/oxygen/32x32/actions/zoom-fit-best.png'
                     onTriggered: {
                         zoomHeight = !zoomHeight
-                        root.paramRepeater.itemAt(delegateIndex).setLowestHighest(zoomHeight)
+                        root.paramRepeater.itemAt(delegateIndex).setMinMax(zoomHeight)
                     }
                 }
             }

--- a/src/qml/views/keyframes/keyframes.qml
+++ b/src/qml/views/keyframes/keyframes.qml
@@ -541,9 +541,8 @@ Rectangle {
             rootIndex: parameterDelegateModel.modelIndex(index)
             width: producer.duration * timeScale
             isCurve: model.isCurve
-            property bool zoomHeight: false
-            minimum: zoomHeight ? model.lowest : model.minimum
-            maximum: zoomHeight ? model.highest : model.maximum
+            minimum: model.minimum
+            maximum: model.maximum
             height: Logic.trackHeight(model.isCurve)
             onClicked: {
                 currentTrack = parameter.DelegateModel.itemsIndex


### PR DESCRIPTION
It looks like a parameter's `minimum` and `maximum` properties are constantly changing as I move a keyframe while `zoomHeight` is `true`.
I made `minimum` and `maximum` property modification one-time event in response to a click on the zoom icon.

`zoomHeight` can be made to be a property of a parameter rather than of a parameter head as it was in the original.