### PR TITLE
Add menu option to move tracks up and down

### DIFF
--- a/src/commands/timelinecommands.cpp
+++ b/src/commands/timelinecommands.cpp
@@ -1215,6 +1215,30 @@ void RemoveTrackCommand::undo()
     }
 }
 
+MoveTrackCommand::MoveTrackCommand(MultitrackModel& model, int fromTrackIndex, int toTrackIndex, QUndoCommand* parent)
+    : QUndoCommand(parent)
+    , m_model(model)
+    , m_fromTrackIndex(qBound(0, fromTrackIndex, qMax(model.rowCount() - 1, 0)))
+    , m_toTrackIndex(qBound(0, toTrackIndex, qMax(model.rowCount() - 1, 0)))
+{
+    if (m_toTrackIndex < m_fromTrackIndex)
+        setText(QObject::tr("Move track down"));
+    else
+        setText(QObject::tr("Move track up"));
+}
+
+void MoveTrackCommand::redo()
+{
+    LOG_DEBUG() << "fromTrackIndex" << m_fromTrackIndex << "toTrackIndex" << m_toTrackIndex;
+    m_model.moveTrack(m_fromTrackIndex, m_toTrackIndex);
+}
+
+void MoveTrackCommand::undo()
+{
+    LOG_DEBUG() << "fromTrackIndex" << m_fromTrackIndex << "toTrackIndex" << m_toTrackIndex;
+    m_model.moveTrack(m_toTrackIndex, m_fromTrackIndex);
+}
+
 ChangeBlendModeCommand::ChangeBlendModeCommand(Mlt::Transition& transition, const QString& propertyName, const QString& mode, QUndoCommand* parent)
     : QUndoCommand(parent)
     , m_transition(transition)

--- a/src/commands/timelinecommands.h
+++ b/src/commands/timelinecommands.h
@@ -488,6 +488,18 @@ private:
     QScopedPointer<Mlt::Producer> m_filtersProducer;
 };
 
+class MoveTrackCommand : public QUndoCommand
+{
+public:
+    MoveTrackCommand(MultitrackModel& model, int fromTrackIndex, int toTrackIndex, QUndoCommand* parent = 0);
+    void redo();
+    void undo();
+private:
+    MultitrackModel& m_model;
+    int m_fromTrackIndex;
+    int m_toTrackIndex;
+};
+
 class ChangeBlendModeCommand : public QObject, public QUndoCommand
 {
     Q_OBJECT

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -494,6 +494,64 @@ void TimelineDock::removeTrack()
     }
 }
 
