### PR TITLE
Further improve accuracy of bubblehelp

### DIFF
--- a/src/qml/views/keyframes/Clip.qml
+++ b/src/qml/views/keyframes/Clip.qml
@@ -429,8 +429,7 @@ Rectangle {
                     var newX = mapToItem(null, x, y).x
                     var delta = Math.round((newX - startX) / timeScale)
                     if (Math.abs(delta) > 0) {
-                        if (clipDuration + originalX + delta > 0)
-                            originalX += delta
+                        originalX += delta
                         clipRoot.trimmingIn(clipRoot, delta, mouse)
                         startX = newX
                     }

--- a/src/qml/views/timeline/Clip.qml
+++ b/src/qml/views/timeline/Clip.qml
@@ -562,8 +562,7 @@ Rectangle {
                     var newX = mapToItem(null, x, y).x
                     var delta = Math.round((newX - startX) / timeScale)
                     if (Math.abs(delta) > 0) {
-                        if (clipDuration + originalX + delta > 0)
-                            originalX += delta
+                        originalX += delta
                         clipRoot.trimmingIn(clipRoot, delta, mouse)
                         startX = newX
                     }


### PR DESCRIPTION
Previously, I didn't think the content of  `trimIn`'s `onPositionChanged` needed to be changed when it comes to bubblehelp.

But I found that `trimIn` handle's bubblehelp delta can also stop counting. This is particularly the case when a longer clip A is trimmed out by trimming in of a shorter clip B to create a transition. `originalX` delta accumulation stops when `clipDuration` stops increasing due to a transition being created.

The same line is deleted in `/keyframes/Clip.qml` though I didn't find any situation this line becomes a problem.