### PR TITLE
Add job priority menu option

### DIFF
--- a/src/jobs/abstractjob.h
+++ b/src/jobs/abstractjob.h
@@ -49,6 +49,7 @@ public:
     void setPostJobAction(PostJobAction* action);
 
 public slots:
+    void start(const QString &program, const QStringList &arguments);
     virtual void start();
     virtual void stop();
 

--- a/src/jobs/ffmpegjob.cpp
+++ b/src/jobs/ffmpegjob.cpp
@@ -55,15 +55,7 @@ void FfmpegJob::start()
     QFileInfo ffmpegPath(shotcutPath, "ffmpeg");
     setReadChannel(QProcess::StandardError);
     LOG_DEBUG() << ffmpegPath.absoluteFilePath() + " " + m_args.join(' ');
-#ifdef Q_OS_WIN
-    QProcess::start(ffmpegPath.absoluteFilePath(), m_args);
-#else
-    m_args.prepend(ffmpegPath.absoluteFilePath());
-    m_args.prepend("3");
-    m_args.prepend("-n");
-    QProcess::start("nice", m_args);
-#endif
-    AbstractJob::start();
+    AbstractJob::start(ffmpegPath.absoluteFilePath(), m_args);
 }
 
 void FfmpegJob::onOpenTriggered()

--- a/src/jobs/ffprobejob.cpp
+++ b/src/jobs/ffprobejob.cpp
@@ -44,8 +44,7 @@ void FfprobeJob::start()
     QFileInfo ffprobePath(shotcutPath, "ffprobe");
     setReadChannel(QProcess::StandardOutput);
     LOG_DEBUG() << ffprobePath.absoluteFilePath()  + " " + m_args.join(' ');
-    QProcess::start(ffprobePath.absoluteFilePath(), m_args);
-    AbstractJob::start();
+    AbstractJob::start(ffprobePath.absoluteFilePath(), m_args);
 }
 
 void FfprobeJob::onFinished(int exitCode, QProcess::ExitStatus exitStatus)

--- a/src/jobs/meltjob.cpp
+++ b/src/jobs/meltjob.cpp
@@ -129,14 +129,8 @@ void MeltJob::start()
 #endif
 #ifdef Q_OS_WIN
     if (m_isStreaming) args << "-getc";
-    QProcess::start(meltPath.absoluteFilePath(), args);
-#else
-    args.prepend(meltPath.absoluteFilePath());
-    args.prepend("3");
-    args.prepend("-n");
-    QProcess::start("nice", args);
 #endif
-    AbstractJob::start();
+    AbstractJob::start(meltPath.absoluteFilePath(), args);
 }
 
 QString MeltJob::xml()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -879,6 +879,15 @@ void MainWindow::setupSettingsMenu()
     ui->menuDrawingMethod = 0;
 #endif
 
+    // Setup the job priority actions
+    group = new QActionGroup(this);
+    group->addAction(ui->actionJobPriorityLow);
+    group->addAction(ui->actionJobPriorityNormal);
+    if (Settings.jobPriority() == "low")
+        ui->actionJobPriorityLow->setChecked(true);
+    else
+        ui->actionJobPriorityNormal->setChecked(true);
+
     // Add custom layouts to View > Layout submenu.
     m_layoutGroup = new QActionGroup(this);
     connect(m_layoutGroup, SIGNAL(triggered(QAction*)), SLOT(onLayoutTriggered(QAction*)));
@@ -3791,6 +3800,16 @@ void MainWindow::on_actionFusionLight_triggered()
 {
     Settings.setTheme("light");
     restartAfterChangeTheme();
+}
+
+void MainWindow::on_actionJobPriorityLow_triggered()
+{
+    Settings.setJobPriority("low");
+}
+
+void MainWindow::on_actionJobPriorityNormal_triggered()
+{
+    Settings.setJobPriority("normal");
 }
 
 void MainWindow::on_actionTutorials_triggered()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -281,6 +281,8 @@ private slots:
     void onLanguageTriggered(QAction*);
     void on_actionSystemTheme_triggered();
     void on_actionFusionDark_triggered();
+    void on_actionJobPriorityLow_triggered();
+    void on_actionJobPriorityNormal_triggered();
     void on_actionFusionLight_triggered();
     void on_actionTutorials_triggered();
     void on_actionRestoreLayout_triggered();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -189,6 +189,13 @@
      <addaction name="actionDrawingDirectX"/>
      <addaction name="actionDrawingSoftware"/>
     </widget>
+    <widget class="QMenu" name="menuJobPriority">
+     <property name="title">
+      <string>Job Priority</string>
+     </property>
+     <addaction name="actionJobPriorityLow"/>
+     <addaction name="actionJobPriorityNormal"/>
+    </widget>
     <widget class="QMenu" name="menuData_Directory">
      <property name="title">
       <string>App Data Directory</string>
@@ -245,6 +252,7 @@
     <addaction name="menuLanguage"/>
     <addaction name="menuTheme"/>
     <addaction name="menuDrawingMethod"/>
+    <addaction name="menuJobPriority"/>
     <addaction name="menuData_Directory"/>
     <addaction name="actionClearRecentOnExit"/>
    </widget>
@@ -809,6 +817,22 @@
    </property>
    <property name="text">
     <string extracomment="Do not translate &quot;Mesa&quot;">Software (Mesa)</string>
+   </property>
+  </action>
+  <action name="actionJobPriorityLow">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Low</string>
+   </property>
+  </action>
+  <action name="actionJobPriorityNormal">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Normal</string>
    </property>
   </action>
   <action name="actionApplicationLog">

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -134,6 +134,16 @@ void ShotcutSettings::setTheme(const QString& s)
     settings.setValue("theme", s);
 }
 
+QString ShotcutSettings::jobPriority() const
+{
+    return settings.value("jobPriority", "low").toString();
+}
+
+void ShotcutSettings::setJobPriority(const QString& s)
+{
+    settings.setValue("jobPriority", s);
+}
+
 bool ShotcutSettings::showTitleBars() const
 {
     return settings.value("titleBars", true).toBool();

--- a/src/settings.h
+++ b/src/settings.h
@@ -68,6 +68,8 @@ public:
     void setRecent(const QStringList&);
     QString theme() const;
     void setTheme(const QString&);
+    QString jobPriority() const;
+    void setJobPriority(const QString&);
     bool showTitleBars() const;
     void setShowTitleBars(bool);
     bool showToolBar() const;


### PR DESCRIPTION
Staging this here for the next release and for discussion.

Added a menu option to choose "low" or "normal" priority for jobs

![image](https://user-images.githubusercontent.com/821968/151103999-337c34d7-3ab1-4be6-864a-7e1739a78296.png)

As suggested here:
https://forum.shotcut.org/t/melt-exe-priority-vs-alder-lake-on-windows-10/31706