+void TimelineDock::moveTrackUp()
+{
+    int trackIndex = currentTrack();
+    const TrackList& trackList = m_model.trackList();
+    if (trackIndex >= trackList.size()) {
+        LOG_DEBUG() << "Track Index out of bounds" << trackIndex;
+        return;
+    }
+    if (trackList[trackIndex].type == VideoTrackType) {
+        bool topVideo = true;
+        foreach (const Track& t, trackList) {
+            if (t.type == VideoTrackType && t.number > trackList[trackIndex].number) {
+                topVideo = false;
+                break;
+            }
+        }
+        if (topVideo) {
+            LOG_DEBUG() << "Can not move top video track up" << trackIndex;
+            return;
+        }
+    }
+    if (trackList[trackIndex].number == 0 && trackList[trackIndex].type == AudioTrackType) {
+        LOG_DEBUG() << "Can not move top audio track up" << trackIndex;
+        return;
+    }
+    MAIN.undoStack()->push(new Timeline::MoveTrackCommand(m_model, trackIndex, trackIndex - 1));
+    setCurrentTrack(trackIndex - 1);
+}
+
+void TimelineDock::moveTrackDown()
+{
+    int trackIndex = currentTrack();
+    const TrackList& trackList = m_model.trackList();
+    if (trackIndex >= trackList.size()) {
+        LOG_DEBUG() << "Track Index out of bounds" << trackIndex;
+        return;
+    }
+    if (trackList[trackIndex].number == 0 && trackList[trackIndex].type == VideoTrackType) {
+        LOG_DEBUG() << "Can not move bottom video track down" << trackIndex;
+        return;
+    }
+    if (trackList[trackIndex].type == AudioTrackType) {
+        bool bottomAudio = true;
+        foreach (const Track& t, trackList) {
+            if (t.type == AudioTrackType && t.number > trackList[trackIndex].number) {
+                bottomAudio = false;
+                break;
+            }
+        }
+        if (bottomAudio) {
+            LOG_DEBUG() << "Can not move bottom audio track down" << trackIndex;
+            return;
+        }
+    }
+    MAIN.undoStack()->push(new Timeline::MoveTrackCommand(m_model, trackIndex, trackIndex + 1));
+    setCurrentTrack(trackIndex + 1);
+}
+
 bool TimelineDock::mergeClipWithNext(int trackIndex, int clipIndex, bool dryrun)
 {
     if (dryrun)

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -148,6 +148,8 @@ public slots:
     void insertAudioTrack();
     void insertVideoTrack();
     void removeTrack();
+    void moveTrackUp();
+    void moveTrackDown();
     void onProducerChanged(Mlt::Producer*);
     void emitSelectedFromSelection();
     void remakeAudioLevels(int trackIndex, int clipIndex, bool force = true);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3076,6 +3076,7 @@ void MainWindow::onMultitrackModified()
             }
         }
     }
+    MLT.refreshConsumer();
 }
 
 void MainWindow::onMultitrackDurationChanged()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2146,7 +2146,9 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
         }
         break;
     case Qt::Key_Up:
