### PR TITLE
Fix corner pin VUI misalignment with video in response to window size change

### DIFF
--- a/src/qml/filters/corners/vui.qml
+++ b/src/qml/filters/corners/vui.qml
@@ -360,5 +360,10 @@ Shotcut.VuiBase {
         target: producer
         onPositionChanged: setCornersControl()
     }
+    
+    Connections {
+        target: video
+        onRectChanged: setCornersControl()
+    }
 }
 


### PR DESCRIPTION
Apply a corner pin filter to a clip and change the application window size horizontally or vertically.
Handle 2, 3, and 4 get misaligned as the width or height of the video is changed under zoom fit.

I added `onRectChanged` in another `Connections`, but I think `onZoomChanged` and `onOffsetChanged` are unnecessary because the first one is taken care of by `scale: zoom` of the `videoItem` `Item` element and the second is taken care of by `contentX: video.offset.x` and `contentY: video.offset.y` of the `Flickable` element.
