### PR TITLE
Add drag track headers to reorder

### DIFF
--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -479,6 +479,25 @@ void TimelineDock::removeTrack()
     }
 }
 
+void TimelineDock::moveTrack(int fromTrackIndex, int toTrackIndex)
+{
+    const TrackList& trackList = m_model.trackList();
+    if (fromTrackIndex >= trackList.size()) {
+        LOG_DEBUG() << "From track index out of bounds" << fromTrackIndex;
+        return;
+    }
+    if (toTrackIndex >= trackList.size()) {
+        LOG_DEBUG() << "To track index out of bounds" << toTrackIndex;
+        return;
+    }
+    if (trackList[fromTrackIndex].type != trackList[toTrackIndex].type) {
+        LOG_DEBUG() << "From/To track types do not match";
+        return;
+    }
+    MAIN.undoStack()->push(new Timeline::MoveTrackCommand(m_model, fromTrackIndex, toTrackIndex));
+    setCurrentTrack(toTrackIndex);
+}
+
 void TimelineDock::moveTrackUp()
 {
     int trackIndex = currentTrack();

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -155,6 +155,7 @@ public slots:
     void insertAudioTrack();
     void insertVideoTrack();
     void removeTrack();
+    void moveTrack(int fromTrackIndex, int toTrackIndex);
     void moveTrackUp();
     void moveTrackDown();
     void onProducerChanged(Mlt::Producer*);

--- a/src/qml/views/timeline/TrackHead.qml
+++ b/src/qml/views/timeline/TrackHead.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2021 Meltytech, LLC
+ * Copyright (c) 2013-2022 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -100,7 +100,10 @@ Rectangle {
         anchors {
             top: parent.top
             left: parent.left
-            margins: (trackHeadRoot.height < 50)? 0 : 4
+            leftMargin: 8
+            rightMargin: (trackHeadRoot.height < 50)? 0 : 4
+            topMargin: (trackHeadRoot.height < 50)? 0 : 4
+            bottomMargin: (trackHeadRoot.height < 50)? 0 : 4
         }
 
         Rectangle {


### PR DESCRIPTION
This is my first attempt at drag-n-drop track reordering. The track headers have an added handle on the left size. When the user hovers the mouse over the handle, and expands and allows the user to drag the track header. Other track headers highlight with a green outline if they are a valid drop target.

![drag_track](https://user-images.githubusercontent.com/821968/154827581-6669fbe5-c036-473d-ae56-c4b614a6ee74.gif)

Feedback is welcome.

Also, any ideas about how to keep this code from exploding in size and complexity? Maybe i should pull out the track header column into its own file to reduce the levels of hirearchy.
