### PR TITLE
Implement new box blur filter based on new MLT box_blur

### DIFF
--- a/src/qml/filters/blur/meta_box_blur_2.qml
+++ b/src/qml/filters/blur/meta_box_blur_2.qml
@@ -4,29 +4,28 @@ import org.shotcut.qml 1.0
 Metadata {
     type: Metadata.Filter
     name: qsTr("Blur: Box")
-    mlt_service: "boxblur"
-    qml: "ui_boxblur.qml"
+    mlt_service: "box_blur"
+    qml: "ui_box_blur_2.qml"
     gpuAlt: "movit.blur"
-    isHidden: true
     keyframes {
         minimumVersion: '3'
         allowAnimateIn: true
         allowAnimateOut: true
-        simpleProperties: ['hori', 'vert']
+        simpleProperties: ['hradius', 'vradius']
         parameters: [
             Parameter {
-                name: qsTr('Width')
-                property: 'hori'
+                name: qsTr('Horizontal')
+                property: 'hradius'
                 isCurve: true
                 minimum: 0
-                maximum: 99
+                maximum: 100
             },
             Parameter {
-                name: qsTr('Height')
-                property: 'vert'
+                name: qsTr('Vertical')
+                property: 'vradius'
                 isCurve: true
                 minimum: 0
-                maximum: 99
+                maximum: 100
             }
         ]
     }

--- a/src/qml/filters/blur/ui_box_blur_2.qml
+++ b/src/qml/filters/blur/ui_box_blur_2.qml
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2022 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
+import Shotcut.Controls 1.0 as Shotcut
+
+Shotcut.KeyframableFilter {
+    width: 200
+    height: 50
+
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set('hradius', 5)
+            filter.set('vradius', 5)
+            filter.savePreset(preset.parameters)
+        }
+        setControls()
+    }
+
+    function getPosition() {
+        return Math.max(producer.position - (filter.in - producer.in), 0)
+    }
+    
+    function setControls() {
+        var position = getPosition()
+        blockUpdate = true
+        wslider.value = filter.getDouble('hradius', position)
+        widthKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('hradius') > 0
+        hslider.value = filter.getDouble('vradius', position)
+        heightKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('vradius') > 0
+        blockUpdate = false
+        enableControls(isSimpleKeyframesActive())
+    }
+
+    function enableControls(enabled) {
+        wslider.enabled = hslider.enabled = enabled
+    }
+
+    function updateSimpleKeyframes() {
+        updateFilter('hradius', wslider.value, widthKeyframesButton, null)
+        updateFilter('vradius', hslider.value, heightKeyframesButton, null)
+    }
+
+    GridLayout {
+        columns: 4
+        anchors.fill: parent
+        anchors.margins: 8
+
+        Label {
+            text: qsTr('Preset')
+            Layout.alignment: Qt.AlignRight
+        }
+        Shotcut.Preset {
+            id: preset
+            Layout.columnSpan: parent.columns - 1
+            parameters: ['hradius', 'vradius']
+            onBeforePresetLoaded: {
+                filter.resetProperty('hradius')
+                filter.resetProperty('vradius')
+            }
+            onPresetSelected: {
+                setControls()
+                initializeSimpleKeyframes()
+            }
+        }
+
+        Label {
+            text: qsTr('Horizontal Radius')
+            Layout.alignment: Qt.AlignRight
+        }
+        Shotcut.SliderSpinner {
+            id: wslider
+            minimumValue: 0
+            maximumValue: 100
+            stepSize: .1
+            decimals: 1
+            suffix: ' %'
+            onValueChanged: updateFilter('hradius', wslider.value, widthKeyframesButton, getPosition())
+        }
+        Shotcut.UndoButton {
+            onClicked: wslider.value = 1
+        }
+        Shotcut.KeyframesButton {
+            id: widthKeyframesButton
+            onToggled: {
+                enableControls(true)
+                toggleKeyframes(checked, 'hradius', wslider.value)
+            }
+        }
+
+        Label {
+            text: qsTr('Vertical Radius')
+            Layout.alignment: Qt.AlignRight
+        }
+        Shotcut.SliderSpinner {
+            id: hslider
+            minimumValue: 0
+            maximumValue: 100
+            stepSize: .1
+            decimals: 1
+            suffix: ' %'
+            onValueChanged: updateFilter('vradius', hslider.value, heightKeyframesButton, getPosition())
+        }
+        Shotcut.UndoButton {
+            onClicked: hslider.value = 5
+        }
+        Shotcut.KeyframesButton {
+            id: heightKeyframesButton
+            onToggled: {
+                enableControls(true)
+                toggleKeyframes(checked, 'vradius', hslider.value)
+            }
+        }
+
+        Item {
+            Layout.fillHeight: true
+        }
+    }
+
+    Connections {
+        target: filter
+        onChanged: setControls()
+        onInChanged: updateSimpleKeyframes()
+        onOutChanged: updateSimpleKeyframes()
+        onAnimateInChanged: updateSimpleKeyframes()
+        onAnimateOutChanged: updateSimpleKeyframes()
+        onPropertyChanged: setControls()
+    }
+
+    Connections {
+        target: producer
+        onPositionChanged: setControls()
+    }
+}


### PR DESCRIPTION
Hide the old filter for backwards compatibility.

Depends on this: https://github.com/mltframework/mlt/pull/776

Provides h/v values in the range of 0-100% (which really maps to a radius of 0-10% of image width in the MLT filter)

![image](https://user-images.githubusercontent.com/821968/156942716-a973e945-0236-466d-bf16-4d7e6ac00e84.png)
