### PR TITLE
Improve audio distortion when reversing a clip.

### DIFF
--- a/src/widgets/avformatproducerwidget.cpp
+++ b/src/widgets/avformatproducerwidget.cpp
@@ -1122,11 +1122,12 @@ void AvformatProducerWidget::on_reverseButton_clicked()
         if (m_producer->get_int("video_index") == -1)
             meltArgs << "vn=1" << "video_off=1";
 
+        ffmpegArgs << "-f" << "mov" << "-codec:a" << "alac";
+
         switch (dialog.format()) {
         case 0:
             path.append("/%1 - %2.mp4");
             nameFilter = tr("MP4 (*.mp4);;All Files (*)");
-            ffmpegArgs << "-f" << "mov" << "-codec:a" << "alac";
             if (ui->scanComboBox->currentIndex()) { // progressive
                 ffmpegArgs << "-codec:v" << "dnxhd" << "-profile:v" << "dnxhr_hq" << "-pix_fmt" << "yuv422p";
             } else { // interlaced
@@ -1137,7 +1138,6 @@ void AvformatProducerWidget::on_reverseButton_clicked()
             meltArgs << "vpreset=medium" << "g=1" << "crf=11";
             break;
         case 1:
-            ffmpegArgs << "-f" << "mov" << "-codec:a" << "alac";
             meltArgs << "acodec=alac";
             if (ui->scanComboBox->currentIndex()) { // progressive
                 ffmpegArgs << "-codec:v" << "dnxhd" << "-profile:v" << "dnxhr_hq" << "-pix_fmt" << "yuv422p";
@@ -1151,9 +1151,7 @@ void AvformatProducerWidget::on_reverseButton_clicked()
             nameFilter = tr("MOV (*.mov);;All Files (*)");
             break;
         case 2:
-            ffmpegSuffix = "mkv";
-            ffmpegArgs << "-f" << "matroska" << "-codec:a" << "pcm_s32le" << "-codec:v" << "utvideo";
-            ffmpegArgs << "-pix_fmt" << "yuv422p";
+            ffmpegArgs << "-codec:v" << "utvideo" << "-pix_fmt" << "yuv422p";
             if (!ui->scanComboBox->currentIndex()) { // interlaced
                 meltArgs << "field_order=" + QString::fromLatin1(ui->fieldOrderComboBox->currentIndex()? "tt" : "bb");
             }


### PR DESCRIPTION
Use eac3 and mov for all intermediate files for reverse. This
combination results in the best audio syncing and the least
artifacts when reversing a clip.

As reported here:
https://forum.shotcut.org/t/reversing-a-clip-on-linux-causes-the-audio-to-crackle/31713

This proposed combination was found through experimentation (trial and error).

ac3 and eac3 are the only audio formats that I can find that result in zero distortions in my tests. Even PCM has occasional distortion. I assume this is due to better seeking to AC3 frames. But I do not know why the seeking would be better for that format. So I chose eac3 @ 640kbps for all quality levels (good, better, best).

Of all the quality levels, "best" had the worst distortion - even when using eac3 for audio. In the decoding log, I see this error:

> [matroska,webm @ 0x55bd10939e80] parser not found for codec utvideo, packets or times may be invalid.
> [matroska,webm @ 0x55bd10939e80] parser not found for codec pcm_s32le, packets or times may be invalid.

In this change, I change intermediates for all quality levels to use MOV format. Using MOV, I do not see the above errors, and I do not hear any distortion in the audio.

Throwing this out for review in case anyone has any other insights worth trying. I do not know if this worked perfectly in the past and suffered a regression when FFMpeg was upgraded. I just know these combinations work pretty good in my tests.