### PR TITLE
Add Align to Reference option in timeline

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,8 @@ add_executable(shotcut
   docks/recentdock.cpp
   docks/encodedock.cpp
   dialogs/addencodepresetdialog.cpp
+  dialogs/alignaudiodialog.cpp
+  dialogs/alignmentarray.cpp
   dialogs/filedatedialog.cpp
   jobqueue.cpp
   docks/jobsdock.cpp
@@ -57,6 +59,7 @@ add_executable(shotcut
   docks/playlistdock.cpp
   dialogs/durationdialog.cpp
   widgets/colorwheel.cpp
+  models/alignclipsmodel.cpp
   models/attachedfiltersmodel.cpp
   models/metadatamodel.cpp
   docks/filtersdock.cpp

--- a/src/commands/timelinecommands.cpp
+++ b/src/commands/timelinecommands.cpp
@@ -1466,7 +1466,7 @@ void ReplaceCommand::undo()
     m_isFirstRedo = false;
 }
 
-AlignCLipsCommand::AlignCLipsCommand(MultitrackModel &model, QUndoCommand *parent)
+AlignClipsCommand::AlignClipsCommand(MultitrackModel &model, QUndoCommand *parent)
     : QUndoCommand(parent)
     , m_model(model)
     , m_undoHelper(m_model)
@@ -1477,7 +1477,7 @@ AlignCLipsCommand::AlignCLipsCommand(MultitrackModel &model, QUndoCommand *paren
     setText(QObject::tr("Align clips to reference track"));
 }
 
-void AlignCLipsCommand::addAlignment(QUuid uuid, int offset, double speedCompensation)
+void AlignClipsCommand::addAlignment(QUuid uuid, int offset, double speedCompensation)
 {
     Alignment alignment;
     alignment.uuid = uuid;
@@ -1486,7 +1486,7 @@ void AlignCLipsCommand::addAlignment(QUuid uuid, int offset, double speedCompens
     m_alignments.append(alignment);
 }
 
-void AlignCLipsCommand::redo()
+void AlignClipsCommand::redo()
 {
     struct ClipItem {
         Mlt::Producer* clip;
@@ -1522,7 +1522,7 @@ void AlignCLipsCommand::redo()
     }
 }
 
-void AlignCLipsCommand::undo()
+void AlignClipsCommand::undo()
 {
     m_undoHelper.undoChanges();
 }

--- a/src/commands/timelinecommands.h
+++ b/src/commands/timelinecommands.h
@@ -571,6 +571,28 @@ private:
     UndoHelper m_undoHelper;
 };
 
+
+class AlignCLipsCommand : public QUndoCommand
+{
+public:
+    AlignCLipsCommand(MultitrackModel& model, QUndoCommand * parent = 0);
+    void addAlignment(QUuid uuid, int offset, double speedCompensation);
+    void redo();
+    void undo();
+
+private:
+    MultitrackModel& m_model;
+    UndoHelper m_undoHelper;
+    bool m_redo;
+    struct Alignment {
+        QUuid uuid;
+        int offset;
+        double speedCompensation;
+    };
+    QVector<Alignment> m_alignments;
+};
+
+
 } // namespace Timeline
 
 #endif

--- a/src/commands/timelinecommands.h
+++ b/src/commands/timelinecommands.h
@@ -572,10 +572,10 @@ private:
 };
 
 
