### PR TITLE
Various keyframe improvement

### DIFF
--- a/src/qml/views/keyframes/Keyframe.qml
+++ b/src/qml/views/keyframes/Keyframe.qml
@@ -35,8 +35,8 @@ Rectangle {
     property double trackValue: (0.5 - (value - minimum) / (maximum - minimum)) * (trackHeight - height - 2.0 * border.width)
     property double minDragX: activeClip.x - width/2
     property double maxDragX: activeClip.x + activeClip.width - width/2
-    property double minDragY: activeClip.y - width/2
-    property double maxDragY: activeClip.y + activeClip.height - width/2
+    property double minDragY: activeClip.y
+    property double maxDragY: activeClip.y + activeClip.height - width
     property bool inRange: position >= (filter.in - producer.in) && position <= (filter.out - producer.in)
 
     signal clicked(var keyframe)

--- a/src/qml/views/keyframes/Keyframe.qml
+++ b/src/qml/views/keyframes/Keyframe.qml
@@ -96,6 +96,12 @@ Rectangle {
                   drag.minimumY = minDragY
                   drag.maximumY = maxDragY
                }
+            }
+        }
+        onEntered: if (isCurve) parent.anchors.verticalCenter = undefined
+        onReleased: if (isCurve) parent.anchors.verticalCenter = parameterRoot.verticalCenter
+        onPositionChanged: {
+            if (isCurve) {
                if (mouse.modifiers & Qt.ControlModifier)
                    drag.axis = Drag.YAxis
                else if (mouse.modifiers & Qt.AltModifier)
@@ -103,10 +109,6 @@ Rectangle {
                else
                    drag.axis = Drag.XAndYAxis
             }
-        }
-        onEntered: if (isCurve) parent.anchors.verticalCenter = undefined
-        onReleased: if (isCurve) parent.anchors.verticalCenter = parameterRoot.verticalCenter
-        onPositionChanged: {
             var newPosition = Math.round((parent.x + parent.width/2) / timeScale)
             var keyPosition = newPosition - (filter.in - producer.in)
             var trackValue = Math.min(Math.max(0, 1.0 - parent.y / (parameterRoot.height - parent.height)), 1.0)

--- a/src/qml/views/keyframes/Keyframe.qml
+++ b/src/qml/views/keyframes/Keyframe.qml
@@ -75,7 +75,7 @@ Rectangle {
         anchors.fill: parent
         acceptedButtons: Qt.LeftButton
         onClicked: producer.position = position
-        onDoubleClicked: removeMenuItem.trigger()
+        onDoubleClicked: removeMenuItem.triggered()
         drag {
             target: parent
             axis: isCurve? Drag.XAndYAxis : Drag.XAxis


### PR DESCRIPTION
Slight adjustment to keyframe `DragY` bounds
- A keyframe can sink half way into the floor or go half way through the ceiling though Line 112
`var trackValue = Math.min(Math.max(0, 1.0 - parent.y / (parameterRoot.height - parent.height)), 1.0)`
is designed to allow a value between `parameterRoot.height - parent.height`.

Double-click no longer deleting keyframe
- Since a year ago or so when QT was upgraded, `trigger()` hasn't worked. Somehow it worked in older QT versions.

Ctrl and Alt during `onPositionChanged`
- If Ctrl and Alt key press checks are in `onPressed`, either key has to be pressed before a left mouse click. I don't think I have experienced that behavior in any other programs. Like in file explorers and forum text edit areas, I can typically be able to press Ctrl during a mouse movement to change the operation from moving to copying.
- I can also release Ctrl and Alt during a mouse movement, and X-axis or Y-axis movement lock is still intact. I also found it strange.

I didn't squash these commits because they look like separate issues. You can squash them upon merge because they look like a collection of tiny changes.