-        if (m_playlistDock->isVisible() && event->modifiers() & Qt::AltModifier && m_playlistDock->model()->rowCount() > 0) {
+        if (isMultitrackValid() && (event->modifiers() & Qt::AltModifier) && (event->modifiers() & Qt::AltModifier) && m_timelineDock->isVisible()) {
+            m_timelineDock->moveTrackUp();
+        } else if (m_playlistDock->isVisible() && event->modifiers() & Qt::AltModifier && m_playlistDock->model()->rowCount() > 0) {
             m_playlistDock->raise();
             m_playlistDock->decrementIndex();
             m_playlistDock->on_actionOpen_triggered();
@@ -2176,7 +2178,9 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
         }
         break;
     case Qt::Key_Down:
-        if (m_playlistDock->isVisible() && event->modifiers() & Qt::AltModifier && m_playlistDock->model()->rowCount() > 0) {
+        if (isMultitrackValid() && (event->modifiers() & Qt::AltModifier) && (event->modifiers() & Qt::ShiftModifier) && m_timelineDock->isVisible()) {
+            m_timelineDock->moveTrackDown();
+        } else if (m_playlistDock->isVisible() && event->modifiers() & Qt::AltModifier && m_playlistDock->model()->rowCount() > 0) {
             m_playlistDock->raise();
             m_playlistDock->incrementIndex();
             m_playlistDock->on_actionOpen_triggered();

--- a/src/models/multitrackmodel.h
+++ b/src/models/multitrackmodel.h
@@ -71,8 +71,11 @@ public:
         FileHashRole,    /// clip only
         SpeedRole,       /// clip only
         IsFilteredRole,
+        IsTopVideoRole,   /// track only
         IsBottomVideoRole,/// track only
-        AudioIndexRole   /// clip only
+        IsTopAudioRole,   /// track only
+        IsBottomAudioRole,/// track only
+        AudioIndexRole    /// clip only
     };
 
     explicit MultitrackModel(QObject *parent = 0);
@@ -106,6 +109,7 @@ public:
     void setScaleFactor(double scale);
     bool isTransition(Mlt::Playlist& playlist, int clipIndex) const;
     void insertTrack(int trackIndex, TrackType type = VideoTrackType);
+    void moveTrack(int fromTrackIndex, int toTrackIndex);
     void insertOrAdjustBlankAt(QList<int> tracks, int position, int length);
     bool mergeClipWithNext(int trackIndex, int clipIndex, bool dryrun);
     Mlt::ClipInfo *findClipByUuid(const QUuid& uuid, int& trackIndex, int& clipIndex);

--- a/src/qml/views/timeline/TrackHead.qml
+++ b/src/qml/views/timeline/TrackHead.qml
@@ -29,7 +29,10 @@ Rectangle {
     property bool isLocked
     property bool isVideo
     property bool isFiltered
+    property bool isTopVideo
     property bool isBottomVideo
+    property bool isTopAudio
+    property bool isBottomAudio
     property bool selected: false
     property bool current: false
     signal clicked()

--- a/src/qml/views/timeline/timeline.qml
+++ b/src/qml/views/timeline/timeline.qml
@@ -220,7 +220,10 @@ Rectangle {
                             isLocked: model.locked
                             isVideo: !model.audio
                             isFiltered: model.filtered
+                            isTopVideo: model.isTopVideo
                             isBottomVideo: model.isBottomVideo
+                            isTopAudio: model.isTopAudio
+                            isBottomAudio: model.isBottomAudio
                             width: headerWidth
                             height: Logic.trackHeight(model.audio)
                             current: index === currentTrack
@@ -517,6 +520,16 @@ Rectangle {
             MenuItem {
                 text: qsTr('Remove Track') + (application.OS === 'OS X'? '    ⌥⌘U' : ' (Ctrl+Alt+U)')
                 onTriggered: timeline.removeTrack()
+            }
+            MenuItem {
+                text: qsTr('Move Track Up')
+                enabled: !trackHeaderRepeater.itemAt(currentTrack).isTopVideo && !trackHeaderRepeater.itemAt(currentTrack).isTopAudio
+                onTriggered: timeline.moveTrackUp()
+            }
+            MenuItem {
+                text: qsTr('Move Track Down')
+                enabled: !trackHeaderRepeater.itemAt(currentTrack).isBottomVideo && !trackHeaderRepeater.itemAt(currentTrack).isBottomAudio
+                onTriggered: timeline.moveTrackDown()
             }
         }
         Menu {

--- a/src/qml/views/timeline/timeline.qml
+++ b/src/qml/views/timeline/timeline.qml
@@ -499,6 +499,7 @@ Rectangle {
         id: menu
         Menu {
             title: qsTr('Track Operations')
+            width: 230
             MenuItem {
                 text: qsTr('Add Audio Track') + (application.OS === 'OS X'? '    ⌘U' : ' (Ctrl+U)')
                 onTriggered: timeline.addAudioTrack();
@@ -522,12 +523,12 @@ Rectangle {
                 onTriggered: timeline.removeTrack()
             }
             MenuItem {
-                text: qsTr('Move Track Up')
+                text: qsTr('Move Track Up') + (application.OS === 'OS X'? '    ⌥⇧↑' : ' (Alt+Shift+↑)')
                 enabled: !trackHeaderRepeater.itemAt(currentTrack).isTopVideo && !trackHeaderRepeater.itemAt(currentTrack).isTopAudio
                 onTriggered: timeline.moveTrackUp()
             }
             MenuItem {
-                text: qsTr('Move Track Down')
+                text: qsTr('Move Track Down') + (application.OS === 'OS X'? '    ⌥⇧↓' : ' (Alt+Shift+↓)')
                 enabled: !trackHeaderRepeater.itemAt(currentTrack).isBottomVideo && !trackHeaderRepeater.itemAt(currentTrack).isBottomAudio
                 onTriggered: timeline.moveTrackDown()
             }


### PR DESCRIPTION
Added simple move up/down options in the track context menu

![image](https://user-images.githubusercontent.com/821968/149844858-db0db0ee-5e20-40f6-8ddb-624c8f2a53a3.png)

Any suggestions for keyboard shortcuts?