-class AlignCLipsCommand : public QUndoCommand
+class AlignClipsCommand : public QUndoCommand
 {
 public:
-    AlignCLipsCommand(MultitrackModel& model, QUndoCommand * parent = 0);
+    AlignClipsCommand(MultitrackModel& model, QUndoCommand * parent = 0);
     void addAlignment(QUuid uuid, int offset, double speedCompensation);
     void redo();
     void undo();

--- a/src/dialogs/alignaudiodialog.cpp
+++ b/src/dialogs/alignaudiodialog.cpp
@@ -1,0 +1,429 @@
+/*
+ * Copyright (c) 2022 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "alignaudiodialog.h"
+
+#include "mainwindow.h"
+#include "commands/timelinecommands.h"
+#include "dialogs/alignmentarray.h"
+#include "dialogs/longuitask.h"
+#include "mltcontroller.h"
+#include "proxymanager.h"
+#include "settings.h"
+#include "shotcut_mlt_properties.h"
+#include "util.h"
+#include "models/multitrackmodel.h"
+#include "qmltypes/qmlapplication.h"
+#include <Logger.h>
+
+#include <QApplication>
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QIcon>
+#include <QLabel>
+#include <QPushButton>
+#include <QStyledItemDelegate>
+#include <QTreeView>
+
+class AudioReader : public QObject
+{
+    Q_OBJECT
+public:
+    AudioReader(QString producerXml, AlignmentArray* array)
+      : QObject()
+      , m_producerXml(producerXml)
+      , m_array(array)
+    {
+    }
+
+    void init(int maxLength)
+    {
+        m_array->init(maxLength);
+    }
+
+    void process()
+    {
+        QScopedPointer<Mlt::Producer> producer(new Mlt::Producer(MLT.profile(), "xml-string", m_producerXml.toUtf8().constData()));
+        size_t frameCount = producer->get_playtime();
+        double total = 0;
+        int progress = 0;
+        double* frameValues = new double[frameCount];
+        for (size_t i = 0; i < frameCount; ++i)
+        {
+            int frequency = 48000;
+            int channels = 1;
+            mlt_audio_format format = mlt_audio_s16;
+            std::unique_ptr<Mlt::Frame> frame(producer->get_frame(i));
+            mlt_position position = mlt_frame_get_position(frame->get_frame());
+            int samples = mlt_audio_calculate_frame_samples(float(producer->get_fps()), frequency, position);
+            int16_t* data = static_cast<int16_t*>(frame->get_audio(format, frequency, channels, samples));
+            frameValues[i] = 0;
+            // Add all values from the frame
+            for(int k = 0; k < samples; ++k)
+            {
+                frameValues[i] += std::abs(data[k]);
+            }
+            // Average the frame values
+            frameValues[i] = frameValues[i] / samples;
+            total += frameValues[i];
+            int newProgress = 100 * i / frameCount;
+            if (newProgress != progress) {
+                progress = newProgress;
+                emit progressUpdate(progress);
+            }
+        }
+        // Normalize to the mean frame value
+        double mean = total / frameCount;
+        for (size_t i = 0; i < frameCount; ++i)
+        {
+            m_array->setValue(i, frameValues[i] - mean);
+        }
+        delete frameValues;
+    }
+
+signals:
+    void progressUpdate(int);
+
+private:
+    QString m_producerXml;
+    AlignmentArray* m_array;
+};
+
+class ClipAudioReader : public QObject
+{
+    Q_OBJECT
+public:
+    ClipAudioReader(QString producerXml, AlignmentArray& referenceArray, int index)
+      : QObject()
+      , m_referenceArray(referenceArray)
+      , m_reader(producerXml, &m_clipArray)
+      , m_index(index)
+      , m_calculateDrift(false)
+    {
+        connect(&m_reader, SIGNAL(progressUpdate(int)), this, SLOT(onReaderProgressUpdate(int)));
+    }
+
+    void init(int maxLength)
+    {
+        m_reader.init(maxLength);
+    }
+
+    void start()
+    {
+        m_future = QtConcurrent::run(this, &ClipAudioReader::process);
+    }
+
+    bool isFinished() { return m_future.isFinished();}
+
+    void process()
+    {
+        onReaderProgressUpdate(0);
+        m_reader.process();
+        double drift = 1.0;
+        int offset = 0;
+        double score;
+        Q_UNUSED(score)
+        if (m_calculateDrift) {
+            score = m_referenceArray.calculateOffsetAndDrift(m_clipArray, 4, 0.1, &drift, &offset);
+        } else {
+            score = m_referenceArray.calculateOffset(m_clipArray, &offset);
+        }
+        onReaderProgressUpdate(100);
+        emit finished(m_index, offset, drift);
+    }
+
+public slots:
+    void onReaderProgressUpdate(int progress)
+    {
+        progress = progress * 99 / 100; // Reader goes from 0-99
+        emit progressUpdate(m_index, progress);
+    }
+
+signals:
+    void progressUpdate(int index, int percent);
+    void finished(int index, int offset, double drift);
+
+private:
+    AlignmentArray m_clipArray;
+    AlignmentArray& m_referenceArray;
+    AudioReader m_reader;
+    int m_index;
+    QFuture<void> m_future;
+    bool m_calculateDrift;
+};
+
+class AlignTableDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+public:
+    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+    {
+        switch (index.column()) {
+            case AlignClipsModel::COLUMN_ERROR:
+            {
+                QIcon icon;
+                if (index.data().toString().isEmpty()) {
+                    icon = QIcon(":/icons/oxygen/32x32/status/task-complete.png");
+                } else {
+                    icon = QIcon(":/icons/oxygen/32x32/status/task-reject.png");
+                }
+                icon.paint(painter, option.rect, Qt::AlignCenter);
+                break;
+            }
+            case AlignClipsModel::COLUMN_NAME:
+            {
+                const AlignClipsModel* model = dynamic_cast<const AlignClipsModel*>(index.model());
+                QStyleOptionProgressBar progressBarOption;
+                progressBarOption.rect = option.rect;
+                progressBarOption.minimum = 0;
+                progressBarOption.maximum = 100;
+                progressBarOption.progress = model->getProgress(index.row());
+                progressBarOption.text = index.data().toString();
+                progressBarOption.textVisible = true;
+                QApplication::style()->drawControl(QStyle::CE_ProgressBar, &progressBarOption, painter);
+                break;
+            }
+            case AlignClipsModel::COLUMN_OFFSET:
+            case AlignClipsModel::COLUMN_DRIFT:
+                QStyledItemDelegate::paint(painter, option, index);
+                break;
+            default:
+                LOG_ERROR() << "Invalid Column" << index.row() << index.column();
+                break;
+        }
+    }
+};
+
+// Include this so that AlignTableDelegate can be declared in the source file.
+#include "alignaudiodialog.moc"
+
+AlignAudioDialog::AlignAudioDialog(QString title, MultitrackModel* model, const QVector<QUuid>& uuids, QWidget* parent)
+    : QDialog(parent)
+    , m_model(model)
+    , m_uuids(uuids)
+    , m_uiTask(nullptr)
+{
+    int col = 0;
+    setWindowTitle(title);
+    setWindowModality(QmlApplication::dialogModality());
+
+    QGridLayout* glayout = new QGridLayout();
+    glayout->setHorizontalSpacing(4);
+    glayout->setVerticalSpacing(2);
+    // Track Combo
+    glayout->addWidget(new QLabel(tr("Reference Audio Track")), col, 0, Qt::AlignRight);
+    m_trackCombo = new QComboBox();
+    int trackCount = m_model->trackList().size();
+    for (int i = 0; i < trackCount; i++) {
+        m_trackCombo->addItem(m_model->getTrackName(i), QVariant(i));
+    }
+    int defaultTrack = Settings.audioReferenceTrack();
+    if (defaultTrack < trackCount) {
+        m_trackCombo->setCurrentIndex(defaultTrack);
+    }
+    if (!connect(m_trackCombo, QOverload<int>::of(&QComboBox::activated), this, &AlignAudioDialog::rebuildClipList))
+         connect(m_trackCombo, SIGNAL(activated(const QString&)), SLOT(rebuildClipList()));
+    glayout->addWidget(m_trackCombo, col++, 1, Qt::AlignLeft);
+    // List
+    m_table = new QTreeView();
+    m_table->setSelectionMode(QAbstractItemView::NoSelection);
+    m_table->setItemsExpandable(false);
+    m_table->setRootIsDecorated(false);
+    m_table->setUniformRowHeights(true);
+    m_table->setSortingEnabled(false);
+    m_table->setModel(&m_alignClipsModel);
+    m_table->setWordWrap(false);
+    m_delegate = new AlignTableDelegate();
+    m_table->setItemDelegate(m_delegate);
+    m_table->header()->setStretchLastSection(false);
+    qreal rowHeight = fontMetrics().height() * devicePixelRatioF();
+    m_table->header()->setMinimumSectionSize(rowHeight);
+    m_table->header()->setSectionResizeMode(AlignClipsModel::COLUMN_ERROR, QHeaderView::Fixed);
+    m_table->setColumnWidth(AlignClipsModel::COLUMN_ERROR, rowHeight);
+    m_table->header()->setSectionResizeMode(AlignClipsModel::COLUMN_NAME, QHeaderView::Stretch);
+    m_table->header()->setSectionResizeMode(AlignClipsModel::COLUMN_OFFSET, QHeaderView::Fixed);
+    m_table->setColumnWidth(AlignClipsModel::COLUMN_OFFSET, fontMetrics().horizontalAdvance("00:00:00:00") * devicePixelRatioF() + 8);
+//    m_table->header()->setSectionResizeMode(AlignClipsModel::COLUMN_DRIFT, QHeaderView::ResizeToContents);
+    glayout->addWidget(m_table, col++, 0, 1, 2);
+    // Button Box + cancel
+    m_buttonBox = new QDialogButtonBox(QDialogButtonBox::Cancel);
+    connect(m_buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+    glayout->addWidget(m_buttonBox, col++, 0, 1, 2);
+    // Process button
+    QPushButton* processButton = m_buttonBox->addButton(tr("Process"), QDialogButtonBox::ActionRole);
+    connect(processButton, SIGNAL(pressed()), this, SLOT(process()));
+    // Apply button
+    QPushButton* applyButton = m_buttonBox->addButton(tr("Apply"), QDialogButtonBox::ApplyRole);
+    connect(applyButton, SIGNAL(pressed()), this, SLOT(apply()));
+    // Process and apply button
+    m_processAndApplyButton = m_buttonBox->addButton(tr("Process + Apply"), QDialogButtonBox::AcceptRole);
+    connect(m_processAndApplyButton, SIGNAL(pressed()), this, SLOT(processAndApply()));
+
+    this->setLayout (glayout);
+    this->setModal(true);
+
+    rebuildClipList();
+
+    resize(500, 300);
+}
+
+AlignAudioDialog::~AlignAudioDialog()
+{
+    delete m_delegate;
+    delete m_uiTask;
+}
+
+void AlignAudioDialog::rebuildClipList()
+{
+    QStringList stringList;
+    m_alignClipsModel.clear();
+    int referenceIndex = m_trackCombo->currentData().toInt();
+    Settings.setAudioReferenceTrack(referenceIndex);
+
+    for (const auto& uuid : m_uuids) {
+        int trackIndex, clipIndex;
+        QScopedPointer<Mlt::ClipInfo> info(m_model->findClipByUuid(uuid, trackIndex, clipIndex));
+        if (info && info->cut && info->cut->is_valid()) {
+            QString clipName = info->cut->get(kShotcutCaptionProperty);
+            QString error;
+            if (clipName.isNull()) {
+                clipName = Util::baseName(ProxyManager::resource(*info->producer));
+                if (clipName == "<producer>") {
+                    clipName = QString::fromUtf8(info->cut->get("mlt_service"));
+                }
+            }
+            if (trackIndex == referenceIndex) {
+                error = tr("This clip will be skipped because it is on the reference track.");
+            }
+            m_alignClipsModel.addClip(clipName, -1, -1, error);
+        }
+    }
+}
+
+void AlignAudioDialog::process()
+{
+    m_uiTask = new LongUiTask(tr("Align Audio"));
+    m_uiTask->setMinimumDuration(0);
+    int referenceTrackIndex = m_trackCombo->currentData().toInt();
+    auto mlt_index = m_model->trackList().at(referenceTrackIndex).mlt_index;
+    QScopedPointer<Mlt::Producer> track(m_model->tractor()->track(mlt_index));
+    int maxLength = track->get_playtime();
+    QString xml = MLT.XML(track.data());
+    AlignmentArray trackArray;
+    AudioReader trackReader(MLT.XML(track.data()), &trackArray);
+    connect(&trackReader, SIGNAL(progressUpdate(int)), this, SLOT(updateReferenceProgress(int)));
+
+    QList<ClipAudioReader*> m_clipReaders;
+    for (const auto& uuid : m_uuids) {
+        int trackIndex, clipIndex;
+        QScopedPointer<Mlt::ClipInfo> info(m_model->findClipByUuid(uuid, trackIndex, clipIndex));
+        if (!info || !info->cut || !info->cut->is_valid()) {
+            continue;
+        }
+        if (trackIndex == referenceTrackIndex) {
+            m_clipReaders.append(nullptr);
+        } else {
+            QString xml = MLT.XML(info->cut);
+            ClipAudioReader* clipReader = new ClipAudioReader(xml, trackArray, m_clipReaders.size());
+            connect(clipReader, SIGNAL(progressUpdate(int, int)), this, SLOT(updateClipProgress(int, int)));
+            connect(clipReader, SIGNAL(finished(int, int, double)), this, SLOT(clipFinished(int, int, double)));
+            m_clipReaders.append(clipReader);
+            maxLength = qMax(maxLength, info->frame_count);
+        }
+    }
+
+    trackReader.init(maxLength);
+    for (const auto& clipReader : m_clipReaders) {
+        if (clipReader) clipReader->init(maxLength);
+    }
+
+    trackReader.process();
+    for (const auto& clipReader : m_clipReaders) {
+        if (clipReader) clipReader->start();
+    }
+
+    for (const auto& clipReader : m_clipReaders) {
+        if (clipReader) {
+            while (!clipReader->isFinished()) {
+                QThread::msleep(10);
+                QCoreApplication::processEvents();
+            }
+            clipReader->deleteLater();
+        }
+    }
+    m_uiTask->deleteLater();
+    m_uiTask = nullptr;
+}
+
+void AlignAudioDialog::apply()
+{
+    Timeline::AlignCLipsCommand* command = new Timeline::AlignCLipsCommand(*m_model);
+    int referenceTrackIndex = m_trackCombo->currentData().toInt();
+    int alignmentCount = 0;
+    int modelIndex = 0;
+    for (const auto& uuid : m_uuids) {
+        int trackIndex, clipIndex;
+        QScopedPointer<Mlt::ClipInfo> info(m_model->findClipByUuid(uuid, trackIndex, clipIndex));
+        if (!info || !info->cut || !info->cut->is_valid()) {
+            continue;
+        }
+        if (trackIndex != referenceTrackIndex) {
+            int offset = m_alignClipsModel.getOffset(modelIndex);
+            if (offset > 0) {
+                double speedCompensation = m_alignClipsModel.getDrift(modelIndex) * 100.0;
+                command->addAlignment(uuid, offset, speedCompensation);
+                alignmentCount++;
+            }
+        }
+        modelIndex++;
+    }
+    if (alignmentCount > 0) {
+        MAIN.undoStack()->push(command);
+    } else {
+        delete command;
+    }
+    accept();
+}
+
+void AlignAudioDialog::processAndApply()
+{
+    process();
+    apply();
+}
+
+void AlignAudioDialog::updateReferenceProgress(int percent)
+{
+    if (m_uiTask) {
+        m_uiTask->reportProgress(tr("Analyze Reference Track"), percent, 100);
+    }
+}
+
+void AlignAudioDialog::updateClipProgress(int index, int percent)
+{
+    m_alignClipsModel.updateProgress(index, percent);
+    if (m_uiTask) {
+        m_uiTask->reportProgress(tr("Analyze Clips"), 0, 0);
+    }
+}
+
+void AlignAudioDialog::clipFinished(int index, int offset, double drift)
+{
+    m_alignClipsModel.updateOffsetAndDrift(index, offset, drift);
+}

--- a/src/dialogs/alignaudiodialog.cpp
+++ b/src/dialogs/alignaudiodialog.cpp
@@ -427,14 +427,12 @@ void AlignAudioDialog::updateClipProgress(int index, int percent)
 void AlignAudioDialog::clipFinished(int index, int offset, double drift, double quality)
 {
     QString error;
-/*
-    if (quality < 50) {
+    LOG_INFO() << "Clip" << index << "Offset:" << offset << "Quality:" << quality;
+    if (quality < 0.01) {
         error = tr("Alignment not found.");
         offset = AlignClipsModel::INVALID_OFFSET;
         drift = AlignClipsModel::INVALID_OFFSET;
     }
-*/
-    LOG_INFO() << "Clip" << index << "Alignment. Offset:" << offset << "Quality:" << quality << "|" << error;
     m_alignClipsModel.updateOffsetAndDrift(index, offset, drift, error);
     m_alignClipsModel.updateProgress(index, 100);
 }

