### PR TITLE
Add tootip to timeline clips

### DIFF
--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -1098,7 +1098,7 @@ bool TimelineDock::blockSelection(bool block)
 void TimelineDock::onProducerModified()
 {
     // The clip name may have changed.
-    emitSelectedChanged(QVector<int>() << MultitrackModel::NameRole);
+    emitSelectedChanged(QVector<int>() << MultitrackModel::NameRole << MultitrackModel::CommentRole);
 }
 
 void TimelineDock::replace(int trackIndex, int clipIndex, const QString& xml)

--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -117,6 +117,13 @@ QVariant MultitrackModel::data(const QModelIndex &index, int role) const
                 }
                 return result;
             }
+            case CommentRole: {
+                QString result;
+                if (info->producer && info->producer->is_valid()) {
+                    result = info->producer->get(kCommentProperty);
+                }
+                return result;
+            }
             case ResourceRole:
             case Qt::DisplayRole: {
                 QString result = QString::fromUtf8(info->resource);
@@ -293,6 +300,7 @@ QHash<int, QByteArray> MultitrackModel::roleNames() const
 {
     QHash<int, QByteArray> roles;
     roles[NameRole] = "name";
+    roles[CommentRole] = "comment";
     roles[ResourceRole] = "resource";
     roles[ServiceRole] = "mlt_service";
     roles[IsBlankRole] = "blank";

--- a/src/models/multitrackmodel.h
+++ b/src/models/multitrackmodel.h
@@ -51,6 +51,7 @@ public:
     /// Two level model: tracks and clips on track
     enum {
         NameRole = Qt::UserRole + 1,
+        CommentRole,     /// clip only
         ResourceRole,    /// clip only
         ServiceRole,     /// clip only
         IsBlankRole,     /// clip only

--- a/src/qml/modules/Shotcut/Controls/HoverTip.qml
+++ b/src/qml/modules/Shotcut/Controls/HoverTip.qml
@@ -26,7 +26,7 @@ MouseArea {
 
     ToolTip {
         id: tip
-        visible: text ? parent.containsMouse : false
+        visible: text ? parent.containsMouse & parent.enabled : false
         delay: 1000
         timeout: 5000
         Component.onCompleted: parent.hoverEnabled = true

--- a/src/qml/views/timeline/Clip.qml
+++ b/src/qml/views/timeline/Clip.qml
@@ -22,6 +22,7 @@ import Shotcut.Controls 1.0 as Shotcut
 Rectangle {
     id: clipRoot
     property string clipName: ''
+    property string clipComment: ''
     property string clipResource: ''
     property string mltService: ''
     property int inPoint: 0
@@ -275,6 +276,31 @@ Rectangle {
             }
         }
     ]
+
+    Shotcut.HoverTip {
+        text: clipName + "\n" + clipComment
+        enabled: !isBlank && !mouseArea.drag.active
+        onEntered: {
+            text = clipName
+            if (clipComment != '') {
+                // Limit comments to 3 lines and 45 characters per line
+                var commentLines = clipComment.split('\n')
+                var lines = 0
+                for (var i = 0; i < commentLines.length && lines < 3; i++) {
+                    var commentLine = commentLines[i]
+                    if (commentLine.length == 0) {
+                        continue
+                    }
+                    if (commentLine.length > 50) {
+                        commentLine = commentLine.substring(0, 50) + "...";
+                    }
+                    text += "\n" + commentLine
+                    lines++
+                }
+            }
+            text += "\n"  + application.timecode(clipDuration)
+        }
+    }
 
     MouseArea {
         anchors.fill: parent

--- a/src/qml/views/timeline/Track.qml
+++ b/src/qml/views/timeline/Track.qml
@@ -67,6 +67,7 @@ Rectangle {
         id: trackModel
         Clip {
             clipName: model.name
+            clipComment: model.comment
             clipResource: model.resource
             clipDuration: model.duration
             mltService: model.mlt_service


### PR DESCRIPTION
Show clip name, comment and duration

As suggested here:
https://forum.shotcut.org/t/show-clips-comments-in-the-timeline/32131/3

This uses the standard tooltip which has a delayed popup after hover

![image](https://user-images.githubusercontent.com/821968/155065046-ec65245d-6dea-4959-9f1e-2fd56d554034.png)
