### PR TITLE
Remove video filters when detaching audio.

### DIFF
--- a/src/commands/timelinecommands.h
+++ b/src/commands/timelinecommands.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020 Meltytech, LLC
+ * Copyright (c) 2013-2021 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -538,7 +538,6 @@ private:
     int m_clipIndex;
     int m_position;
     int m_targetTrackIndex;
-    QString m_audioIndex;
     QString m_xml;
     UndoHelper m_undoHelper;
     bool m_trackAdded;


### PR DESCRIPTION
Remove video filters from the audio clip
Remove audio filters from the video clip

As reported here:
https://forum.shotcut.org/t/detach-audio-duplicates-video-filters-on-audio-and-leave-audio-filters-on-video/29795