--- a/src/dialogs/alignaudiodialog.cpp
+++ b/src/dialogs/alignaudiodialog.cpp
@@ -48,11 +48,11 @@ class AudioReader : public QObject
     Q_OBJECT
 public:
     AudioReader(QString producerXml, AlignmentArray* array, int in = -1, int out = -1)
-      : QObject()
-      , m_producerXml(producerXml)
-      , m_array(array)
-      , m_in(in)
-      , m_out(out)
+        : QObject()
+        , m_producerXml(producerXml)
+        , m_array(array)
+        , m_in(in)
+        , m_out(out)
     {
     }
 
@@ -70,8 +70,7 @@ public:
         size_t frameCount = producer->get_playtime();
         std::vector<double> values(frameCount);
         int progress = 0;
-        for (size_t i = 0; i < frameCount; ++i)
-        {
+        for (size_t i = 0; i < frameCount; ++i) {
             int frequency = 48000;
             int channels = 1;
             mlt_audio_format format = mlt_audio_s16;
@@ -81,8 +80,7 @@ public:
             int16_t* data = static_cast<int16_t*>(frame->get_audio(format, frequency, channels, samples));
             double sampleTotal = 0;
             // Add all values from the frame
-            for(int k = 0; k < samples; ++k)
-            {
+            for (int k = 0; k < samples; ++k) {
                 sampleTotal += data[k];
             }
             // Average the sample values
@@ -111,11 +109,11 @@ class ClipAudioReader : public QObject
     Q_OBJECT
 public:
     ClipAudioReader(QString producerXml, AlignmentArray& referenceArray, int index, int in, int out)
-      : QObject()
-      , m_referenceArray(referenceArray)
-      , m_reader(producerXml, &m_clipArray, in, out)
-      , m_index(index)
-      , m_calculateDrift(false)
+        : QObject()
+        , m_referenceArray(referenceArray)
+        , m_reader(producerXml, &m_clipArray, in, out)
+        , m_index(index)
+        , m_calculateDrift(false)
     {
         connect(&m_reader, SIGNAL(progressUpdate(int)), this, SLOT(onReaderProgressUpdate(int)));
     }
@@ -130,7 +128,10 @@ public:
         m_future = QtConcurrent::run(this, &ClipAudioReader::process);
     }
 
-    bool isFinished() { return m_future.isFinished();}
+    bool isFinished()
+    {
+        return m_future.isFinished();
+    }
 
     void process()
     {
@@ -176,38 +177,36 @@ public:
     {
         const AlignClipsModel* model = dynamic_cast<const AlignClipsModel*>(index.model());
         switch (index.column()) {
-            case AlignClipsModel::COLUMN_ERROR:
-            {
-                QIcon icon;
-                if (!index.data().toString().isEmpty()) {
-                    icon = QIcon(":/icons/oxygen/32x32/status/task-reject.png");
-                } else if (model->getProgress(index.row()) == 100) {
-                    icon = QIcon(":/icons/oxygen/32x32/status/task-complete.png");
-                }
-                icon.paint(painter, option.rect, Qt::AlignCenter);
-                break;
+        case AlignClipsModel::COLUMN_ERROR: {
+            QIcon icon;
+            if (!index.data().toString().isEmpty()) {
+                icon = QIcon(":/icons/oxygen/32x32/status/task-reject.png");
+            } else if (model->getProgress(index.row()) == 100) {
+                icon = QIcon(":/icons/oxygen/32x32/status/task-complete.png");
             }
-            case AlignClipsModel::COLUMN_NAME:
-            {
-                int progress = model->getProgress(index.row());
-                if (progress > 0 ) {
-                    QStyleOptionProgressBar progressBarOption;
-                    progressBarOption.rect = option.rect;
-                    progressBarOption.minimum = 0;
-                    progressBarOption.maximum = 100;
-                    progressBarOption.progress = progress;
-                    QApplication::style()->drawControl(QStyle::CE_ProgressBar, &progressBarOption, painter);
-                }
-                painter->drawText(option.rect, Qt::AlignLeft | Qt::AlignVCenter, index.data().toString() );
-                break;
+            icon.paint(painter, option.rect, Qt::AlignCenter);
+            break;
+        }
+        case AlignClipsModel::COLUMN_NAME: {
+            int progress = model->getProgress(index.row());
+            if (progress > 0 ) {
+                QStyleOptionProgressBar progressBarOption;
+                progressBarOption.rect = option.rect;
+                progressBarOption.minimum = 0;
+                progressBarOption.maximum = 100;
+                progressBarOption.progress = progress;
+                QApplication::style()->drawControl(QStyle::CE_ProgressBar, &progressBarOption, painter);
             }
-            case AlignClipsModel::COLUMN_OFFSET:
+            painter->drawText(option.rect, Qt::AlignLeft | Qt::AlignVCenter, index.data().toString() );
+            break;
+        }
+        case AlignClipsModel::COLUMN_OFFSET:
 //            case AlignClipsModel::COLUMN_DRIFT:
-                QStyledItemDelegate::paint(painter, option, index);
-                break;
-            default:
-                LOG_ERROR() << "Invalid Column" << index.row() << index.column();
-                break;
+            QStyledItemDelegate::paint(painter, option, index);
+            break;
+        default:
+            LOG_ERROR() << "Invalid Column" << index.row() << index.column();
+            break;
         }
     }
 };
@@ -229,7 +228,7 @@ AlignAudioDialog::AlignAudioDialog(QString title, MultitrackModel* model, const 
     glayout->setHorizontalSpacing(4);
     glayout->setVerticalSpacing(2);
     // Track Combo
-    glayout->addWidget(new QLabel(tr("Reference Audio Track")), col, 0, Qt::AlignRight);
+    glayout->addWidget(new QLabel(tr("Reference audio track")), col, 0, Qt::AlignRight);
     m_trackCombo = new QComboBox();
     int trackCount = m_model->trackList().size();
     for (int i = 0; i < trackCount; i++) {
@@ -240,7 +239,7 @@ AlignAudioDialog::AlignAudioDialog(QString title, MultitrackModel* model, const 
         m_trackCombo->setCurrentIndex(defaultTrack);
     }
     if (!connect(m_trackCombo, QOverload<int>::of(&QComboBox::activated), this, &AlignAudioDialog::rebuildClipList))
-         connect(m_trackCombo, SIGNAL(activated(const QString&)), SLOT(rebuildClipList()));
+        connect(m_trackCombo, SIGNAL(activated(const QString&)), SLOT(rebuildClipList()));
     glayout->addWidget(m_trackCombo, col++, 1, Qt::AlignLeft);
     // List
     m_table = new QTreeView();
@@ -375,7 +374,7 @@ void AlignAudioDialog::process()
 
 void AlignAudioDialog::apply()
 {
-    Timeline::AlignCLipsCommand* command = new Timeline::AlignCLipsCommand(*m_model);
+    Timeline::AlignClipsCommand* command = new Timeline::AlignClipsCommand(*m_model);
     int referenceTrackIndex = m_trackCombo->currentData().toInt();
     int alignmentCount = 0;
     int modelIndex = 0;

--- a/src/dialogs/alignaudiodialog.h
+++ b/src/dialogs/alignaudiodialog.h
@@ -49,7 +49,7 @@ private slots:
     void processAndApply();
     void updateReferenceProgress(int percent);
     void updateClipProgress(int index, int percent);
-    void clipFinished(int index, int offset, double drift);
+    void clipFinished(int index, int offset, double drift, double quality);
 
 private:
     AlignTableDelegate* m_delegate;

--- a/src/dialogs/alignaudiodialog.h
+++ b/src/dialogs/alignaudiodialog.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ALIGNAUDIODIALOG_H
+#define ALIGNAUDIODIALOG_H
+
+#include "models/alignclipsmodel.h"
+
+#include <QDialog>
+#include <QUuid>
+
+class QComboBox;
+class QDialogButtonBox;
+class QLabel;
+class QListWidget;
+class QLineEdit;
+class QPushButton;
+class QTreeView;
+
+class AlignTableDelegate;
+class MultitrackModel;
+class LongUiTask;
+
+class AlignAudioDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit AlignAudioDialog(QString title, MultitrackModel* model, const QVector<QUuid>& uuids, QWidget *parent = 0);
+    virtual ~AlignAudioDialog();
+
+private slots:
+    void rebuildClipList();
+    void process();
+    void apply();
+    void processAndApply();
+    void updateReferenceProgress(int percent);
+    void updateClipProgress(int index, int percent);
+    void clipFinished(int index, int offset, double drift);
+
+private:
+    AlignTableDelegate* m_delegate;
+    MultitrackModel* m_model;
+    AlignClipsModel m_alignClipsModel;
+    QVector<QUuid> m_uuids;
+    QComboBox* m_trackCombo;
+    QTreeView* m_table;
+    QDialogButtonBox* m_buttonBox;
+    QPushButton* m_processAndApplyButton;
+    LongUiTask* m_uiTask;
+};
+
+#endif // ALIGNAUDIODIALOG_H

--- a/src/dialogs/alignmentarray.cpp
+++ b/src/dialogs/alignmentarray.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2022 Meltytech, LLC
+ *
+ * Author: André Caldas de Souza <andrecaldas@unb.br>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "alignmentarray.h"
+
+#include <QMutex>
+#include <QMutexLocker>
+
+#include <iostream>
+#include <algorithm>
+#include <cstring>
+#include <cmath>
+#include <cassert>
+
+// FFTW plan functions are not threadsafe
+static QMutex s_fftwPlanningMutex;
+
+AlignmentArray::AlignmentArray()
+    : m_isTransformed(false)
+{
+}
+
+AlignmentArray::AlignmentArray(size_t minimum_size)
+    : AlignmentArray()
+{
+    init(minimum_size);
+}
+
+AlignmentArray::~AlignmentArray()
+{
+    QMutexLocker locker(&s_fftwPlanningMutex);
+    fftw_free(reinterpret_cast<fftw_complex*>(m_buffer));
+    fftw_destroy_plan(m_plan);
+}
+
+void AlignmentArray::init(size_t minimumSize)
+{
+    m_minimumSize = minimumSize;
+    // Pad zeros to the nearest power of 2
+    m_actualComplexSize = 1;
+    while(minimumSize > m_actualComplexSize)
+    {
+        m_actualComplexSize *= 2;
+    }
+    QMutexLocker locker(&s_fftwPlanningMutex);
+    fftw_complex* buf = fftw_alloc_complex(m_actualComplexSize);
+    m_buffer = reinterpret_cast<std::complex<double>*>(buf);
+    m_plan = fftw_plan_dft_1d(m_actualComplexSize, buf, buf, FFTW_FORWARD, FFTW_ESTIMATE);
+    std::fill( m_buffer, m_buffer + m_actualComplexSize, std::complex<double>(0) );
+}
+
+void AlignmentArray::setValue(size_t index, double value)
+{
+    if (index < m_actualComplexSize) {
+        m_buffer[index] = value;
+    }
+}
+
+double AlignmentArray::calculateOffset(AlignmentArray &from, int* offset)
+{
+    // Create a destination for the correlation values
+    s_fftwPlanningMutex.lock();
+    std::complex<double>* correlationBuf = reinterpret_cast<std::complex<double>*>(fftw_alloc_complex(m_actualComplexSize));
+    fftw_plan correlationPlan = fftw_plan_dft_1d(m_actualComplexSize, reinterpret_cast<fftw_complex*>(correlationBuf), reinterpret_cast<fftw_complex*>(correlationBuf), FFTW_BACKWARD, FFTW_ESTIMATE);
+    s_fftwPlanningMutex.unlock();
+    // Ensure the two sequences are transformed
+    transform();
+    from.transform();
+
+    // Calculate the correlation
+    for(size_t i = 0; i < m_actualComplexSize; ++i)
+    {
+        correlationBuf[i] = m_buffer[i] * std::conj(from.m_buffer[i]);
+    }
+    fftw_execute(correlationPlan);
+
+    // Find the maximum correlation
+    double max = 0;
+    for (size_t i = 0; i < m_actualComplexSize; ++i)
+    {
+        double norm = std::norm(correlationBuf[i]);
+        if (max < norm) {
+            *offset = i;
+            max = norm;
+        }
+    }
+
+    if ( 2 * *offset > (int)m_actualComplexSize )
+    {
+        *offset -= ((int)m_actualComplexSize);
+    }
+
+    s_fftwPlanningMutex.lock();
+    fftw_free(correlationBuf);
+    fftw_destroy_plan(correlationPlan);
+    s_fftwPlanningMutex.unlock();
+
+    return max;
+}
+
+double AlignmentArray::calculateOffsetAndDrift(AlignmentArray& from, int precision, double drift_range, double* drift, int* offset)
+{
+    static const int FINAL_PRECISION = 9;
+    double drift_step = std::pow(10.0, -precision);
+    double max_score = *drift;
+    double best_drift = 1.0;
+
+    for(double d = *drift - drift_range; d <= *drift + drift_range; d += drift_step)
+    {
+        // Copy the "from" sequence with a shift
+        AlignmentArray drifted(m_actualComplexSize);
+        double factor = 1.0 / d;
+        int shift = 0;
+        for(size_t i = 0; i < m_minimumSize; ++i)
+        {
+            int newShift = std::round(factor * i) - i;
+            while(newShift > shift)
+            {
+                drifted.m_buffer[i + shift] = from.m_buffer[i];
+                ++shift;
+            }
+            shift = newShift;
+            drifted.m_buffer[i + shift] = from.m_buffer[i];
+        }
+        double score = calculateOffset(drifted, offset);
+        if(score > max_score)
+        {
+            max_score = score;
+            best_drift = d;
+        }
+    }
+    *drift = best_drift;
+
+    if(precision < FINAL_PRECISION)
+    {
+        max_score = calculateOffsetAndDrift(from, precision + 1, drift_range / 10, drift, offset);
+    }
+    return max_score;
+}
+
+void AlignmentArray::transform()
+{
+    s_fftwPlanningMutex.lock();
+    if (!m_isTransformed)
+    {
+        m_isTransformed = true;
+        s_fftwPlanningMutex.unlock();
+        fftw_execute(m_plan);
+    }
+    s_fftwPlanningMutex.unlock();
+}

--- a/src/dialogs/alignmentarray.h
+++ b/src/dialogs/alignmentarray.h
@@ -20,8 +20,11 @@
 #ifndef ALIGNMENTARRAY_H
 #define ALIGNMENTARRAY_H
 
+#include <QMutex>
+
 #include <complex.h>
 #include <fftw3.h>
+#include <vector>
 
 class AlignmentArray
 {
@@ -31,7 +34,7 @@ public:
     virtual ~AlignmentArray();
 
     void init(size_t minimum_size);
-    void setValue(size_t index, double value);
+    void setValues(const std::vector<double>& values);
     double calculateOffset(AlignmentArray &from, int* offset);
     double calculateOffsetAndDrift(AlignmentArray& from, int precision, double drift_range, double* drift_about, int* offset);
 
@@ -39,9 +42,11 @@ private:
     void transform();
     fftw_plan m_plan;
     std::complex<double>* m_buffer;
+    std::vector<double> m_values;
     size_t m_minimumSize;
     size_t m_actualComplexSize;
     bool m_isTransformed = false;
+    QMutex m_transformMutex;
 };
 
 #endif

--- a/src/dialogs/alignmentarray.h
+++ b/src/dialogs/alignmentarray.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 Meltytech, LLC
+ *
+ * Author: André Caldas de Souza <andrecaldas@unb.br>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ALIGNMENTARRAY_H
+#define ALIGNMENTARRAY_H
+
+#include <complex.h>
+#include <fftw3.h>
+
+class AlignmentArray
+{
+public:
+    AlignmentArray();
+    AlignmentArray(size_t minimum_size);
+    virtual ~AlignmentArray();
+
+    void init(size_t minimum_size);
+    void setValue(size_t index, double value);
+    double calculateOffset(AlignmentArray &from, int* offset);
+    double calculateOffsetAndDrift(AlignmentArray& from, int precision, double drift_range, double* drift_about, int* offset);
+
+private:
+    void transform();
+    fftw_plan m_plan;
+    std::complex<double>* m_buffer;
+    size_t m_minimumSize;
+    size_t m_actualComplexSize;
+    bool m_isTransformed = false;
+};
+
+#endif
+

--- a/src/dialogs/alignmentarray.h
+++ b/src/dialogs/alignmentarray.h
@@ -46,7 +46,7 @@ private:
     double m_autocorrelationMax;
     size_t m_minimumSize;
     size_t m_actualComplexSize;
-    bool m_isTransformed = false;
+    bool m_isTransformed;
     QMutex m_transformMutex;
 };
 

--- a/src/dialogs/alignmentarray.h
+++ b/src/dialogs/alignmentarray.h
@@ -40,9 +40,10 @@ public:
 
 private:
     void transform();
-    fftw_plan m_plan;
-    std::complex<double>* m_buffer;
     std::vector<double> m_values;
+    fftw_plan m_forwardPlan;
+    std::complex<double>* m_forwardBuf;
+    double m_autocorrelationMax;
     size_t m_minimumSize;
     size_t m_actualComplexSize;
     bool m_isTransformed = false;

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -29,6 +29,7 @@
 #include "settings.h"
 #include "util.h"
 #include "proxymanager.h"
+#include "dialogs/alignaudiodialog.h"
 #include "dialogs/editmarkerdialog.h"
 #include "dialogs/longuitask.h"
 
@@ -662,6 +663,15 @@ void TimelineDock::addVideoTrack()
         setSelection();
     MAIN.undoStack()->push(
         new Timeline::AddTrackCommand(m_model, true));
+}
+
+void TimelineDock::alignSelectedClips()
+{
+    auto selection = selectionUuids();
+    saveAndClearSelection();
+    AlignAudioDialog dialog(tr("Align clips to audio reference"), &m_model, selection, this);
+    dialog.exec();
+    restoreSelection();
 }
 
 void TimelineDock::onShowFrame(const SharedFrame& frame)

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -669,7 +669,7 @@ void TimelineDock::alignSelectedClips()
 {
     auto selection = selectionUuids();
     saveAndClearSelection();
-    AlignAudioDialog dialog(tr("Align clips to audio reference"), &m_model, selection, this);
+    AlignAudioDialog dialog(tr("Align To Reference Track"), &m_model, selection, this);
     dialog.exec();
     restoreSelection();
 }

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -121,6 +121,7 @@ signals:
 public slots:
     void addAudioTrack();
     void addVideoTrack();
+    void alignSelectedClips();
     void onShowFrame(const SharedFrame& frame);
     void onSeeked(int position);
     void append(int trackIndex);

--- a/src/models/alignclipsmodel.cpp
+++ b/src/models/alignclipsmodel.cpp
@@ -120,14 +120,14 @@ QVariant AlignClipsModel::data(const QModelIndex& index, int role) const
     QVariant result;
 
     switch (role) {
-        case Qt::StatusTipRole:
-        case Qt::FontRole:
-        case Qt::SizeHintRole:
-        case Qt::DecorationRole:
-        case Qt::CheckStateRole:
-        case Qt::BackgroundRole:
-        case Qt::ForegroundRole:
-            return result;
+    case Qt::StatusTipRole:
+    case Qt::FontRole:
+    case Qt::SizeHintRole:
+    case Qt::DecorationRole:
+    case Qt::CheckStateRole:
+    case Qt::BackgroundRole:
+    case Qt::ForegroundRole:
+        return result;
     }
 
     if (!index.isValid() || index.column() < 0 || index.column() >= COLUMN_COUNT || index.row() < 0 || index.row() >= m_clips.size()) {
@@ -137,61 +137,60 @@ QVariant AlignClipsModel::data(const QModelIndex& index, int role) const
 
     const ClipAlignment& clip = m_clips[index.row()];
     switch (role) {
-        case Qt::DisplayRole:
-            switch (index.column()) {
-                case COLUMN_ERROR:
-                    result = clip.error;
-                    break;
-                case COLUMN_NAME:
-                    result = clip.name;
-                    break;
-                case COLUMN_OFFSET:
-                    if (clip.progress != 0 && clip.offset != INVALID_OFFSET && MLT.producer() && MLT.producer()->is_valid())
-                        if (clip.offset >= 0) {
-                            result = MLT.producer()->frames_to_time(clip.offset, mlt_time_smpte_df);
-                        } else {
-                            result = QString("-") + MLT.producer()->frames_to_time(-clip.offset, mlt_time_smpte_df);
-                        }
-                    break;
-/*
-                case COLUMN_DRIFT:
-                    if (clip.drift >= 0)
-                        result = QLocale().toString(clip.drift * 100.0, 'g', 4);
-                    break;
-*/
-                default:
-                    LOG_ERROR() << "Invalid Column" << index.row() << index.column() << roleNames()[role] << role;
-                    break;
-            }
+    case Qt::DisplayRole:
+        switch (index.column()) {
+        case COLUMN_ERROR:
+            result = clip.error;
             break;
-        case Qt::ToolTipRole:
-            return clip.error;
-        case Qt::TextAlignmentRole:
-            switch (index.column()) {
-                case COLUMN_NAME:
-                    result = Qt::AlignLeft;
-                    break;
-                case COLUMN_ERROR:
-                case COLUMN_OFFSET:
+        case COLUMN_NAME:
+            result = clip.name;
+            break;
+        case COLUMN_OFFSET:
+            if (clip.progress != 0 && clip.offset != INVALID_OFFSET && MLT.producer() && MLT.producer()->is_valid())
+                if (clip.offset >= 0) {
+                    result = MLT.producer()->frames_to_time(clip.offset, mlt_time_smpte_df);
+                } else {
+                    result = QString("-") + MLT.producer()->frames_to_time(-clip.offset, mlt_time_smpte_df);
+                }
+            break;
+        /*
+                        case COLUMN_DRIFT:
+                            if (clip.drift >= 0)
+                                result = QLocale().toString(clip.drift * 100.0, 'g', 4);
+                            break;
+        */
+        default:
+            LOG_ERROR() << "Invalid Column" << index.row() << index.column() << roleNames()[role] << role;
+            break;
+        }
+        break;
+    case Qt::ToolTipRole:
+        return clip.error;
+    case Qt::TextAlignmentRole:
+        switch (index.column()) {
+        case COLUMN_NAME:
+            result = Qt::AlignLeft;
+            break;
+        case COLUMN_ERROR:
+        case COLUMN_OFFSET:
 //                case COLUMN_DRIFT:
-                    result = Qt::AlignCenter;
-                    break;
-                default:
-                    LOG_ERROR() << "Invalid Column" << index.row() << index.column() << roleNames()[role] << role;
-                    break;
-            }
+            result = Qt::AlignCenter;
             break;
         default:
-            LOG_ERROR() << "Invalid Role" << index.row() << index.column() << roleNames()[role] << role;
+            LOG_ERROR() << "Invalid Column" << index.row() << index.column() << roleNames()[role] << role;
             break;
+        }
+        break;
+    default:
+        LOG_ERROR() << "Invalid Role" << index.row() << index.column() << roleNames()[role] << role;
+        break;
     }
     return result;
 }
 
 QVariant AlignClipsModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
-    if (role == Qt::DisplayRole && orientation == Qt::Horizontal)
-    {
+    if (role == Qt::DisplayRole && orientation == Qt::Horizontal) {
         switch (section) {
         case COLUMN_ERROR:
             return QVariant();

--- a/src/models/alignclipsmodel.cpp
+++ b/src/models/alignclipsmodel.cpp
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2022 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "alignclipsmodel.h"
+
+#include <Logger.h>
+#include "mltcontroller.h"
+
+AlignClipsModel::AlignClipsModel(QObject* parent)
+    : QAbstractItemModel(parent)
+{
+}
+
+AlignClipsModel::~AlignClipsModel()
+{
+}
+
+void AlignClipsModel::clear()
+{
+    beginResetModel();
+    m_clips.clear();
+    endResetModel();
+}
+
+void AlignClipsModel::addClip(const QString& name, int offset, int drift, const QString& error)
+{
+    beginInsertRows(QModelIndex(), m_clips.size(), m_clips.size());
+    ClipAlignment newClip;
+    newClip.name = name;
+    newClip.offset = offset;
+    newClip.drift = drift;
+    newClip.error = error;
+    newClip.progress = 0;
+    m_clips.append(newClip);
+    endInsertRows();
+}
+
+void AlignClipsModel::updateProgress(int row, int percent)
+{
+    QModelIndex modelIndex = index(row, COLUMN_NAME);
+    if (!modelIndex.isValid() || modelIndex.column() < 0 || modelIndex.column() >= COLUMN_COUNT || modelIndex.row() < 0 || modelIndex.row() >= m_clips.size()) {
+        LOG_ERROR() << "Invalid Index: " << modelIndex.row() << modelIndex.column();
+        return;
+    }
+    m_clips[modelIndex.row()].progress = percent;
+    emit dataChanged(modelIndex, modelIndex);
+}
+
+int AlignClipsModel::getProgress(int row) const
+{
+    if (row < 0 || row > m_clips.size()) {
+        LOG_ERROR() << "Invalid row: " << row;
+        return 0;
+    }
+    return m_clips[row].progress;
+}
+
+void AlignClipsModel::updateOffsetAndDrift(int row, int offset, double drift)
+{
+    if (row < 0 || row >= m_clips.size()) {
+        LOG_ERROR() << "Invalid Row: " << row;
+        return;
+    }
+    m_clips[row].offset = offset;
+    m_clips[row].drift = drift;
+    emit dataChanged(index(row, COLUMN_OFFSET), index(row, COLUMN_DRIFT));
+}
+
+int AlignClipsModel::getOffset(int row)
+{
+    int offset = 0;
+    if (row < 0 || row >= m_clips.size()) {
+        LOG_ERROR() << "Invalid Row: " << row;
+    } else {
+        offset = m_clips[row].offset;
+    }
+    return offset;
+}
+
+double AlignClipsModel::getDrift(int row)
+{
+    int drift = 0;
+    if (row < 0 || row >= m_clips.size()) {
+        LOG_ERROR() << "Invalid Row: " << row;
+    } else {
+        drift = m_clips[row].drift;
+    }
+    return drift;
+}
+
+int AlignClipsModel::rowCount(const QModelIndex& parent) const
+{
+    Q_UNUSED(parent)
+    return m_clips.size();
+}
+
+int AlignClipsModel::columnCount(const QModelIndex& parent) const
+{
+    Q_UNUSED(parent)
+    return COLUMN_COUNT;
+}
+
+QVariant AlignClipsModel::data(const QModelIndex& index, int role) const
+{
+    QVariant result;
+
+    switch (role) {
+        case Qt::StatusTipRole:
+        case Qt::FontRole:
+        case Qt::SizeHintRole:
+        case Qt::DecorationRole:
+        case Qt::CheckStateRole:
+        case Qt::BackgroundRole:
+        case Qt::ForegroundRole:
+            return result;
+    }
+
+    if (!index.isValid() || index.column() < 0 || index.column() >= COLUMN_COUNT || index.row() < 0 || index.row() >= m_clips.size()) {
+        LOG_ERROR() << "Invalid Index: " << index.row() << index.column() << role;
+        return result;
+    }
+
+    const ClipAlignment& clip = m_clips[index.row()];
+    switch (role) {
+        case Qt::DisplayRole:
+            switch (index.column()) {
+                case COLUMN_ERROR:
+                    result = clip.error;
+                    break;
+                case COLUMN_NAME:
+                    result = clip.name;
+                    break;
+                case COLUMN_OFFSET:
+                    if (clip.offset >= 0 && MLT.producer() && MLT.producer()->is_valid())
+                        result = MLT.producer()->frames_to_time(clip.offset, mlt_time_smpte_df);
+                    break;
+                case COLUMN_DRIFT:
+                    if (clip.drift >= 0)
+                        result = QLocale().toString(clip.drift * 100.0, 'g', 4);
+                    break;
+                default:
+                    LOG_ERROR() << "Invalid Column" << index.row() << index.column() << roleNames()[role] << role;
+                    break;
+            }
+            break;
+        case Qt::ToolTipRole:
+            return clip.error;
+        case Qt::TextAlignmentRole:
+            switch (index.column()) {
+                case COLUMN_NAME:
+                    result = Qt::AlignLeft;
+                    break;
+                case COLUMN_ERROR:
+                case COLUMN_OFFSET:
+                case COLUMN_DRIFT:
+                    result = Qt::AlignCenter;
+                    break;
+                default:
+                    LOG_ERROR() << "Invalid Column" << index.row() << index.column() << roleNames()[role] << role;
+                    break;
+            }
+            break;
+        default:
+            LOG_ERROR() << "Invalid Role" << index.row() << index.column() << roleNames()[role] << role;
+            break;
+    }
+    return result;
+}
+
+QVariant AlignClipsModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (role == Qt::DisplayRole && orientation == Qt::Horizontal)
+    {
+        switch (section) {
+        case COLUMN_ERROR:
+            return QVariant();
+        case COLUMN_NAME:
+            return tr("Clip");
+        case COLUMN_OFFSET:
+            return tr("Offset");
+        case COLUMN_DRIFT:
+            return tr("Drift");
+        default:
+            break;
+        }
+    }
+    return QVariant();
+}
+
+QModelIndex AlignClipsModel::index(int row, int column, const QModelIndex& parent) const
+{
+    Q_UNUSED(parent)
+    if (column < 0 || column >= COLUMN_COUNT || row < 0 || row >= m_clips.size())
+        return QModelIndex();
+    return createIndex(row, column, (int)0);
+}
+
+QModelIndex AlignClipsModel::parent(const QModelIndex& index) const
+{
+    Q_UNUSED(index)
+    return QModelIndex();
+}

--- a/src/models/alignclipsmodel.h
+++ b/src/models/alignclipsmodel.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ALIGNCLIPSMODEL_H
+#define ALIGNCLIPSMODEL_H
+
+#include <QAbstractItemModel>
+
+class AlignClipsModel : public QAbstractItemModel
+{
+    Q_OBJECT
+
+public:
+
+    enum Columns {
+        COLUMN_ERROR = 0,
+        COLUMN_NAME,
+        COLUMN_OFFSET,
+        COLUMN_COUNT,
+        COLUMN_DRIFT, // Future use
+    };
+
+    explicit AlignClipsModel(QObject* parent = 0);
+    virtual ~AlignClipsModel();
+    void clear();
+    void addClip(const QString& name, int offset, int drift, const QString& error);
+    void updateProgress(int row, int percent);
+    int getProgress(int row) const;
+    void updateOffsetAndDrift(int row, int offset, double drift);
+    int getOffset(int row);
+    double getDrift(int row);
+
+protected:
+    // Implement QAbstractItemModel
+    int rowCount(const QModelIndex& parent) const;
+    int columnCount(const QModelIndex& parent) const;
+    QVariant data(const QModelIndex& index, int role) const;
+    QVariant headerData(int section, Qt::Orientation orientation, int role) const;
+    QModelIndex index(int row, int column = 0, const QModelIndex& parent = QModelIndex()) const;
+    QModelIndex parent(const QModelIndex& index) const;
+
+private:
+    typedef struct {
+        QString name;
+        int offset;
+        double drift;
+        QString error;
+        int progress;
+    } ClipAlignment;
+    QList<ClipAlignment> m_clips;
+};
+
+#endif // ALIGNCLIPSMODEL_H

--- a/src/models/alignclipsmodel.h
+++ b/src/models/alignclipsmodel.h
@@ -20,6 +20,8 @@
 
 #include <QAbstractItemModel>
 
+#include <limits>
+
 class AlignClipsModel : public QAbstractItemModel
 {
     Q_OBJECT
@@ -30,9 +32,10 @@ public:
         COLUMN_ERROR = 0,
         COLUMN_NAME,
         COLUMN_OFFSET,
+//        COLUMN_DRIFT, // Future use
         COLUMN_COUNT,
-        COLUMN_DRIFT, // Future use
     };
+    static const int INVALID_OFFSET = std::numeric_limits<int>::max();
 
     explicit AlignClipsModel(QObject* parent = 0);
     virtual ~AlignClipsModel();
@@ -40,7 +43,7 @@ public:
     void addClip(const QString& name, int offset, int drift, const QString& error);
     void updateProgress(int row, int percent);
     int getProgress(int row) const;
-    void updateOffsetAndDrift(int row, int offset, double drift);
+    void updateOffsetAndDrift(int row, int offset, double drift, const QString& error);
     int getOffset(int row);
     double getDrift(int row);
 

--- a/src/qml/views/timeline/Clip.qml
+++ b/src/qml/views/timeline/Clip.qml
@@ -739,6 +739,13 @@ Rectangle {
         }
         MenuItem {
             enabled: !isBlank
+            text: qsTr('Align To Reference Track')
+            onTriggered: {
+                timeline.alignSelectedClips()
+            }
+        }
+        MenuItem {
+            enabled: !isBlank
             text: qsTr('Properties')
             onTriggered: {
                 clipRoot.forceActiveFocus()

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -658,6 +658,15 @@ void ShotcutSettings::setTimelineFramebufferWaveform(bool b)
     emit timelineFramebufferWaveformChanged();
 }
 
+int ShotcutSettings::audioReferenceTrack() const
+{
+    return settings.value("timeline/audioReferenceTrack", 0).toInt();
+}
+void ShotcutSettings::setAudioReferenceTrack(int track)
+{
+    settings.setValue("timeline/audioReferenceTrack", track);
+}
+
 QString ShotcutSettings::filterFavorite(const QString& filterName)
 {
     return settings.value("filter/favorite/" + filterName, "").toString();

--- a/src/settings.h
+++ b/src/settings.h
@@ -176,6 +176,8 @@ public:
     void setTimelineScrollZoom(bool);
     bool timelineFramebufferWaveform() const;
     void setTimelineFramebufferWaveform(bool);
+    int audioReferenceTrack() const;
+    void setAudioReferenceTrack(int);
 
     // filter
     QString filterFavorite(const QString& filterName);

--- a/src/src.pro
+++ b/src/src.pro
@@ -53,6 +53,8 @@ SOURCES += main.cpp\
     docks/recentdock.cpp \
     docks/encodedock.cpp \
     dialogs/addencodepresetdialog.cpp \
+    dialogs/alignaudiodialog.cpp \
+    dialogs/alignmentarray.cpp \
     dialogs/filedatedialog.cpp \
     jobqueue.cpp \
     docks/jobsdock.cpp \
@@ -65,6 +67,7 @@ SOURCES += main.cpp\
     docks/playlistdock.cpp \
     dialogs/durationdialog.cpp \
     widgets/colorwheel.cpp \
+    models/alignclipsmodel.cpp \
     models/attachedfiltersmodel.cpp \
     models/metadatamodel.cpp \
     docks/filtersdock.cpp \
@@ -192,6 +195,8 @@ HEADERS  += mainwindow.h \
     docks/recentdock.h \
     docks/encodedock.h \
     dialogs/addencodepresetdialog.h \
+    dialogs/alignaudiodialog.h \
+    dialogs/alignmentarray.h \
     dialogs/filedatedialog.h \
     jobqueue.h \
     docks/jobsdock.h \
@@ -205,6 +210,7 @@ HEADERS  += mainwindow.h \
     dialogs/durationdialog.h \
     transportcontrol.h \
     widgets/colorwheel.h \
+    models/alignclipsmodel.h \
     models/attachedfiltersmodel.h \
     models/metadatamodel.h \
     docks/filtersdock.h \
@@ -373,6 +379,8 @@ debug_and_release {
     LIBS += -L../CuteLogger
 }
 LIBS += -lCuteLogger
+
+LIBS += -lfftw3
 
 isEmpty(SHOTCUT_VERSION) {
     !win32:SHOTCUT_VERSION = $$system(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%y.%m.%d" 2>/dev/null || date -u -r "${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%y.%m.%d")


### PR DESCRIPTION
This is phase 1 of the "Align to Reference" feature.

This phase allows multiple timeline clips to be selected. The user selects the reference track to align to. Clips can only be aligned to a track and not to a specific clip. If a clip is on the reference track, it will be flagged as an error. An undo command allows the entire change to be reverted with undo.

This adds a project link dependency to fftw3 (which is already available in our builds)

Demo:

https://user-images.githubusercontent.com/821968/162655869-dbb9c31f-e4cd-4834-be7c-762867f03c4c.mp4

Future phases:
2) Quality threshold to detect clips that can not be aligned. In Phase 1, unrelated clips will still find some alignment (even though there really is none)
3) Drift compensation - automatically apply a speed factor to a clip to correct cameras that record at different rates (some code for this exists, but it is not ready for testing)