### PR TITLE
Use the word "name" to lable the marker text field

### DIFF
--- a/src/docks/markersdock.cpp
+++ b/src/docks/markersdock.cpp
@@ -193,7 +193,7 @@ MarkersDock::MarkersDock(QWidget *parent) :
     action = moreMenu->addAction(tr("Color"), this, SLOT(onColorColumnToggled(bool)));
     action->setCheckable(true);
     action->setChecked(Settings.markersShowColumn("color"));
-    action = moreMenu->addAction(tr("Text"), this, SLOT(onTextColumnToggled(bool)));
+    action = moreMenu->addAction(tr("Name"), this, SLOT(onTextColumnToggled(bool)));
     action->setCheckable(true);
     action->setChecked(Settings.markersShowColumn("text"));
     action = moreMenu->addAction(tr("Start"), this, SLOT(onStartColumnToggled(bool)));

--- a/src/models/markersmodel.cpp
+++ b/src/models/markersmodel.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Meltytech, LLC
+ * Copyright (c) 2021-2022 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@
 
 enum Columns {
     COLUMN_COLOR = 0,
-    COLUMN_TEXT,
+    COLUMN_NAME,
     COLUMN_START,
     COLUMN_END,
     COLUMN_DURATION,
@@ -651,7 +651,7 @@ QVariant MarkersModel::data(const QModelIndex& index, int role) const
                 case COLUMN_COLOR:
                     result = marker.color;
                     break;
-                case COLUMN_TEXT:
+                case COLUMN_NAME:
                     result = marker.text;
                     break;
                 case COLUMN_START:
@@ -711,8 +711,8 @@ QVariant MarkersModel::headerData(int section, Qt::Orientation orientation, int 
         switch (section) {
         case COLUMN_COLOR:
             return tr("Color");
-        case COLUMN_TEXT:
-            return tr("Marker");
+        case COLUMN_NAME:
+            return tr("Name");
         case COLUMN_START:
             return tr("Start");
         case COLUMN_END:

--- a/src/widgets/editmarkerwidget.cpp
+++ b/src/widgets/editmarkerwidget.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Meltytech, LLC
+ * Copyright (c) 2021-2022 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -42,7 +42,7 @@ EditMarkerWidget::EditMarkerWidget(QWidget *parent, const QString& text, const Q
 
     m_textField = new QLineEdit(text);
     connect(m_textField, SIGNAL(editingFinished()), SIGNAL(valuesChanged()));
-    m_textField->setToolTip(tr("Set the text for this marker."));
+    m_textField->setToolTip(tr("Set the name for this marker."));
     grid->addWidget(m_textField, 0, 0, 1, 2);
 
     m_colorButton = new QPushButton(tr("Color..."));


### PR DESCRIPTION
As suggested here:
https://forum.shotcut.org/t/fix-name-of-column-in-markers-panel/31957

Staging in this pull request because it changes translation strings and we may want to wait until after the next release.