### PR TITLE
Format QML code style using qmlformat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,3 +67,8 @@ add_custom_target(astyle COMMAND
   astyle --project=.astylerc --ignore-exclude-errors --recursive "./*.cpp,*.h"
 )
 
+file(GLOB_RECURSE QML_SRC "src/qml/*.qml")
+add_custom_target(qmlformat COMMAND
+  ${CMAKE_PREFIX_PATH}/bin/qmlformat -i ${QML_SRC}
+)
+

--- a/src/qml/filters/alpha_adjust/ui.qml
+++ b/src/qml/filters/alpha_adjust/ui.qml
@@ -15,36 +15,37 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import QtQml.Models 2.12
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
-import QtQml.Models 2.12
 
 Item {
-    width: 200
-    height: 50
     property string paramOperation: '2'
     property string paramThreshold: '3'
     property string paramAmount: '4'
     property string paramInvert: '5'
 
+    width: 200
+    height: 50
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set(paramOperation, 0)
-            filter.set(paramThreshold, 0.5)
-            filter.set(paramAmount, 0.5)
+            filter.set(paramOperation, 0);
+            filter.set(paramThreshold, 0.5);
+            filter.set(paramAmount, 0.5);
         }
-        var current = filter.getDouble(paramOperation)
+        var current = filter.getDouble(paramOperation);
         for (var i = 0; i < operationModel.count; ++i) {
             if (operationModel.get(i).value === current) {
-                modeCombo.currentIndex = i
-                break
+                modeCombo.currentIndex = i;
+                break;
             }
         }
-        sliderAmount.value = filter.getDouble(paramAmount) * 100
-        invertCheckbox.checked = filter.get(paramInvert) === '1'
+        sliderAmount.value = filter.getDouble(paramAmount) * 100;
+        invertCheckbox.checked = filter.get(paramInvert) === '1';
     }
+
     GridLayout {
         anchors.fill: parent
         anchors.margins: 8
@@ -54,29 +55,67 @@ Item {
             text: qsTr('Mode')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: modeCombo
+
             implicitWidth: 180
-            model: ListModel {
-                id: operationModel
-                ListElement { text: qsTr('No Change'); value: 0.0 }
-                ListElement { text: qsTr('Shave'); value: 0.2 }
-                ListElement { text: qsTr('Shrink Hard'); value: 0.3 }
-                ListElement { text: qsTr('Shrink Soft'); value: 0.4 }
-                ListElement { text: qsTr('Grow Hard'); value: 0.6 }
-                ListElement { text: qsTr('Grow Soft'); value: 0.7 }
-                ListElement { text: qsTr('Threshold'); value: 0.8 }
-                ListElement { text: qsTr('Blur'); value: 1.0 }
-            }
             textRole: 'text'
             onActivated: {
-                filter.set(paramOperation, operationModel.get(currentIndex).value)
+                filter.set(paramOperation, operationModel.get(currentIndex).value);
             }
+
+            model: ListModel {
+                id: operationModel
+
+                ListElement {
+                    text: qsTr('No Change')
+                    value: 0
+                }
+
+                ListElement {
+                    text: qsTr('Shave')
+                    value: 0.2
+                }
+
+                ListElement {
+                    text: qsTr('Shrink Hard')
+                    value: 0.3
+                }
+
+                ListElement {
+                    text: qsTr('Shrink Soft')
+                    value: 0.4
+                }
+
+                ListElement {
+                    text: qsTr('Grow Hard')
+                    value: 0.6
+                }
+
+                ListElement {
+                    text: qsTr('Grow Soft')
+                    value: 0.7
+                }
+
+                ListElement {
+                    text: qsTr('Threshold')
+                    value: 0.8
+                }
+
+                ListElement {
+                    text: qsTr('Blur')
+                    value: 1
+                }
+
+            }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filter.set(paramOperation, operationModel.get(0).value)
-                modeCombo.currentIndex = 0
+                filter.set(paramOperation, operationModel.get(0).value);
+                modeCombo.currentIndex = 0;
             }
         }
 
@@ -84,32 +123,43 @@ Item {
             text: qsTr('Amount')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderAmount
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
             suffix: ' %'
             value: filter.getDouble(paramAmount) * 100
             onValueChanged: {
-                filter.set(paramAmount, value / 100)
-                filter.set(paramThreshold, value / 100)
+                filter.set(paramAmount, value / 100);
+                filter.set(paramThreshold, value / 100);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderAmount.value = 50
         }
 
-        Label {}
+        Label {
+        }
+
         CheckBox {
             id: invertCheckbox
+
             text: qsTr('Invert')
             onCheckedChanged: filter.set(paramInvert, checked)
         }
+
         Shotcut.UndoButton {
             onClicked: invertCheckbox.checked = false
         }
 
-        Item { Layout.fillHeight: true }
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
+
 }

--- a/src/qml/filters/alpha_view/meta.qml
+++ b/src/qml/filters/alpha_view/meta.qml
@@ -25,5 +25,4 @@ Metadata {
     mlt_service: 'frei0r.alpha0ps'
     objectName: 'alphaChannelView'
     qml: 'ui.qml'
-    
 }

--- a/src/qml/filters/alpha_view/ui.qml
+++ b/src/qml/filters/alpha_view/ui.qml
@@ -15,56 +15,94 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import QtQml.Models 2.12
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
-import QtQml.Models 2.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 200
-    height: 50
     property string paramDisplay: '0'
     property string paramUseInput: '1'
+
+    width: 200
+    height: 50
     Component.onCompleted: {
-        filter.set('threads', 0)
+        filter.set('threads', 0);
         if (filter.isNew) {
-            filter.set(paramUseInput, 1)
-            filter.set(paramDisplay, 0.21)
+            filter.set(paramUseInput, 1);
+            filter.set(paramDisplay, 0.21);
         }
-        var current = filter.getDouble(paramDisplay)
+        var current = filter.getDouble(paramDisplay);
         for (var i = 0; i < displayModel.count; ++i) {
             if (displayModel.get(i).value === current) {
-                displayCombo.currentIndex = i
-                break
+                displayCombo.currentIndex = i;
+                break;
             }
         }
     }
+
     ColumnLayout {
         anchors.fill: parent
         anchors.margins: 8
 
         RowLayout {
-            Label { text: qsTr('Display') }
+            Label {
+                text: qsTr('Display')
+            }
+
             Shotcut.ComboBox {
                 id: displayCombo
+
                 implicitWidth: 200
-                model: ListModel {
-                    id: displayModel
-                    ListElement { text: qsTr('Gray Alpha'); value: 0.21 }
-                    ListElement { text: qsTr('Red & Gray Alpha'); value: 0.36 }
-                    ListElement { text: qsTr('Checkered Background'); value: 1.00 }
-                    ListElement { text: qsTr('Black Background'); value: 0.50 }
-                    ListElement { text: qsTr('Gray Background'); value: 0.64 }
-                    ListElement { text: qsTr('White Background'); value: 0.79 }
-                }
                 textRole: 'text'
                 onActivated: {
-                    filter.set(paramDisplay, displayModel.get(currentIndex).value)
+                    filter.set(paramDisplay, displayModel.get(currentIndex).value);
                 }
-            }
-        }
-        Item { Layout.fillHeight: true }
-    }
-}
 
+                model: ListModel {
+                    id: displayModel
+
+                    ListElement {
+                        text: qsTr('Gray Alpha')
+                        value: 0.21
+                    }
+
+                    ListElement {
+                        text: qsTr('Red & Gray Alpha')
+                        value: 0.36
+                    }
+
+                    ListElement {
+                        text: qsTr('Checkered Background')
+                        value: 1
+                    }
+
+                    ListElement {
+                        text: qsTr('Black Background')
+                        value: 0.5
+                    }
+
+                    ListElement {
+                        text: qsTr('Gray Background')
+                        value: 0.64
+                    }
+
+                    ListElement {
+                        text: qsTr('White Background')
+                        value: 0.79
+                    }
+
+                }
+
+            }
+
+        }
+
+        Item {
+            Layout.fillHeight: true
+        }
+
+    }
+
+}

--- a/src/qml/filters/audio_balance/meta.qml
+++ b/src/qml/filters/audio_balance/meta.qml
@@ -8,6 +8,7 @@ Metadata {
     mlt_service: 'panner'
     objectName: 'audioBalance'
     qml: 'ui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -22,4 +23,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/audio_balance/ui.qml
+++ b/src/qml/filters/audio_balance/ui.qml
@@ -21,76 +21,78 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 350
-    height: 50
     property bool blockUpdate: true
     property double startValue: 0.5
     property double middleValue: 0.5
     property double endValue: 0.5
 
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set('start', 0.5)
-            filter.set('split', 0.5)
-            filter.savePreset(preset.parameters)
-        } else {
-            // Convert old version of filter.
-            if (filter.getDouble('start') !== 0.5)
-                filter.set('split', filter.getDouble('start'))
-
-            middleValue = filter.getDouble('split', filter.animateIn)
-            if (filter.animateIn > 0)
-                startValue = filter.getDouble('split', 0)
-            if (filter.animateOut > 0)
-                endValue = filter.getDouble('split', filter.duration - 1)
-        }
-        setControls()
-    }
-
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        slider.value = filter.getDouble('split', position) * slider.maximumValue
-        blockUpdate = false
-        slider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
-        keyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('split') > 0
+        var position = getPosition();
+        blockUpdate = true;
+        slider.value = filter.getDouble('split', position) * slider.maximumValue;
+        blockUpdate = false;
+        slider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
+        keyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('split') > 0;
     }
 
     function updateFilter(position) {
-        if (blockUpdate) return
-        var value = slider.value / slider.maximumValue
+        if (blockUpdate)
+            return ;
 
+        var value = slider.value / slider.maximumValue;
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValue = value
+                startValue = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValue = value
+                endValue = value;
             else
-                middleValue = value
+                middleValue = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty('split')
-            keyframesButton.checked = false
+            filter.resetProperty('split');
+            keyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set('split', startValue, 0)
-                filter.set('split', middleValue, filter.animateIn - 1)
+                filter.set('split', startValue, 0);
+                filter.set('split', middleValue, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set('split', middleValue, filter.duration - filter.animateOut)
-                filter.set('split', endValue, filter.duration - 1)
+                filter.set('split', middleValue, filter.duration - filter.animateOut);
+                filter.set('split', endValue, filter.duration - 1);
             }
         } else if (!keyframesButton.checked) {
-            filter.resetProperty('split')
-            filter.set('split', middleValue)
+            filter.resetProperty('split');
+            filter.set('split', middleValue);
         } else if (position !== null) {
-            filter.set('split', value, position)
+            filter.set('split', value, position);
         }
+    }
+
+    width: 350
+    height: 50
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set('start', 0.5);
+            filter.set('split', 0.5);
+            filter.savePreset(preset.parameters);
+        } else {
+            // Convert old version of filter.
+            if (filter.getDouble('start') !== 0.5)
+                filter.set('split', filter.getDouble('start'));
+
+            middleValue = filter.getDouble('split', filter.animateIn);
+            if (filter.animateIn > 0)
+                startValue = filter.getDouble('split', 0);
+
+            if (filter.animateOut > 0)
+                endValue = filter.getDouble('split', filter.duration - 1);
+
+        }
+        setControls();
     }
 
     GridLayout {
@@ -102,26 +104,34 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: parent.columns - 1
             parameters: ['split']
             onBeforePresetLoaded: {
-                filter.resetProperty(parameters[0])
+                filter.resetProperty(parameters[0]);
             }
             onPresetSelected: {
-                setControls()
-                middleValue = filter.getDouble(parameters[0], filter.animateIn)
+                setControls();
+                middleValue = filter.getDouble(parameters[0], filter.animateIn);
                 if (filter.animateIn > 0)
-                    startValue = filter.getDouble(parameters[0], 0)
+                    startValue = filter.getDouble(parameters[0], 0);
+
                 if (filter.animateOut > 0)
-                    endValue = filter.getDouble(parameters[0], filter.duration - 1)
+                    endValue = filter.getDouble(parameters[0], filter.duration - 1);
+
             }
         }
 
-        Label { text: qsTr('Left') }
+        Label {
+            text: qsTr('Left')
+        }
+
         Shotcut.SliderSpinner {
             id: slider
+
             minimumValue: 0
             maximumValue: 1000
             ratio: 1000
@@ -129,21 +139,24 @@ Item {
             label: qsTr('Right')
             onValueChanged: updateFilter(getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: slider.value = 500
         }
+
         Shotcut.KeyframesButton {
             id: keyframesButton
+
             onToggled: {
-                var value = slider.value / slider.maximumValue
+                var value = slider.value / slider.maximumValue;
                 if (checked) {
-                    blockUpdate = true
-                    filter.clearSimpleAnimation('split')
-                    blockUpdate = false
-                    filter.set('split', value, getPosition())
+                    blockUpdate = true;
+                    filter.clearSimpleAnimation('split');
+                    blockUpdate = false;
+                    filter.set('split', value, getPosition());
                 } else {
-                    filter.resetProperty('split')
-                    filter.set('split', value)
+                    filter.resetProperty('split');
+                    filter.set('split', value);
                 }
             }
         }
@@ -151,20 +164,43 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateFilter(null);
+        }
+
+        function onOutChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateInChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateOutChanged() {
+            updateFilter(null);
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateFilter(null) }
-        function onOutChanged() { updateFilter(null) }
-        function onAnimateInChanged() { updateFilter(null) }
-        function onAnimateOutChanged() { updateFilter(null) }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/audio_bandpass/ui.qml
+++ b/src/qml/filters/audio_bandpass/ui.qml
@@ -22,25 +22,25 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
+    function setControls() {
+        sliderCenter.value = filter.getDouble('0');
+        sliderBandwidth.value = filter.getDouble('1');
+        sliderStages.value = filter.get('2');
+        sliderWetness.value = filter.getDouble('wetness') * sliderWetness.maximumValue;
+    }
+
     width: 350
     height: 150
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set('0', 322)
-            filter.set('1', 322)
-            filter.set('2', 1)
-            filter.set('wetness', 1.0)
-            filter.savePreset(preset.parameters)
+            filter.set('0', 322);
+            filter.set('1', 322);
+            filter.set('2', 1);
+            filter.set('wetness', 1);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        sliderCenter.value = filter.getDouble('0')
-        sliderBandwidth.value = filter.getDouble('1')
-        sliderStages.value = filter.get('2')
-        sliderWetness.value = filter.getDouble('wetness') * sliderWetness.maximumValue
+        setControls();
     }
 
     GridLayout {
@@ -52,8 +52,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ['0', '1', '2', 'wetness']
             Layout.columnSpan: 2
             onPresetSelected: setControls()
@@ -63,17 +65,20 @@ Item {
             text: qsTr('Center frequency')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderCenter
+
             minimumValue: 5
             maximumValue: 21600
             suffix: ' Hz'
             spinnerWidth: 100
             value: filter.getDouble('0')
             onValueChanged: {
-                filter.set('0', value)
+                filter.set('0', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderCenter.value = 322
         }
@@ -82,17 +87,20 @@ Item {
             text: qsTr('Bandwidth')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderBandwidth
+
             minimumValue: 5
             maximumValue: 21600
             suffix: ' Hz'
             spinnerWidth: 100
             value: filter.getDouble('1')
             onValueChanged: {
-                filter.set('1', value)
+                filter.set('1', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderBandwidth.value = 322
         }
@@ -101,16 +109,19 @@ Item {
             text: qsTr('Rolloff rate')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderStages
+
             minimumValue: 1
             maximumValue: 10
             spinnerWidth: 100
             value: filter.get('2')
             onValueChanged: {
-                filter.set('2', value)
+                filter.set('2', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderStages.value = 1
         }
@@ -119,8 +130,10 @@ Item {
             text: qsTr('Dry')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderWetness
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -129,15 +142,18 @@ Item {
             suffix: ' %'
             value: filter.getDouble('wetness') * maximumValue
             onValueChanged: {
-                filter.set('wetness', value / maximumValue)
+                filter.set('wetness', value / maximumValue);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderWetness.value = sliderWetness.maximumValue
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/audio_basstreble/ui.qml
+++ b/src/qml/filters/audio_basstreble/ui.qml
@@ -22,31 +22,34 @@ import Shotcut.Controls 1.0 as Shotcut
 
 Item {
     id: background
+
+    function setControls() {
+        sliderLow.value = filter.getDouble('0');
+        sliderMid.value = filter.getDouble('1');
+        sliderHigh.value = filter.getDouble('2');
+    }
+
     width: 350
     height: 200
-
-    SystemPalette { id: activePalette }
-
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set('0', 0)
-            filter.set('1', 0)
-            filter.set('2', 0)
-            filter.set('wetness', 1.0)
-            filter.savePreset(preset.parameters)
+            filter.set('0', 0);
+            filter.set('1', 0);
+            filter.set('2', 0);
+            filter.set('wetness', 1);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
+        setControls();
     }
 
-    function setControls() {
-        sliderLow.value = filter.getDouble('0')
-        sliderMid.value = filter.getDouble('1')
-        sliderHigh.value = filter.getDouble('2')
+    SystemPalette {
+        id: activePalette
     }
 
     Rectangle {
         id: topLine
+
         height: 1
         width: lowColumn.width * 3 + 20
         color: activePalette.text
@@ -64,11 +67,13 @@ Item {
     Label {
         text: '+12 dB'
         font.pointSize: bassLabel.font.pointSize - 1
+
         anchors {
             right: topLine.left
             rightMargin: 8
             verticalCenter: topLine.verticalCenter
         }
+
     }
 
     Rectangle {
@@ -88,6 +93,7 @@ Item {
 
     Rectangle {
         id: zeroLine
+
         height: 2
         width: lowColumn.width * 3 + gridLayout.anchors.margins * 2
         color: activePalette.text
@@ -105,11 +111,13 @@ Item {
     Label {
         text: '0 dB'
         font.pointSize: bassLabel.font.pointSize - 1
+
         anchors {
             right: zeroLine.left
             rightMargin: 8
             verticalCenter: zeroLine.verticalCenter
         }
+
     }
 
     Rectangle {
@@ -129,6 +137,7 @@ Item {
 
     Rectangle {
         id: bottomLine
+
         height: 1
         width: lowColumn.width * 3 + gridLayout.anchors.margins * 2
         color: activePalette.text
@@ -146,33 +155,42 @@ Item {
     Label {
         text: '-12 dB'
         font.pointSize: bassLabel.font.pointSize - 1
+
         anchors {
             right: bottomLine.left
             rightMargin: 8
             verticalCenter: bottomLine.verticalCenter
         }
+
     }
 
     GridLayout {
         id: gridLayout
+
+        property double leftMargin: (width - lowColumn.width * 3 - columnSpacing * 2) / 2
+
         anchors.fill: parent
         anchors.margins: 8
         columns: 5
-        property double leftMargin: (width - lowColumn.width * 3 - columnSpacing * 2) / 2
 
         RowLayout {
             id: presetLayout
+
             spacing: 8
             Layout.columnSpan: parent.columns
+
             Label {
                 text: qsTr('Preset')
                 Layout.alignment: Qt.AlignRight
             }
+
             Shotcut.Preset {
                 id: preset
+
                 parameters: ['0', '1', '2']
                 onPresetSelected: setControls()
             }
+
         }
 
         Item {
@@ -181,11 +199,13 @@ Item {
 
         ColumnLayout {
             id: lowColumn
+
             Layout.minimumWidth: 80
             Layout.alignment: Qt.AlignHCenter
 
             Slider {
                 id: sliderLow
+
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillHeight: true
                 orientation: Qt.Vertical
@@ -193,14 +213,25 @@ Item {
                 to: 12
                 value: filter.getDouble('0')
                 onValueChanged: filter.set('0', value)
-                Shotcut.HoverTip { text: '%1 dB'.arg(Math.round(parent.value * 10) / 10) }
+
+                Shotcut.HoverTip {
+                    text: '%1 dB'.arg(Math.round(parent.value * 10) / 10)
+                }
+
             }
+
             Label {
                 id: bassLabel
+
                 text: qsTr('Bass')
                 Layout.alignment: Qt.AlignHCenter
-                Shotcut.HoverTip { text: '100 Hz' }
+
+                Shotcut.HoverTip {
+                    text: '100 Hz'
+                }
+
             }
+
         }
 
         ColumnLayout {
@@ -209,6 +240,7 @@ Item {
 
             Slider {
                 id: sliderMid
+
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillHeight: true
                 orientation: Qt.Vertical
@@ -216,13 +248,23 @@ Item {
                 to: 12
                 value: filter.getDouble('1')
                 onValueChanged: filter.set('1', value)
-                Shotcut.HoverTip { text: '%1 dB'.arg(Math.round(parent.value * 10) / 10) }
+
+                Shotcut.HoverTip {
+                    text: '%1 dB'.arg(Math.round(parent.value * 10) / 10)
+                }
+
             }
+
             Label {
                 text: qsTr('Middle', 'Bass & Treble audio filter')
                 Layout.alignment: Qt.AlignHCenter
-                Shotcut.HoverTip { text: '1000 Hz' }
+
+                Shotcut.HoverTip {
+                    text: '1000 Hz'
+                }
+
             }
+
         }
 
         ColumnLayout {
@@ -231,6 +273,7 @@ Item {
 
             Slider {
                 id: sliderHigh
+
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillHeight: true
                 orientation: Qt.Vertical
@@ -238,17 +281,29 @@ Item {
                 to: 12
                 value: filter.getDouble('2')
                 onValueChanged: filter.set('2', value)
-                Shotcut.HoverTip { text: '%1 dB'.arg(Math.round(parent.value * 10) / 10) }
+
+                Shotcut.HoverTip {
+                    text: '%1 dB'.arg(Math.round(parent.value * 10) / 10)
+                }
+
             }
+
             Label {
                 text: qsTr('Treble')
                 Layout.alignment: Qt.AlignHCenter
-                Shotcut.HoverTip { text: '10000 Hz' }
+
+                Shotcut.HoverTip {
+                    text: '10000 Hz'
+                }
+
             }
+
         }
 
         Item {
             Layout.fillWidth: true
         }
+
     }
+
 }

--- a/src/qml/filters/audio_channelcopy/ui.qml
+++ b/src/qml/filters/audio_channelcopy/ui.qml
@@ -21,32 +21,28 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 100
-    height: 50
     property string fromParameter: 'from'
     property string toParameter: 'to'
+
+    width: 100
+    height: 50
     Component.onCompleted: {
         if (application.audioChannels() === 1) {
-            fromCombo.enabled = false
-            toCombo.enabled = false
+            fromCombo.enabled = false;
+            toCombo.enabled = false;
         } else if (application.audioChannels() === 6) {
-            fromCombo.model = [qsTr('Front left'),
-                           qsTr('Front right'),
-                           qsTr('Center'),
-                           qsTr('Low frequency'),
-                           qsTr('Left surround'),
-                           qsTr('Right surround')]
+            fromCombo.model = [qsTr('Front left'), qsTr('Front right'), qsTr('Center'), qsTr('Low frequency'), qsTr('Left surround'), qsTr('Right surround')];
         }
         if (filter.isNew) {
             // Set default parameter values
-            fromCombo.currentIndex = 0
-            filter.set(fromParameter, fromCombo.currentIndex)
-            toCombo.currentIndex = (application.audioChannels() === 1) ? 0 : 1
-            filter.set(toParameter, toCombo.currentIndex)
+            fromCombo.currentIndex = 0;
+            filter.set(fromParameter, fromCombo.currentIndex);
+            toCombo.currentIndex = (application.audioChannels() === 1) ? 0 : 1;
+            filter.set(toParameter, toCombo.currentIndex);
         } else {
             // Initialize parameter values
-            fromCombo.currentIndex = filter.get(fromParameter)
-            toCombo.currentIndex = filter.get(toParameter)
+            fromCombo.currentIndex = filter.get(fromParameter);
+            toCombo.currentIndex = filter.get(toParameter);
         }
     }
 
@@ -55,21 +51,34 @@ Item {
         anchors.margins: 8
 
         RowLayout {
-            Label { text: qsTr('Copy from') }
+            Label {
+                text: qsTr('Copy from')
+            }
+
             Shotcut.ComboBox {
                 id: fromCombo
+
                 model: [qsTr('Left'), qsTr('Right')]
                 onActivated: filter.set(fromParameter, currentIndex)
             }
-            Label { text: qsTr('to') }
+
+            Label {
+                text: qsTr('to')
+            }
+
             Shotcut.ComboBox {
                 id: toCombo
+
                 model: fromCombo.model
                 onActivated: filter.set(toParameter, currentIndex)
             }
+
         }
+
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/audio_compressor/ui.qml
+++ b/src/qml/filters/audio_compressor/ui.qml
@@ -16,46 +16,47 @@
  */
 
 import QtQuick 2.12
-import QtQuick.Layouts 1.12
 import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
+    function setControls() {
+        sliderPeak.value = filter.getDouble('0') * sliderPeak.maximumValue;
+        sliderAttack.value = filter.getDouble('1');
+        sliderRelease.value = filter.getDouble('2');
+        sliderThreshold.value = filter.getDouble('3');
+        sliderRatio.value = filter.getDouble('4');
+        sliderRadius.value = filter.getDouble('5');
+        sliderGain.value = filter.getDouble('6');
+    }
+
     width: 350
     height: 300
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set('0', 0)
-            filter.set('1', 100)
-            filter.set('2', 400)
-            filter.set('3', 0)
-            filter.set('4', 1)
-            filter.set('5', 3.25)
-            filter.set('6', 0)
-            filter.savePreset(preset.parameters)
+            filter.set('0', 0);
+            filter.set('1', 100);
+            filter.set('2', 400);
+            filter.set('3', 0);
+            filter.set('4', 1);
+            filter.set('5', 3.25);
+            filter.set('6', 0);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-        timer.start()
-    }
-
-    function setControls() {
-        sliderPeak.value = filter.getDouble('0') * sliderPeak.maximumValue
-        sliderAttack.value = filter.getDouble('1')
-        sliderRelease.value = filter.getDouble('2')
-        sliderThreshold.value = filter.getDouble('3')
-        sliderRatio.value = filter.getDouble('4')
-        sliderRadius.value = filter.getDouble('5')
-        sliderGain.value = filter.getDouble('6')
+        setControls();
+        timer.start();
     }
 
     Timer {
         id: timer
+
         interval: 100
         running: false
         repeat: true
         onTriggered: {
-            grGauge.value = filter.getDouble('8[0]')
+            grGauge.value = filter.getDouble('8[0]');
         }
     }
 
@@ -68,8 +69,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ['0', '1', '2', '3', '4', '5', '6']
             Layout.columnSpan: 2
             onPresetSelected: setControls()
@@ -78,10 +81,16 @@ Item {
         Label {
             text: qsTr('RMS')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The balance between the RMS and peak envelope followers. RMS is generally better for subtle, musical compression and peak is better for heavier, fast compression and percussion.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The balance between the RMS and peak envelope followers. RMS is generally better for subtle, musical compression and peak is better for heavier, fast compression and percussion.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderPeak
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -89,9 +98,10 @@ Item {
             suffix: ' %'
             value: filter.getDouble('0') * maximumValue
             onValueChanged: {
-                filter.set('0', value / maximumValue)
+                filter.set('0', value / maximumValue);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderPeak.value = sliderPeak.minimumValue
         }
@@ -100,16 +110,19 @@ Item {
             text: qsTr('Attack')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderAttack
+
             minimumValue: 2
             maximumValue: 400
             suffix: ' ms'
             value: filter.getDouble('1')
             onValueChanged: {
-                filter.set('1', value)
+                filter.set('1', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderAttack.value = 100
         }
@@ -118,16 +131,19 @@ Item {
             text: qsTr('Release')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderRelease
+
             minimumValue: 2
             maximumValue: 800
             suffix: ' ms'
             value: filter.getDouble('2')
             onValueChanged: {
-                filter.set('2', value)
+                filter.set('2', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderRelease.value = 400
         }
@@ -135,19 +151,26 @@ Item {
         Label {
             text: qsTr('Threshold')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The point at which the compressor will start to kick in.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The point at which the compressor will start to kick in.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderThreshold
+
             minimumValue: -30
             maximumValue: 0
             decimals: 1
             suffix: ' dB'
             value: filter.getDouble('3')
             onValueChanged: {
-                filter.set('3', value)
+                filter.set('3', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderThreshold.value = 0
         }
@@ -155,18 +178,25 @@ Item {
         Label {
             text: qsTr('Ratio')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The gain reduction ratio used when the signal level exceeds the threshold.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The gain reduction ratio used when the signal level exceeds the threshold.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderRatio
+
             minimumValue: 1
             maximumValue: 20
             prefix: ' 1:'
             value: filter.getDouble('4')
             onValueChanged: {
-                filter.set('4', value)
+                filter.set('4', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderRatio.value = 1
         }
@@ -174,19 +204,26 @@ Item {
         Label {
             text: qsTr('Knee radius')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The distance from the threshold where the knee curve starts.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The distance from the threshold where the knee curve starts.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderRadius
+
             minimumValue: 1
             maximumValue: 10
             decimals: 1
             suffix: ' dB'
             value: filter.getDouble('5')
             onValueChanged: {
-                filter.set('5', value)
+                filter.set('5', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderRadius.value = 3.25
         }
@@ -194,19 +231,26 @@ Item {
         Label {
             text: qsTr('Makeup gain')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The gain of the makeup input signal.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The gain of the makeup input signal.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderGain
+
             minimumValue: 0
             maximumValue: 24
             decimals: 1
             suffix: ' dB'
             value: filter.getDouble('6')
             onValueChanged: {
-                filter.set('6', value)
+                filter.set('6', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderGain.value = 0
         }
@@ -216,6 +260,7 @@ Item {
             Layout.fillWidth: true
             Layout.minimumHeight: 12
             color: 'transparent'
+
             Rectangle {
                 anchors.verticalCenter: parent.verticalCenter
                 width: parent.width
@@ -223,18 +268,26 @@ Item {
                 radius: 2
                 color: activePalette.text
             }
+
         }
 
         Label {
             id: grLabel
+
             text: qsTr('Gain Reduction')
             Layout.alignment: Qt.AlignRight | Qt.AlignTop
-            Shotcut.HoverTip {text: qsTr('Status indicator showing the gain reduction applied by the compressor.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('Status indicator showing the gain reduction applied by the compressor.')
+            }
+
         }
+
         Shotcut.Gauge {
+            id: grGauge
+
             Layout.columnSpan: 2
             Layout.fillWidth: true
-            id: grGauge
             from: -24
             value: 0
             to: 0
@@ -244,17 +297,22 @@ Item {
 
         Label {
             id: link_Text
+
             Layout.columnSpan: 3
             text: qsTr('About dynamic range compression')
             font.underline: true
+
             MouseArea {
                 anchors.fill: parent
                 onClicked: Qt.openUrlExternally('https://en.wikipedia.org/wiki/Dynamic_range_compression')
             }
+
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/audio_delay/ui.qml
+++ b/src/qml/filters/audio_delay/ui.qml
@@ -22,23 +22,23 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
+    function setControls() {
+        sliderDelay.value = filter.getDouble('0');
+        sliderFeedback.value = filter.getDouble('1');
+        sliderWetness.value = filter.getDouble('wetness') * sliderWetness.maximumValue;
+    }
+
     width: 350
     height: 125
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set('0', 1)
-            filter.set('1', -10)
-            filter.set('wetness', 1.0)
-            filter.savePreset(preset.parameters)
+            filter.set('0', 1);
+            filter.set('1', -10);
+            filter.set('wetness', 1);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        sliderDelay.value = filter.getDouble('0')
-        sliderFeedback.value = filter.getDouble('1')
-        sliderWetness.value = filter.getDouble('wetness') * sliderWetness.maximumValue
+        setControls();
     }
 
     GridLayout {
@@ -50,8 +50,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ['0', '1', 'wetness']
             Layout.columnSpan: 2
             onPresetSelected: setControls()
@@ -60,19 +62,26 @@ Item {
         Label {
             text: qsTr('Delay')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The neutral delay time is 2 seconds.\nTimes above 2 seconds will have reduced quality.\nTimes below will have increased CPU usage.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The neutral delay time is 2 seconds.\nTimes above 2 seconds will have reduced quality.\nTimes below will have increased CPU usage.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderDelay
+
             minimumValue: 0
             maximumValue: 4
             suffix: ' s'
             decimals: 2
             value: filter.getDouble('0')
             onValueChanged: {
-                filter.set('0', value)
+                filter.set('0', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderDelay.value = 1
         }
@@ -81,17 +90,20 @@ Item {
             text: qsTr('Feedback')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderFeedback
+
             minimumValue: -70
             maximumValue: 0
             suffix: ' dB'
             decimals: 1
             value: filter.getDouble('1')
             onValueChanged: {
-                filter.set('1', value)
+                filter.set('1', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderFeedback.value = -10
         }
@@ -100,8 +112,10 @@ Item {
             text: qsTr('Dry')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderWetness
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -109,15 +123,18 @@ Item {
             suffix: ' %'
             value: filter.getDouble('wetness') * maximumValue
             onValueChanged: {
-                filter.set('wetness', value / maximumValue)
+                filter.set('wetness', value / maximumValue);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderWetness.value = sliderWetness.maximumValue
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/audio_eq15band/meta.qml
+++ b/src/qml/filters/audio_eq15band/meta.qml
@@ -8,6 +8,7 @@ Metadata {
     mlt_service: 'ladspa.1197'
     objectName: '15BandEq'
     qml: 'ui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -21,4 +22,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/audio_eq15band/ui.qml
+++ b/src/qml/filters/audio_eq15band/ui.qml
@@ -21,86 +21,86 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Shotcut.KeyframableFilter {
+    property bool blockControls: false
+
+    function setControls() {
+        if (blockControls)
+            return ;
+
+        var position = getPosition();
+        blockUpdate = true;
+        slider0.value = filter.getDouble('0', position);
+        slider1.value = filter.getDouble('1', position);
+        slider2.value = filter.getDouble('2', position);
+        slider3.value = filter.getDouble('3', position);
+        slider4.value = filter.getDouble('4', position);
+        slider5.value = filter.getDouble('5', position);
+        slider6.value = filter.getDouble('6', position);
+        slider7.value = filter.getDouble('7', position);
+        slider8.value = filter.getDouble('8', position);
+        slider9.value = filter.getDouble('9', position);
+        slider10.value = filter.getDouble('10', position);
+        slider11.value = filter.getDouble('11', position);
+        slider12.value = filter.getDouble('12', position);
+        slider13.value = filter.getDouble('13', position);
+        slider14.value = filter.getDouble('14', position);
+        keyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('0') > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        slider0.enabled = slider1.enabled = slider2.enabled = slider3.enabled = slider4.enabled = slider5.enabled = slider6.enabled = slider7.enabled = slider8.enabled = slider9.enabled = slider10.enabled = slider11.enabled = slider12.enabled = slider13.enabled = slider14.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes(position) {
+        if (blockUpdate)
+            return ;
+
+        setControls();
+        updateFilter('0', slider0.value, keyframesButton, position);
+        updateFilter('1', slider1.value, keyframesButton, position);
+        updateFilter('2', slider2.value, keyframesButton, position);
+        updateFilter('3', slider3.value, keyframesButton, position);
+        updateFilter('4', slider4.value, keyframesButton, position);
+        updateFilter('5', slider5.value, keyframesButton, position);
+        updateFilter('6', slider6.value, keyframesButton, position);
+        updateFilter('7', slider7.value, keyframesButton, position);
+        updateFilter('8', slider8.value, keyframesButton, position);
+        updateFilter('9', slider9.value, keyframesButton, position);
+        updateFilter('10', slider10.value, keyframesButton, position);
+        updateFilter('11', slider11.value, keyframesButton, position);
+        updateFilter('12', slider12.value, keyframesButton, position);
+        updateFilter('13', slider13.value, keyframesButton, position);
+        updateFilter('14', slider14.value, keyframesButton, position);
+    }
+
     keyframableParameters: ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14']
     startValues: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     middleValues: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     endValues: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    property bool blockControls: false
-
     width: 200
     height: 430
-
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set('0', 0)
-            filter.set('1', 0)
-            filter.set('2', 0)
-            filter.set('3', 0)
-            filter.set('4', 0)
-            filter.set('5', 0)
-            filter.set('6', 0)
-            filter.set('7', 0)
-            filter.set('8', 0)
-            filter.set('9', 0)
-            filter.set('10', 0)
-            filter.set('11', 0)
-            filter.set('12', 0)
-            filter.set('13', 0)
-            filter.set('14', 0)
-            filter.savePreset(preset.parameters)
+            filter.set('0', 0);
+            filter.set('1', 0);
+            filter.set('2', 0);
+            filter.set('3', 0);
+            filter.set('4', 0);
+            filter.set('5', 0);
+            filter.set('6', 0);
+            filter.set('7', 0);
+            filter.set('8', 0);
+            filter.set('9', 0);
+            filter.set('10', 0);
+            filter.set('11', 0);
+            filter.set('12', 0);
+            filter.set('13', 0);
+            filter.set('14', 0);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        if (blockControls) return
-        var position = getPosition()
-        blockUpdate = true
-        slider0.value = filter.getDouble('0', position)
-        slider1.value = filter.getDouble('1', position)
-        slider2.value = filter.getDouble('2', position)
-        slider3.value = filter.getDouble('3', position)
-        slider4.value = filter.getDouble('4', position)
-        slider5.value = filter.getDouble('5', position)
-        slider6.value = filter.getDouble('6', position)
-        slider7.value = filter.getDouble('7', position)
-        slider8.value = filter.getDouble('8', position)
-        slider9.value = filter.getDouble('9', position)
-        slider10.value = filter.getDouble('10', position)
-        slider11.value = filter.getDouble('11', position)
-        slider12.value = filter.getDouble('12', position)
-        slider13.value = filter.getDouble('13', position)
-        slider14.value = filter.getDouble('14', position)
-        keyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('0') > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        slider0.enabled = slider1.enabled = slider2.enabled = slider3.enabled =
-            slider4.enabled = slider5.enabled = slider6.enabled = slider7.enabled =
-            slider8.enabled = slider9.enabled = slider10.enabled = slider11.enabled =
-            slider12.enabled = slider13.enabled = slider14.enabled = enabled
-    }
-
-    function updateSimpleKeyframes(position) {
-        if (blockUpdate) return
-        setControls()
-        updateFilter('0', slider0.value, keyframesButton, position)
-        updateFilter('1', slider1.value, keyframesButton, position)
-        updateFilter('2', slider2.value, keyframesButton, position)
-        updateFilter('3', slider3.value, keyframesButton, position)
-        updateFilter('4', slider4.value, keyframesButton, position)
-        updateFilter('5', slider5.value, keyframesButton, position)
-        updateFilter('6', slider6.value, keyframesButton, position)
-        updateFilter('7', slider7.value, keyframesButton, position)
-        updateFilter('8', slider8.value, keyframesButton, position)
-        updateFilter('9', slider9.value, keyframesButton, position)
-        updateFilter('10', slider10.value, keyframesButton, position)
-        updateFilter('11', slider11.value, keyframesButton, position)
-        updateFilter('12', slider12.value, keyframesButton, position)
-        updateFilter('13', slider13.value, keyframesButton, position)
-        updateFilter('14', slider14.value, keyframesButton, position)
+        setControls();
     }
 
     GridLayout {
@@ -112,16 +112,18 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: keyframableParameters
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -129,19 +131,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('50 Hz')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider0
+
             minimumValue: -20
             maximumValue: 20
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider0.value = 0
         }
@@ -149,59 +154,70 @@ Shotcut.KeyframableFilter {
         ColumnLayout {
             Layout.rowSpan: 15
             height: (keyframesButton.height + 5) * Layout.rowSpan
-            SystemPalette { id: activePalette }
+
+            SystemPalette {
+                id: activePalette
+            }
+
             Rectangle {
                 color: activePalette.text
                 width: 1
                 height: parent.height / 2
                 Layout.alignment: Qt.AlignHCenter
             }
+
             Shotcut.KeyframesButton {
                 id: keyframesButton
+
                 onToggled: {
-                    toggleKeyframes(checked, '0', slider0.value)
-                    toggleKeyframes(checked, '1', slider1.value)
-                    toggleKeyframes(checked, '2', slider2.value)
-                    toggleKeyframes(checked, '3', slider3.value)
-                    toggleKeyframes(checked, '4', slider4.value)
-                    toggleKeyframes(checked, '5', slider5.value)
-                    toggleKeyframes(checked, '6', slider6.value)
-                    toggleKeyframes(checked, '7', slider7.value)
-                    toggleKeyframes(checked, '8', slider8.value)
-                    toggleKeyframes(checked, '9', slider9.value)
-                    toggleKeyframes(checked, '10', slider10.value)
-                    toggleKeyframes(checked, '11', slider11.value)
-                    toggleKeyframes(checked, '12', slider12.value)
-                    toggleKeyframes(checked, '13', slider13.value)
-                    toggleKeyframes(checked, '14', slider14.value)
-                    setControls()
+                    toggleKeyframes(checked, '0', slider0.value);
+                    toggleKeyframes(checked, '1', slider1.value);
+                    toggleKeyframes(checked, '2', slider2.value);
+                    toggleKeyframes(checked, '3', slider3.value);
+                    toggleKeyframes(checked, '4', slider4.value);
+                    toggleKeyframes(checked, '5', slider5.value);
+                    toggleKeyframes(checked, '6', slider6.value);
+                    toggleKeyframes(checked, '7', slider7.value);
+                    toggleKeyframes(checked, '8', slider8.value);
+                    toggleKeyframes(checked, '9', slider9.value);
+                    toggleKeyframes(checked, '10', slider10.value);
+                    toggleKeyframes(checked, '11', slider11.value);
+                    toggleKeyframes(checked, '12', slider12.value);
+                    toggleKeyframes(checked, '13', slider13.value);
+                    toggleKeyframes(checked, '14', slider14.value);
+                    setControls();
                 }
             }
+
             Rectangle {
                 color: activePalette.text
                 width: 1
                 height: parent.height / 2
                 Layout.alignment: Qt.AlignHCenter
             }
+
         }
 
         Label {
             text: qsTr('100 Hz')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider1
+
             minimumValue: -20
             maximumValue: 20
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider1.value = 0
         }
@@ -210,19 +226,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('156 Hz')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider2
+
             minimumValue: -20
             maximumValue: 20
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider2.value = 0
         }
@@ -231,19 +250,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('220 Hz')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider3
+
             minimumValue: -20
             maximumValue: 20
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider3.value = 0
         }
@@ -252,19 +274,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('311 Hz')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider4
+
             minimumValue: -20
             maximumValue: 20
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider4.value = 0
         }
@@ -273,19 +298,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('440 Hz')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider5
+
             minimumValue: -20
             maximumValue: 20
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider5.value = 0
         }
@@ -294,19 +322,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('622 Hz')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider6
+
             minimumValue: -20
             maximumValue: 20
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider6.value = 0
         }
@@ -315,19 +346,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('880 Hz')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider7
+
             minimumValue: -20
             maximumValue: 20
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider7.value = 0
         }
@@ -336,19 +370,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('1250 Hz')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider8
+
             minimumValue: -20
             maximumValue: 20
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider8.value = 0
         }
@@ -357,19 +394,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('1750 Hz')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider9
+
             minimumValue: -20
             maximumValue: 20
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider9.value = 0
         }
@@ -378,19 +418,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('2500 Hz')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider10
+
             minimumValue: -20
             maximumValue: 20
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider10.value = 0
         }
@@ -399,19 +442,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('3500 Hz')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider11
+
             minimumValue: -20
             maximumValue: 20
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider11.value = 0
         }
@@ -420,19 +466,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('5000 Hz')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider12
+
             minimumValue: -20
             maximumValue: 20
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider12.value = 0
         }
@@ -441,19 +490,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('10000 Hz')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider13
+
             minimumValue: -20
             maximumValue: 20
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider13.value = 0
         }
@@ -462,40 +514,66 @@ Shotcut.KeyframableFilter {
             text: qsTr('20000 Hz')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider14
+
             minimumValue: -20
             maximumValue: 20
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider14.value = 0
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes(null);
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes(null);
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes(null);
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes(null);
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes(null) }
-        function onOutChanged() { updateSimpleKeyframes(null) }
-        function onAnimateInChanged() { updateSimpleKeyframes(null) }
-        function onAnimateOutChanged() { updateSimpleKeyframes(null) }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/audio_eq3band/meta.qml
+++ b/src/qml/filters/audio_eq3band/meta.qml
@@ -8,6 +8,7 @@ Metadata {
     mlt_service: 'ladspa.1204'
     objectName: '3BandEq'
     qml: 'ui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -21,4 +22,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/audio_eq3band/ui.qml
+++ b/src/qml/filters/audio_eq3band/ui.qml
@@ -21,70 +21,88 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Shotcut.KeyframableFilter {
+    // The three band EQ is implemented by using a 3 band parametric
+    // EQ with shelves. Many of the parametric EQ parameters are fixed
+    // and the user only has control over three gain parameters for
+    // Low, Mid and High tone adjustment
+
+    property bool blockControls: false
+
+    function setControls() {
+        if (blockControls)
+            return ;
+
+        var position = getPosition();
+        blockUpdate = true;
+        lowSlider.value = filter.getDouble('0', position);
+        midSlider.value = filter.getDouble('6', position);
+        highSlider.value = filter.getDouble('12', position);
+        keyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('0') > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        lowSlider.enabled = midSlider.enabled = highSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes(position) {
+        if (blockUpdate)
+            return ;
+
+        setControls();
+        updateFilter('0', lowSlider.value, keyframesButton, position);
+        updateFilter('6', midSlider.value, keyframesButton, position);
+        updateFilter('12', highSlider.value, keyframesButton, position);
+    }
+
     keyframableParameters: ['0', '6', '12']
     startValues: [0, 0, 0]
     middleValues: [0, 0, 0]
     endValues: [0, 0, 0]
-    property bool blockControls: false
-
     width: 200
     height: 230
-
     Component.onCompleted: {
         if (filter.isNew) {
-            // The three band EQ is implemented by using a 3 band parametric
-            // EQ with shelves. Many of the parametric EQ parameters are fixed
-            // and the user only has control over three gain parameters for
-            // Low, Mid and High tone adjustment
-
             // Low Shelf - adjusts Low tone
-            filter.set('0', 0)     // gain      - adjustable
-            filter.set('1', 200)   // frequency - fixed
-            filter.set('2', 0.5)   // slope     - fixed
+            filter.set('0', 0);
+            // gain      - adjustable
+            filter.set('1', 200);
+            // frequency - fixed
+            filter.set('2', 0.5);
+            // slope     - fixed
             // Band 1 - not used
-            filter.set('3', 0)     // gain      - fixed
-            filter.set('4', 1000)  // frequency - fixed
-            filter.set('5', 1)     // Q         - fixed
+            filter.set('3', 0);
+            // gain      - fixed
+            filter.set('4', 1000);
+            // frequency - fixed
+            filter.set('5', 1);
+            // Q         - fixed
             // Band 2 - adjusts Mid tone
-            filter.set('6', 0)     // gain      - adjustable
-            filter.set('7', 1000)  // frequency - fixed
-            filter.set('8', 1)     // Q         - fixed
+            filter.set('6', 0);
+            // gain      - adjustable
+            filter.set('7', 1000);
+            // frequency - fixed
+            filter.set('8', 1);
+            // Q         - fixed
             // Band 3 - not used
-            filter.set('9', 0)     // gain      - fixed
-            filter.set('10', 1000) // frequency - fixed
-            filter.set('11', 1)    // Q         - fixed
+            filter.set('9', 0);
+            // gain      - fixed
+            filter.set('10', 1000);
+            // frequency - fixed
+            filter.set('11', 1);
+            // Q         - fixed
             // High Shelf - adjusts High tone
-            filter.set('12', 0)    // gain      - adjustable
-            filter.set('13', 5000) // frequency - fixed
-            filter.set('14', 0.5)  // slope     - fixed
-            filter.set('.dummy', '')
-            filter.savePreset(preset.parameters)
+            filter.set('12', 0);
+            // gain      - adjustable
+            filter.set('13', 5000);
+            // frequency - fixed
+            filter.set('14', 0.5);
+            // slope     - fixed
+            filter.set('.dummy', '');
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        if (blockControls) return
-        var position = getPosition()
-        blockUpdate = true
-        lowSlider.value = filter.getDouble('0', position)
-        midSlider.value = filter.getDouble('6', position)
-        highSlider.value = filter.getDouble('12', position)
-        keyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('0') > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        lowSlider.enabled = midSlider.enabled = highSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes(position) {
-        if (blockUpdate) return
-        setControls()
-        updateFilter('0', lowSlider.value, keyframesButton, position)
-        updateFilter('6', midSlider.value, keyframesButton, position)
-        updateFilter('12', highSlider.value, keyframesButton, position)
+        setControls();
     }
 
     GridLayout {
@@ -96,16 +114,18 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: keyframableParameters.concat('.dummy')
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -113,19 +133,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('Low')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: lowSlider
+
             minimumValue: -20
             maximumValue: 20
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: lowSlider.value = 0
         }
@@ -133,47 +156,58 @@ Shotcut.KeyframableFilter {
         ColumnLayout {
             Layout.rowSpan: 3
             height: (keyframesButton.height + 5) * Layout.rowSpan
-            SystemPalette { id: activePalette }
+
+            SystemPalette {
+                id: activePalette
+            }
+
             Rectangle {
                 color: activePalette.text
                 width: 1
                 height: keyframesButton.height
                 Layout.alignment: Qt.AlignHCenter
             }
+
             Shotcut.KeyframesButton {
                 id: keyframesButton
+
                 onToggled: {
-                    toggleKeyframes(checked, '0', lowSlider.value)
-                    toggleKeyframes(checked, '6', midSlider.value)
-                    toggleKeyframes(checked, '12', highSlider.value)
-                    setControls()
+                    toggleKeyframes(checked, '0', lowSlider.value);
+                    toggleKeyframes(checked, '6', midSlider.value);
+                    toggleKeyframes(checked, '12', highSlider.value);
+                    setControls();
                 }
             }
+
             Rectangle {
                 color: activePalette.text
                 width: 1
                 height: keyframesButton.height
                 Layout.alignment: Qt.AlignHCenter
             }
+
         }
 
         Label {
             text: qsTr('Mid')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: midSlider
+
             minimumValue: -20
             maximumValue: 20
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: midSlider.value = 0
         }
@@ -182,40 +216,66 @@ Shotcut.KeyframableFilter {
             text: qsTr('High')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: highSlider
+
             minimumValue: -20
             maximumValue: 20
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: highSlider.value = 0
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes(null);
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes(null);
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes(null);
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes(null);
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes(null) }
-        function onOutChanged() { updateSimpleKeyframes(null) }
-        function onAnimateInChanged() { updateSimpleKeyframes(null) }
-        function onAnimateOutChanged() { updateSimpleKeyframes(null) }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/audio_eqparametric/meta.qml
+++ b/src/qml/filters/audio_eqparametric/meta.qml
@@ -8,6 +8,7 @@ Metadata {
     mlt_service: 'ladspa.1204'
     objectName: 'parametricEq'
     qml: 'ui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -21,4 +22,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/audio_eqparametric/ui.qml
+++ b/src/qml/filters/audio_eqparametric/ui.qml
@@ -21,86 +21,86 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Shotcut.KeyframableFilter {
-    keyframableParameters: ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14']
     property var defaultValues: [0, 50, 0.5, 0, 100, 1, 0, 700, 1, 0, 5000, 1, 0, 15000, 0.5]
-    startValues: [0, 100, 0.5, 0, 100, 1, 0, 700, 1, 0, 5000, 1, 0, 15000, 0.5]
-    middleValues: [0, 100, 0.5, 0, 100, 1, 0, 700, 1, 0, 5000, 1, 0, 15000, 0.5]
-    endValues: [0, 100, 0.5, 0, 100, 1, 0, 700, 1, 0, 5000, 1, 0, 15000, 0.5]
     property bool blockControls: false
 
-    width: 200
-    height: 550
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            filter.set('0', defaultValues[0])
-            filter.set('1', defaultValues[1])
-            filter.set('2', defaultValues[2])
-            filter.set('3', defaultValues[3])
-            filter.set('4', defaultValues[4])
-            filter.set('5', defaultValues[5])
-            filter.set('6', defaultValues[6])
-            filter.set('7', defaultValues[7])
-            filter.set('8', defaultValues[8])
-            filter.set('9', defaultValues[9])
-            filter.set('10', defaultValues[10])
-            filter.set('11', defaultValues[11])
-            filter.set('12', defaultValues[12])
-            filter.set('13', defaultValues[13])
-            filter.set('14', defaultValues[14])
-            filter.savePreset(preset.parameters)
-        }
-        setControls()
-    }
-
     function setControls() {
-        if (blockControls) return
-        var position = getPosition()
-        blockUpdate = true
-        slider0.value = filter.getDouble('0', position)
-        slider1.value = filter.getDouble('1', position)
-        slider2.value = filter.getDouble('2', position)
-        slider3.value = filter.getDouble('3', position)
-        slider4.value = filter.getDouble('4', position)
-        slider5.value = filter.getDouble('5', position)
-        slider6.value = filter.getDouble('6', position)
-        slider7.value = filter.getDouble('7', position)
-        slider8.value = filter.getDouble('8', position)
-        slider9.value = filter.getDouble('9', position)
-        slider10.value = filter.getDouble('10', position)
-        slider11.value = filter.getDouble('11', position)
-        slider12.value = filter.getDouble('12', position)
-        slider13.value = filter.getDouble('13', position)
-        slider14.value = filter.getDouble('14', position)
-        keyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('0') > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
+        if (blockControls)
+            return ;
+
+        var position = getPosition();
+        blockUpdate = true;
+        slider0.value = filter.getDouble('0', position);
+        slider1.value = filter.getDouble('1', position);
+        slider2.value = filter.getDouble('2', position);
+        slider3.value = filter.getDouble('3', position);
+        slider4.value = filter.getDouble('4', position);
+        slider5.value = filter.getDouble('5', position);
+        slider6.value = filter.getDouble('6', position);
+        slider7.value = filter.getDouble('7', position);
+        slider8.value = filter.getDouble('8', position);
+        slider9.value = filter.getDouble('9', position);
+        slider10.value = filter.getDouble('10', position);
+        slider11.value = filter.getDouble('11', position);
+        slider12.value = filter.getDouble('12', position);
+        slider13.value = filter.getDouble('13', position);
+        slider14.value = filter.getDouble('14', position);
+        keyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('0') > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
     }
 
     function enableControls(enabled) {
-        slider0.enabled = slider1.enabled = slider2.enabled = slider3.enabled =
-            slider4.enabled = slider5.enabled = slider6.enabled = slider7.enabled =
-            slider8.enabled = slider9.enabled = slider10.enabled = slider11.enabled =
-            slider12.enabled = slider13.enabled = slider14.enabled = enabled
+        slider0.enabled = slider1.enabled = slider2.enabled = slider3.enabled = slider4.enabled = slider5.enabled = slider6.enabled = slider7.enabled = slider8.enabled = slider9.enabled = slider10.enabled = slider11.enabled = slider12.enabled = slider13.enabled = slider14.enabled = enabled;
     }
 
     function updateSimpleKeyframes(position) {
-        if (blockUpdate) return
-        updateFilter('0', slider0.value, keyframesButton, position)
-        updateFilter('1', slider1.value, keyframesButton, position)
-        updateFilter('2', slider2.value, keyframesButton, position)
-        updateFilter('3', slider3.value, keyframesButton, position)
-        updateFilter('4', slider4.value, keyframesButton, position)
-        updateFilter('5', slider5.value, keyframesButton, position)
-        updateFilter('6', slider6.value, keyframesButton, position)
-        updateFilter('7', slider7.value, keyframesButton, position)
-        updateFilter('8', slider8.value, keyframesButton, position)
-        updateFilter('9', slider9.value, keyframesButton, position)
-        updateFilter('10', slider10.value, keyframesButton, position)
-        updateFilter('11', slider11.value, keyframesButton, position)
-        updateFilter('12', slider12.value, keyframesButton, position)
-        updateFilter('13', slider13.value, keyframesButton, position)
-        updateFilter('14', slider14.value, keyframesButton, position)
+        if (blockUpdate)
+            return ;
+
+        updateFilter('0', slider0.value, keyframesButton, position);
+        updateFilter('1', slider1.value, keyframesButton, position);
+        updateFilter('2', slider2.value, keyframesButton, position);
+        updateFilter('3', slider3.value, keyframesButton, position);
+        updateFilter('4', slider4.value, keyframesButton, position);
+        updateFilter('5', slider5.value, keyframesButton, position);
+        updateFilter('6', slider6.value, keyframesButton, position);
+        updateFilter('7', slider7.value, keyframesButton, position);
+        updateFilter('8', slider8.value, keyframesButton, position);
+        updateFilter('9', slider9.value, keyframesButton, position);
+        updateFilter('10', slider10.value, keyframesButton, position);
+        updateFilter('11', slider11.value, keyframesButton, position);
+        updateFilter('12', slider12.value, keyframesButton, position);
+        updateFilter('13', slider13.value, keyframesButton, position);
+        updateFilter('14', slider14.value, keyframesButton, position);
+    }
+
+    keyframableParameters: ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14']
+    startValues: [0, 100, 0.5, 0, 100, 1, 0, 700, 1, 0, 5000, 1, 0, 15000, 0.5]
+    middleValues: [0, 100, 0.5, 0, 100, 1, 0, 700, 1, 0, 5000, 1, 0, 15000, 0.5]
+    endValues: [0, 100, 0.5, 0, 100, 1, 0, 700, 1, 0, 5000, 1, 0, 15000, 0.5]
+    width: 200
+    height: 550
+    Component.onCompleted: {
+        if (filter.isNew) {
+            filter.set('0', defaultValues[0]);
+            filter.set('1', defaultValues[1]);
+            filter.set('2', defaultValues[2]);
+            filter.set('3', defaultValues[3]);
+            filter.set('4', defaultValues[4]);
+            filter.set('5', defaultValues[5]);
+            filter.set('6', defaultValues[6]);
+            filter.set('7', defaultValues[7]);
+            filter.set('8', defaultValues[8]);
+            filter.set('9', defaultValues[9]);
+            filter.set('10', defaultValues[10]);
+            filter.set('11', defaultValues[11]);
+            filter.set('12', defaultValues[12]);
+            filter.set('13', defaultValues[13]);
+            filter.set('14', defaultValues[14]);
+            filter.savePreset(preset.parameters);
+        }
+        setControls();
     }
 
     GridLayout {
@@ -112,16 +112,18 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: keyframableParameters
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -134,59 +136,70 @@ Shotcut.KeyframableFilter {
         ColumnLayout {
             Layout.rowSpan: 20
             height: (keyframesButton.height + 5) * Layout.rowSpan
-            SystemPalette { id: activePalette }
+
+            SystemPalette {
+                id: activePalette
+            }
+
             Rectangle {
                 color: activePalette.text
                 width: 1
                 height: parent.height / 2
                 Layout.alignment: Qt.AlignHCenter
             }
+
             Shotcut.KeyframesButton {
                 id: keyframesButton
+
                 onToggled: {
-                    toggleKeyframes(checked, '0', slider0.value)
-                    toggleKeyframes(checked, '1', slider1.value)
-                    toggleKeyframes(checked, '2', slider2.value)
-                    toggleKeyframes(checked, '3', slider3.value)
-                    toggleKeyframes(checked, '4', slider4.value)
-                    toggleKeyframes(checked, '5', slider5.value)
-                    toggleKeyframes(checked, '6', slider6.value)
-                    toggleKeyframes(checked, '7', slider7.value)
-                    toggleKeyframes(checked, '8', slider8.value)
-                    toggleKeyframes(checked, '9', slider9.value)
-                    toggleKeyframes(checked, '10', slider10.value)
-                    toggleKeyframes(checked, '11', slider11.value)
-                    toggleKeyframes(checked, '12', slider12.value)
-                    toggleKeyframes(checked, '13', slider13.value)
-                    toggleKeyframes(checked, '14', slider14.value)
-                    setControls()
+                    toggleKeyframes(checked, '0', slider0.value);
+                    toggleKeyframes(checked, '1', slider1.value);
+                    toggleKeyframes(checked, '2', slider2.value);
+                    toggleKeyframes(checked, '3', slider3.value);
+                    toggleKeyframes(checked, '4', slider4.value);
+                    toggleKeyframes(checked, '5', slider5.value);
+                    toggleKeyframes(checked, '6', slider6.value);
+                    toggleKeyframes(checked, '7', slider7.value);
+                    toggleKeyframes(checked, '8', slider8.value);
+                    toggleKeyframes(checked, '9', slider9.value);
+                    toggleKeyframes(checked, '10', slider10.value);
+                    toggleKeyframes(checked, '11', slider11.value);
+                    toggleKeyframes(checked, '12', slider12.value);
+                    toggleKeyframes(checked, '13', slider13.value);
+                    toggleKeyframes(checked, '14', slider14.value);
+                    setControls();
                 }
             }
+
             Rectangle {
                 color: activePalette.text
                 width: 1
                 height: parent.height / 2
                 Layout.alignment: Qt.AlignHCenter
             }
+
         }
 
         Label {
             text: qsTr('Frequency')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider1
+
             minimumValue: 20
             maximumValue: 20000
             stepSize: 0.1
             decimals: 1
             suffix: ' Hz'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider1.value = defaultValues[1]
         }
@@ -195,19 +208,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('Gain')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider0
+
             minimumValue: -30
             maximumValue: 30
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider0.value = defaultValues[0]
         }
@@ -216,18 +232,21 @@ Shotcut.KeyframableFilter {
             text: qsTr('Slope')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider2
+
             minimumValue: 0
             maximumValue: 1
             stepSize: 0.1
             decimals: 1
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider2.value = defaultValues[2]
         }
@@ -242,19 +261,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('Frequency')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider4
+
             minimumValue: 20
             maximumValue: 20000
             stepSize: 0.1
             decimals: 1
             suffix: ' Hz'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider4.value = defaultValues[4]
         }
@@ -263,19 +285,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('Gain')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider3
+
             minimumValue: -30
             maximumValue: 30
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider3.value = defaultValues[3]
         }
@@ -284,19 +309,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('Bandwidth', 'Parametric equalizer bandwidth')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider5
+
             minimumValue: 0
             maximumValue: 4
             stepSize: 0.1
             decimals: 1
             suffix: qsTr(' octaves')
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider5.value = defaultValues[5]
         }
@@ -311,19 +339,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('Frequency')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider7
+
             minimumValue: 20
             maximumValue: 20000
             stepSize: 0.1
             decimals: 1
             suffix: ' Hz'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider7.value = defaultValues[7]
         }
@@ -332,19 +363,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('Gain')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider6
+
             minimumValue: -30
             maximumValue: 30
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider6.value = defaultValues[6]
         }
@@ -353,23 +387,26 @@ Shotcut.KeyframableFilter {
             text: qsTr('Bandwidth', 'Parametric equalizer bandwidth')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider8
+
             minimumValue: 0
             maximumValue: 4
             stepSize: 0.1
             decimals: 1
             suffix: qsTr(' octaves')
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider8.value = defaultValues[8]
         }
-        
+
         Label {
             text: qsTr('<b>Band 3</b>')
             Layout.columnSpan: 3
@@ -380,19 +417,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('Frequency')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider10
+
             minimumValue: 20
             maximumValue: 20000
             stepSize: 0.1
             decimals: 1
             suffix: ' Hz'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider10.value = defaultValues[10]
         }
@@ -401,19 +441,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('Gain')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider9
+
             minimumValue: -30
             maximumValue: 30
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider9.value = defaultValues[9]
         }
@@ -422,19 +465,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('Bandwidth', 'Parametric equalizer bandwidth')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider11
+
             minimumValue: 0
             maximumValue: 4
             stepSize: 0.1
             decimals: 1
             suffix: qsTr(' octaves')
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider11.value = defaultValues[11]
         }
@@ -449,19 +495,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('Frequency')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider13
+
             minimumValue: 20
             maximumValue: 20000
             stepSize: 0.1
             decimals: 1
             suffix: ' Hz'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider13.value = defaultValues[13]
         }
@@ -470,19 +519,22 @@ Shotcut.KeyframableFilter {
             text: qsTr('Gain')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider12
+
             minimumValue: -30
             maximumValue: 30
             stepSize: 0.1
             decimals: 1
             suffix: ' dB'
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider12.value = defaultValues[12]
         }
@@ -491,39 +543,65 @@ Shotcut.KeyframableFilter {
             text: qsTr('Slope')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider14
+
             minimumValue: 0
             maximumValue: 1
             stepSize: 0.1
             decimals: 1
             onValueChanged: {
-                blockControls = true
-                updateSimpleKeyframes(getPosition())
-                blockControls = false
+                blockControls = true;
+                updateSimpleKeyframes(getPosition());
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: slider14.value = defaultValues[14]
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes(null);
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes(null);
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes(null);
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes(null);
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes(null) }
-        function onOutChanged() { updateSimpleKeyframes(null) }
-        function onAnimateInChanged() { updateSimpleKeyframes(null) }
-        function onAnimateOutChanged() { updateSimpleKeyframes(null) }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/audio_expander/ui.qml
+++ b/src/qml/filters/audio_expander/ui.qml
@@ -21,31 +21,31 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
+    function setControls() {
+        sliderPeak.value = filter.getDouble('0') * sliderPeak.maximumValue;
+        sliderAttack.value = filter.getDouble('1');
+        sliderRelease.value = filter.getDouble('2');
+        sliderThreshold.value = filter.getDouble('3');
+        sliderRatio.value = filter.getDouble('4');
+        sliderRadius.value = filter.getDouble('5');
+        sliderGain.value = filter.getDouble('6');
+    }
+
     width: 350
     height: 225
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set('0', 0)
-            filter.set('1', 100)
-            filter.set('2', 400)
-            filter.set('3', 0)
-            filter.set('4', 1)
-            filter.set('5', 3.25)
-            filter.set('6', 0)
-            filter.savePreset(preset.parameters)
+            filter.set('0', 0);
+            filter.set('1', 100);
+            filter.set('2', 400);
+            filter.set('3', 0);
+            filter.set('4', 1);
+            filter.set('5', 3.25);
+            filter.set('6', 0);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        sliderPeak.value = filter.getDouble('0') * sliderPeak.maximumValue
-        sliderAttack.value = filter.getDouble('1')
-        sliderRelease.value = filter.getDouble('2')
-        sliderThreshold.value = filter.getDouble('3')
-        sliderRatio.value = filter.getDouble('4')
-        sliderRadius.value = filter.getDouble('5')
-        sliderGain.value = filter.getDouble('6')
+        setControls();
     }
 
     GridLayout {
@@ -57,8 +57,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ['0', '1', '2', '3', '4', '5', '6']
             Layout.columnSpan: 2
             onPresetSelected: setControls()
@@ -67,10 +69,16 @@ Item {
         Label {
             text: qsTr('RMS')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The balance between the RMS and peak envelope followers.\nRMS is generally better for subtle, musical compression.\nPeak is better for heavier, fast compression and percussion.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The balance between the RMS and peak envelope followers.\nRMS is generally better for subtle, musical compression.\nPeak is better for heavier, fast compression and percussion.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderPeak
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -78,9 +86,10 @@ Item {
             suffix: ' %'
             value: filter.getDouble('0') * maximumValue
             onValueChanged: {
-                filter.set('0', value / maximumValue)
+                filter.set('0', value / maximumValue);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderPeak.value = sliderPeak.minimumValue
         }
@@ -89,16 +98,19 @@ Item {
             text: qsTr('Attack')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderAttack
+
             minimumValue: 2
             maximumValue: 400
             suffix: ' ms'
             value: filter.getDouble('1')
             onValueChanged: {
-                filter.set('1', value)
+                filter.set('1', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderAttack.value = 100
         }
@@ -107,16 +119,19 @@ Item {
             text: qsTr('Release')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderRelease
+
             minimumValue: 2
             maximumValue: 800
             suffix: ' ms'
             value: filter.getDouble('2')
             onValueChanged: {
-                filter.set('2', value)
+                filter.set('2', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderRelease.value = 400
         }
@@ -124,19 +139,26 @@ Item {
         Label {
             text: qsTr('Threshold')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The point at which the compressor will start to kick in.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The point at which the compressor will start to kick in.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderThreshold
+
             minimumValue: -30
             maximumValue: 0
             decimals: 1
             suffix: ' dB'
             value: filter.getDouble('3')
             onValueChanged: {
-                filter.set('3', value)
+                filter.set('3', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderThreshold.value = 0
         }
@@ -144,18 +166,25 @@ Item {
         Label {
             text: qsTr('Ratio')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The gain reduction ratio used when the signal level exceeds the threshold.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The gain reduction ratio used when the signal level exceeds the threshold.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderRatio
+
             minimumValue: 1
             maximumValue: 20
             prefix: ' 1:'
             value: filter.getDouble('4')
             onValueChanged: {
-                filter.set('4', value)
+                filter.set('4', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderRatio.value = 1
         }
@@ -163,45 +192,61 @@ Item {
         Label {
             text: qsTr('Knee radius')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The distance from the threshold where the knee curve starts.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The distance from the threshold where the knee curve starts.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderRadius
+
             minimumValue: 1
             maximumValue: 10
             decimals: 1
             suffix: ' dB'
             value: filter.getDouble('5')
             onValueChanged: {
-                filter.set('5', value)
+                filter.set('5', value);
             }
         }
 
         Shotcut.UndoButton {
             onClicked: sliderRadius.value = 3.25
         }
+
         Label {
             text: qsTr('Attenuation')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The gain of the output signal.\nUsed to correct for excessive amplitude caused by the extra dynamic range.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The gain of the output signal.\nUsed to correct for excessive amplitude caused by the extra dynamic range.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderGain
+
             minimumValue: -24
             maximumValue: 0
             decimals: 1
             suffix: ' dB'
             value: filter.getDouble('6')
             onValueChanged: {
-                filter.set('6', value)
+                filter.set('6', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderGain.value = 0
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/audio_fadein/meta.qml
+++ b/src/qml/filters/audio_fadein/meta.qml
@@ -10,8 +10,10 @@ Metadata {
     qml: "ui.qml"
     isFavorite: true
     allowMultiple: false
+
     keyframes {
         allowTrim: false
         allowAnimateIn: true
     }
+
 }

--- a/src/qml/filters/audio_fadein/ui.qml
+++ b/src/qml/filters/audio_fadein/ui.qml
@@ -21,29 +21,30 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
+    property alias duration: timeSpinner.value
+
     width: 100
     height: 50
     objectName: 'fadeIn'
-    property alias duration: timeSpinner.value
-
     Component.onCompleted: {
         if (filter.isNew) {
-            duration = Math.ceil(settings.audioInDuration * profile.fps)
+            duration = Math.ceil(settings.audioInDuration * profile.fps);
         } else if (filter.animateIn === 0) {
             // Convert legacy filter.
-            duration = filter.duration
-            filter.set('in', producer.in )
-            filter.set('out', producer.out )
+            duration = filter.duration;
+            filter.set('in', producer.in);
+            filter.set('out', producer.out);
         } else {
-            duration = filter.animateIn
+            duration = filter.animateIn;
         }
     }
 
     Connections {
-        target: filter
         function onAnimateInChanged() {
-            duration = filter.animateIn
+            duration = filter.animateIn;
         }
+
+        target: filter
     }
 
     ColumnLayout {
@@ -51,27 +52,35 @@ Item {
         anchors.margins: 8
 
         RowLayout {
-            Label { text: qsTr('Duration') }
+            Label {
+                text: qsTr('Duration')
+            }
+
             Shotcut.TimeSpinner {
                 id: timeSpinner
+
                 minimumValue: 2
                 maximumValue: 5000
                 onValueChanged: {
-                    filter.animateIn = duration
-                    filter.resetProperty('level')
-                    filter.set('level', -60, 0)
-                    filter.set('level', 0, Math.min(duration, filter.duration) - 1)
+                    filter.animateIn = duration;
+                    filter.resetProperty('level');
+                    filter.set('level', -60, 0);
+                    filter.set('level', 0, Math.min(duration, filter.duration) - 1);
                 }
                 onSetDefaultClicked: {
-                    duration = Math.ceil(settings.audioInDuration * profile.fps)
+                    duration = Math.ceil(settings.audioInDuration * profile.fps);
                 }
                 onSaveDefaultClicked: {
-                    settings.audioInDuration = duration / profile.fps
+                    settings.audioInDuration = duration / profile.fps;
                 }
             }
+
         }
+
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/audio_fadeout/meta.qml
+++ b/src/qml/filters/audio_fadeout/meta.qml
@@ -10,8 +10,10 @@ Metadata {
     qml: "ui.qml"
     isFavorite: true
     allowMultiple: false
+
     keyframes {
         allowTrim: false
         allowAnimateOut: true
     }
+
 }

--- a/src/qml/filters/audio_fadeout/ui.qml
+++ b/src/qml/filters/audio_fadeout/ui.qml
@@ -21,35 +21,36 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
+    property alias duration: timeSpinner.value
+
+    function updateFilter() {
+        filter.resetProperty('level');
+        filter.set('level', 0, Math.max(filter.duration - duration, 0));
+        filter.set('level', -60, filter.duration - 1);
+    }
+
     width: 100
     height: 50
     objectName: 'fadeOut'
-    property alias duration: timeSpinner.value
-
     Component.onCompleted: {
         if (filter.isNew) {
-            duration = Math.ceil(settings.audioOutDuration * profile.fps)
+            duration = Math.ceil(settings.audioOutDuration * profile.fps);
         } else if (filter.animateOut === 0) {
             // Convert legacy filter.
-            duration = filter.duration
-            filter.set('in', producer.in )
-            filter.set('out', producer.out )
+            duration = filter.duration;
+            filter.set('in', producer.in);
+            filter.set('out', producer.out);
         } else {
-            duration = filter.animateOut
+            duration = filter.animateOut;
         }
     }
 
     Connections {
-        target: filter
         function onAnimateOutChanged() {
-            duration = filter.animateOut
+            duration = filter.animateOut;
         }
-    }
 
-    function updateFilter() {
-        filter.resetProperty('level')
-        filter.set('level', 0, Math.max(filter.duration - duration, 0))
-        filter.set('level', -60, filter.duration - 1)
+        target: filter
     }
 
     ColumnLayout {
@@ -57,25 +58,33 @@ Item {
         anchors.margins: 8
 
         RowLayout {
-            Label { text: qsTr('Duration') }
+            Label {
+                text: qsTr('Duration')
+            }
+
             Shotcut.TimeSpinner {
                 id: timeSpinner
+
                 minimumValue: 2
                 maximumValue: 5000
                 onValueChanged: {
-                    filter.animateOut = duration
-                    updateFilter()
+                    filter.animateOut = duration;
+                    updateFilter();
                 }
                 onSetDefaultClicked: {
-                    duration = Math.ceil(settings.audioOutDuration * profile.fps)
+                    duration = Math.ceil(settings.audioOutDuration * profile.fps);
                 }
                 onSaveDefaultClicked: {
-                    settings.audioOutDuration = duration / profile.fps
+                    settings.audioOutDuration = duration / profile.fps;
                 }
             }
+
         }
+
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/audio_gain/meta.qml
+++ b/src/qml/filters/audio_gain/meta.qml
@@ -8,6 +8,7 @@ Metadata {
     mlt_service: "volume"
     qml: "ui.qml"
     isFavorite: true
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -22,4 +23,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/audio_gain/ui.qml
+++ b/src/qml/filters/audio_gain/ui.qml
@@ -21,101 +21,120 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 200
-    height: 50
     property bool blockUpdate: true
-    property double startValue: 0.0
-    property double middleValue: 0.0
-    property double endValue: 0.0
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set('level', 0)
-            filter.savePreset(preset.parameters)
-        } else {
-            // Convert old version of filter.
-            if (filter.getDouble('gain') !== 0.0) {
-                filter.set('level', toDb(filter.getDouble('gain')))
-                filter.resetProperty('gain')
-            }
-
-            middleValue = filter.getDouble('level', filter.animateIn)
-            if (filter.animateIn > 0)
-                startValue = filter.getDouble('level', 0)
-            if (filter.animateOut > 0)
-                endValue = filter.getDouble('level', filter.duration - 1)
-        }
-        setControls()
-    }
-
-    Connections {
-        target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateFilter(null) }
-        function onOutChanged() { updateFilter(null) }
-        function onAnimateInChanged() { updateFilter(null) }
-        function onAnimateOutChanged() { updateFilter(null) }
-        function onPropertyChanged(name) { setControls() }
-    }
-
-    Connections {
-        target: producer
-        function onPositionChanged() {
-            setControls()
-        }
-    }
+    property double startValue: 0
+    property double middleValue: 0
+    property double endValue: 0
 
     function toDb(value) {
-        return 20 * Math.log(value) / Math.LN10
+        return 20 * Math.log(value) / Math.LN10;
     }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        gainSlider.value = filter.getDouble('level', position)
-        if (filter.animateIn > 0 || filter.animateOut > 0) {
-            gainSlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
-        } else {
-            gainSlider.enabled = true
-        }
-        gainKeyframesButton.checked = filter.keyframeCount('level') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-        blockUpdate = false
+        var position = getPosition();
+        blockUpdate = true;
+        gainSlider.value = filter.getDouble('level', position);
+        if (filter.animateIn > 0 || filter.animateOut > 0)
+            gainSlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
+        else
+            gainSlider.enabled = true;
+        gainKeyframesButton.checked = filter.keyframeCount('level') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+        blockUpdate = false;
     }
 
     function updateFilter(position) {
-        if (blockUpdate) return
+        if (blockUpdate)
+            return ;
 
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValue = gainSlider.value
+                startValue = gainSlider.value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValue = gainSlider.value
+                endValue = gainSlider.value;
             else
-                middleValue = gainSlider.value
+                middleValue = gainSlider.value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty('level')
-            gainKeyframesButton.checked = false
+            filter.resetProperty('level');
+            gainKeyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set('level', startValue, 0)
-                filter.set('level', middleValue, filter.animateIn - 1)
+                filter.set('level', startValue, 0);
+                filter.set('level', middleValue, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set('level', middleValue, filter.duration - filter.animateOut)
-                filter.set('level', endValue, filter.duration - 1)
+                filter.set('level', middleValue, filter.duration - filter.animateOut);
+                filter.set('level', endValue, filter.duration - 1);
             }
         } else if (!gainKeyframesButton.checked) {
-            filter.resetProperty('level')
-            filter.set('level', middleValue)
+            filter.resetProperty('level');
+            filter.set('level', middleValue);
         } else if (position !== null) {
-            filter.set('level', gainSlider.value, position)
+            filter.set('level', gainSlider.value, position);
         }
+    }
+
+    width: 200
+    height: 50
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set('level', 0);
+            filter.savePreset(preset.parameters);
+        } else {
+            // Convert old version of filter.
+            if (filter.getDouble('gain') !== 0) {
+                filter.set('level', toDb(filter.getDouble('gain')));
+                filter.resetProperty('gain');
+            }
+            middleValue = filter.getDouble('level', filter.animateIn);
+            if (filter.animateIn > 0)
+                startValue = filter.getDouble('level', 0);
+
+            if (filter.animateOut > 0)
+                endValue = filter.getDouble('level', filter.duration - 1);
+
+        }
+        setControls();
+    }
+
+    Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateFilter(null);
+        }
+
+        function onOutChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateInChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateOutChanged() {
+            updateFilter(null);
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
+        target: filter
+    }
+
+    Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
+        target: producer
     }
 
     GridLayout {
@@ -127,20 +146,24 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: parent.columns - 1
             parameters: ['level']
             onBeforePresetLoaded: {
-                filter.resetProperty(parameters[0])
+                filter.resetProperty(parameters[0]);
             }
             onPresetSelected: {
-                setControls()
-                middleValue = filter.getDouble(parameters[0], filter.animateIn)
+                setControls();
+                middleValue = filter.getDouble(parameters[0], filter.animateIn);
                 if (filter.animateIn > 0)
-                    startValue = filter.getDouble(parameters[0], 0)
+                    startValue = filter.getDouble(parameters[0], 0);
+
                 if (filter.animateOut > 0)
-                    endValue = filter.getDouble(parameters[0], filter.duration - 1)
+                    endValue = filter.getDouble(parameters[0], filter.duration - 1);
+
             }
         }
 
@@ -148,28 +171,33 @@ Item {
             text: qsTr('Level')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: gainSlider
+
             minimumValue: -70
             maximumValue: 24
             suffix: ' dB'
             decimals: 1
             onValueChanged: updateFilter(getPosition())
         }
+
         Shotcut.UndoButton {
-            onClicked: gainSlider.value = 0.0
+            onClicked: gainSlider.value = 0
         }
+
         Shotcut.KeyframesButton {
             id: gainKeyframesButton
+
             onToggled: {
                 if (checked) {
-                    blockUpdate = true
-                    filter.clearSimpleAnimation('level')
-                    blockUpdate = false
-                    filter.set('level', gainSlider.value, getPosition())
+                    blockUpdate = true;
+                    filter.clearSimpleAnimation('level');
+                    blockUpdate = false;
+                    filter.set('level', gainSlider.value, getPosition());
                 } else {
-                    filter.resetProperty('level')
-                    filter.set('level', gainSlider.value)
+                    filter.resetProperty('level');
+                    filter.set('level', gainSlider.value);
                 }
             }
         }
@@ -177,5 +205,7 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/audio_highpass/meta.qml
+++ b/src/qml/filters/audio_highpass/meta.qml
@@ -7,6 +7,7 @@ Metadata {
     name: qsTr("High Pass")
     mlt_service: 'ladspa.1890'
     qml: 'ui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -36,4 +37,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/audio_highpass/ui.qml
+++ b/src/qml/filters/audio_highpass/ui.qml
@@ -25,6 +25,30 @@ Shotcut.KeyframableFilter {
     property string cutoffProperty: '0'
     property string stagesProperty: '1'
     property string wetnessProperty: 'wetness'
+
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        sliderCutoff.value = filter.getDouble(cutoffProperty, position);
+        cutoffKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(cutoffProperty) > 0;
+        sliderStages.value = filter.getDouble(stagesProperty, position);
+        stagesKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(stagesProperty) > 0;
+        sliderWetness.value = filter.getDouble(wetnessProperty, position) * sliderWetness.maximumValue;
+        wetnessKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(wetnessProperty) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        sliderCutoff.enabled = sliderStages.enabled = sliderWetness.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        updateFilter(cutoffProperty, sliderCutoff.value, cutoffKeyframesButton, null);
+        updateFilter(stagesProperty, sliderStages.value, stagesKeyframesButton, null);
+        updateFilter(wetnessProperty, sliderWetness.value / sliderWetness.maximumValue, wetnessKeyframesButton, null);
+    }
+
     width: 350
     height: 125
     keyframableParameters: preset.parameters
@@ -34,35 +58,12 @@ Shotcut.KeyframableFilter {
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set(cutoffProperty, 39)
-            filter.set(stagesProperty, 1)
-            filter.set(wetnessProperty, 1.0)
-            filter.savePreset(preset.parameters)
+            filter.set(cutoffProperty, 39);
+            filter.set(stagesProperty, 1);
+            filter.set(wetnessProperty, 1);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        sliderCutoff.value = filter.getDouble(cutoffProperty, position)
-        cutoffKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(cutoffProperty) > 0
-        sliderStages.value = filter.getDouble(stagesProperty, position)
-        stagesKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(stagesProperty) > 0
-        sliderWetness.value = filter.getDouble(wetnessProperty, position) * sliderWetness.maximumValue
-        wetnessKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(wetnessProperty) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        sliderCutoff.enabled = sliderStages.enabled = sliderWetness.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        updateFilter(cutoffProperty, sliderCutoff.value, cutoffKeyframesButton, null)
-        updateFilter(stagesProperty, sliderStages.value, stagesKeyframesButton, null)
-        updateFilter(wetnessProperty, sliderWetness.value / sliderWetness.maximumValue, wetnessKeyframesButton, null)
+        setControls();
     }
 
     GridLayout {
@@ -74,65 +75,82 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [cutoffProperty, stagesProperty, wetnessProperty]
             Layout.columnSpan: parent.columns - 1
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
-        Label { text: qsTr('Cutoff frequency')
-        Layout.alignment: Qt.AlignRight
+        Label {
+            text: qsTr('Cutoff frequency')
+            Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderCutoff
+
             minimumValue: 5
             maximumValue: 21600
             suffix: ' Hz'
             onValueChanged: updateFilter(cutoffProperty, value, cutoffKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: sliderCutoff.value = 39
         }
+
         Shotcut.KeyframesButton {
             id: cutoffKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, cutoffProperty, sliderCutoff.value)
+                enableControls(true);
+                toggleKeyframes(checked, cutoffProperty, sliderCutoff.value);
             }
         }
 
-        Label { text: qsTr('Rolloff rate')
-        Layout.alignment: Qt.AlignRight
+        Label {
+            text: qsTr('Rolloff rate')
+            Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderStages
+
             minimumValue: 1
             maximumValue: 10
             onValueChanged: updateFilter(stagesProperty, value, stagesKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: sliderStages.value = 1
         }
+
         Shotcut.KeyframesButton {
             id: stagesKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, stagesProperty, sliderStages.value)
+                enableControls(true);
+                toggleKeyframes(checked, stagesProperty, sliderStages.value);
             }
         }
 
-        Label { text: qsTr('Dry')
-        Layout.alignment: Qt.AlignRight
+        Label {
+            text: qsTr('Dry')
+            Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderWetness
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -140,34 +158,60 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(wetnessProperty, value / maximumValue, wetnessKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: sliderWetness.value = sliderWetness.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: wetnessKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, wetnessProperty, sliderWetness.value / sliderWetness.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, wetnessProperty, sliderWetness.value / sliderWetness.maximumValue);
             }
         }
 
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/audio_limiter/ui.qml
+++ b/src/qml/filters/audio_limiter/ui.qml
@@ -21,33 +21,34 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
+    function setControls() {
+        sliderInput.value = filter.getDouble('0');
+        sliderLimit.value = filter.getDouble('1');
+        sliderRelease.value = filter.getDouble('2');
+    }
+
     width: 350
     height: 125
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set('0', 0)
-            filter.set('1', 0)
-            filter.set('2', .51)
-            filter.savePreset(preset.parameters)
+            filter.set('0', 0);
+            filter.set('1', 0);
+            filter.set('2', 0.51);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-        timer.start()
-    }
-
-    function setControls() {
-        sliderInput.value = filter.getDouble('0')
-        sliderLimit.value = filter.getDouble('1')
-        sliderRelease.value = filter.getDouble('2')
+        setControls();
+        timer.start();
     }
 
     Timer {
         id: timer
+
         interval: 100
         running: false
         repeat: true
         onTriggered: {
-            grGauge.value = filter.getDouble('3[0]') * -1.0
+            grGauge.value = filter.getDouble('3[0]') * -1;
         }
     }
 
@@ -60,8 +61,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ['0', '1', '2']
             Layout.columnSpan: 2
             onPresetSelected: setControls()
@@ -70,19 +73,26 @@ Item {
         Label {
             text: qsTr('Input gain')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('Gain that is applied to the input stage. Can be used to trim gain to bring it roughly under the limit or to push the signal against the limit.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('Gain that is applied to the input stage. Can be used to trim gain to bring it roughly under the limit or to push the signal against the limit.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderInput
+
             minimumValue: -20
             maximumValue: 20
             suffix: ' dB'
             decimals: 1
             value: filter.getDouble('0')
             onValueChanged: {
-                filter.set('0', value)
+                filter.set('0', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderInput.value = 0
         }
@@ -90,19 +100,26 @@ Item {
         Label {
             text: qsTr('Limit')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The maximum output amplitude. Peaks over this level will be attenuated as smoothly as possible to bring them as close as possible to this level.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The maximum output amplitude. Peaks over this level will be attenuated as smoothly as possible to bring them as close as possible to this level.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderLimit
+
             minimumValue: -20
             maximumValue: 0
             suffix: ' dB'
             decimals: 1
             value: filter.getDouble('1')
             onValueChanged: {
-                filter.set('1', value)
+                filter.set('1', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderLimit.value = 0
         }
@@ -110,21 +127,28 @@ Item {
         Label {
             text: qsTr('Release')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The time taken for the limiter\'s attenuation to return to 0 dB\'s.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The time taken for the limiter\'s attenuation to return to 0 dB\'s.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderRelease
-            minimumValue: .01
+
+            minimumValue: 0.01
             maximumValue: 2
             suffix: ' s'
             decimals: 2
             value: filter.getDouble('2')
             onValueChanged: {
-                filter.set('2', value)
+                filter.set('2', value);
             }
         }
+
         Shotcut.UndoButton {
-            onClicked: sliderRelease.value = .51
+            onClicked: sliderRelease.value = 0.51
         }
 
         Rectangle {
@@ -132,6 +156,7 @@ Item {
             Layout.fillWidth: true
             Layout.minimumHeight: 12
             color: 'transparent'
+
             Rectangle {
                 anchors.verticalCenter: parent.verticalCenter
                 width: parent.width
@@ -139,17 +164,24 @@ Item {
                 radius: 2
                 color: activePalette.text
             }
+
         }
 
         Label {
             text: qsTr('Gain Reduction')
             Layout.alignment: Qt.AlignRight | Qt.AlignTop
-            Shotcut.HoverTip {text: qsTr('Status indicator showing the gain reduction applied by the compressor.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('Status indicator showing the gain reduction applied by the compressor.')
+            }
+
         }
+
         Shotcut.Gauge {
+            id: grGauge
+
             Layout.columnSpan: 2
             Layout.fillWidth: true
-            id: grGauge
             from: -24
             value: 0
             to: 0
@@ -158,7 +190,9 @@ Item {
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/audio_lowpass/meta.qml
+++ b/src/qml/filters/audio_lowpass/meta.qml
@@ -7,6 +7,7 @@ Metadata {
     name: qsTr("Low Pass")
     mlt_service: 'ladspa.1891'
     qml: 'ui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -36,4 +37,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/audio_lowpass/ui.qml
+++ b/src/qml/filters/audio_lowpass/ui.qml
@@ -25,6 +25,30 @@ Shotcut.KeyframableFilter {
     property string cutoffProperty: '0'
     property string stagesProperty: '1'
     property string wetnessProperty: 'wetness'
+
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        sliderCutoff.value = filter.getDouble(cutoffProperty, position);
+        cutoffKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(cutoffProperty) > 0;
+        sliderStages.value = filter.getDouble(stagesProperty, position);
+        stagesKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(stagesProperty) > 0;
+        sliderWetness.value = filter.getDouble(wetnessProperty, position) * sliderWetness.maximumValue;
+        wetnessKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(wetnessProperty) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        sliderCutoff.enabled = sliderStages.enabled = sliderWetness.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        updateFilter(cutoffProperty, sliderCutoff.value, cutoffKeyframesButton, null);
+        updateFilter(stagesProperty, sliderStages.value, stagesKeyframesButton, null);
+        updateFilter(wetnessProperty, sliderWetness.value / sliderWetness.maximumValue, wetnessKeyframesButton, null);
+    }
+
     width: 350
     height: 125
     keyframableParameters: preset.parameters
@@ -34,35 +58,12 @@ Shotcut.KeyframableFilter {
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set(cutoffProperty, 2637)
-            filter.set(stagesProperty, 1)
-            filter.set(wetnessProperty, 1.0)
-            filter.savePreset(preset.parameters)
+            filter.set(cutoffProperty, 2637);
+            filter.set(stagesProperty, 1);
+            filter.set(wetnessProperty, 1);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        sliderCutoff.value = filter.getDouble(cutoffProperty, position)
-        cutoffKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(cutoffProperty) > 0
-        sliderStages.value = filter.getDouble(stagesProperty, position)
-        stagesKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(stagesProperty) > 0
-        sliderWetness.value = filter.getDouble(wetnessProperty, position) * sliderWetness.maximumValue
-        wetnessKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(wetnessProperty) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        sliderCutoff.enabled = sliderStages.enabled = sliderWetness.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        updateFilter(cutoffProperty, sliderCutoff.value, cutoffKeyframesButton, null)
-        updateFilter(stagesProperty, sliderStages.value, stagesKeyframesButton, null)
-        updateFilter(wetnessProperty, sliderWetness.value / sliderWetness.maximumValue, wetnessKeyframesButton, null)
+        setControls();
     }
 
     GridLayout {
@@ -70,21 +71,22 @@ Shotcut.KeyframableFilter {
         anchors.margins: 8
         columns: 4
 
-
         Label {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [cutoffProperty, stagesProperty, wetnessProperty]
             Layout.columnSpan: parent.columns - 1
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -95,19 +97,23 @@ Shotcut.KeyframableFilter {
 
         Shotcut.SliderSpinner {
             id: sliderCutoff
+
             minimumValue: 5
             maximumValue: 21600
             suffix: ' Hz'
             onValueChanged: updateFilter(cutoffProperty, value, cutoffKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: sliderCutoff.value = 2637
         }
+
         Shotcut.KeyframesButton {
             id: cutoffKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, cutoffProperty, sliderCutoff.value)
+                enableControls(true);
+                toggleKeyframes(checked, cutoffProperty, sliderCutoff.value);
             }
         }
 
@@ -115,21 +121,25 @@ Shotcut.KeyframableFilter {
             text: qsTr('Rolloff rate')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderStages
+
             minimumValue: 1
             maximumValue: 10
             onValueChanged: updateFilter(stagesProperty, value, stagesKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: sliderStages.value = 1
         }
 
         Shotcut.KeyframesButton {
             id: stagesKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, stagesProperty, sliderStages.value)
+                enableControls(true);
+                toggleKeyframes(checked, stagesProperty, sliderStages.value);
             }
         }
 
@@ -137,8 +147,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Dry')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderWetness
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -146,35 +158,60 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(wetnessProperty, value / maximumValue, wetnessKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: sliderWetness.value = sliderWetness.maximumValue
         }
 
         Shotcut.KeyframesButton {
             id: wetnessKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, wetnessProperty, sliderWetness.value / sliderWetness.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, wetnessProperty, sliderWetness.value / sliderWetness.maximumValue);
             }
         }
 
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/audio_mute/ui.qml
+++ b/src/qml/filters/audio_mute/ui.qml
@@ -19,13 +19,15 @@
 import QtQuick 2.1
 
 Item {
+    // Set default parameter values
+
+    property string gainParameter: 'gain'
+
     width: 350
     height: 10
-    property string gainParameter: 'gain'
     Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set(gainParameter, 0)
-        }
+        if (filter.isNew)
+            filter.set(gainParameter, 0);
+
     }
 }

--- a/src/qml/filters/audio_noisegate/meta.qml
+++ b/src/qml/filters/audio_noisegate/meta.qml
@@ -7,6 +7,7 @@ Metadata {
     name: qsTr("Noise Gate")
     mlt_service: 'ladspa.1410'
     qml: 'ui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -63,4 +64,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/audio_noisegate/ui.qml
+++ b/src/qml/filters/audio_noisegate/ui.qml
@@ -21,7 +21,6 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Shotcut.KeyframableFilter {
-
     property string lfkey: '0'
     property string hfkey: '1'
     property string threshold: '2'
@@ -38,64 +37,61 @@ Shotcut.KeyframableFilter {
     property double decayDefault: 2001
     property double rangeDefault: -90
 
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        lfkeySlider.value = filter.getDouble(lfkey, position);
+        hfkeySlider.value = filter.getDouble(hfkey, position);
+        thresholdSlider.value = filter.getDouble(threshold, position);
+        attackSlider.value = filter.getDouble(attack, position);
+        holdSlider.value = filter.getDouble(hold, position);
+        decaySlider.value = filter.getDouble(decay, position);
+        rangeSlider.value = filter.getDouble(range, position);
+        lfkeyKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(lfkey) > 0;
+        hfkeyKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(hfkey) > 0;
+        thresholdKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(threshold) > 0;
+        attackKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(attack) > 0;
+        holdKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(hold) > 0;
+        decayKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(decay) > 0;
+        rangeKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(range) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        lfkeySlider.enabled = hfkeySlider.enabled = thresholdSlider.enabled = thresholdSlider.enabled = attackSlider.enabled = holdSlider.enabled = decaySlider.enabled = rangeSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        setControls();
+        updateFilter(lfkey, lfkeySlider.value, lfkeyKeyframesButton, null);
+        updateFilter(hfkey, hfkeySlider.value, hfkeyKeyframesButton, null);
+        updateFilter(threshold, thresholdSlider.value, thresholdKeyframesButton, null);
+        updateFilter(attack, attackSlider.value, attackKeyframesButton, null);
+        updateFilter(hold, holdSlider.value, holdKeyframesButton, null);
+        updateFilter(decay, decaySlider.value, decayKeyframesButton, null);
+        updateFilter(range, rangeSlider.value, rangeKeyframesButton, null);
+    }
+
     keyframableParameters: [lfkey, hfkey, threshold, attack, hold, decay, range]
     startValues: [lfkeyDefault, hfkeyDefault, thresholdDefault, attackDefault, holdDefault, decayDefault, rangeDefault]
     middleValues: [lfkeyDefault, hfkeyDefault, thresholdDefault, attackDefault, holdDefault, decayDefault, rangeDefault]
     endValues: [lfkeyDefault, hfkeyDefault, thresholdDefault, attackDefault, holdDefault, decayDefault, rangeDefault]
-
     width: 200
     height: 250
-
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set(lfkey, lfkeyDefault)
-            filter.set(hfkey, hfkeyDefault)
-            filter.set(threshold, thresholdDefault)
-            filter.set(attack, attackDefault)
-            filter.set(hold, holdDefault)
-            filter.set(decay, decayDefault)
-            filter.set(range, rangeDefault)
-            filter.savePreset(preset.parameters)
+            filter.set(lfkey, lfkeyDefault);
+            filter.set(hfkey, hfkeyDefault);
+            filter.set(threshold, thresholdDefault);
+            filter.set(attack, attackDefault);
+            filter.set(hold, holdDefault);
+            filter.set(decay, decayDefault);
+            filter.set(range, rangeDefault);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-        outputCheckbox.checked = filter.get(output) === '-1'
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        lfkeySlider.value = filter.getDouble(lfkey, position)
-        hfkeySlider.value = filter.getDouble(hfkey, position)
-        thresholdSlider.value = filter.getDouble(threshold, position)
-        attackSlider.value = filter.getDouble(attack, position)
-        holdSlider.value = filter.getDouble(hold, position)
-        decaySlider.value = filter.getDouble(decay, position)
-        rangeSlider.value = filter.getDouble(range, position)
-        lfkeyKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(lfkey) > 0
-        hfkeyKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(hfkey) > 0
-        thresholdKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(threshold) > 0
-        attackKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(attack) > 0
-        holdKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(hold) > 0
-        decayKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(decay) > 0
-        rangeKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(range) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        lfkeySlider.enabled = hfkeySlider.enabled = thresholdSlider.enabled = thresholdSlider.enabled =
-        attackSlider.enabled = holdSlider.enabled = decaySlider.enabled = rangeSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        setControls()
-        updateFilter(lfkey, lfkeySlider.value, lfkeyKeyframesButton, null)
-        updateFilter(hfkey, hfkeySlider.value, hfkeyKeyframesButton, null)
-        updateFilter(threshold, thresholdSlider.value, thresholdKeyframesButton, null)
-        updateFilter(attack, attackSlider.value, attackKeyframesButton, null)
-        updateFilter(hold, holdSlider.value, holdKeyframesButton, null)
-        updateFilter(decay, decaySlider.value, decayKeyframesButton, null)
-        updateFilter(range, rangeSlider.value, rangeKeyframesButton, null)
+        setControls();
+        outputCheckbox.checked = filter.get(output) === '-1';
     }
 
     GridLayout {
@@ -107,16 +103,18 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [lfkey, hfkey, threshold, attack, hold, decay, range]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -124,8 +122,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Key Filter: Low Frequency')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: lfkeySlider
+
             minimumValue: 33.6
             maximumValue: 4800
             stepSize: 0.1
@@ -133,14 +133,17 @@ Shotcut.KeyframableFilter {
             suffix: ' Hz'
             onValueChanged: updateFilter(lfkey, value, lfkeyKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: lfkeySlider.value = lfkeyDefault
         }
+
         Shotcut.KeyframesButton {
             id: lfkeyKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, lfkey, lfkeySlider.value)
+                enableControls(true);
+                toggleKeyframes(checked, lfkey, lfkeySlider.value);
             }
         }
 
@@ -148,8 +151,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Key Filter: High Frequency')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: hfkeySlider
+
             minimumValue: 240
             maximumValue: 23520
             stepSize: 0.1
@@ -157,31 +162,39 @@ Shotcut.KeyframableFilter {
             suffix: ' Hz'
             onValueChanged: updateFilter(hfkey, value, hfkeyKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: hfkeySlider.value = hfkeyDefault
         }
+
         Shotcut.KeyframesButton {
             id: hfkeyKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, hfkey, hfkeySlider.value)
+                enableControls(true);
+                toggleKeyframes(checked, hfkey, hfkeySlider.value);
             }
         }
 
-        Label {}
+        Label {
+        }
+
         CheckBox {
             id: outputCheckbox
+
             Layout.columnSpan: 3
             text: qsTr('Output key only')
-            onClicked: filter.set(output, checked? -1 : 0)
+            onClicked: filter.set(output, checked ? -1 : 0)
         }
 
         Label {
             text: qsTr('Threshold')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: thresholdSlider
+
             minimumValue: -70
             maximumValue: 20
             stepSize: 0.1
@@ -189,14 +202,17 @@ Shotcut.KeyframableFilter {
             suffix: ' dB'
             onValueChanged: updateFilter(threshold, value, thresholdKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: thresholdSlider.value = thresholdDefault
         }
+
         Shotcut.KeyframesButton {
             id: thresholdKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, threshold, thresholdSlider.value)
+                enableControls(true);
+                toggleKeyframes(checked, threshold, thresholdSlider.value);
             }
         }
 
@@ -204,22 +220,27 @@ Shotcut.KeyframableFilter {
             text: qsTr('Attack')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: attackSlider
+
             minimumValue: 0.01
             maximumValue: 1000
             stepSize: 1
             suffix: ' ms'
             onValueChanged: updateFilter(attack, value, attackKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: attackSlider.value = attackDefault
         }
+
         Shotcut.KeyframesButton {
             id: attackKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, attack, attackSlider.value)
+                enableControls(true);
+                toggleKeyframes(checked, attack, attackSlider.value);
             }
         }
 
@@ -227,22 +248,27 @@ Shotcut.KeyframableFilter {
             text: qsTr('Hold')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: holdSlider
+
             minimumValue: 2
             maximumValue: 2000
             stepSize: 1
             suffix: ' ms'
-            onValueChanged: updateFilter(hold, value , holdKeyframesButton, getPosition())
+            onValueChanged: updateFilter(hold, value, holdKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: holdSlider.value = holdDefault
         }
+
         Shotcut.KeyframesButton {
             id: holdKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, hold, holdSlider.value)
+                enableControls(true);
+                toggleKeyframes(checked, hold, holdSlider.value);
             }
         }
 
@@ -250,22 +276,27 @@ Shotcut.KeyframableFilter {
             text: qsTr('Decay')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: decaySlider
+
             minimumValue: 2
             maximumValue: 4000
             stepSize: 1
             suffix: ' ms'
             onValueChanged: updateFilter(decay, value, decayKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: decaySlider.value = decayDefault
         }
+
         Shotcut.KeyframesButton {
             id: decayKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, decay, decaySlider.value)
+                enableControls(true);
+                toggleKeyframes(checked, decay, decaySlider.value);
             }
         }
 
@@ -273,8 +304,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Range')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: rangeSlider
+
             minimumValue: -90
             maximumValue: 0
             stepSize: 0.1
@@ -282,34 +315,60 @@ Shotcut.KeyframableFilter {
             suffix: ' dB'
             onValueChanged: updateFilter(range, value, rangeKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: rangeSlider.value = rangeDefault
         }
+
         Shotcut.KeyframesButton {
             id: rangeKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, range, rangeSlider.value)
+                enableControls(true);
+                toggleKeyframes(checked, range, rangeSlider.value);
             }
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/audio_normalize_1p/ui.qml
+++ b/src/qml/filters/audio_normalize_1p/ui.qml
@@ -21,69 +21,75 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
+    function setControls() {
+        programSlider.value = filter.getDouble('target_loudness');
+        windowSlider.value = filter.getDouble('window');
+        maxgainSlider.value = filter.getDouble('max_gain');
+        mingainSlider.value = filter.getDouble('min_gain');
+        maxrateSlider.value = filter.getDouble('max_rate');
+    }
+
     width: 480
     height: 325
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set('target_loudness', -23.0)
-            filter.set('window', 10.0)
-            filter.set('max_gain', 15.0)
-            filter.set('min_gain', -15.0)
-            filter.set('max_rate', 3.0)
-            filter.savePreset(preset.parameters)
+            filter.set('target_loudness', -23);
+            filter.set('window', 10);
+            filter.set('max_gain', 15);
+            filter.set('min_gain', -15);
+            filter.set('max_rate', 3);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-        timer.start()
+        setControls();
+        timer.start();
     }
 
-    function setControls() {
-        programSlider.value = filter.getDouble('target_loudness')
-        windowSlider.value = filter.getDouble('window')
-        maxgainSlider.value = filter.getDouble('max_gain')
-        mingainSlider.value = filter.getDouble('min_gain')
-        maxrateSlider.value = filter.getDouble('max_rate')
+    SystemPalette {
+        id: activePalette
     }
-    
-    SystemPalette { id: activePalette }
 
     Timer {
         id: timer
+
+        property int _prevResetVal: 0
+        property int _resetCountDown: 0
+
         interval: 200
         running: false
         repeat: true
-        property int _prevResetVal: 0
-        property int _resetCountDown: 0
         onTriggered: {
-            loudnessGauge.value = filter.getDouble('in_loudness')
-            gainGauge.value = filter.getDouble('out_gain')
-            if( filter.get('reset_count') != _prevResetVal ) {
-                _prevResetVal = filter.get('reset_count')
-                _resetCountDown = 1000 / timer.interval
-                resetIndicator.active = true
-            } else if( _resetCountDown != 0 ) {
-                _resetCountDown--
+            loudnessGauge.value = filter.getDouble('in_loudness');
+            gainGauge.value = filter.getDouble('out_gain');
+            if (filter.get('reset_count') != _prevResetVal) {
+                _prevResetVal = filter.get('reset_count');
+                _resetCountDown = 1000 / timer.interval;
+                resetIndicator.active = true;
+            } else if (_resetCountDown != 0) {
+                _resetCountDown--;
             } else {
-                resetIndicator.active = false
+                resetIndicator.active = false;
             }
-            
         }
     }
 
     GridLayout {
         id: grid
+
         anchors.fill: parent
         anchors.margins: 8
         columns: 3
         columnSpacing: 8
         rowSpacing: 8
-        
+
         Label {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ['target_loudness', 'window', 'max_gain', 'min_gain', 'max_rate']
             Layout.columnSpan: 2
             onPresetSelected: setControls()
@@ -92,29 +98,42 @@ Item {
         Label {
             text: qsTr('Target Loudness')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The target loudness of the output in LUFS.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The target loudness of the output in LUFS.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: programSlider
-            minimumValue: -50.0
-            maximumValue: -10.0
+
+            minimumValue: -50
+            maximumValue: -10
             decimals: 1
             suffix: ' LUFS'
             spinnerWidth: 100
             value: filter.getDouble('target_loudness')
             onValueChanged: filter.set('target_loudness', value)
         }
+
         Shotcut.UndoButton {
-            onClicked: programSlider.value = -23.0
+            onClicked: programSlider.value = -23
         }
 
         Label {
             text: qsTr('Analysis Window')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The amount of history to use to calculate the input loudness.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The amount of history to use to calculate the input loudness.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: windowSlider
+
             minimumValue: 2
             maximumValue: 600
             decimals: 0
@@ -123,25 +142,33 @@ Item {
             value: filter.getDouble('window')
             onValueChanged: filter.set('window', value)
         }
+
         Shotcut.UndoButton {
-            onClicked: windowSlider.value = 20.0
+            onClicked: windowSlider.value = 20
         }
 
         Label {
             text: qsTr('Maximum Gain')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The maximum that the gain can be increased.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The maximum that the gain can be increased.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: maxgainSlider
-            minimumValue: 0.0
-            maximumValue: 30.0
+
+            minimumValue: 0
+            maximumValue: 30
             decimals: 1
             suffix: ' dB'
             spinnerWidth: 100
             value: filter.getDouble('max_gain')
             onValueChanged: filter.set('max_gain', value)
         }
+
         Shotcut.UndoButton {
             onClicked: maxgainSlider.value = 15
         }
@@ -149,31 +176,44 @@ Item {
         Label {
             text: qsTr('Minimum Gain')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The maximum that the gain can be decreased.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The maximum that the gain can be decreased.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: mingainSlider
-            minimumValue: -30.0
-            maximumValue: 0.0
+
+            minimumValue: -30
+            maximumValue: 0
             decimals: 1
             suffix: ' dB'
             spinnerWidth: 100
             value: filter.getDouble('min_gain')
             onValueChanged: filter.set('min_gain', value)
         }
+
         Shotcut.UndoButton {
-            onClicked: mingainSlider.value = -15.0
+            onClicked: mingainSlider.value = -15
         }
 
         Label {
             text: qsTr('Maximum Rate')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The maximum rate that the gain can be changed.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The maximum rate that the gain can be changed.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: maxrateSlider
+
             minimumValue: 0.5
-            maximumValue: 9.0
+            maximumValue: 9
             decimals: 1
             stepSize: 0.1
             suffix: ' dB/s'
@@ -181,15 +221,17 @@ Item {
             value: filter.getDouble('max_rate')
             onValueChanged: filter.set('max_rate', value)
         }
+
         Shotcut.UndoButton {
-            onClicked: maxrateSlider.value = 3.0
+            onClicked: maxrateSlider.value = 3
         }
-        
+
         Rectangle {
             Layout.columnSpan: 3
             Layout.fillWidth: true
             Layout.minimumHeight: 12
             color: 'transparent'
+
             Rectangle {
                 anchors.verticalCenter: parent.verticalCenter
                 width: parent.width
@@ -197,35 +239,48 @@ Item {
                 radius: 2
                 color: activePalette.text
             }
+
         }
 
         Label {
             text: qsTr('Input Loudness')
             Layout.alignment: Qt.AlignRight | Qt.AlignTop
-            Shotcut.HoverTip {text: qsTr('Status indicator showing the loudness measured on the input.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('Status indicator showing the loudness measured on the input.')
+            }
+
         }
+
         Shotcut.Gauge {
+            id: loudnessGauge
+
             Layout.columnSpan: 2
             Layout.fillWidth: true
             Layout.leftMargin: 4
             Layout.rightMargin: 4
-            id: loudnessGauge
             from: -50
             value: -50
             to: 0
             orientation: Qt.Horizontal
             decimals: 0
         }
-        
+
         Label {
             text: qsTr('Output Gain')
             Layout.alignment: Qt.AlignRight | Qt.AlignTop
-            Shotcut.HoverTip {text: qsTr('Status indicator showing the gain being applied.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('Status indicator showing the gain being applied.')
+            }
+
         }
+
         Shotcut.Gauge {
+            id: gainGauge
+
             Layout.columnSpan: 2
             Layout.fillWidth: true
-            id: gainGauge
             from: Math.floor(mingainSlider.value)
             value: 0
             to: Math.ceil(maxgainSlider.value)
@@ -236,28 +291,39 @@ Item {
         Label {
             text: qsTr('Reset')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('Status indicator showing when the loudness measurement is reset.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('Status indicator showing when the loudness measurement is reset.')
+            }
+
         }
+
         Rectangle {
-            property bool active: false
-            Layout.columnSpan: 2
             id: resetIndicator
+
+            property bool active: false
+
+            Layout.columnSpan: 2
             width: 20
             height: width
             radius: 10
             color: activePalette.alternateBase
+
             Rectangle {
                 x: 3
                 y: 3
                 width: 14
                 height: width
                 radius: 7
-                color: parent.active? activePalette.highlight : activePalette.base
+                color: parent.active ? activePalette.highlight : activePalette.base
             }
+
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/audio_normalize_2p/meta.qml
+++ b/src/qml/filters/audio_normalize_2p/meta.qml
@@ -9,7 +9,9 @@ Metadata {
     qml: "ui.qml"
     isClipOnly: true
     allowMultiple: false
+
     keyframes {
         allowTrim: false
     }
+
 }

--- a/src/qml/filters/audio_normalize_2p/ui.qml
+++ b/src/qml/filters/audio_normalize_2p/ui.qml
@@ -16,48 +16,45 @@
  */
 
 import QtQuick 2.12
-import QtQuick.Dialogs 1.3
 import QtQuick.Controls 2.12
+import QtQuick.Dialogs 1.3
 import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 350
-    height: 50
-
-    Component.onCompleted: {
-        setStatus(false)
+    function setStatus(inProgress) {
+        if (inProgress) {
+            status.text = qsTr('Analyzing...');
+            results.text = '--';
+            normalizationGain.text = '--';
+        } else if (filter.get("results").length > 0) {
+            status.text = qsTr('Analysis complete.');
+            var loudnessValue = filter.get("results").split('\t')[0].split('L:')[1];
+            loudnessValue = Math.round(loudnessValue * 100) / 100;
+            results.text = qsTr('%1 LUFS').arg(loudnessValue);
+            var gainValue = programSlider.value - loudnessValue;
+            gainValue = Math.round(gainValue * 100) / 100;
+            normalizationGain.text = qsTr('%1 dB').arg(gainValue);
+        } else {
+            status.text = qsTr('Click "Analyze" to use this filter.');
+            results.text = '--';
+            normalizationGain.text = '--';
+        }
     }
 
-    function setStatus( inProgress ) {
-        if (inProgress) {
-            status.text = qsTr('Analyzing...')
-            results.text = '--'
-            normalizationGain.text = '--'
-        }
-        else if (filter.get("results").length > 0 ) {
-            status.text = qsTr('Analysis complete.')
-            var loudnessValue = filter.get("results").split('\t')[0].split('L:')[1]
-            loudnessValue = Math.round(loudnessValue * 100) / 100
-            results.text = qsTr('%1 LUFS').arg(loudnessValue)
-            var gainValue = programSlider.value - loudnessValue
-            gainValue = Math.round(gainValue * 100) / 100
-            normalizationGain.text = qsTr('%1 dB').arg(gainValue)
-        }
-        else
-        {
-            status.text = qsTr('Click "Analyze" to use this filter.')
-            results.text = '--'
-            normalizationGain.text = '--'
-        }
+    width: 350
+    height: 50
+    Component.onCompleted: {
+        setStatus(false);
     }
 
     Connections {
-        target: filter
         function onAnalyzeFinished() {
-            setStatus(false)
-            button.enabled = true
+            setStatus(false);
+            button.enabled = true;
         }
+
+        target: filter
     }
 
     GridLayout {
@@ -69,33 +66,38 @@ Item {
             Layout.alignment: Qt.AlignRight
             text: qsTr('Target Loudness')
         }
+
         Shotcut.SliderSpinner {
             id: programSlider
-            minimumValue: -50.0
-            maximumValue: -10.0
+
+            minimumValue: -50
+            maximumValue: -10
             decimals: 1
             suffix: ' LUFS'
             spinnerWidth: 100
             value: filter ? filter.getDouble('program') : 0
             onValueChanged: {
-                if (filter) {
-                    filter.set('program', value)
-                }
+                if (filter)
+                    filter.set('program', value);
+
             }
         }
+
         Shotcut.UndoButton {
-            onClicked: programSlider.value = -23.0
+            onClicked: programSlider.value = -23
         }
 
         Label {
         }
+
         Shotcut.Button {
-            Layout.columnSpan: 2
             id: button
+
+            Layout.columnSpan: 2
             text: qsTr('Analyze')
             onClicked: {
-                button.enabled = false
-                setStatus(true)
+                button.enabled = false;
+                setStatus(true);
                 filter.analyze(true);
             }
         }
@@ -105,6 +107,7 @@ Item {
             Layout.fillWidth: true
             Layout.minimumHeight: 12
             color: 'transparent'
+
             Rectangle {
                 anchors.verticalCenter: parent.verticalCenter
                 width: parent.width
@@ -112,35 +115,51 @@ Item {
                 radius: 2
                 color: activePalette.text
             }
+
         }
 
         Label {
-            Layout.columnSpan: 3
             id: status
+
+            Layout.columnSpan: 3
         }
 
         Label {
             text: qsTr('Detected Loudness:')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The loudness calculated by the analysis.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The loudness calculated by the analysis.')
+            }
+
         }
+
         Label {
-            Layout.columnSpan: 2
             id: results
+
+            Layout.columnSpan: 2
         }
 
         Label {
             text: qsTr('Normalization Gain:')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The gain applied to normalize to the Target Loudness.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The gain applied to normalize to the Target Loudness.')
+            }
+
         }
+
         Label {
-            Layout.columnSpan: 2
             id: normalizationGain
+
+            Layout.columnSpan: 2
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/audio_notch/ui.qml
+++ b/src/qml/filters/audio_notch/ui.qml
@@ -21,25 +21,25 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
+    function setControls() {
+        sliderCenter.value = filter.getDouble('0');
+        sliderBandwidth.value = filter.getDouble('1');
+        sliderStages.value = filter.getDouble('2');
+        sliderWetness.value = filter.getDouble('wetness') * sliderWetness.maximumValue;
+    }
+
     width: 350
     height: 150
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set('0', 322)
-            filter.set('1', 322)
-            filter.set('2', 1)
-            filter.set('wetness', 1.0)
-            filter.savePreset(preset.parameters)
+            filter.set('0', 322);
+            filter.set('1', 322);
+            filter.set('2', 1);
+            filter.set('wetness', 1);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        sliderCenter.value = filter.getDouble('0')
-        sliderBandwidth.value = filter.getDouble('1')
-        sliderStages.value = filter.getDouble('2')
-        sliderWetness.value = filter.getDouble('wetness') * sliderWetness.maximumValue
+        setControls();
     }
 
     GridLayout {
@@ -51,8 +51,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ['0', '1', '2', 'wetness']
             Layout.columnSpan: 2
             onPresetSelected: setControls()
@@ -62,16 +64,19 @@ Item {
             text: qsTr('Center frequency')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderCenter
+
             minimumValue: 5
             maximumValue: 21600
             suffix: ' Hz'
             value: filter.getDouble('0')
             onValueChanged: {
-                filter.set('0', value)
+                filter.set('0', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderCenter.value = 322
         }
@@ -80,16 +85,19 @@ Item {
             text: qsTr('Bandwidth')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderBandwidth
+
             minimumValue: 5
             maximumValue: 21600
             suffix: ' Hz'
             value: filter.getDouble('1')
             onValueChanged: {
-                filter.set('1', value)
+                filter.set('1', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderBandwidth.value = 322
         }
@@ -98,15 +106,18 @@ Item {
             text: qsTr('Rolloff rate')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderStages
+
             minimumValue: 1
             maximumValue: 10
             value: filter.get('2')
             onValueChanged: {
-                filter.set('2', value)
+                filter.set('2', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderStages.value = 1
         }
@@ -115,8 +126,10 @@ Item {
             text: qsTr('Dry')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderWetness
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -124,15 +137,18 @@ Item {
             suffix: ' %'
             value: filter.getDouble('wetness') * maximumValue
             onValueChanged: {
-                filter.set('wetness', value / maximumValue)
+                filter.set('wetness', value / maximumValue);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderWetness.value = sliderWetness.maximumValue
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/audio_pan/meta.qml
+++ b/src/qml/filters/audio_pan/meta.qml
@@ -8,6 +8,7 @@ Metadata {
     mlt_service: 'panner'
     objectName: 'audioPan'
     qml: 'ui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -22,4 +23,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/audio_pan/ui.qml
+++ b/src/qml/filters/audio_pan/ui.qml
@@ -21,79 +21,81 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 350
-    height: 80
     property bool blockUpdate: true
     property double startValue: 0
     property double middleValue: 0
     property double endValue: 0
 
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            combo.currentIndex = 0
-            filter.set('channel', 0)
-            filter.set('start', 0)
-            filter.set('split', 0)
-            filter.savePreset(preset.parameters)
-        } else {
-            // Convert old version of filter.
-            if (filter.getDouble('start') !== 0.0)
-                filter.set('split', filter.getDouble('start'))
-
-            middleValue = filter.getDouble('split', filter.animateIn)
-            if (filter.animateIn > 0)
-                startValue = filter.getDouble('split', 0)
-            if (filter.animateOut > 0)
-                endValue = filter.getDouble('split', filter.duration - 1)
-        }
-        setControls()
-        combo.currentIndex = filter.get("channel")
-    }
-
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        slider.value = filter.getDouble('split', position) * slider.maximumValue
-        keyframesButton.checked = filter.keyframeCount('split') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-        blockUpdate = false
-        slider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        slider.value = filter.getDouble('split', position) * slider.maximumValue;
+        keyframesButton.checked = filter.keyframeCount('split') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+        blockUpdate = false;
+        slider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function updateFilter(position) {
-        if (blockUpdate) return
-        var value = slider.value / slider.maximumValue
+        if (blockUpdate)
+            return ;
 
+        var value = slider.value / slider.maximumValue;
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValue = value
+                startValue = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValue = value
+                endValue = value;
             else
-                middleValue = value
+                middleValue = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty('split')
-            keyframesButton.checked = false
+            filter.resetProperty('split');
+            keyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set('split', startValue, 0)
-                filter.set('split', middleValue, filter.animateIn - 1)
+                filter.set('split', startValue, 0);
+                filter.set('split', middleValue, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set('split', middleValue, filter.duration - filter.animateOut)
-                filter.set('split', endValue, filter.duration - 1)
+                filter.set('split', middleValue, filter.duration - filter.animateOut);
+                filter.set('split', endValue, filter.duration - 1);
             }
         } else if (!keyframesButton.checked) {
-            filter.resetProperty('split')
-            filter.set('split', middleValue)
+            filter.resetProperty('split');
+            filter.set('split', middleValue);
         } else if (position !== null) {
-            filter.set('split', value, position)
+            filter.set('split', value, position);
         }
+    }
+
+    width: 350
+    height: 80
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            combo.currentIndex = 0;
+            filter.set('channel', 0);
+            filter.set('start', 0);
+            filter.set('split', 0);
+            filter.savePreset(preset.parameters);
+        } else {
+            // Convert old version of filter.
+            if (filter.getDouble('start') !== 0)
+                filter.set('split', filter.getDouble('start'));
+
+            middleValue = filter.getDouble('split', filter.animateIn);
+            if (filter.animateIn > 0)
+                startValue = filter.getDouble('split', 0);
+
+            if (filter.animateOut > 0)
+                endValue = filter.getDouble('split', filter.duration - 1);
+
+        }
+        setControls();
+        combo.currentIndex = filter.get("channel");
     }
 
     GridLayout {
@@ -105,21 +107,25 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: parent.columns - 1
             parameters: ['split', 'channel']
             onBeforePresetLoaded: {
-                filter.resetProperty(parameters[0])
+                filter.resetProperty(parameters[0]);
             }
             onPresetSelected: {
-                setControls()
-                combo.currentIndex = filter.get("channel")
-                middleValue = filter.getDouble(parameters[0], filter.animateIn)
+                setControls();
+                combo.currentIndex = filter.get("channel");
+                middleValue = filter.getDouble(parameters[0], filter.animateIn);
                 if (filter.animateIn > 0)
-                    startValue = filter.getDouble(parameters[0], 0)
+                    startValue = filter.getDouble(parameters[0], 0);
+
                 if (filter.animateOut > 0)
-                    endValue = filter.getDouble(parameters[0], filter.duration - 1)
+                    endValue = filter.getDouble(parameters[0], filter.duration - 1);
+
             }
         }
 
@@ -127,8 +133,10 @@ Item {
             text: qsTr('Channel')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: combo
+
             Layout.columnSpan: 3
             model: [qsTr('Left'), qsTr('Right')]
             onActivated: filter.set('channel', currentIndex)
@@ -138,8 +146,10 @@ Item {
             text: qsTr('Left')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider
+
             minimumValue: 0
             maximumValue: 1000
             label: qsTr('Right')
@@ -147,21 +157,24 @@ Item {
             decimals: 2
             onValueChanged: updateFilter(getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: slider.value = 0
         }
+
         Shotcut.KeyframesButton {
             id: keyframesButton
+
             onToggled: {
-                var value = slider.value / slider.maximumValue
+                var value = slider.value / slider.maximumValue;
                 if (checked) {
-                    blockUpdate = true
-                    filter.clearSimpleAnimation('split')
-                    blockUpdate = false
-                    filter.set('split', value, getPosition())
+                    blockUpdate = true;
+                    filter.clearSimpleAnimation('split');
+                    blockUpdate = false;
+                    filter.set('split', value, getPosition());
                 } else {
-                    filter.resetProperty('split')
-                    filter.set('split', value)
+                    filter.resetProperty('split');
+                    filter.set('split', value);
                 }
             }
         }
@@ -169,20 +182,43 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateFilter(null);
+        }
+
+        function onOutChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateInChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateOutChanged() {
+            updateFilter(null);
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateFilter(null) }
-        function onOutChanged() { updateFilter(null) }
-        function onAnimateInChanged() { updateFilter(null) }
-        function onAnimateOutChanged() { updateFilter(null) }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/audio_pitch/meta.qml
+++ b/src/qml/filters/audio_pitch/meta.qml
@@ -8,6 +8,7 @@ Metadata {
     mlt_service: "rbpitch"
     qml: "ui.qml"
     isFavorite: false
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -17,9 +18,10 @@ Metadata {
                 name: qsTr('Pitch', 'audio pitch or tone')
                 property: 'octaveshift'
                 isCurve: true
-                minimum: -2.0
-                maximum: 2.0
+                minimum: -2
+                maximum: 2
             }
         ]
     }
+
 }

--- a/src/qml/filters/audio_pitch/ui.qml
+++ b/src/qml/filters/audio_pitch/ui.qml
@@ -21,95 +21,116 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 200
-    height: 50
     property bool blockUpdate: true
-    property double startValue: 0.0
-    property double middleValue: 0.0
-    property double endValue: 0.0
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set('octaveshift', 0.0)
-            filter.savePreset(preset.parameters)
-        } else {
-            middleValue = filter.getDouble('octaveshift', filter.animateIn)
-            if (filter.animateIn > 0)
-                startValue = filter.getDouble('octaveshift', 0)
-            if (filter.animateOut > 0)
-                endValue = filter.getDouble('octaveshift', filter.duration - 1)
-        }
-        setControls()
-    }
-
-    Connections {
-        target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateFilter(null) }
-        function onOutChanged() { updateFilter(null) }
-        function onAnimateInChanged() { updateFilter(null) }
-        function onAnimateOutChanged() { updateFilter(null) }
-        function onPropertyChanged(name) { setControls() }
-    }
-
-    Connections {
-        target: producer
-        function onPositionChanged() {
-            if (filter.animateIn > 0 || filter.animateOut > 0) {
-                setControls()
-            } else {
-                blockUpdate = true
-                octaveSlider.value = filter.getDouble('octaveshift', getPosition())
-                blockUpdate = false
-                octaveSlider.enabled = true
-            }
-        }
-    }
+    property double startValue: 0
+    property double middleValue: 0
+    property double endValue: 0
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        octaveSlider.value = filter.getDouble('octaveshift', position)
-        frequencySlider.value = 1.0 / Math.pow(2, filter.getDouble('octaveshift', position))
-        octaveKeyframesButton.checked = filter.keyframeCount('octaveshift') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-        blockUpdate = false
-        octaveSlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        octaveSlider.value = filter.getDouble('octaveshift', position);
+        frequencySlider.value = 1 / Math.pow(2, filter.getDouble('octaveshift', position));
+        octaveKeyframesButton.checked = filter.keyframeCount('octaveshift') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+        blockUpdate = false;
+        octaveSlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function updateFilter(position) {
-        if (blockUpdate) return
+        if (blockUpdate)
+            return ;
 
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValue = octaveSlider.value
+                startValue = octaveSlider.value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValue = octaveSlider.value
+                endValue = octaveSlider.value;
             else
-                middleValue = octaveSlider.value
+                middleValue = octaveSlider.value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty('octaveshift')
-            octaveKeyframesButton.checked = false
+            filter.resetProperty('octaveshift');
+            octaveKeyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set('octaveshift', startValue, 0)
-                filter.set('octaveshift', middleValue, filter.animateIn - 1)
+                filter.set('octaveshift', startValue, 0);
+                filter.set('octaveshift', middleValue, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set('octaveshift', middleValue, filter.duration - filter.animateOut)
-                filter.set('octaveshift', endValue, filter.duration - 1)
+                filter.set('octaveshift', middleValue, filter.duration - filter.animateOut);
+                filter.set('octaveshift', endValue, filter.duration - 1);
             }
         } else if (!octaveKeyframesButton.checked) {
-            filter.resetProperty('octaveshift')
-            filter.set('octaveshift', middleValue)
+            filter.resetProperty('octaveshift');
+            filter.set('octaveshift', middleValue);
         } else if (position !== null) {
-            filter.set('octaveshift', octaveSlider.value, position)
+            filter.set('octaveshift', octaveSlider.value, position);
         }
+    }
+
+    width: 200
+    height: 50
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set('octaveshift', 0);
+            filter.savePreset(preset.parameters);
+        } else {
+            middleValue = filter.getDouble('octaveshift', filter.animateIn);
+            if (filter.animateIn > 0)
+                startValue = filter.getDouble('octaveshift', 0);
+
+            if (filter.animateOut > 0)
+                endValue = filter.getDouble('octaveshift', filter.duration - 1);
+
+        }
+        setControls();
+    }
+
+    Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateFilter(null);
+        }
+
+        function onOutChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateInChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateOutChanged() {
+            updateFilter(null);
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
+        target: filter
+    }
+
+    Connections {
+        function onPositionChanged() {
+            if (filter.animateIn > 0 || filter.animateOut > 0) {
+                setControls();
+            } else {
+                blockUpdate = true;
+                octaveSlider.value = filter.getDouble('octaveshift', getPosition());
+                blockUpdate = false;
+                octaveSlider.enabled = true;
+            }
+        }
+
+        target: producer
     }
 
     GridLayout {
@@ -121,56 +142,69 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: parent.columns - 1
             parameters: ['octaveshift']
             onBeforePresetLoaded: {
-                filter.resetProperty(parameters[0])
+                filter.resetProperty(parameters[0]);
             }
             onPresetSelected: {
-                setControls()
-                middleValue = filter.getDouble(parameters[0], filter.animateIn)
+                setControls();
+                middleValue = filter.getDouble(parameters[0], filter.animateIn);
                 if (filter.animateIn > 0)
-                    startValue = filter.getDouble(parameters[0], 0)
+                    startValue = filter.getDouble(parameters[0], 0);
+
                 if (filter.animateOut > 0)
-                    endValue = filter.getDouble(parameters[0], filter.duration - 1)
+                    endValue = filter.getDouble(parameters[0], filter.duration - 1);
+
             }
         }
 
         Label {
             text: qsTr('Octave Shift')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Specify the pitch shift in octaves.\n-1 shifts down an octave.\n+1 shifts up an octave.\n0 is unchanged.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Specify the pitch shift in octaves.\n-1 shifts down an octave.\n+1 shifts up an octave.\n0 is unchanged.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: octaveSlider
-            minimumValue: -2.0
-            maximumValue: 2.0
+
+            minimumValue: -2
+            maximumValue: 2
             decimals: 6
-            stepSize: 1.0/12.0 // 12 half steps in an octave
+            stepSize: 1 / 12 // 12 half steps in an octave
             spinnerWidth: 100
             onValueChanged: {
-                updateFilter(getPosition())
-                if (frequencySlider.noUpdate == false) {
-                    frequencySlider.value = 1.0 / Math.pow(2, value)
-                }
+                updateFilter(getPosition());
+                if (frequencySlider.noUpdate == false)
+                    frequencySlider.value = 1 / Math.pow(2, value);
+
             }
         }
+
         Shotcut.UndoButton {
-            onClicked: octaveSlider.value = 0.0
+            onClicked: octaveSlider.value = 0
         }
+
         Shotcut.KeyframesButton {
             id: octaveKeyframesButton
+
             onToggled: {
                 if (checked) {
-                    blockUpdate = true
-                    filter.clearSimpleAnimation('octaveshift')
-                    blockUpdate = false
-                    filter.set('octaveshift', octaveSlider.value, getPosition())
+                    blockUpdate = true;
+                    filter.clearSimpleAnimation('octaveshift');
+                    blockUpdate = false;
+                    filter.set('octaveshift', octaveSlider.value, getPosition());
                 } else {
-                    filter.resetProperty('octaveshift')
-                    filter.set('octaveshift', octaveSlider.value)
+                    filter.resetProperty('octaveshift');
+                    filter.set('octaveshift', octaveSlider.value);
                 }
             }
         }
@@ -178,23 +212,31 @@ Item {
         Label {
             text: qsTr('Speed Compensation')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Specify the speed change that should be compensated for.\n2x will halve the pitch to compensate for the speed being doubled.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Specify the speed change that should be compensated for.\n2x will halve the pitch to compensate for the speed being doubled.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            property bool noUpdate: false
             id: frequencySlider
+
+            property bool noUpdate: false
+
             minimumValue: 0.25
-            maximumValue: 4.0
+            maximumValue: 4
             decimals: 6
             spinnerWidth: 100
             suffix: ' x'
             enabled: octaveSlider.enabled
             onValueChanged: {
-                noUpdate = true
-                octaveSlider.value = Math.log(1.0 / value) / Math.log(2)
-                noUpdate = false
+                noUpdate = true;
+                octaveSlider.value = Math.log(1 / value) / Math.log(2);
+                noUpdate = false;
             }
         }
+
         Item {
             Layout.columnSpan: 2
         }
@@ -202,5 +244,7 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/audio_reverb/meta.qml
+++ b/src/qml/filters/audio_reverb/meta.qml
@@ -7,6 +7,7 @@ Metadata {
     name: qsTr("Reverb")
     mlt_service: 'ladspa.1216'
     qml: 'ui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -24,7 +25,7 @@ Metadata {
                 name: qsTr('Reverb time')
                 property: '1'
                 isCurve: true
-                minimum: .1
+                minimum: 0.1
                 maximum: 30
                 units: 's'
             },
@@ -70,4 +71,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/audio_reverb/ui.qml
+++ b/src/qml/filters/audio_reverb/ui.qml
@@ -28,110 +28,105 @@ Shotcut.KeyframableFilter {
     property string dryProperty: '4'
     property string reflectionProperty: '5'
     property string tailProperty: '6'
-    width: 350
-    height: 250
-    keyframableParameters: preset.parameters
-    startValues: [1, .1, 0, 0, -70, -70, -70]
-    middleValues: [30, 7.5, 0.5, 0.75, 0, -10, -17.5]
-    endValues: [1, .1, 0, 0, -70, -70, -70]
-    Component.onCompleted: {
-        filter.blockSignals = true
-        if (filter.isNew) {
-            // Set preset parameter values
-            filter.set('0', 40)
-            filter.set('1', 4)
-            filter.set('2', 0.9)
-            filter.set('3', 0.75)
-            filter.set('4', 0)
-            filter.set('5', -22)
-            filter.set('6', -28)
-            filter.savePreset(preset.parameters, qsTr('Quick fix'))
-
-            filter.set('0', 50)
-            filter.set('1', 1.5)
-            filter.set('2', 0.1)
-            filter.set('3', 0.75)
-            filter.set('4', -1.5)
-            filter.set('5', -10)
-            filter.set('6', -20)
-            filter.savePreset(preset.parameters, qsTr('Small hall'))
-
-            filter.set('0', 40)
-            filter.set('1', 20)
-            filter.set('2', 0.5)
-            filter.set('3', 0.75)
-            filter.set('4', 0)
-            filter.set('5', -10)
-            filter.set('6', -30)
-            filter.savePreset(preset.parameters, qsTr('Large hall'))
-
-            filter.set('0', 6)
-            filter.set('1', 15)
-            filter.set('2', 0.9)
-            filter.set('3', 0.1)
-            filter.set('4', -10)
-            filter.set('5', -10)
-            filter.set('6', -10)
-            filter.savePreset(preset.parameters, qsTr('Sewer'))
-
-            filter.set('0', 6)
-            filter.set('1', 15)
-            filter.set('2', 0.9)
-            filter.set('3', .1)
-            filter.set('4', -10)
-            filter.set('5', -10)
-            filter.set('6', -10)
-            filter.savePreset(preset.parameters, qsTr('Church'))
-
-            // Set default parameter values
-            filter.set('0', 30)
-            filter.set('1', 7.5)
-            filter.set('2', 0.5)
-            filter.set('3', 0.75)
-            filter.set('4', 0)
-            filter.set('5', -10)
-            filter.set('6', -17.5)
-            filter.savePreset(preset.parameters)
-        }
-        filter.blockSignals = false
-        filter.changed()
-        setControls()
-    }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        sliderRoom.value = filter.getDouble(roomProperty, position)
-        roomKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(roomProperty) > 0
-        sliderTime.value = filter.getDouble(timeProperty, position)
-        timeKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(timeProperty) > 0
-        sliderDamp.value = filter.getDouble(dampProperty, position) * sliderDamp.maximumValue
-        dampKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(dampProperty) > 0
-        sliderInput.value = filter.getDouble(inputProperty, position) * sliderInput.maximumValue
-        inputKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(inputProperty) > 0
-        sliderDry.value = filter.getDouble(dryProperty, position)
-        dryKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(dryProperty) > 0
-        sliderReflection.value = filter.getDouble(reflectionProperty, position)
-        reflectionKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(reflectionProperty) > 0
-        sliderTail.value = filter.getDouble(tailProperty, position)
-        tailKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(tailProperty) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
+        var position = getPosition();
+        blockUpdate = true;
+        sliderRoom.value = filter.getDouble(roomProperty, position);
+        roomKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(roomProperty) > 0;
+        sliderTime.value = filter.getDouble(timeProperty, position);
+        timeKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(timeProperty) > 0;
+        sliderDamp.value = filter.getDouble(dampProperty, position) * sliderDamp.maximumValue;
+        dampKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(dampProperty) > 0;
+        sliderInput.value = filter.getDouble(inputProperty, position) * sliderInput.maximumValue;
+        inputKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(inputProperty) > 0;
+        sliderDry.value = filter.getDouble(dryProperty, position);
+        dryKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(dryProperty) > 0;
+        sliderReflection.value = filter.getDouble(reflectionProperty, position);
+        reflectionKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(reflectionProperty) > 0;
+        sliderTail.value = filter.getDouble(tailProperty, position);
+        tailKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(tailProperty) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
     }
 
     function enableControls(enabled) {
-        sliderRoom.enabled = sliderTime.enabled = sliderDamp.enabled = sliderInput.enabled = sliderDry.enabled =
-                sliderReflection.enabled = sliderTail.enabled = enabled
+        sliderRoom.enabled = sliderTime.enabled = sliderDamp.enabled = sliderInput.enabled = sliderDry.enabled = sliderReflection.enabled = sliderTail.enabled = enabled;
     }
 
     function updateSimpleKeyframes() {
-        updateFilter(roomProperty, sliderRoom.value, roomKeyframesButton, null)
-        updateFilter(timeProperty, sliderTime.value, timeKeyframesButton, null)
-        updateFilter(dampProperty, sliderDamp.value / sliderDamp.maximumValue, dampKeyframesButton, null)
-        updateFilter(inputProperty, sliderInput.value / sliderInput.maximumValue, inputKeyframesButton, null)
-        updateFilter(dryProperty, sliderDry.value, dryKeyframesButton, null)
-        updateFilter(reflectionProperty, sliderReflection.value, reflectionKeyframesButton, null)
-        updateFilter(tailProperty, sliderTail.value, tailKeyframesButton, null)
+        updateFilter(roomProperty, sliderRoom.value, roomKeyframesButton, null);
+        updateFilter(timeProperty, sliderTime.value, timeKeyframesButton, null);
+        updateFilter(dampProperty, sliderDamp.value / sliderDamp.maximumValue, dampKeyframesButton, null);
+        updateFilter(inputProperty, sliderInput.value / sliderInput.maximumValue, inputKeyframesButton, null);
+        updateFilter(dryProperty, sliderDry.value, dryKeyframesButton, null);
+        updateFilter(reflectionProperty, sliderReflection.value, reflectionKeyframesButton, null);
+        updateFilter(tailProperty, sliderTail.value, tailKeyframesButton, null);
+    }
+
+    width: 350
+    height: 250
+    keyframableParameters: preset.parameters
+    startValues: [1, 0.1, 0, 0, -70, -70, -70]
+    middleValues: [30, 7.5, 0.5, 0.75, 0, -10, -17.5]
+    endValues: [1, 0.1, 0, 0, -70, -70, -70]
+    Component.onCompleted: {
+        filter.blockSignals = true;
+        if (filter.isNew) {
+            // Set preset parameter values
+            filter.set('0', 40);
+            filter.set('1', 4);
+            filter.set('2', 0.9);
+            filter.set('3', 0.75);
+            filter.set('4', 0);
+            filter.set('5', -22);
+            filter.set('6', -28);
+            filter.savePreset(preset.parameters, qsTr('Quick fix'));
+            filter.set('0', 50);
+            filter.set('1', 1.5);
+            filter.set('2', 0.1);
+            filter.set('3', 0.75);
+            filter.set('4', -1.5);
+            filter.set('5', -10);
+            filter.set('6', -20);
+            filter.savePreset(preset.parameters, qsTr('Small hall'));
+            filter.set('0', 40);
+            filter.set('1', 20);
+            filter.set('2', 0.5);
+            filter.set('3', 0.75);
+            filter.set('4', 0);
+            filter.set('5', -10);
+            filter.set('6', -30);
+            filter.savePreset(preset.parameters, qsTr('Large hall'));
+            filter.set('0', 6);
+            filter.set('1', 15);
+            filter.set('2', 0.9);
+            filter.set('3', 0.1);
+            filter.set('4', -10);
+            filter.set('5', -10);
+            filter.set('6', -10);
+            filter.savePreset(preset.parameters, qsTr('Sewer'));
+            filter.set('0', 6);
+            filter.set('1', 15);
+            filter.set('2', 0.9);
+            filter.set('3', 0.1);
+            filter.set('4', -10);
+            filter.set('5', -10);
+            filter.set('6', -10);
+            filter.savePreset(preset.parameters, qsTr('Church'));
+            // Set default parameter values
+            filter.set('0', 30);
+            filter.set('1', 7.5);
+            filter.set('2', 0.5);
+            filter.set('3', 0.75);
+            filter.set('4', 0);
+            filter.set('5', -10);
+            filter.set('6', -17.5);
+            filter.savePreset(preset.parameters);
+        }
+        filter.blockSignals = false;
+        filter.changed();
+        setControls();
     }
 
     GridLayout {
@@ -143,39 +138,50 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ['0', '1', '2', '3', '4', '5', '6']
-            Layout.columnSpan: parent.columns-1
+            Layout.columnSpan: parent.columns - 1
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
         Label {
             text: qsTr('Room size')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The size of the room, in meters. Excessively large, and excessively small values will make it sound a bit unrealistic. Values of around 30 sound good.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The size of the room, in meters. Excessively large, and excessively small values will make it sound a bit unrealistic. Values of around 30 sound good.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderRoom
+
             minimumValue: 1
             maximumValue: 300
             suffix: ' m'
             onValueChanged: updateFilter(roomProperty, value, roomKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: sliderRoom.value = 30
         }
+
         Shotcut.KeyframesButton {
             id: roomKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, roomProperty, sliderRoom.value)
+                enableControls(true);
+                toggleKeyframes(checked, roomProperty, sliderRoom.value);
             }
         }
 
@@ -183,104 +189,142 @@ Shotcut.KeyframableFilter {
             text: qsTr('Reverb time')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderTime
-            minimumValue: .1
+
+            minimumValue: 0.1
             maximumValue: 30
             decimals: 1
             suffix: ' s'
             onValueChanged: updateFilter(timeProperty, value, timeKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: sliderTime.value = 7.5
         }
+
         Shotcut.KeyframesButton {
             id: timeKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, timeProperty, sliderTime.value)
+                enableControls(true);
+                toggleKeyframes(checked, timeProperty, sliderTime.value);
             }
         }
 
         Label {
             text: qsTr('Damping')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('This controls the high frequency damping (a lowpass filter), values near 1 will make it sound very bright, values near 0 will make it sound very dark.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('This controls the high frequency damping (a lowpass filter), values near 1 will make it sound very bright, values near 0 will make it sound very dark.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderDamp
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter(dampProperty, value / maximumValue, dampKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: sliderDamp.value = 0.5 * sliderDamp.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: dampKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, dampProperty, sliderDamp.value / sliderDamp.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, dampProperty, sliderDamp.value / sliderDamp.maximumValue);
             }
         }
 
         Label {
             text: qsTr('Input bandwidth')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('This is like a damping control for the input, it has a similar effect to the damping control, but is subtly different.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('This is like a damping control for the input, it has a similar effect to the damping control, but is subtly different.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderInput
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter(inputProperty, value / maximumValue, inputKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: sliderInput.value = 0.75 * sliderInput.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: inputKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, inputProperty, sliderInput.value / sliderInput.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, inputProperty, sliderInput.value / sliderInput.maximumValue);
             }
         }
 
         Label {
             text: qsTr('Dry signal level')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The amount of dry signal to be mixed with the reverberated signal.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The amount of dry signal to be mixed with the reverberated signal.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderDry
+
             minimumValue: -70
             maximumValue: 0
             suffix: ' dB'
             decimals: 1
             onValueChanged: updateFilter(dryProperty, value, dryKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: sliderDry.value = 0
         }
+
         Shotcut.KeyframesButton {
             id: dryKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, dryProperty, sliderDry.value)
+                enableControls(true);
+                toggleKeyframes(checked, dryProperty, sliderDry.value);
             }
         }
 
         Label {
             text: qsTr('Early reflection level')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The distance from the threshold where the knee curve starts.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The distance from the threshold where the knee curve starts.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderReflection
+
             minimumValue: -70
             maximumValue: 0
             suffix: ' dB'
@@ -290,35 +334,46 @@ Shotcut.KeyframableFilter {
         Shotcut.UndoButton {
             onClicked: sliderReflection.value = -10
         }
+
         Shotcut.KeyframesButton {
             id: reflectionKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, reflectionProperty, sliderReflection.value)
+                enableControls(true);
+                toggleKeyframes(checked, reflectionProperty, sliderReflection.value);
             }
         }
 
         Label {
             text: qsTr('Tail level')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The quantity of early reflections (scatter reflections directly from the source).')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The quantity of early reflections (scatter reflections directly from the source).')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: sliderTail
+
             minimumValue: -70
             maximumValue: 0
             decimals: 1
             suffix: ' dB'
             onValueChanged: updateFilter(tailProperty, value, tailKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: sliderTail.value = -17.5
         }
+
         Shotcut.KeyframesButton {
             id: tailKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, tailProperty, sliderTail.value)
+                enableControls(true);
+                toggleKeyframes(checked, tailProperty, sliderTail.value);
             }
         }
 
@@ -326,29 +381,54 @@ Shotcut.KeyframableFilter {
             Layout.columnSpan: parent.columns
             text: qsTr('About reverb')
             font.underline: true
+
             MouseArea {
                 anchors.fill: parent
                 onClicked: Qt.openUrlExternally('https://wiki.audacityteam.org/wiki/GVerb')
             }
+
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/audio_stereoenhance/ui.qml
+++ b/src/qml/filters/audio_stereoenhance/ui.qml
@@ -20,48 +20,49 @@ import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
-Item{
+Item {
     property bool blockControls: false
 
-    width: 200
-    height: 130
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            filter.set('av.level_in', 1)
-            filter.set('av.level_out', fromDb(-3))
-            filter.set('av.side_gain', 1)
-            filter.set('av.middle_source', 'mid')
-            filter.set('av.middle_phase', 0)
-            filter.set('av.left_delay', 0)
-            filter.set('av.left_balance', 1)
-            filter.set('av.left_gain', 1)
-            filter.set('av.left_phase', 1)
-            filter.set('av.right_delay', 10.0)
-            filter.set('av.right_balance', -1)
-            filter.set('av.right_gain', 1)
-            filter.set('av.right_phase', 1)
-            filter.savePreset(preset.parameters)
-        }
-        setControls()
-    }
-
     function toDb(value) {
-        return Math.round(20.0 * Math.log10(value) * 100.0) / 100.0
+        return Math.round(20 * Math.log10(value) * 100) / 100;
     }
 
     function fromDb(value) {
-        return Math.pow(10.0, value / 20.0) 
+        return Math.pow(10, value / 20);
     }
 
     function setControls() {
-        if (blockControls) return
-        sliderLeftDelay.value = filter.getDouble('av.left_delay')
-        sliderLeftLevel.value = toDb(filter.getDouble('av.left_gain'))
-        sliderRightDelay.value = filter.getDouble('av.right_delay')
-        sliderRightLevel.value = toDb(filter.getDouble('av.right_gain'))
-        sliderOutputLevel.value = toDb(filter.getDouble('av.level_out'))
-        sourceCombo.currentIndex = sourceCombo.valueToIndex()
+        if (blockControls)
+            return ;
+
+        sliderLeftDelay.value = filter.getDouble('av.left_delay');
+        sliderLeftLevel.value = toDb(filter.getDouble('av.left_gain'));
+        sliderRightDelay.value = filter.getDouble('av.right_delay');
+        sliderRightLevel.value = toDb(filter.getDouble('av.right_gain'));
+        sliderOutputLevel.value = toDb(filter.getDouble('av.level_out'));
+        sourceCombo.currentIndex = sourceCombo.valueToIndex();
+    }
+
+    width: 200
+    height: 130
+    Component.onCompleted: {
+        if (filter.isNew) {
+            filter.set('av.level_in', 1);
+            filter.set('av.level_out', fromDb(-3));
+            filter.set('av.side_gain', 1);
+            filter.set('av.middle_source', 'mid');
+            filter.set('av.middle_phase', 0);
+            filter.set('av.left_delay', 0);
+            filter.set('av.left_balance', 1);
+            filter.set('av.left_gain', 1);
+            filter.set('av.left_phase', 1);
+            filter.set('av.right_delay', 10);
+            filter.set('av.right_balance', -1);
+            filter.set('av.right_gain', 1);
+            filter.set('av.right_phase', 1);
+            filter.savePreset(preset.parameters);
+        }
+        setControls();
     }
 
     GridLayout {
@@ -73,12 +74,14 @@ Item{
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ['av.level_in', 'av.level_out', 'av.side_gain', 'av.middle_source', 'av.middle_phase', 'av.left_delay', 'av.left_balance', 'av.left_gain', 'av.left_phase', 'av.right_delay', 'av.right_balance', 'av.right_gain', 'av.right_phase']
             Layout.columnSpan: 2
             onPresetSelected: {
-                setControls()
+                setControls();
             }
         }
 
@@ -86,22 +89,29 @@ Item{
             text: qsTr('Source')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
-            Layout.columnSpan: 2
             id: sourceCombo
-            model: [qsTr('Left'), qsTr('Right'), qsTr('Middle (L+R)'), qsTr('Side (L-R)')]
+
             property var values: ['left', 'right', 'mid', 'side']
+
             function valueToIndex() {
-                var w = filter.get('av.middle_source')
-                for (var i = 0; i < values.length; ++i)
-                    if (values[i] === w) break;
-                if (i === values.length) i = 0;
+                var w = filter.get('av.middle_source');
+                for (var i = 0; i < values.length; ++i) if (values[i] === w) {
+                    break;
+                }
+                if (i === values.length)
+                    i = 0;
+
                 return i;
             }
+
+            Layout.columnSpan: 2
+            model: [qsTr('Left'), qsTr('Right'), qsTr('Middle (L+R)'), qsTr('Side (L-R)')]
             onActivated: {
-                blockControls = true
-                filter.set('av.middle_source', values[index])
-                blockControls = false
+                blockControls = true;
+                filter.set('av.middle_source', values[index]);
+                blockControls = false;
             }
         }
 
@@ -109,20 +119,25 @@ Item{
             text: qsTr('Left delay')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderLeftDelay
+
             minimumValue: 0
             maximumValue: 40
             stepSize: 0.1
             decimals: 1
             suffix: ' ms'
             onValueChanged: {
-                if (blockControls) return
-                blockControls = true
-                filter.set('av.left_delay', value)
-                blockControls = false
+                if (blockControls)
+                    return ;
+
+                blockControls = true;
+                filter.set('av.left_delay', value);
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderLeftDelay.value = 0
         }
@@ -131,20 +146,25 @@ Item{
             text: qsTr('Left delay gain')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderLeftLevel
+
             minimumValue: -16
             maximumValue: 16
             suffix: ' dB'
             decimals: 1
             stepSize: 0.1
             onValueChanged: {
-                if (blockControls) return
-                blockControls = true
-                filter.set('av.left_gain', fromDb(value))
-                blockControls = false
+                if (blockControls)
+                    return ;
+
+                blockControls = true;
+                filter.set('av.left_gain', fromDb(value));
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderLeftLevel.value = 0
         }
@@ -153,42 +173,52 @@ Item{
             text: qsTr('Right delay')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderRightDelay
+
             minimumValue: 0
             maximumValue: 40
             stepSize: 0.1
             decimals: 1
             suffix: ' ms'
             onValueChanged: {
-                if (blockControls) return
-                blockControls = true
-                filter.set('av.right_delay', value)
-                blockControls = false
+                if (blockControls)
+                    return ;
+
+                blockControls = true;
+                filter.set('av.right_delay', value);
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
-            onClicked: sliderRightDelay.value = 10.0
+            onClicked: sliderRightDelay.value = 10
         }
 
         Label {
             text: qsTr('Right delay gain')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderRightLevel
+
             minimumValue: -16
             maximumValue: 16
             suffix: ' dB'
             decimals: 1
             stepSize: 0.1
             onValueChanged: {
-                if (blockControls) return
-                blockControls = true
-                filter.set('av.right_gain', fromDb(value))
-                blockControls = false
+                if (blockControls)
+                    return ;
+
+                blockControls = true;
+                filter.set('av.right_gain', fromDb(value));
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderRightLevel.value = 0
         }
@@ -197,34 +227,53 @@ Item{
             text: qsTr('Output gain')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderOutputLevel
+
             minimumValue: -16
             maximumValue: 16
             suffix: ' dB'
             decimals: 1
             stepSize: 0.1
             onValueChanged: {
-                if (blockControls) return
-                blockControls = true
-                filter.set('av.level_out', fromDb(value))
-                blockControls = false
+                if (blockControls)
+                    return ;
+
+                blockControls = true;
+                filter.set('av.level_out', fromDb(value));
+                blockControls = false;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: sliderOutputLevel.value = -3
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            setControls();
+        }
+
+        function onOutChanged() {
+            setControls();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { setControls() }
-        function onOutChanged() { setControls() }
-        function onPropertyChanged(name) { setControls() }
     }
+
 }

--- a/src/qml/filters/audio_swapchannels/ui.qml
+++ b/src/qml/filters/audio_swapchannels/ui.qml
@@ -21,33 +21,29 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 100
-    height: 50
     property string fromParameter: 'from'
     property string toParameter: 'to'
+
+    width: 100
+    height: 50
     Component.onCompleted: {
         if (application.audioChannels() === 1) {
-            fromCombo.enabled = false
-            toCombo.enabled = false
+            fromCombo.enabled = false;
+            toCombo.enabled = false;
         } else if (application.audioChannels() === 6) {
-            fromCombo.model = [qsTr('Front left'),
-                           qsTr('Front right'),
-                           qsTr('Center'),
-                           qsTr('Low frequency'),
-                           qsTr('Left surround'),
-                           qsTr('Right surround')]
+            fromCombo.model = [qsTr('Front left'), qsTr('Front right'), qsTr('Center'), qsTr('Low frequency'), qsTr('Left surround'), qsTr('Right surround')];
         }
-        filter.set('swap', 1)
+        filter.set('swap', 1);
         if (filter.isNew) {
             // Set default parameter values
-            fromCombo.currentIndex = 0
-            filter.set(fromParameter, 0)
-            toCombo.currentIndex = (application.audioChannels() === 1) ? 0 : 1
-            filter.set(fromParameter, toCombo.currentIndex)
+            fromCombo.currentIndex = 0;
+            filter.set(fromParameter, 0);
+            toCombo.currentIndex = (application.audioChannels() === 1) ? 0 : 1;
+            filter.set(fromParameter, toCombo.currentIndex);
         } else {
             // Initialize parameter values
-            fromCombo.currentIndex = filter.get(fromParameter)
-            toCombo.currentIndex = filter.get(toParameter)
+            fromCombo.currentIndex = filter.get(fromParameter);
+            toCombo.currentIndex = filter.get(toParameter);
         }
     }
 
@@ -56,21 +52,34 @@ Item {
         anchors.margins: 8
 
         RowLayout {
-            Label { text: qsTr('Swap') }
+            Label {
+                text: qsTr('Swap')
+            }
+
             Shotcut.ComboBox {
                 id: fromCombo
+
                 model: [qsTr('Left'), qsTr('Right')]
                 onActivated: filter.set(fromParameter, currentIndex)
             }
-            Label { text: qsTr('with') }
+
+            Label {
+                text: qsTr('with')
+            }
+
             Shotcut.ComboBox {
                 id: toCombo
+
                 model: fromCombo.model
                 onActivated: filter.set(toParameter, currentIndex)
             }
+
         }
+
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/audiolevelgraph/ui.qml
+++ b/src/qml/filters/audiolevelgraph/ui.qml
@@ -24,69 +24,64 @@ Item {
     property string rectProperty: "rect"
     property rect filterRect: filter.getRect(rectProperty)
     property var defaultParameters: [rectProperty, 'type', 'color.1', 'color.2', 'color.3', 'color.4', 'color.5', 'color.6', 'color.7', 'color.8', 'color.9', 'color.10', 'bgcolor', 'thickness', 'fill', 'mirror', 'reverse', 'channels', 'segments', 'segment_gap']
-
     property bool _disableUpdate: true
 
-    width: 400
-    height: 350
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            filter.set(rectProperty, '0%/0%:10%x100%')
-            filter.set('type', 'bar')
-            filter.set('color.1', '#ffff0000')
-            filter.set('color.2', '#ffffff00')
-            filter.set('color.3', '#ff00ff00')
-            filter.set('color.4', '#ff00ff00')
-            filter.set('color.5', '#ff00ff00')
-            filter.set('color.6', '#ff00ff00')
-            filter.set('color.7', '#ff00ff00')
-            filter.set('bgcolor', '#00ffffff')
-            filter.set('thickness', '15')
-            filter.set('mirror', '0')
-            filter.set('reverse', '0')
-            filter.set('channels', '2')
-            filter.set('segments', '7')
-            filter.set('segment_gap', '8')
-            filter.savePreset(defaultParameters)
-        }
-        setControls()
-    }
-
     function setFilter() {
-        var x = rectX.value
-        var y = rectY.value
-        var w = rectW.value
-        var h = rectH.value
-        if (x !== filterRect.x ||
-            y !== filterRect.y ||
-            w !== filterRect.width ||
-            h !== filterRect.height) {
-            filterRect.x = x
-            filterRect.y = y
-            filterRect.width = w
-            filterRect.height = h
-            filter.set(rectProperty, filterRect)
+        var x = rectX.value;
+        var y = rectY.value;
+        var w = rectW.value;
+        var h = rectH.value;
+        if (x !== filterRect.x || y !== filterRect.y || w !== filterRect.width || h !== filterRect.height) {
+            filterRect.x = x;
+            filterRect.y = y;
+            filterRect.width = w;
+            filterRect.height = h;
+            filter.set(rectProperty, filterRect);
         }
     }
 
     function setControls() {
-        _disableUpdate = true
-        fgGradient.colors = filter.getGradient('color')
-        bgColor.value = filter.get('bgcolor')
-        thicknessSlider.value = filter.getDouble('thickness')
-        mirrorCheckbox.checked = filter.get('mirror') == 1
-        reverseCheckbox.checked = filter.get('reverse') == 1
-        channelsSlider.value = filter.getDouble('channels')
-        segmentsSlider.value = filter.getDouble('segments')
-        segmentGapSlider.value = filter.getDouble('segment_gap')
-        rectX.value = filterRect.x
-        rectY.value = filterRect.y
-        rectW.value = filterRect.width
-        rectH.value = filterRect.height
-        typeCombo.currentIndex = typeCombo.valueToIndex()
-        segmentsSlider.enabled = segmentGapSlider.enabled = (typeCombo.currentIndex == 1)
-        _disableUpdate = false
+        _disableUpdate = true;
+        fgGradient.colors = filter.getGradient('color');
+        bgColor.value = filter.get('bgcolor');
+        thicknessSlider.value = filter.getDouble('thickness');
+        mirrorCheckbox.checked = filter.get('mirror') == 1;
+        reverseCheckbox.checked = filter.get('reverse') == 1;
+        channelsSlider.value = filter.getDouble('channels');
+        segmentsSlider.value = filter.getDouble('segments');
+        segmentGapSlider.value = filter.getDouble('segment_gap');
+        rectX.value = filterRect.x;
+        rectY.value = filterRect.y;
+        rectW.value = filterRect.width;
+        rectH.value = filterRect.height;
+        typeCombo.currentIndex = typeCombo.valueToIndex();
+        segmentsSlider.enabled = segmentGapSlider.enabled = (typeCombo.currentIndex == 1);
+        _disableUpdate = false;
+    }
+
+    width: 400
+    height: 350
+    Component.onCompleted: {
+        if (filter.isNew) {
+            filter.set(rectProperty, '0%/0%:10%x100%');
+            filter.set('type', 'bar');
+            filter.set('color.1', '#ffff0000');
+            filter.set('color.2', '#ffffff00');
+            filter.set('color.3', '#ff00ff00');
+            filter.set('color.4', '#ff00ff00');
+            filter.set('color.5', '#ff00ff00');
+            filter.set('color.6', '#ff00ff00');
+            filter.set('color.7', '#ff00ff00');
+            filter.set('bgcolor', '#00ffffff');
+            filter.set('thickness', '15');
+            filter.set('mirror', '0');
+            filter.set('reverse', '0');
+            filter.set('channels', '2');
+            filter.set('segments', '7');
+            filter.set('segment_gap', '8');
+            filter.savePreset(defaultParameters);
+        }
+        setControls();
     }
 
     GridLayout {
@@ -98,14 +93,16 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: defaultParameters
             Layout.columnSpan: 4
             onPresetSelected: setControls()
             onBeforePresetLoaded: {
                 // Clear all gradient colors before loading the new values
-                filter.setGradient('color', [])
+                filter.setGradient('color', []);
             }
         }
 
@@ -113,21 +110,28 @@ Item {
             text: qsTr('Type')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
-            Layout.columnSpan: 4
             id: typeCombo
-            model: [qsTr('Bar'), qsTr('Segment')]
+
             property var values: ['bar', 'segment']
+
             function valueToIndex() {
-                var w = filter.get('type')
-                for (var i = 0; i < values.length; ++i)
-                    if (values[i] === w) break;
-                if (i === values.length) i = 0;
+                var w = filter.get('type');
+                for (var i = 0; i < values.length; ++i) if (values[i] === w) {
+                    break;
+                }
+                if (i === values.length)
+                    i = 0;
+
                 return i;
             }
+
+            Layout.columnSpan: 4
+            model: [qsTr('Bar'), qsTr('Segment')]
             onActivated: {
-                filter.set('type', values[index])
-                segmentsSlider.enabled = segmentGapSlider.enabled = (typeCombo.currentIndex == 1)
+                filter.set('type', values[index]);
+                segmentsSlider.enabled = segmentGapSlider.enabled = (typeCombo.currentIndex == 1);
             }
         }
 
@@ -135,12 +139,16 @@ Item {
             text: qsTr('Graph Colors')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.GradientControl {
-            Layout.columnSpan: 4
             id: fgGradient
+
+            Layout.columnSpan: 4
             onGradientChanged: {
-                 if (_disableUpdate) return
-                 filter.setGradient('color', colors)
+                if (_disableUpdate)
+                    return ;
+
+                filter.setGradient('color', colors);
             }
         }
 
@@ -148,9 +156,11 @@ Item {
             text: qsTr('Background Color')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ColorPicker {
-            Layout.columnSpan: 4
             id: bgColor
+
+            Layout.columnSpan: 4
             eyedropper: true
             alpha: true
             onValueChanged: filter.set('bgcolor', value)
@@ -160,16 +170,23 @@ Item {
             text: qsTr('Thickness')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: thicknessSlider
+
+            Layout.columnSpan: 3
             minimumValue: 0
             maximumValue: 100
             decimals: 0
             suffix: ' px'
             onValueChanged: filter.set("thickness", value)
-            Shotcut.HoverTip { text: 'Set the thickness of the bars (in pixels)' }
+
+            Shotcut.HoverTip {
+                text: 'Set the thickness of the bars (in pixels)'
+            }
+
         }
+
         Shotcut.UndoButton {
             onClicked: thicknessSlider.value = 15
         }
@@ -178,70 +195,110 @@ Item {
             text: qsTr('Position')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Layout.columnSpan: 4
+
             Shotcut.DoubleSpinBox {
                 id: rectX
+
                 value: filterRect.x
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.x !== value) setFilter()
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.x !== value)
+                        setFilter();
+
+                }
             }
-            Label { text: ','; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: ','
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectY
+
                 value: filterRect.y
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.y !== value) setFilter()
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.y !== value)
+                        setFilter();
+
+                }
             }
+
         }
 
         Label {
             text: qsTr('Size')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Layout.columnSpan: 4
+
             Shotcut.DoubleSpinBox {
                 id: rectW
+
                 value: filterRect.width
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.width !== value) setFilter()
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.width !== value)
+                        setFilter();
+
+                }
             }
-            Label { text: 'x'; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: 'x'
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectH
+
                 value: filterRect.height
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.height !== value) setFilter()
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.height !== value)
+                        setFilter();
+
+                }
             }
+
         }
 
         Label {
             Layout.alignment: Qt.AlignRight
         }
+
         CheckBox {
-            Layout.columnSpan: 4
             id: mirrorCheckbox
+
+            Layout.columnSpan: 4
             text: qsTr('Mirror the levels.')
             onClicked: filter.set('mirror', checked ? 1 : 0)
         }
@@ -249,27 +306,40 @@ Item {
         Label {
             Layout.alignment: Qt.AlignRight
         }
+
         CheckBox {
-            Layout.columnSpan: 4
             id: reverseCheckbox
+
+            Layout.columnSpan: 4
             text: qsTr('Reverse the levels.')
             onClicked: filter.set('reverse', checked ? 1 : 0)
-            Shotcut.HoverTip { text: 'Reverse the order of channels.' }
+
+            Shotcut.HoverTip {
+                text: 'Reverse the order of channels.'
+            }
+
         }
 
         Label {
             text: qsTr('Channels')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: channelsSlider
+
+            Layout.columnSpan: 3
             minimumValue: 1
             maximumValue: 10
             decimals: 0
             onValueChanged: filter.set("channels", value)
-            Shotcut.HoverTip { text: 'The number of audio channels to show.' }
+
+            Shotcut.HoverTip {
+                text: 'The number of audio channels to show.'
+            }
+
         }
+
         Shotcut.UndoButton {
             onClicked: channelsSlider.value = 2
         }
@@ -278,15 +348,22 @@ Item {
             text: qsTr('Segments')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: segmentsSlider
+
+            Layout.columnSpan: 3
             minimumValue: 2
             maximumValue: 100
             decimals: 0
             onValueChanged: filter.set("segments", value)
-            Shotcut.HoverTip { text: 'The number of segments in the segment graph' }
+
+            Shotcut.HoverTip {
+                text: 'The number of segments in the segment graph'
+            }
+
         }
+
         Shotcut.UndoButton {
             onClicked: segmentGapSlider.value = 8
         }
@@ -295,30 +372,42 @@ Item {
             text: qsTr('Segment Gap')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: segmentGapSlider
+
+            Layout.columnSpan: 3
             minimumValue: 0
             maximumValue: 100
             decimals: 0
             onValueChanged: filter.set("segment_gap", value)
-            Shotcut.HoverTip { text: 'Space between segments in the segment graph (in pixels)' }
+
+            Shotcut.HoverTip {
+                text: 'Space between segments in the segment graph (in pixels)'
+            }
+
         }
+
         Shotcut.UndoButton {
             onClicked: segmentGapSlider.value = 8
         }
 
-        Item { Layout.fillHeight: true }
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
 
     Connections {
-        target: filter
         function onChanged() {
-            var newValue = filter.getRect(rectProperty)
+            var newValue = filter.getRect(rectProperty);
             if (filterRect !== newValue) {
-                filterRect = newValue
-                setControls()
+                filterRect = newValue;
+                setControls();
             }
         }
+
+        target: filter
     }
+
 }

--- a/src/qml/filters/audiolevelgraph/vui.qml
+++ b/src/qml/filters/audiolevelgraph/vui.qml
@@ -20,12 +20,12 @@ import Shotcut.Controls 1.0 as Shotcut
 
 Shotcut.VuiBase {
     property string rectProperty: "rect"
-    property real zoom: (video.zoom > 0)? video.zoom : 1.0
+    property real zoom: (video.zoom > 0) ? video.zoom : 1
     property rect filterRect: filter.getRect(rectProperty)
 
     Component.onCompleted: {
-        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag'))
-        rectangle.setHandles(filter.getRect(rectProperty))
+        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag'));
+        rectangle.setHandles(filter.getRect(rectProperty));
     }
 
     Flickable {
@@ -39,6 +39,7 @@ Shotcut.VuiBase {
 
         Item {
             id: videoItem
+
             x: video.rect.x
             y: video.rect.y
             width: video.rect.width
@@ -47,32 +48,37 @@ Shotcut.VuiBase {
 
             Shotcut.RectangleControl {
                 id: rectangle
+
                 widthScale: video.rect.width / profile.width
                 heightScale: video.rect.height / profile.height
                 handleSize: Math.max(Math.round(8 / zoom), 4)
                 borderSize: Math.max(Math.round(1.33 / zoom), 1)
                 onWidthScaleChanged: setHandles(filter.getRect(rectProperty))
                 onHeightScaleChanged: setHandles(filter.getRect(rectProperty))
-                onRectChanged:  {
-                    filterRect.x = Math.round(rect.x / rectangle.widthScale)
-                    filterRect.y = Math.round(rect.y / rectangle.heightScale)
-                    filterRect.width = Math.round(rect.width / rectangle.widthScale)
-                    filterRect.height = Math.round(rect.height / rectangle.heightScale)
-                    filter.set(rectProperty, filterRect)
+                onRectChanged: {
+                    filterRect.x = Math.round(rect.x / rectangle.widthScale);
+                    filterRect.y = Math.round(rect.y / rectangle.heightScale);
+                    filterRect.width = Math.round(rect.width / rectangle.widthScale);
+                    filterRect.height = Math.round(rect.height / rectangle.heightScale);
+                    filter.set(rectProperty, filterRect);
                 }
             }
+
         }
+
     }
 
     Connections {
-        target: filter
         function onChanged() {
-            var newRect = filter.getRect(rectProperty)
+            var newRect = filter.getRect(rectProperty);
             if (filterRect !== newRect) {
-                filterRect = newRect
-                rectangle.setHandles(filterRect)
+                filterRect = newRect;
+                rectangle.setHandles(filterRect);
             }
-            videoItem.enabled = filter.get('disable') !== '1'
+            videoItem.enabled = filter.get('disable') !== '1';
         }
+
+        target: filter
     }
+
 }

--- a/src/qml/filters/bigsh0t_eq_mask/meta.qml
+++ b/src/qml/filters/bigsh0t_eq_mask/meta.qml
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0-or-later */
+// SPDX-License-Identifier: GPL-2.0-or-later
 import QtQuick 2.0
 import org.shotcut.qml 1.0
 
@@ -8,6 +8,7 @@ Metadata {
     mlt_service: "frei0r.bigsh0t_eq_mask"
     objectName: "bigsh0t_eq_mask"
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -43,4 +44,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/bigsh0t_eq_mask/ui.qml
+++ b/src/qml/filters/bigsh0t_eq_mask/ui.qml
@@ -1,77 +1,243 @@
-
-
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
-
 Item {
-    width: 350
-    height: 200
     property bool blockUpdate: true
-
-    property double hfov0Start : 0.0; property double hfov0Middle : 0.0; property double hfov0End : 0.0;
-    property double hfov1Start : 0.0; property double hfov1Middle : 0.0; property double hfov1End : 0.0;
-    property double vfov0Start : 0.0; property double vfov0Middle : 0.0; property double vfov0End : 0.0;
-    property double vfov1Start : 0.0; property double vfov1Middle : 0.0; property double vfov1End : 0.0;
+    property double hfov0Start: 0
+    property double hfov0Middle: 0
+    property double hfov0End: 0
+    property double hfov1Start: 0
+    property double hfov1Middle: 0
+    property double hfov1End: 0
+    property double vfov0Start: 0
+    property double vfov0Middle: 0
+    property double vfov0End: 0
+    property double vfov1Start: 0
+    property double vfov1Middle: 0
+    property double vfov1End: 0
 
     function updateSimpleKeyframes() {
         if (filter.animateIn > 0 || filter.animateOut > 0) {
             // When enabling simple keyframes, initialize the keyframes with the current value
-            if (filter.keyframeCount("hfov0") <= 0) {
-                hfov0Start = hfov0Middle = hfov0End = filter.getDouble("hfov0")
-            }
-            if (filter.keyframeCount("hfov1") <= 0) {
-                hfov1Start = hfov1Middle = hfov1End = filter.getDouble("hfov1")
-            }
-            if (filter.keyframeCount("vfov0") <= 0) {
-                vfov0Start = vfov0Middle = vfov0End = filter.getDouble("vfov0")
-            }
-            if (filter.keyframeCount("vfov1") <= 0) {
-                vfov1Start = vfov1Middle = vfov1End = filter.getDouble("vfov1")
-            }
-        }
-        setControls()
-        updateProperty_hfov0(null)
-        updateProperty_hfov1(null)
-        updateProperty_vfov0(null)
-        updateProperty_vfov1(null)
-    }
+            if (filter.keyframeCount("hfov0") <= 0)
+                hfov0Start = hfov0Middle = hfov0End = filter.getDouble("hfov0");
 
-    Component.onCompleted: {
-        if (filter.isNew) { filter.set("hfov0", 180); } else { hfov0Middle = filter.getDouble("hfov0", filter.animateIn); if (filter.animateIn > 0) { hfov0Start = filter.getDouble("hfov0", 0); } if (filter.animateOut > 0) { hfov0End = filter.getDouble("hfov0", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("hfov1", 200); } else { hfov1Middle = filter.getDouble("hfov1", filter.animateIn); if (filter.animateIn > 0) { hfov1Start = filter.getDouble("hfov1", 0); } if (filter.animateOut > 0) { hfov1End = filter.getDouble("hfov1", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("vfov0", 140); } else { vfov0Middle = filter.getDouble("vfov0", filter.animateIn); if (filter.animateIn > 0) { vfov0Start = filter.getDouble("vfov0", 0); } if (filter.animateOut > 0) { vfov0End = filter.getDouble("vfov0", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("vfov1", 160); } else { vfov1Middle = filter.getDouble("vfov1", filter.animateIn); if (filter.animateIn > 0) { vfov1Start = filter.getDouble("vfov1", 0); } if (filter.animateOut > 0) { vfov1End = filter.getDouble("vfov1", filter.duration - 1); } }
+            if (filter.keyframeCount("hfov1") <= 0)
+                hfov1Start = hfov1Middle = hfov1End = filter.getDouble("hfov1");
 
-        if (filter.isNew) {
-            filter.savePreset(preset.parameters)
+            if (filter.keyframeCount("vfov0") <= 0)
+                vfov0Start = vfov0Middle = vfov0End = filter.getDouble("vfov0");
+
+            if (filter.keyframeCount("vfov1") <= 0)
+                vfov1Start = vfov1Middle = vfov1End = filter.getDouble("vfov1");
+
         }
-        setControls()
+        setControls();
+        updateProperty_hfov0(null);
+        updateProperty_hfov1(null);
+        updateProperty_vfov0(null);
+        updateProperty_vfov1(null);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        hfov0Slider.value = filter.getDouble("hfov0", position)
-        hfov0KeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("hfov0") > 0
-        hfov1Slider.value = filter.getDouble("hfov1", position)
-        hfov1KeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("hfov1") > 0
-        vfov0Slider.value = filter.getDouble("vfov0", position)
-        vfov0KeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("vfov0") > 0
-        vfov1Slider.value = filter.getDouble("vfov1", position)
-        vfov1KeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("vfov1") > 0
-        blockUpdate = false
+        var position = getPosition();
+        blockUpdate = true;
+        hfov0Slider.value = filter.getDouble("hfov0", position);
+        hfov0KeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("hfov0") > 0;
+        hfov1Slider.value = filter.getDouble("hfov1", position);
+        hfov1KeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("hfov1") > 0;
+        vfov0Slider.value = filter.getDouble("vfov0", position);
+        vfov0KeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("vfov0") > 0;
+        vfov1Slider.value = filter.getDouble("vfov1", position);
+        vfov1KeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("vfov1") > 0;
+        blockUpdate = false;
     }
 
-    function updateProperty_hfov0 (position) { if (blockUpdate) return; var value = hfov0Slider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { hfov0Start = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { hfov0End = value; } else { hfov0Middle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("hfov0"); hfov0KeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("hfov0", hfov0Start, 0); filter.set("hfov0", hfov0Middle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("hfov0", hfov0Middle, filter.duration - filter.animateOut); filter.set("hfov0", hfov0End, filter.duration - 1); } } else if (!hfov0KeyframesButton.checked) { filter.resetProperty("hfov0"); filter.set("hfov0", hfov0Middle); } else if (position !== null) { filter.set("hfov0", value, position); } }
-    function updateProperty_hfov1 (position) { if (blockUpdate) return; var value = hfov1Slider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { hfov1Start = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { hfov1End = value; } else { hfov1Middle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("hfov1"); hfov1KeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("hfov1", hfov1Start, 0); filter.set("hfov1", hfov1Middle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("hfov1", hfov1Middle, filter.duration - filter.animateOut); filter.set("hfov1", hfov1End, filter.duration - 1); } } else if (!hfov1KeyframesButton.checked) { filter.resetProperty("hfov1"); filter.set("hfov1", hfov1Middle); } else if (position !== null) { filter.set("hfov1", value, position); } }
-    function updateProperty_vfov0 (position) { if (blockUpdate) return; var value = vfov0Slider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { vfov0Start = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { vfov0End = value; } else { vfov0Middle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("vfov0"); vfov0KeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("vfov0", vfov0Start, 0); filter.set("vfov0", vfov0Middle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("vfov0", vfov0Middle, filter.duration - filter.animateOut); filter.set("vfov0", vfov0End, filter.duration - 1); } } else if (!vfov0KeyframesButton.checked) { filter.resetProperty("vfov0"); filter.set("vfov0", vfov0Middle); } else if (position !== null) { filter.set("vfov0", value, position); } }
-    function updateProperty_vfov1 (position) { if (blockUpdate) return; var value = vfov1Slider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { vfov1Start = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { vfov1End = value; } else { vfov1Middle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("vfov1"); vfov1KeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("vfov1", vfov1Start, 0); filter.set("vfov1", vfov1Middle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("vfov1", vfov1Middle, filter.duration - filter.animateOut); filter.set("vfov1", vfov1End, filter.duration - 1); } } else if (!vfov1KeyframesButton.checked) { filter.resetProperty("vfov1"); filter.set("vfov1", vfov1Middle); } else if (position !== null) { filter.set("vfov1", value, position); } }
+    function updateProperty_hfov0(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = hfov0Slider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                hfov0Start = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                hfov0End = value;
+            else
+                hfov0Middle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("hfov0");
+            hfov0KeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("hfov0", hfov0Start, 0);
+                filter.set("hfov0", hfov0Middle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("hfov0", hfov0Middle, filter.duration - filter.animateOut);
+                filter.set("hfov0", hfov0End, filter.duration - 1);
+            }
+        } else if (!hfov0KeyframesButton.checked) {
+            filter.resetProperty("hfov0");
+            filter.set("hfov0", hfov0Middle);
+        } else if (position !== null) {
+            filter.set("hfov0", value, position);
+        }
+    }
+
+    function updateProperty_hfov1(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = hfov1Slider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                hfov1Start = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                hfov1End = value;
+            else
+                hfov1Middle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("hfov1");
+            hfov1KeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("hfov1", hfov1Start, 0);
+                filter.set("hfov1", hfov1Middle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("hfov1", hfov1Middle, filter.duration - filter.animateOut);
+                filter.set("hfov1", hfov1End, filter.duration - 1);
+            }
+        } else if (!hfov1KeyframesButton.checked) {
+            filter.resetProperty("hfov1");
+            filter.set("hfov1", hfov1Middle);
+        } else if (position !== null) {
+            filter.set("hfov1", value, position);
+        }
+    }
+
+    function updateProperty_vfov0(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = vfov0Slider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                vfov0Start = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                vfov0End = value;
+            else
+                vfov0Middle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("vfov0");
+            vfov0KeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("vfov0", vfov0Start, 0);
+                filter.set("vfov0", vfov0Middle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("vfov0", vfov0Middle, filter.duration - filter.animateOut);
+                filter.set("vfov0", vfov0End, filter.duration - 1);
+            }
+        } else if (!vfov0KeyframesButton.checked) {
+            filter.resetProperty("vfov0");
+            filter.set("vfov0", vfov0Middle);
+        } else if (position !== null) {
+            filter.set("vfov0", value, position);
+        }
+    }
+
+    function updateProperty_vfov1(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = vfov1Slider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                vfov1Start = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                vfov1End = value;
+            else
+                vfov1Middle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("vfov1");
+            vfov1KeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("vfov1", vfov1Start, 0);
+                filter.set("vfov1", vfov1Middle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("vfov1", vfov1Middle, filter.duration - filter.animateOut);
+                filter.set("vfov1", vfov1End, filter.duration - 1);
+            }
+        } else if (!vfov1KeyframesButton.checked) {
+            filter.resetProperty("vfov1");
+            filter.set("vfov1", vfov1Middle);
+        } else if (position !== null) {
+            filter.set("vfov1", value, position);
+        }
+    }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
+    }
+
+    width: 350
+    height: 200
+    Component.onCompleted: {
+        if (filter.isNew) {
+            filter.set("hfov0", 180);
+        } else {
+            hfov0Middle = filter.getDouble("hfov0", filter.animateIn);
+            if (filter.animateIn > 0)
+                hfov0Start = filter.getDouble("hfov0", 0);
+
+            if (filter.animateOut > 0)
+                hfov0End = filter.getDouble("hfov0", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("hfov1", 200);
+        } else {
+            hfov1Middle = filter.getDouble("hfov1", filter.animateIn);
+            if (filter.animateIn > 0)
+                hfov1Start = filter.getDouble("hfov1", 0);
+
+            if (filter.animateOut > 0)
+                hfov1End = filter.getDouble("hfov1", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("vfov0", 140);
+        } else {
+            vfov0Middle = filter.getDouble("vfov0", filter.animateIn);
+            if (filter.animateIn > 0)
+                vfov0Start = filter.getDouble("vfov0", 0);
+
+            if (filter.animateOut > 0)
+                vfov0End = filter.getDouble("vfov0", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("vfov1", 160);
+        } else {
+            vfov1Middle = filter.getDouble("vfov1", filter.animateIn);
+            if (filter.animateIn > 0)
+                vfov1Start = filter.getDouble("vfov1", 0);
+
+            if (filter.animateOut > 0)
+                vfov1End = filter.getDouble("vfov1", filter.duration - 1);
+
+        }
+        if (filter.isNew)
+            filter.savePreset(preset.parameters);
+
+        setControls();
     }
 
     GridLayout {
@@ -83,21 +249,47 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ["hfov0", "hfov1", "vfov0", "vfov1"]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                filter.resetProperty('hfov0')
-                filter.resetProperty('hfov1')
-                filter.resetProperty('vfov0')
-                filter.resetProperty('vfov1')
+                filter.resetProperty('hfov0');
+                filter.resetProperty('hfov1');
+                filter.resetProperty('vfov0');
+                filter.resetProperty('vfov1');
             }
             onPresetSelected: {
-                hfov0Middle = filter.getDouble("hfov0", filter.animateIn); if (filter.animateIn > 0) { hfov0Start = filter.getDouble("hfov0", 0); } if (filter.animateOut > 0) { hfov0End = filter.getDouble("hfov0", filter.duration - 1); }
-                hfov1Middle = filter.getDouble("hfov1", filter.animateIn); if (filter.animateIn > 0) { hfov1Start = filter.getDouble("hfov1", 0); } if (filter.animateOut > 0) { hfov1End = filter.getDouble("hfov1", filter.duration - 1); }
-                vfov0Middle = filter.getDouble("vfov0", filter.animateIn); if (filter.animateIn > 0) { vfov0Start = filter.getDouble("vfov0", 0); } if (filter.animateOut > 0) { vfov0End = filter.getDouble("vfov0", filter.duration - 1); }
-                vfov1Middle = filter.getDouble("vfov1", filter.animateIn); if (filter.animateIn > 0) { vfov1Start = filter.getDouble("vfov1", 0); } if (filter.animateOut > 0) { vfov1End = filter.getDouble("vfov1", filter.duration - 1); }
+                hfov0Middle = filter.getDouble("hfov0", filter.animateIn);
+                if (filter.animateIn > 0)
+                    hfov0Start = filter.getDouble("hfov0", 0);
+
+                if (filter.animateOut > 0)
+                    hfov0End = filter.getDouble("hfov0", filter.duration - 1);
+
+                hfov1Middle = filter.getDouble("hfov1", filter.animateIn);
+                if (filter.animateIn > 0)
+                    hfov1Start = filter.getDouble("hfov1", 0);
+
+                if (filter.animateOut > 0)
+                    hfov1End = filter.getDouble("hfov1", filter.duration - 1);
+
+                vfov0Middle = filter.getDouble("vfov0", filter.animateIn);
+                if (filter.animateIn > 0)
+                    vfov0Start = filter.getDouble("vfov0", 0);
+
+                if (filter.animateOut > 0)
+                    vfov0End = filter.getDouble("vfov0", filter.duration - 1);
+
+                vfov1Middle = filter.getDouble("vfov1", filter.animateIn);
+                if (filter.animateIn > 0)
+                    vfov1Start = filter.getDouble("vfov1", 0);
+
+                if (filter.animateOut > 0)
+                    vfov1End = filter.getDouble("vfov1", filter.duration - 1);
+
                 setControls(null);
             }
         }
@@ -112,35 +304,89 @@ Item {
             text: qsTr('Start')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: hfov0Slider
+
             minimumValue: 0
             maximumValue: 360
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_hfov0(getPosition())
         }
+
         Shotcut.UndoButton {
             id: hfov0Undo
+
             onClicked: hfov0Slider.value = 180
         }
-        Shotcut.KeyframesButton { id: hfov0KeyframesButton; onToggled: { var value = hfov0Slider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("hfov0"); hfov0Slider.enabled = true; } filter.clearSimpleAnimation("hfov0"); blockUpdate = false; filter.set("hfov0", value, getPosition()); } else { filter.resetProperty("hfov0"); filter.set("hfov0", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: hfov0KeyframesButton
+
+            onToggled: {
+                var value = hfov0Slider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("hfov0");
+                        hfov0Slider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("hfov0");
+                    blockUpdate = false;
+                    filter.set("hfov0", value, getPosition());
+                } else {
+                    filter.resetProperty("hfov0");
+                    filter.set("hfov0", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('End')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: hfov1Slider
+
             minimumValue: 0
             maximumValue: 360
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_hfov1(getPosition())
         }
+
         Shotcut.UndoButton {
             id: hfov1Undo
+
             onClicked: hfov1Slider.value = 200
         }
-        Shotcut.KeyframesButton { id: hfov1KeyframesButton; onToggled: { var value = hfov1Slider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("hfov1"); hfov1Slider.enabled = true; } filter.clearSimpleAnimation("hfov1"); blockUpdate = false; filter.set("hfov1", value, getPosition()); } else { filter.resetProperty("hfov1"); filter.set("hfov1", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: hfov1KeyframesButton
+
+            onToggled: {
+                var value = hfov1Slider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("hfov1");
+                        hfov1Slider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("hfov1");
+                    blockUpdate = false;
+                    filter.set("hfov1", value, getPosition());
+                } else {
+                    filter.resetProperty("hfov1");
+                    filter.set("hfov1", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Vertical')
@@ -152,52 +398,130 @@ Item {
             text: qsTr('Start')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: vfov0Slider
+
             minimumValue: 0
             maximumValue: 360
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_vfov0(getPosition())
         }
+
         Shotcut.UndoButton {
             id: vfov0Undo
+
             onClicked: vfov0Slider.value = 140
         }
-        Shotcut.KeyframesButton { id: vfov0KeyframesButton; onToggled: { var value = vfov0Slider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("vfov0"); vfov0Slider.enabled = true; } filter.clearSimpleAnimation("vfov0"); blockUpdate = false; filter.set("vfov0", value, getPosition()); } else { filter.resetProperty("vfov0"); filter.set("vfov0", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: vfov0KeyframesButton
+
+            onToggled: {
+                var value = vfov0Slider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("vfov0");
+                        vfov0Slider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("vfov0");
+                    blockUpdate = false;
+                    filter.set("vfov0", value, getPosition());
+                } else {
+                    filter.resetProperty("vfov0");
+                    filter.set("vfov0", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('End')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: vfov1Slider
+
             minimumValue: 0
             maximumValue: 360
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_vfov1(getPosition())
         }
+
         Shotcut.UndoButton {
             id: vfov1Undo
+
             onClicked: vfov1Slider.value = 160
         }
-        Shotcut.KeyframesButton { id: vfov1KeyframesButton; onToggled: { var value = vfov1Slider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("vfov1"); vfov1Slider.enabled = true; } filter.clearSimpleAnimation("vfov1"); blockUpdate = false; filter.set("vfov1", value, getPosition()); } else { filter.resetProperty("vfov1"); filter.set("vfov1", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: vfov1KeyframesButton
+
+            onToggled: {
+                var value = vfov1Slider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("vfov1");
+                        vfov1Slider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("vfov1");
+                    blockUpdate = false;
+                    filter.set("vfov1", value, getPosition());
+                } else {
+                    filter.resetProperty("vfov1");
+                    filter.set("vfov1", value);
+                }
+            }
+        }
+
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/bigsh0t_eq_to_rect/meta.qml
+++ b/src/qml/filters/bigsh0t_eq_to_rect/meta.qml
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0-or-later */
+// SPDX-License-Identifier: GPL-2.0-or-later
 import QtQuick 2.0
 import org.shotcut.qml 1.0
 
@@ -9,6 +9,7 @@ Metadata {
     objectName: "bigsh0t_eq_to_rect"
     qml: "ui.qml"
     vui: "vui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -51,4 +52,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/bigsh0t_eq_to_rect/ui.qml
+++ b/src/qml/filters/bigsh0t_eq_to_rect/ui.qml
@@ -1,91 +1,310 @@
-
-
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
-
 Item {
-    width: 350
-    height: 200
     property bool blockUpdate: true
-
-    property double yawStart : 0.0; property double yawMiddle : 0.0; property double yawEnd : 0.0;
-    property double pitchStart : 0.0; property double pitchMiddle : 0.0; property double pitchEnd : 0.0;
-    property double rollStart : 0.0; property double rollMiddle : 0.0; property double rollEnd : 0.0;
-    property double fovStart : 0.0; property double fovMiddle : 0.0; property double fovEnd : 0.0;
-    property double fisheyeStart : 0.0; property double fisheyeMiddle : 0.0; property double fisheyeEnd : 0.0;
-    property int interpolationValue : 0;
+    property double yawStart: 0
+    property double yawMiddle: 0
+    property double yawEnd: 0
+    property double pitchStart: 0
+    property double pitchMiddle: 0
+    property double pitchEnd: 0
+    property double rollStart: 0
+    property double rollMiddle: 0
+    property double rollEnd: 0
+    property double fovStart: 0
+    property double fovMiddle: 0
+    property double fovEnd: 0
+    property double fisheyeStart: 0
+    property double fisheyeMiddle: 0
+    property double fisheyeEnd: 0
+    property int interpolationValue: 0
 
     function updateSimpleKeyframes() {
         if (filter.animateIn > 0 || filter.animateOut > 0) {
             // When enabling simple keyframes, initialize the keyframes with the current value
-            if (filter.keyframeCount("yaw") <= 0) {
-                yawStart = yawMiddle = yawEnd = filter.getDouble("yaw")
-            }
-            if (filter.keyframeCount("pitch") <= 0) {
-                pitchStart = pitchMiddle = pitchEnd = filter.getDouble("pitch")
-            }
-            if (filter.keyframeCount("roll") <= 0) {
-                rollStart = rollMiddle = rollEnd = filter.getDouble("roll")
-            }
-            if (filter.keyframeCount("fov") <= 0) {
-                fovStart = fovMiddle = fovEnd = filter.getDouble("fov")
-            }
-            if (filter.keyframeCount("fisheye") <= 0) {
-                fisheyeStart = fisheyeMiddle = fisheyeEnd = filter.getDouble("fisheye")
-            }
-        }
-        setControls()
-        updateProperty_yaw (null)
-        updateProperty_pitch (null)
-        updateProperty_roll (null)
-        updateProperty_fov (null)
-        updateProperty_fisheye (null)
-        updateProperty_interpolation ()
-    }
+            if (filter.keyframeCount("yaw") <= 0)
+                yawStart = yawMiddle = yawEnd = filter.getDouble("yaw");
 
-    Component.onCompleted: {
-        if (filter.isNew) { filter.set("yaw", 0); } else { yawMiddle = filter.getDouble("yaw", filter.animateIn); if (filter.animateIn > 0) { yawStart = filter.getDouble("yaw", 0); } if (filter.animateOut > 0) { yawEnd = filter.getDouble("yaw", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("pitch", 0); } else { pitchMiddle = filter.getDouble("pitch", filter.animateIn); if (filter.animateIn > 0) { pitchStart = filter.getDouble("pitch", 0); } if (filter.animateOut > 0) { pitchEnd = filter.getDouble("pitch", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("roll", 0); } else { rollMiddle = filter.getDouble("roll", filter.animateIn); if (filter.animateIn > 0) { rollStart = filter.getDouble("roll", 0); } if (filter.animateOut > 0) { rollEnd = filter.getDouble("roll", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("fov", 90); } else { fovMiddle = filter.getDouble("fov", filter.animateIn); if (filter.animateIn > 0) { fovStart = filter.getDouble("fov", 0); } if (filter.animateOut > 0) { fovEnd = filter.getDouble("fov", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("fisheye", 0); } else { fisheyeMiddle = filter.getDouble("fisheye", filter.animateIn); if (filter.animateIn > 0) { fisheyeStart = filter.getDouble("fisheye", 0); } if (filter.animateOut > 0) { fisheyeEnd = filter.getDouble("fisheye", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("interpolation", 1); } else { interpolationValue = filter.get("interpolation"); }
+            if (filter.keyframeCount("pitch") <= 0)
+                pitchStart = pitchMiddle = pitchEnd = filter.getDouble("pitch");
 
-        if (filter.isNew) {
-            filter.savePreset(preset.parameters)
+            if (filter.keyframeCount("roll") <= 0)
+                rollStart = rollMiddle = rollEnd = filter.getDouble("roll");
+
+            if (filter.keyframeCount("fov") <= 0)
+                fovStart = fovMiddle = fovEnd = filter.getDouble("fov");
+
+            if (filter.keyframeCount("fisheye") <= 0)
+                fisheyeStart = fisheyeMiddle = fisheyeEnd = filter.getDouble("fisheye");
+
         }
-        setControls()
+        setControls();
+        updateProperty_yaw(null);
+        updateProperty_pitch(null);
+        updateProperty_roll(null);
+        updateProperty_fov(null);
+        updateProperty_fisheye(null);
+        updateProperty_interpolation();
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        yawSlider.value = filter.getDouble("yaw", position)
-        yawKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("yaw") > 0
-        pitchSlider.value = filter.getDouble("pitch", position)
-        pitchKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("pitch") > 0
-        rollSlider.value = filter.getDouble("roll", position)
-        rollKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("roll") > 0
-        fovSlider.value = filter.getDouble("fov", position)
-        fovKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("fov") > 0
-        fisheyeSlider.value = filter.getDouble("fisheye", position)
-        fisheyeKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("fisheye") > 0
-        interpolationComboBox.currentIndex = filter.get("interpolation")
-        blockUpdate = false
+        var position = getPosition();
+        blockUpdate = true;
+        yawSlider.value = filter.getDouble("yaw", position);
+        yawKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("yaw") > 0;
+        pitchSlider.value = filter.getDouble("pitch", position);
+        pitchKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("pitch") > 0;
+        rollSlider.value = filter.getDouble("roll", position);
+        rollKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("roll") > 0;
+        fovSlider.value = filter.getDouble("fov", position);
+        fovKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("fov") > 0;
+        fisheyeSlider.value = filter.getDouble("fisheye", position);
+        fisheyeKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("fisheye") > 0;
+        interpolationComboBox.currentIndex = filter.get("interpolation");
+        blockUpdate = false;
     }
 
-    function updateProperty_yaw (position) { if (blockUpdate) return; var value = yawSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { yawStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { yawEnd = value; } else { yawMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("yaw"); yawKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("yaw", yawStart, 0); filter.set("yaw", yawMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("yaw", yawMiddle, filter.duration - filter.animateOut); filter.set("yaw", yawEnd, filter.duration - 1); } } else if (!yawKeyframesButton.checked) { filter.resetProperty("yaw"); filter.set("yaw", yawMiddle); } else if (position !== null) { filter.set("yaw", value, position); } }
-    function updateProperty_pitch (position) { if (blockUpdate) return; var value = pitchSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { pitchStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { pitchEnd = value; } else { pitchMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("pitch"); pitchKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("pitch", pitchStart, 0); filter.set("pitch", pitchMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("pitch", pitchMiddle, filter.duration - filter.animateOut); filter.set("pitch", pitchEnd, filter.duration - 1); } } else if (!pitchKeyframesButton.checked) { filter.resetProperty("pitch"); filter.set("pitch", pitchMiddle); } else if (position !== null) { filter.set("pitch", value, position); } }
-    function updateProperty_roll (position) { if (blockUpdate) return; var value = rollSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { rollStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { rollEnd = value; } else { rollMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("roll"); rollKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("roll", rollStart, 0); filter.set("roll", rollMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("roll", rollMiddle, filter.duration - filter.animateOut); filter.set("roll", rollEnd, filter.duration - 1); } } else if (!rollKeyframesButton.checked) { filter.resetProperty("roll"); filter.set("roll", rollMiddle); } else if (position !== null) { filter.set("roll", value, position); } }
-    function updateProperty_fov (position) { if (blockUpdate) return; var value = fovSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { fovStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { fovEnd = value; } else { fovMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("fov"); fovKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("fov", fovStart, 0); filter.set("fov", fovMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("fov", fovMiddle, filter.duration - filter.animateOut); filter.set("fov", fovEnd, filter.duration - 1); } } else if (!fovKeyframesButton.checked) { filter.resetProperty("fov"); filter.set("fov", fovMiddle); } else if (position !== null) { filter.set("fov", value, position); } }
-    function updateProperty_fisheye (position) { if (blockUpdate) return; var value = fisheyeSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { fisheyeStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { fisheyeEnd = value; } else { fisheyeMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("fisheye"); fisheyeKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("fisheye", fisheyeStart, 0); filter.set("fisheye", fisheyeMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("fisheye", fisheyeMiddle, filter.duration - filter.animateOut); filter.set("fisheye", fisheyeEnd, filter.duration - 1); } } else if (!fisheyeKeyframesButton.checked) { filter.resetProperty("fisheye"); filter.set("fisheye", fisheyeMiddle); } else if (position !== null) { filter.set("fisheye", value, position); } }
-    function updateProperty_interpolation () { if (blockUpdate) return; var value = interpolationComboBox.currentIndex; filter.set("interpolation", value); }
+    function updateProperty_yaw(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = yawSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                yawStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                yawEnd = value;
+            else
+                yawMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("yaw");
+            yawKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("yaw", yawStart, 0);
+                filter.set("yaw", yawMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("yaw", yawMiddle, filter.duration - filter.animateOut);
+                filter.set("yaw", yawEnd, filter.duration - 1);
+            }
+        } else if (!yawKeyframesButton.checked) {
+            filter.resetProperty("yaw");
+            filter.set("yaw", yawMiddle);
+        } else if (position !== null) {
+            filter.set("yaw", value, position);
+        }
+    }
+
+    function updateProperty_pitch(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = pitchSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                pitchStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                pitchEnd = value;
+            else
+                pitchMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("pitch");
+            pitchKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("pitch", pitchStart, 0);
+                filter.set("pitch", pitchMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("pitch", pitchMiddle, filter.duration - filter.animateOut);
+                filter.set("pitch", pitchEnd, filter.duration - 1);
+            }
+        } else if (!pitchKeyframesButton.checked) {
+            filter.resetProperty("pitch");
+            filter.set("pitch", pitchMiddle);
+        } else if (position !== null) {
+            filter.set("pitch", value, position);
+        }
+    }
+
+    function updateProperty_roll(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = rollSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                rollStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                rollEnd = value;
+            else
+                rollMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("roll");
+            rollKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("roll", rollStart, 0);
+                filter.set("roll", rollMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("roll", rollMiddle, filter.duration - filter.animateOut);
+                filter.set("roll", rollEnd, filter.duration - 1);
+            }
+        } else if (!rollKeyframesButton.checked) {
+            filter.resetProperty("roll");
+            filter.set("roll", rollMiddle);
+        } else if (position !== null) {
+            filter.set("roll", value, position);
+        }
+    }
+
+    function updateProperty_fov(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = fovSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                fovStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                fovEnd = value;
+            else
+                fovMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("fov");
+            fovKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("fov", fovStart, 0);
+                filter.set("fov", fovMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("fov", fovMiddle, filter.duration - filter.animateOut);
+                filter.set("fov", fovEnd, filter.duration - 1);
+            }
+        } else if (!fovKeyframesButton.checked) {
+            filter.resetProperty("fov");
+            filter.set("fov", fovMiddle);
+        } else if (position !== null) {
+            filter.set("fov", value, position);
+        }
+    }
+
+    function updateProperty_fisheye(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = fisheyeSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                fisheyeStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                fisheyeEnd = value;
+            else
+                fisheyeMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("fisheye");
+            fisheyeKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("fisheye", fisheyeStart, 0);
+                filter.set("fisheye", fisheyeMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("fisheye", fisheyeMiddle, filter.duration - filter.animateOut);
+                filter.set("fisheye", fisheyeEnd, filter.duration - 1);
+            }
+        } else if (!fisheyeKeyframesButton.checked) {
+            filter.resetProperty("fisheye");
+            filter.set("fisheye", fisheyeMiddle);
+        } else if (position !== null) {
+            filter.set("fisheye", value, position);
+        }
+    }
+
+    function updateProperty_interpolation() {
+        if (blockUpdate)
+            return ;
+
+        var value = interpolationComboBox.currentIndex;
+        filter.set("interpolation", value);
+    }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
+    }
+
+    width: 350
+    height: 200
+    Component.onCompleted: {
+        if (filter.isNew) {
+            filter.set("yaw", 0);
+        } else {
+            yawMiddle = filter.getDouble("yaw", filter.animateIn);
+            if (filter.animateIn > 0)
+                yawStart = filter.getDouble("yaw", 0);
+
+            if (filter.animateOut > 0)
+                yawEnd = filter.getDouble("yaw", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("pitch", 0);
+        } else {
+            pitchMiddle = filter.getDouble("pitch", filter.animateIn);
+            if (filter.animateIn > 0)
+                pitchStart = filter.getDouble("pitch", 0);
+
+            if (filter.animateOut > 0)
+                pitchEnd = filter.getDouble("pitch", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("roll", 0);
+        } else {
+            rollMiddle = filter.getDouble("roll", filter.animateIn);
+            if (filter.animateIn > 0)
+                rollStart = filter.getDouble("roll", 0);
+
+            if (filter.animateOut > 0)
+                rollEnd = filter.getDouble("roll", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("fov", 90);
+        } else {
+            fovMiddle = filter.getDouble("fov", filter.animateIn);
+            if (filter.animateIn > 0)
+                fovStart = filter.getDouble("fov", 0);
+
+            if (filter.animateOut > 0)
+                fovEnd = filter.getDouble("fov", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("fisheye", 0);
+        } else {
+            fisheyeMiddle = filter.getDouble("fisheye", filter.animateIn);
+            if (filter.animateIn > 0)
+                fisheyeStart = filter.getDouble("fisheye", 0);
+
+            if (filter.animateOut > 0)
+                fisheyeEnd = filter.getDouble("fisheye", filter.duration - 1);
+
+        }
+        if (filter.isNew)
+            filter.set("interpolation", 1);
+        else
+            interpolationValue = filter.get("interpolation");
+        if (filter.isNew)
+            filter.savePreset(preset.parameters);
+
+        setControls();
     }
 
     GridLayout {
@@ -97,24 +316,56 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ["yaw", "pitch", "roll", "fov", "interpolation", "fisheye"]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                filter.resetProperty('yaw')
-                filter.resetProperty('pitch')
-                filter.resetProperty('roll')
-                filter.resetProperty('fov')
-                filter.resetProperty('fisheye')
-                filter.resetProperty('interpolation')
+                filter.resetProperty('yaw');
+                filter.resetProperty('pitch');
+                filter.resetProperty('roll');
+                filter.resetProperty('fov');
+                filter.resetProperty('fisheye');
+                filter.resetProperty('interpolation');
             }
             onPresetSelected: {
-                yawMiddle = filter.getDouble("yaw", filter.animateIn); if (filter.animateIn > 0) { yawStart = filter.getDouble("yaw", 0); } if (filter.animateOut > 0) { yawEnd = filter.getDouble("yaw", filter.duration - 1); }
-                pitchMiddle = filter.getDouble("pitch", filter.animateIn); if (filter.animateIn > 0) { pitchStart = filter.getDouble("pitch", 0); } if (filter.animateOut > 0) { pitchEnd = filter.getDouble("pitch", filter.duration - 1); }
-                rollMiddle = filter.getDouble("roll", filter.animateIn); if (filter.animateIn > 0) { rollStart = filter.getDouble("roll", 0); } if (filter.animateOut > 0) { rollEnd = filter.getDouble("roll", filter.duration - 1); }
-                fovMiddle = filter.getDouble("fov", filter.animateIn); if (filter.animateIn > 0) { fovStart = filter.getDouble("fov", 0); } if (filter.animateOut > 0) { fovEnd = filter.getDouble("fov", filter.duration - 1); }
-                fisheyeMiddle = filter.getDouble("fisheye", filter.animateIn); if (filter.animateIn > 0) { fisheyeStart = filter.getDouble("fisheye", 0); } if (filter.animateOut > 0) { fisheyeEnd = filter.getDouble("fisheye", filter.duration - 1); }
+                yawMiddle = filter.getDouble("yaw", filter.animateIn);
+                if (filter.animateIn > 0)
+                    yawStart = filter.getDouble("yaw", 0);
+
+                if (filter.animateOut > 0)
+                    yawEnd = filter.getDouble("yaw", filter.duration - 1);
+
+                pitchMiddle = filter.getDouble("pitch", filter.animateIn);
+                if (filter.animateIn > 0)
+                    pitchStart = filter.getDouble("pitch", 0);
+
+                if (filter.animateOut > 0)
+                    pitchEnd = filter.getDouble("pitch", filter.duration - 1);
+
+                rollMiddle = filter.getDouble("roll", filter.animateIn);
+                if (filter.animateIn > 0)
+                    rollStart = filter.getDouble("roll", 0);
+
+                if (filter.animateOut > 0)
+                    rollEnd = filter.getDouble("roll", filter.duration - 1);
+
+                fovMiddle = filter.getDouble("fov", filter.animateIn);
+                if (filter.animateIn > 0)
+                    fovStart = filter.getDouble("fov", 0);
+
+                if (filter.animateOut > 0)
+                    fovEnd = filter.getDouble("fov", filter.duration - 1);
+
+                fisheyeMiddle = filter.getDouble("fisheye", filter.animateIn);
+                if (filter.animateIn > 0)
+                    fisheyeStart = filter.getDouble("fisheye", 0);
+
+                if (filter.animateOut > 0)
+                    fisheyeEnd = filter.getDouble("fisheye", filter.duration - 1);
+
                 interpolationValue = filter.get("interpolation");
                 setControls(null);
             }
@@ -124,92 +375,209 @@ Item {
             text: qsTr('Interpolation')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
+            id: interpolationComboBox
+
             currentIndex: 0
             model: ["Nearest-neighbor", "Bilinear"]
-            id: interpolationComboBox
             onCurrentIndexChanged: updateProperty_interpolation()
         }
+
         Shotcut.UndoButton {
             id: interpolationUndo
+
             onClicked: interpolationComboBox.currentIndex = 0
         }
-        Item { Layout.fillWidth: true }
+
+        Item {
+            Layout.fillWidth: true
+        }
 
         Label {
             text: qsTr('Yaw')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: yawSlider
+
             minimumValue: -360
             maximumValue: 360
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_yaw(getPosition())
         }
+
         Shotcut.UndoButton {
             id: yawUndo
+
             onClicked: yawSlider.value = 0
         }
-        Shotcut.KeyframesButton { id: yawKeyframesButton; onToggled: { var value = yawSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("yaw"); yawSlider.enabled = true; } filter.clearSimpleAnimation("yaw"); blockUpdate = false; filter.set("yaw", value, getPosition()); } else { filter.resetProperty("yaw"); filter.set("yaw", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: yawKeyframesButton
+
+            onToggled: {
+                var value = yawSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("yaw");
+                        yawSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("yaw");
+                    blockUpdate = false;
+                    filter.set("yaw", value, getPosition());
+                } else {
+                    filter.resetProperty("yaw");
+                    filter.set("yaw", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Pitch', 'rotation around the side-to-side axis (roll, pitch, yaw)')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: pitchSlider
+
             minimumValue: -180
             maximumValue: 180
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_pitch(getPosition())
         }
+
         Shotcut.UndoButton {
             id: pitchUndo
+
             onClicked: pitchSlider.value = 0
         }
-        Shotcut.KeyframesButton { id: pitchKeyframesButton; onToggled: { var value = pitchSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("pitch"); pitchSlider.enabled = true; } filter.clearSimpleAnimation("pitch"); blockUpdate = false; filter.set("pitch", value, getPosition()); } else { filter.resetProperty("pitch"); filter.set("pitch", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: pitchKeyframesButton
+
+            onToggled: {
+                var value = pitchSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("pitch");
+                        pitchSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("pitch");
+                    blockUpdate = false;
+                    filter.set("pitch", value, getPosition());
+                } else {
+                    filter.resetProperty("pitch");
+                    filter.set("pitch", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Roll')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: rollSlider
+
             minimumValue: -180
             maximumValue: 180
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_roll(getPosition())
         }
+
         Shotcut.UndoButton {
             id: rollUndo
+
             onClicked: rollSlider.value = 0
         }
-        Shotcut.KeyframesButton { id: rollKeyframesButton; onToggled: { var value = rollSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("roll"); rollSlider.enabled = true; } filter.clearSimpleAnimation("roll"); blockUpdate = false; filter.set("roll", value, getPosition()); } else { filter.resetProperty("roll"); filter.set("roll", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: rollKeyframesButton
+
+            onToggled: {
+                var value = rollSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("roll");
+                        rollSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("roll");
+                    blockUpdate = false;
+                    filter.set("roll", value, getPosition());
+                } else {
+                    filter.resetProperty("roll");
+                    filter.set("roll", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('FOV')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: fovSlider
+
             minimumValue: 0
             maximumValue: 720
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_fov(getPosition())
         }
+
         Shotcut.UndoButton {
             id: fovUndo
+
             onClicked: fovSlider.value = 90
         }
-        Shotcut.KeyframesButton { id: fovKeyframesButton; onToggled: { var value = fovSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("fov"); fovSlider.enabled = true; } filter.clearSimpleAnimation("fov"); blockUpdate = false; filter.set("fov", value, getPosition()); } else { filter.resetProperty("fov"); filter.set("fov", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: fovKeyframesButton
+
+            onToggled: {
+                var value = fovSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("fov");
+                        fovSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("fov");
+                    blockUpdate = false;
+                    filter.set("fov", value, getPosition());
+                } else {
+                    filter.resetProperty("fov");
+                    filter.set("fov", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Fisheye')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: fisheyeSlider
+
             minimumValue: 0
             maximumValue: 100
             suffix: ' %'
@@ -217,28 +585,74 @@ Item {
             stepSize: 1
             onValueChanged: updateProperty_fisheye(getPosition())
         }
+
         Shotcut.UndoButton {
             id: fisheyeUndo
+
             onClicked: fisheyeSlider.value = 0
         }
-        Shotcut.KeyframesButton { id: fisheyeKeyframesButton; onToggled: { var value = fisheyeSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("fisheye"); fisheyeSlider.enabled = true; } filter.clearSimpleAnimation("fisheye"); blockUpdate = false; filter.set("fisheye", value, getPosition()); } else { filter.resetProperty("fisheye"); filter.set("fisheye", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: fisheyeKeyframesButton
+
+            onToggled: {
+                var value = fisheyeSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("fisheye");
+                        fisheyeSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("fisheye");
+                    blockUpdate = false;
+                    filter.set("fisheye", value, getPosition());
+                } else {
+                    filter.resetProperty("fisheye");
+                    filter.set("fisheye", value);
+                }
+            }
+        }
+
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/bigsh0t_eq_to_stereo/meta.qml
+++ b/src/qml/filters/bigsh0t_eq_to_stereo/meta.qml
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0-or-later */
+// SPDX-License-Identifier: GPL-2.0-or-later
 import QtQuick 2.0
 import org.shotcut.qml 1.0
 
@@ -9,6 +9,7 @@ Metadata {
     objectName: "bigsh0t_eq_to_stereo"
     qml: "ui.qml"
     vui: "vui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -51,4 +52,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/bigsh0t_eq_to_stereo/ui.qml
+++ b/src/qml/filters/bigsh0t_eq_to_stereo/ui.qml
@@ -1,90 +1,311 @@
-/* SPDX-License-Identifier: GPL-2.0-or-later */
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
-
 Item {
-    width: 350
-    height: 200
     property bool blockUpdate: true
-
-    property double yawStart : 0.0; property double yawMiddle : 0.0; property double yawEnd : 0.0;
-    property double pitchStart : 0.0; property double pitchMiddle : 0.0; property double pitchEnd : 0.0;
-    property double rollStart : 0.0; property double rollMiddle : 0.0; property double rollEnd : 0.0;
-    property double fovStart : 0.0; property double fovMiddle : 0.0; property double fovEnd : 0.0;
-    property double amountStart : 0.0; property double amountMiddle : 0.0; property double amountEnd : 0.0;
-    property int interpolationValue : 0;
+    property double yawStart: 0
+    property double yawMiddle: 0
+    property double yawEnd: 0
+    property double pitchStart: 0
+    property double pitchMiddle: 0
+    property double pitchEnd: 0
+    property double rollStart: 0
+    property double rollMiddle: 0
+    property double rollEnd: 0
+    property double fovStart: 0
+    property double fovMiddle: 0
+    property double fovEnd: 0
+    property double amountStart: 0
+    property double amountMiddle: 0
+    property double amountEnd: 0
+    property int interpolationValue: 0
 
     function updateSimpleKeyframes() {
         if (filter.animateIn > 0 || filter.animateOut > 0) {
             // When enabling simple keyframes, initialize the keyframes with the current value
-            if (filter.keyframeCount("yaw") <= 0) {
-                yawStart = yawMiddle = yawEnd = filter.getDouble("yaw")
-            }
-            if (filter.keyframeCount("pitch") <= 0) {
-                pitchStart = pitchMiddle = pitchEnd = filter.getDouble("pitch")
-            }
-            if (filter.keyframeCount("roll") <= 0) {
-                rollStart = rollMiddle = rollEnd = filter.getDouble("roll")
-            }
-            if (filter.keyframeCount("fov") <= 0) {
-                fovStart = fovMiddle = fovEnd = filter.getDouble("fov")
-            }
-            if (filter.keyframeCount("amount") <= 0) {
-                amountStart = amountMiddle = amountEnd = filter.getDouble("amount")
-            }
-        }
-        setControls()
-        updateProperty_yaw (null)
-        updateProperty_pitch (null)
-        updateProperty_roll (null)
-        updateProperty_fov (null)
-        updateProperty_amount (null)
-        updateProperty_interpolation ()
-    }
+            if (filter.keyframeCount("yaw") <= 0)
+                yawStart = yawMiddle = yawEnd = filter.getDouble("yaw");
 
-    Component.onCompleted: {
-        if (filter.isNew) { filter.set("yaw", 0); } else { yawMiddle = filter.getDouble("yaw", filter.animateIn); if (filter.animateIn > 0) { yawStart = filter.getDouble("yaw", 0); } if (filter.animateOut > 0) { yawEnd = filter.getDouble("yaw", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("pitch", -90); } else { pitchMiddle = filter.getDouble("pitch", filter.animateIn); if (filter.animateIn > 0) { pitchStart = filter.getDouble("pitch", 0); } if (filter.animateOut > 0) { pitchEnd = filter.getDouble("pitch", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("roll", 0); } else { rollMiddle = filter.getDouble("roll", filter.animateIn); if (filter.animateIn > 0) { rollStart = filter.getDouble("roll", 0); } if (filter.animateOut > 0) { rollEnd = filter.getDouble("roll", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("fov", 160); } else { fovMiddle = filter.getDouble("fov", filter.animateIn); if (filter.animateIn > 0) { fovStart = filter.getDouble("fov", 0); } if (filter.animateOut > 0) { fovEnd = filter.getDouble("fov", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("amount", 100); } else { amountMiddle = filter.getDouble("amount", filter.animateIn); if (filter.animateIn > 0) { amountStart = filter.getDouble("amount", 0); } if (filter.animateOut > 0) { amountEnd = filter.getDouble("amount", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("interpolation", 1); } else { interpolationValue = filter.get("interpolation"); }
+            if (filter.keyframeCount("pitch") <= 0)
+                pitchStart = pitchMiddle = pitchEnd = filter.getDouble("pitch");
 
-        if (filter.isNew) {
-            filter.savePreset(preset.parameters)
+            if (filter.keyframeCount("roll") <= 0)
+                rollStart = rollMiddle = rollEnd = filter.getDouble("roll");
+
+            if (filter.keyframeCount("fov") <= 0)
+                fovStart = fovMiddle = fovEnd = filter.getDouble("fov");
+
+            if (filter.keyframeCount("amount") <= 0)
+                amountStart = amountMiddle = amountEnd = filter.getDouble("amount");
+
         }
-        setControls()
+        setControls();
+        updateProperty_yaw(null);
+        updateProperty_pitch(null);
+        updateProperty_roll(null);
+        updateProperty_fov(null);
+        updateProperty_amount(null);
+        updateProperty_interpolation();
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        yawSlider.value = filter.getDouble("yaw", position)
-        yawKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("yaw") > 0
-        pitchSlider.value = filter.getDouble("pitch", position)
-        pitchKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("pitch") > 0
-        rollSlider.value = filter.getDouble("roll", position)
-        rollKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("roll") > 0
-        fovSlider.value = filter.getDouble("fov", position)
-        fovKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("fov") > 0
-        amountSlider.value = filter.getDouble("amount", position)
-        interpolationComboBox.currentIndex = filter.get("interpolation")
-        blockUpdate = false
+        var position = getPosition();
+        blockUpdate = true;
+        yawSlider.value = filter.getDouble("yaw", position);
+        yawKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("yaw") > 0;
+        pitchSlider.value = filter.getDouble("pitch", position);
+        pitchKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("pitch") > 0;
+        rollSlider.value = filter.getDouble("roll", position);
+        rollKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("roll") > 0;
+        fovSlider.value = filter.getDouble("fov", position);
+        fovKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("fov") > 0;
+        amountSlider.value = filter.getDouble("amount", position);
+        interpolationComboBox.currentIndex = filter.get("interpolation");
+        blockUpdate = false;
     }
 
-    function updateProperty_yaw (position) { if (blockUpdate) return; var value = yawSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { yawStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { yawEnd = value; } else { yawMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("yaw"); yawKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("yaw", yawStart, 0); filter.set("yaw", yawMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("yaw", yawMiddle, filter.duration - filter.animateOut); filter.set("yaw", yawEnd, filter.duration - 1); } } else if (!yawKeyframesButton.checked) { filter.resetProperty("yaw"); filter.set("yaw", yawMiddle); } else if (position !== null) { filter.set("yaw", value, position); } }
-    function updateProperty_pitch (position) { if (blockUpdate) return; var value = pitchSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { pitchStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { pitchEnd = value; } else { pitchMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("pitch"); pitchKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("pitch", pitchStart, 0); filter.set("pitch", pitchMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("pitch", pitchMiddle, filter.duration - filter.animateOut); filter.set("pitch", pitchEnd, filter.duration - 1); } } else if (!pitchKeyframesButton.checked) { filter.resetProperty("pitch"); filter.set("pitch", pitchMiddle); } else if (position !== null) { filter.set("pitch", value, position); } }
-    function updateProperty_roll (position) { if (blockUpdate) return; var value = rollSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { rollStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { rollEnd = value; } else { rollMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("roll"); rollKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("roll", rollStart, 0); filter.set("roll", rollMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("roll", rollMiddle, filter.duration - filter.animateOut); filter.set("roll", rollEnd, filter.duration - 1); } } else if (!rollKeyframesButton.checked) { filter.resetProperty("roll"); filter.set("roll", rollMiddle); } else if (position !== null) { filter.set("roll", value, position); } }
-    function updateProperty_fov (position) { if (blockUpdate) return; var value = fovSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { fovStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { fovEnd = value; } else { fovMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("fov"); fovKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("fov", fovStart, 0); filter.set("fov", fovMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("fov", fovMiddle, filter.duration - filter.animateOut); filter.set("fov", fovEnd, filter.duration - 1); } } else if (!fovKeyframesButton.checked) { filter.resetProperty("fov"); filter.set("fov", fovMiddle); } else if (position !== null) { filter.set("fov", value, position); } }
-    function updateProperty_amount (position) { if (blockUpdate) return; var value = amountSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { amountStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { amountEnd = value; } else { amountMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("amount"); amountKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("amount", amountStart, 0); filter.set("amount", amountMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("amount", amountMiddle, filter.duration - filter.animateOut); filter.set("amount", amountEnd, filter.duration - 1); } } else if (!amountKeyframesButton.checked) { filter.resetProperty("amount"); filter.set("amount", amountMiddle); } else if (position !== null) { filter.set("amount", value, position); } }
-    function updateProperty_interpolation () { if (blockUpdate) return; var value = interpolationComboBox.currentIndex; filter.set("interpolation", value); }
+    function updateProperty_yaw(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = yawSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                yawStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                yawEnd = value;
+            else
+                yawMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("yaw");
+            yawKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("yaw", yawStart, 0);
+                filter.set("yaw", yawMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("yaw", yawMiddle, filter.duration - filter.animateOut);
+                filter.set("yaw", yawEnd, filter.duration - 1);
+            }
+        } else if (!yawKeyframesButton.checked) {
+            filter.resetProperty("yaw");
+            filter.set("yaw", yawMiddle);
+        } else if (position !== null) {
+            filter.set("yaw", value, position);
+        }
+    }
+
+    function updateProperty_pitch(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = pitchSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                pitchStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                pitchEnd = value;
+            else
+                pitchMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("pitch");
+            pitchKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("pitch", pitchStart, 0);
+                filter.set("pitch", pitchMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("pitch", pitchMiddle, filter.duration - filter.animateOut);
+                filter.set("pitch", pitchEnd, filter.duration - 1);
+            }
+        } else if (!pitchKeyframesButton.checked) {
+            filter.resetProperty("pitch");
+            filter.set("pitch", pitchMiddle);
+        } else if (position !== null) {
+            filter.set("pitch", value, position);
+        }
+    }
+
+    function updateProperty_roll(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = rollSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                rollStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                rollEnd = value;
+            else
+                rollMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("roll");
+            rollKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("roll", rollStart, 0);
+                filter.set("roll", rollMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("roll", rollMiddle, filter.duration - filter.animateOut);
+                filter.set("roll", rollEnd, filter.duration - 1);
+            }
+        } else if (!rollKeyframesButton.checked) {
+            filter.resetProperty("roll");
+            filter.set("roll", rollMiddle);
+        } else if (position !== null) {
+            filter.set("roll", value, position);
+        }
+    }
+
+    function updateProperty_fov(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = fovSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                fovStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                fovEnd = value;
+            else
+                fovMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("fov");
+            fovKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("fov", fovStart, 0);
+                filter.set("fov", fovMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("fov", fovMiddle, filter.duration - filter.animateOut);
+                filter.set("fov", fovEnd, filter.duration - 1);
+            }
+        } else if (!fovKeyframesButton.checked) {
+            filter.resetProperty("fov");
+            filter.set("fov", fovMiddle);
+        } else if (position !== null) {
+            filter.set("fov", value, position);
+        }
+    }
+
+    function updateProperty_amount(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = amountSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                amountStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                amountEnd = value;
+            else
+                amountMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("amount");
+            amountKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("amount", amountStart, 0);
+                filter.set("amount", amountMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("amount", amountMiddle, filter.duration - filter.animateOut);
+                filter.set("amount", amountEnd, filter.duration - 1);
+            }
+        } else if (!amountKeyframesButton.checked) {
+            filter.resetProperty("amount");
+            filter.set("amount", amountMiddle);
+        } else if (position !== null) {
+            filter.set("amount", value, position);
+        }
+    }
+
+    function updateProperty_interpolation() {
+        if (blockUpdate)
+            return ;
+
+        var value = interpolationComboBox.currentIndex;
+        filter.set("interpolation", value);
+    }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
+    }
+
+    width: 350
+    height: 200
+    Component.onCompleted: {
+        if (filter.isNew) {
+            filter.set("yaw", 0);
+        } else {
+            yawMiddle = filter.getDouble("yaw", filter.animateIn);
+            if (filter.animateIn > 0)
+                yawStart = filter.getDouble("yaw", 0);
+
+            if (filter.animateOut > 0)
+                yawEnd = filter.getDouble("yaw", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("pitch", -90);
+        } else {
+            pitchMiddle = filter.getDouble("pitch", filter.animateIn);
+            if (filter.animateIn > 0)
+                pitchStart = filter.getDouble("pitch", 0);
+
+            if (filter.animateOut > 0)
+                pitchEnd = filter.getDouble("pitch", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("roll", 0);
+        } else {
+            rollMiddle = filter.getDouble("roll", filter.animateIn);
+            if (filter.animateIn > 0)
+                rollStart = filter.getDouble("roll", 0);
+
+            if (filter.animateOut > 0)
+                rollEnd = filter.getDouble("roll", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("fov", 160);
+        } else {
+            fovMiddle = filter.getDouble("fov", filter.animateIn);
+            if (filter.animateIn > 0)
+                fovStart = filter.getDouble("fov", 0);
+
+            if (filter.animateOut > 0)
+                fovEnd = filter.getDouble("fov", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("amount", 100);
+        } else {
+            amountMiddle = filter.getDouble("amount", filter.animateIn);
+            if (filter.animateIn > 0)
+                amountStart = filter.getDouble("amount", 0);
+
+            if (filter.animateOut > 0)
+                amountEnd = filter.getDouble("amount", filter.duration - 1);
+
+        }
+        if (filter.isNew)
+            filter.set("interpolation", 1);
+        else
+            interpolationValue = filter.get("interpolation");
+        if (filter.isNew)
+            filter.savePreset(preset.parameters);
+
+        setControls();
     }
 
     GridLayout {
@@ -96,24 +317,56 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ["yaw", "pitch", "roll", "fov", "interpolation", "amount"]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                filter.resetProperty('yaw')
-                filter.resetProperty('pitch')
-                filter.resetProperty('roll')
-                filter.resetProperty('fov')
-                filter.resetProperty('amount')
-                filter.resetProperty('interpolation')
+                filter.resetProperty('yaw');
+                filter.resetProperty('pitch');
+                filter.resetProperty('roll');
+                filter.resetProperty('fov');
+                filter.resetProperty('amount');
+                filter.resetProperty('interpolation');
             }
             onPresetSelected: {
-                yawMiddle = filter.getDouble("yaw", filter.animateIn); if (filter.animateIn > 0) { yawStart = filter.getDouble("yaw", 0); } if (filter.animateOut > 0) { yawEnd = filter.getDouble("yaw", filter.duration - 1); }
-                pitchMiddle = filter.getDouble("pitch", filter.animateIn); if (filter.animateIn > 0) { pitchStart = filter.getDouble("pitch", 0); } if (filter.animateOut > 0) { pitchEnd = filter.getDouble("pitch", filter.duration - 1); }
-                rollMiddle = filter.getDouble("roll", filter.animateIn); if (filter.animateIn > 0) { rollStart = filter.getDouble("roll", 0); } if (filter.animateOut > 0) { rollEnd = filter.getDouble("roll", filter.duration - 1); }
-                fovMiddle = filter.getDouble("fov", filter.animateIn); if (filter.animateIn > 0) { fovStart = filter.getDouble("fov", 0); } if (filter.animateOut > 0) { fovEnd = filter.getDouble("fov", filter.duration - 1); }
-                amountMiddle = filter.getDouble("amount", filter.animateIn); if (filter.animateIn > 0) { amountStart = filter.getDouble("amount", 0); } if (filter.animateOut > 0) { amountEnd = filter.getDouble("amount", filter.duration - 1); }
+                yawMiddle = filter.getDouble("yaw", filter.animateIn);
+                if (filter.animateIn > 0)
+                    yawStart = filter.getDouble("yaw", 0);
+
+                if (filter.animateOut > 0)
+                    yawEnd = filter.getDouble("yaw", filter.duration - 1);
+
+                pitchMiddle = filter.getDouble("pitch", filter.animateIn);
+                if (filter.animateIn > 0)
+                    pitchStart = filter.getDouble("pitch", 0);
+
+                if (filter.animateOut > 0)
+                    pitchEnd = filter.getDouble("pitch", filter.duration - 1);
+
+                rollMiddle = filter.getDouble("roll", filter.animateIn);
+                if (filter.animateIn > 0)
+                    rollStart = filter.getDouble("roll", 0);
+
+                if (filter.animateOut > 0)
+                    rollEnd = filter.getDouble("roll", filter.duration - 1);
+
+                fovMiddle = filter.getDouble("fov", filter.animateIn);
+                if (filter.animateIn > 0)
+                    fovStart = filter.getDouble("fov", 0);
+
+                if (filter.animateOut > 0)
+                    fovEnd = filter.getDouble("fov", filter.duration - 1);
+
+                amountMiddle = filter.getDouble("amount", filter.animateIn);
+                if (filter.animateIn > 0)
+                    amountStart = filter.getDouble("amount", 0);
+
+                if (filter.animateOut > 0)
+                    amountEnd = filter.getDouble("amount", filter.duration - 1);
+
                 interpolationValue = filter.get("interpolation");
                 setControls(null);
             }
@@ -123,93 +376,210 @@ Item {
             text: qsTr('Interpolation')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
+            id: interpolationComboBox
+
             currentIndex: 0
             implicitWidth: 180
             model: ["Nearest-neighbor", "Bilinear"]
-            id: interpolationComboBox
             onCurrentIndexChanged: updateProperty_interpolation()
         }
+
         Shotcut.UndoButton {
             id: interpolationUndo
+
             onClicked: interpolationComboBox.currentIndex = 0
         }
-        Item { Layout.fillWidth: true }
+
+        Item {
+            Layout.fillWidth: true
+        }
 
         Label {
             text: qsTr('Yaw')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: yawSlider
+
             minimumValue: -360
             maximumValue: 360
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_yaw(getPosition())
         }
+
         Shotcut.UndoButton {
             id: yawUndo
+
             onClicked: yawSlider.value = 0
         }
-        Shotcut.KeyframesButton { id: yawKeyframesButton; onToggled: { var value = yawSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("yaw"); yawSlider.enabled = true; } filter.clearSimpleAnimation("yaw"); blockUpdate = false; filter.set("yaw", value, getPosition()); } else { filter.resetProperty("yaw"); filter.set("yaw", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: yawKeyframesButton
+
+            onToggled: {
+                var value = yawSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("yaw");
+                        yawSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("yaw");
+                    blockUpdate = false;
+                    filter.set("yaw", value, getPosition());
+                } else {
+                    filter.resetProperty("yaw");
+                    filter.set("yaw", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Pitch', 'rotation around the side-to-side axis (roll, pitch, yaw)')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: pitchSlider
+
             minimumValue: -180
             maximumValue: 180
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_pitch(getPosition())
         }
+
         Shotcut.UndoButton {
             id: pitchUndo
+
             onClicked: pitchSlider.value = -90
         }
-        Shotcut.KeyframesButton { id: pitchKeyframesButton; onToggled: { var value = pitchSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("pitch"); pitchSlider.enabled = true; } filter.clearSimpleAnimation("pitch"); blockUpdate = false; filter.set("pitch", value, getPosition()); } else { filter.resetProperty("pitch"); filter.set("pitch", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: pitchKeyframesButton
+
+            onToggled: {
+                var value = pitchSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("pitch");
+                        pitchSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("pitch");
+                    blockUpdate = false;
+                    filter.set("pitch", value, getPosition());
+                } else {
+                    filter.resetProperty("pitch");
+                    filter.set("pitch", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Roll')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: rollSlider
+
             minimumValue: -180
             maximumValue: 180
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_roll(getPosition())
         }
+
         Shotcut.UndoButton {
             id: rollUndo
+
             onClicked: rollSlider.value = 0
         }
-        Shotcut.KeyframesButton { id: rollKeyframesButton; onToggled: { var value = rollSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("roll"); rollSlider.enabled = true; } filter.clearSimpleAnimation("roll"); blockUpdate = false; filter.set("roll", value, getPosition()); } else { filter.resetProperty("roll"); filter.set("roll", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: rollKeyframesButton
+
+            onToggled: {
+                var value = rollSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("roll");
+                        rollSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("roll");
+                    blockUpdate = false;
+                    filter.set("roll", value, getPosition());
+                } else {
+                    filter.resetProperty("roll");
+                    filter.set("roll", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('FOV')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: fovSlider
+
             minimumValue: 0
             maximumValue: 180
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_fov(getPosition())
         }
+
         Shotcut.UndoButton {
             id: fovUndo
+
             onClicked: fovSlider.value = 160
         }
-        Shotcut.KeyframesButton { id: fovKeyframesButton; onToggled: { var value = fovSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("fov"); fovSlider.enabled = true; } filter.clearSimpleAnimation("fov"); blockUpdate = false; filter.set("fov", value, getPosition()); } else { filter.resetProperty("fov"); filter.set("fov", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: fovKeyframesButton
+
+            onToggled: {
+                var value = fovSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("fov");
+                        fovSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("fov");
+                    blockUpdate = false;
+                    filter.set("fov", value, getPosition());
+                } else {
+                    filter.resetProperty("fov");
+                    filter.set("fov", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Amount')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: amountSlider
+
             minimumValue: 0
             maximumValue: 100
             suffix: ' %'
@@ -217,28 +587,74 @@ Item {
             stepSize: 1
             onValueChanged: updateProperty_amount(getPosition())
         }
+
         Shotcut.UndoButton {
             id: amountUndo
+
             onClicked: amountSlider.value = 100
         }
-        Shotcut.KeyframesButton { id: amountKeyframesButton; onToggled: { var value = amountSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("amount"); amountSlider.enabled = true; } filter.clearSimpleAnimation("amount"); blockUpdate = false; filter.set("amount", value, getPosition()); } else { filter.resetProperty("amount"); filter.set("amount", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: amountKeyframesButton
+
+            onToggled: {
+                var value = amountSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("amount");
+                        amountSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("amount");
+                    blockUpdate = false;
+                    filter.set("amount", value, getPosition());
+                } else {
+                    filter.resetProperty("amount");
+                    filter.set("amount", value);
+                }
+            }
+        }
+
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/bigsh0t_eq_to_stereo/vui.qml
+++ b/src/qml/filters/bigsh0t_eq_to_stereo/vui.qml
@@ -24,76 +24,80 @@ Shotcut.VuiBase {
     property var middleValues: []
     property var endValues: []
 
+    function clamp(x, min, max) {
+        return Math.max(min, Math.min(max, x));
+    }
+
+    function getPosition() {
+        return Math.max(producer.position - (filter.in - producer.in), 0);
+    }
+
+    function updateProperty(name, value) {
+        var index = keyframableParameters.indexOf(name);
+        var position = getPosition();
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                startValues[index] = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                endValues[index] = value;
+            else
+                middleValues[index] = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty(name);
+            if (filter.animateIn > 0) {
+                filter.set(name, startValues[index], 0);
+                filter.set(name, middleValues[index], filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set(name, middleValues[index], filter.duration - filter.animateOut);
+                filter.set(name, endValues[index], filter.duration - 1);
+            }
+        } else if (filter.keyframeCount(name) <= 0) {
+            filter.resetProperty(name);
+            filter.set(name, middleValues[index]);
+        } else if (position !== null) {
+            filter.set(name, value, position);
+        }
+    }
+
     Connections {
+        function onChanged() {
+            mouseArea.enabled = filter.get('disable') !== '1';
+        }
+
         target: filter
-        function onChanged() { mouseArea.enabled = filter.get('disable') !== '1' }
     }
 
     MouseArea {
         id: mouseArea
-        anchors.fill: parent
 
         property double startYaw
         property double startPitch
         property double startRoll
         property int startX
         property int startY
+
+        anchors.fill: parent
         onPressed: {
-            startX = mouse.x
-            startY = mouse.y
-            startYaw = filter.getDouble('yaw', getPosition())
-            startPitch = filter.getDouble('pitch', getPosition())
-            startRoll = filter.getDouble('roll', getPosition())
+            startX = mouse.x;
+            startY = mouse.y;
+            startYaw = filter.getDouble('yaw', getPosition());
+            startPitch = filter.getDouble('pitch', getPosition());
+            startRoll = filter.getDouble('roll', getPosition());
         }
         onPositionChanged: {
             if (mouse.modifiers == Qt.ControlModifier) {
-                updateProperty('roll', clamp(startRoll + 0.5 * (startY - mouse.y), -180, 180))
+                updateProperty('roll', clamp(startRoll + 0.5 * (startY - mouse.y), -180, 180));
             } else {
-                updateProperty('yaw', clamp(startYaw + 0.2 * (startX - mouse.x), -360, 360))
-                updateProperty('pitch', clamp(startPitch + 0.1 * (mouse.y - startY), -180, 180))
+                updateProperty('yaw', clamp(startYaw + 0.2 * (startX - mouse.x), -360, 360));
+                updateProperty('pitch', clamp(startPitch + 0.1 * (mouse.y - startY), -180, 180));
             }
         }
         onWheel: {
-            var fov = filter.getDouble('fov', getPosition())
-            updateProperty('fov', clamp(fov + 0.03 * wheel.angleDelta.y, 0, 180))
+            var fov = filter.getDouble('fov', getPosition());
+            updateProperty('fov', clamp(fov + 0.03 * wheel.angleDelta.y, 0, 180));
         }
     }
 
-    function clamp(x, min, max) {
-        return Math.max(min, Math.min(max, x))
-    }
-
-    function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
-    }
-
-    function updateProperty(name, value) {
-        var index = keyframableParameters.indexOf(name)
-        var position = getPosition()
-
-        if (position !== null) {
-            if (position <= 0 && filter.animateIn > 0) {
-                startValues[index] = value
-            } else if (position >= filter.duration - 1 && filter.animateOut > 0) {
-                endValues[index] = value
-            } else {
-                middleValues[index] = value
-            }
-        } if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(name)
-            if (filter.animateIn > 0) {
-                filter.set(name, startValues[index], 0)
-                filter.set(name, middleValues[index], filter.animateIn - 1)
-            }
-            if (filter.animateOut > 0) {
-                filter.set(name, middleValues[index], filter.duration - filter.animateOut)
-                filter.set(name, endValues[index], filter.duration - 1)
-            }
-        } else if (filter.keyframeCount(name) <= 0) {
-            filter.resetProperty(name)
-            filter.set(name, middleValues[index])
-        } else if (position !== null) {
-            filter.set(name, value, position)
-        }
-    }
 }

--- a/src/qml/filters/bigsh0t_hemi_to_eq/meta.qml
+++ b/src/qml/filters/bigsh0t_hemi_to_eq/meta.qml
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0-or-later */
+// SPDX-License-Identifier: GPL-2.0-or-later
 import QtQuick 2.0
 import org.shotcut.qml 1.0
 
@@ -8,6 +8,7 @@ Metadata {
     mlt_service: "frei0r.bigsh0t_hemi_to_eq"
     objectName: "bigsh0t_hemi_to_eq"
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -106,4 +107,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/bigsh0t_hemi_to_eq/ui.qml
+++ b/src/qml/filters/bigsh0t_hemi_to_eq/ui.qml
@@ -1,181 +1,741 @@
-
-
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
-
 Item {
-    width: 350
-    height: 550
     property bool blockUpdate: true
-
-    property double yawStart : 0.0; property double yawMiddle : 0.0; property double yawEnd : 0.0;
-    property double pitchStart : 0.0; property double pitchMiddle : 0.0; property double pitchEnd : 0.0;
-    property double rollStart : 0.0; property double rollMiddle : 0.0; property double rollEnd : 0.0;
-
-    property double frontXStart : 0.0; property double frontXMiddle : 0.0; property double frontXEnd : 0.0;
-    property double frontYStart : 0.0; property double frontYMiddle : 0.0; property double frontYEnd : 0.0;
-    property double frontUpStart : 0.0; property double frontUpMiddle : 0.0; property double frontUpEnd : 0.0;
-
-    property double backXStart : 0.0; property double backXMiddle : 0.0; property double backXEnd : 0.0;
-    property double backYStart : 0.0; property double backYMiddle : 0.0; property double backYEnd : 0.0;
-    property double backUpStart : 0.0; property double backUpMiddle : 0.0; property double backUpEnd : 0.0;
-
-    property double fovStart : 0.0; property double fovMiddle : 0.0; property double fovEnd : 0.0;
-    property double radiusStart : 0.0; property double radiusMiddle : 0.0; property double radiusEnd : 0.0;
-
-    property double nadirRadiusStart : 0.0; property double nadirRadiusMiddle : 0.0; property double nadirRadiusEnd : 0.0;
-    property double nadirCorrectionStartStart : 0.0; property double nadirCorrectionStartMiddle : 0.0; property double nadirCorrectionStartEnd : 0.0;
-
-    property int interpolationValue : 0;
-    property int projectionValue : 0;
+    property double yawStart: 0
+    property double yawMiddle: 0
+    property double yawEnd: 0
+    property double pitchStart: 0
+    property double pitchMiddle: 0
+    property double pitchEnd: 0
+    property double rollStart: 0
+    property double rollMiddle: 0
+    property double rollEnd: 0
+    property double frontXStart: 0
+    property double frontXMiddle: 0
+    property double frontXEnd: 0
+    property double frontYStart: 0
+    property double frontYMiddle: 0
+    property double frontYEnd: 0
+    property double frontUpStart: 0
+    property double frontUpMiddle: 0
+    property double frontUpEnd: 0
+    property double backXStart: 0
+    property double backXMiddle: 0
+    property double backXEnd: 0
+    property double backYStart: 0
+    property double backYMiddle: 0
+    property double backYEnd: 0
+    property double backUpStart: 0
+    property double backUpMiddle: 0
+    property double backUpEnd: 0
+    property double fovStart: 0
+    property double fovMiddle: 0
+    property double fovEnd: 0
+    property double radiusStart: 0
+    property double radiusMiddle: 0
+    property double radiusEnd: 0
+    property double nadirRadiusStart: 0
+    property double nadirRadiusMiddle: 0
+    property double nadirRadiusEnd: 0
+    property double nadirCorrectionStartStart: 0
+    property double nadirCorrectionStartMiddle: 0
+    property double nadirCorrectionStartEnd: 0
+    property int interpolationValue: 0
+    property int projectionValue: 0
 
     function updateSimpleKeyframes() {
         if (filter.animateIn > 0 || filter.animateOut > 0) {
             // When enabling simple keyframes, initialize the keyframes with the current value
-            if (filter.keyframeCount("yaw") <= 0) {
-                yawStart = yawMiddle = yawEnd = filter.getDouble("yaw")
-            }
-            if (filter.keyframeCount("pitch") <= 0) {
-                pitchStart = pitchMiddle = pitchEnd = filter.getDouble("pitch")
-            }
-            if (filter.keyframeCount("roll") <= 0) {
-                rollStart = rollMiddle = rollEnd = filter.getDouble("roll")
-            }
-            if (filter.keyframeCount("frontX") <= 0) {
-                frontXStart = frontXMiddle = frontXEnd = filter.getDouble("frontX")
-            }
-            if (filter.keyframeCount("frontY") <= 0) {
-                frontYStart = frontYMiddle = frontYEnd = filter.getDouble("frontY")
-            }
-            if (filter.keyframeCount("frontUp") <= 0) {
-                frontUpStart = frontUpMiddle = frontUpEnd = filter.getDouble("frontUp")
-            }
-            if (filter.keyframeCount("backX") <= 0) {
-                backXStart = backXMiddle = backXEnd = filter.getDouble("backX")
-            }
-            if (filter.keyframeCount("backY") <= 0) {
-                backYStart = backYMiddle = backYEnd = filter.getDouble("backY")
-            }
-            if (filter.keyframeCount("backUp") <= 0) {
-                backUpStart = backUpMiddle = backUpEnd = filter.getDouble("backUp")
-            }
-            if (filter.keyframeCount("fov") <= 0) {
-                fovStart = fovMiddle = fovEnd = filter.getDouble("fov")
-            }
-            if (filter.keyframeCount("radius") <= 0) {
-                radiusStart = radiusMiddle = radiusEnd = filter.getDouble("radius")
-            }
-            if (filter.keyframeCount("nadirRadius") <= 0) {
-                nadirRadiusStart = nadirRadiusMiddle = nadirRadiusEnd = filter.getDouble("nadirRadius")
-            }
-            if (filter.keyframeCount("nadirCorrectionStart") <= 0) {
-                nadirCorrectionStartStart = nadirCorrectionStartMiddle = nadirCorrectionStartEnd = filter.getDouble("nadirCorrectionStart")
-            }
+            if (filter.keyframeCount("yaw") <= 0)
+                yawStart = yawMiddle = yawEnd = filter.getDouble("yaw");
+
+            if (filter.keyframeCount("pitch") <= 0)
+                pitchStart = pitchMiddle = pitchEnd = filter.getDouble("pitch");
+
+            if (filter.keyframeCount("roll") <= 0)
+                rollStart = rollMiddle = rollEnd = filter.getDouble("roll");
+
+            if (filter.keyframeCount("frontX") <= 0)
+                frontXStart = frontXMiddle = frontXEnd = filter.getDouble("frontX");
+
+            if (filter.keyframeCount("frontY") <= 0)
+                frontYStart = frontYMiddle = frontYEnd = filter.getDouble("frontY");
+
+            if (filter.keyframeCount("frontUp") <= 0)
+                frontUpStart = frontUpMiddle = frontUpEnd = filter.getDouble("frontUp");
+
+            if (filter.keyframeCount("backX") <= 0)
+                backXStart = backXMiddle = backXEnd = filter.getDouble("backX");
+
+            if (filter.keyframeCount("backY") <= 0)
+                backYStart = backYMiddle = backYEnd = filter.getDouble("backY");
+
+            if (filter.keyframeCount("backUp") <= 0)
+                backUpStart = backUpMiddle = backUpEnd = filter.getDouble("backUp");
+
+            if (filter.keyframeCount("fov") <= 0)
+                fovStart = fovMiddle = fovEnd = filter.getDouble("fov");
+
+            if (filter.keyframeCount("radius") <= 0)
+                radiusStart = radiusMiddle = radiusEnd = filter.getDouble("radius");
+
+            if (filter.keyframeCount("nadirRadius") <= 0)
+                nadirRadiusStart = nadirRadiusMiddle = nadirRadiusEnd = filter.getDouble("nadirRadius");
+
+            if (filter.keyframeCount("nadirCorrectionStart") <= 0)
+                nadirCorrectionStartStart = nadirCorrectionStartMiddle = nadirCorrectionStartEnd = filter.getDouble("nadirCorrectionStart");
+
         }
-        setControls()
-        updateProperty_yaw(null)
-        updateProperty_pitch(null)
-        updateProperty_roll(null)
-        updateProperty_frontX(null)
-        updateProperty_frontY(null)
-        updateProperty_frontUp(null)
-        updateProperty_backX(null)
-        updateProperty_backY(null)
-        updateProperty_backUp(null)
-        updateProperty_fov(null)
-        updateProperty_radius(null)
-        updateProperty_nadirRadius(null)
-        updateProperty_nadirCorrectionStart(null)
-        updateProperty_interpolation()
-        updateProperty_projection()
-    }
-
-    Component.onCompleted: {
-        if (filter.isNew) { filter.set("yaw", 0); } else { yawMiddle = filter.getDouble("yaw", filter.animateIn); if (filter.animateIn > 0) { yawStart = filter.getDouble("yaw", 0); } if (filter.animateOut > 0) { yawEnd = filter.getDouble("yaw", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("pitch", 0); } else { pitchMiddle = filter.getDouble("pitch", filter.animateIn); if (filter.animateIn > 0) { pitchStart = filter.getDouble("pitch", 0); } if (filter.animateOut > 0) { pitchEnd = filter.getDouble("pitch", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("roll", 0); } else { rollMiddle = filter.getDouble("roll", filter.animateIn); if (filter.animateIn > 0) { rollStart = filter.getDouble("roll", 0); } if (filter.animateOut > 0) { rollEnd = filter.getDouble("roll", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("frontX", 0.75); } else { frontXMiddle = filter.getDouble("frontX", filter.animateIn); if (filter.animateIn > 0) { frontXStart = filter.getDouble("frontX", 0); } if (filter.animateOut > 0) { frontXEnd = filter.getDouble("frontX", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("frontY", 0.5); } else { frontYMiddle = filter.getDouble("frontY", filter.animateIn); if (filter.animateIn > 0) { frontYStart = filter.getDouble("frontY", 0); } if (filter.animateOut > 0) { frontYEnd = filter.getDouble("frontY", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("frontUp", 90); } else { frontUpMiddle = filter.getDouble("frontUp", filter.animateIn); if (filter.animateIn > 0) { frontUpStart = filter.getDouble("frontUp", 0); } if (filter.animateOut > 0) { frontUpEnd = filter.getDouble("frontUp", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("backX", 0.25); } else { backXMiddle = filter.getDouble("backX", filter.animateIn); if (filter.animateIn > 0) { backXStart = filter.getDouble("backX", 0); } if (filter.animateOut > 0) { backXEnd = filter.getDouble("backX", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("backY", 0.5); } else { backYMiddle = filter.getDouble("backY", filter.animateIn); if (filter.animateIn > 0) { backYStart = filter.getDouble("backY", 0); } if (filter.animateOut > 0) { backYEnd = filter.getDouble("backY", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("backUp", 270); } else { backUpMiddle = filter.getDouble("backUp", filter.animateIn); if (filter.animateIn > 0) { backUpStart = filter.getDouble("backUp", 0); } if (filter.animateOut > 0) { backUpEnd = filter.getDouble("backUp", filter.duration - 1); } }
-
-        if (filter.isNew) { filter.set("fov", 180); } else { fovMiddle = filter.getDouble("fov", filter.animateIn); if (filter.animateIn > 0) { fovStart = filter.getDouble("fov", 0); } if (filter.animateOut > 0) { fovEnd = filter.getDouble("fov", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("radius", 0.25); } else { radiusMiddle = filter.getDouble("radius", filter.animateIn); if (filter.animateIn > 0) { radiusStart = filter.getDouble("radius", 0); } if (filter.animateOut > 0) { radiusEnd = filter.getDouble("radius", filter.duration - 1); } }
-
-        if (filter.isNew) { filter.set("nadirRadius", 0.2229); } else { nadirRadiusMiddle = filter.getDouble("nadirRadius", filter.animateIn); if (filter.animateIn > 0) { nadirRadiusStart = filter.getDouble("nadirRadius", 0); } if (filter.animateOut > 0) { nadirRadiusEnd = filter.getDouble("nadirRadius", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("nadirCorrectionStart", 0.8); } else { nadirCorrectionStartMiddle = filter.getDouble("nadirCorrectionStart", filter.animateIn); if (filter.animateIn > 0) { nadirCorrectionStartStart = filter.getDouble("nadirCorrectionStart", 0); } if (filter.animateOut > 0) { nadirCorrectionStartEnd = filter.getDouble("nadirCorrectionStart", filter.duration - 1); } }
-
-        if (filter.isNew) { filter.set("interpolation", 1); } else { interpolationValue = filter.get("interpolation"); }
-        if (filter.isNew) { filter.set("projection", 0); } else { projectionValue = filter.get("projection"); }
-
-        if (filter.isNew) {
-            filter.savePreset(preset.parameters)
-        }
-        setControls()
+        setControls();
+        updateProperty_yaw(null);
+        updateProperty_pitch(null);
+        updateProperty_roll(null);
+        updateProperty_frontX(null);
+        updateProperty_frontY(null);
+        updateProperty_frontUp(null);
+        updateProperty_backX(null);
+        updateProperty_backY(null);
+        updateProperty_backUp(null);
+        updateProperty_fov(null);
+        updateProperty_radius(null);
+        updateProperty_nadirRadius(null);
+        updateProperty_nadirCorrectionStart(null);
+        updateProperty_interpolation();
+        updateProperty_projection();
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        yawSlider.value = filter.getDouble("yaw", position)
-        yawKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("yaw") > 0
-        pitchSlider.value = filter.getDouble("pitch", position)
-        pitchKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("pitch") > 0
-        rollSlider.value = filter.getDouble("roll", position)
-        rollKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("roll") > 0
-        frontXSlider.value = filter.getDouble("frontX", position)
-        frontXKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("frontX") > 0
-        frontYSlider.value = filter.getDouble("frontY", position)
-        frontYKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("frontY") > 0
-        frontUpSlider.value = filter.getDouble("frontUp", position)
-        frontUpKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("frontUp") > 0
-        backXSlider.value = filter.getDouble("backX", position)
-        backXKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("backX") > 0
-        backYSlider.value = filter.getDouble("backY", position)
-        backYKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("backY") > 0
-        backUpSlider.value = filter.getDouble("backUp", position)
-        backUpKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("backUp") > 0
-        fovSlider.value = filter.getDouble("fov", position)
-        fovKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("fov") > 0
-        radiusSlider.value = filter.getDouble("radius", position)
-        radiusKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("radius") > 0
-        nadirRadiusSlider.value = filter.getDouble("nadirRadius", position)
-        nadirRadiusKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("nadirRadius") > 0
-        nadirCorrectionStartSlider.value = filter.getDouble("nadirCorrectionStart", position)
-        nadirCorrectionStartKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("nadirCorrectionStart") > 0
-        interpolationComboBox.currentIndex = filter.get("interpolation")
-        projectionComboBox.currentIndex = filter.get("projection")
-
-        blockUpdate = false
+        var position = getPosition();
+        blockUpdate = true;
+        yawSlider.value = filter.getDouble("yaw", position);
+        yawKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("yaw") > 0;
+        pitchSlider.value = filter.getDouble("pitch", position);
+        pitchKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("pitch") > 0;
+        rollSlider.value = filter.getDouble("roll", position);
+        rollKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("roll") > 0;
+        frontXSlider.value = filter.getDouble("frontX", position);
+        frontXKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("frontX") > 0;
+        frontYSlider.value = filter.getDouble("frontY", position);
+        frontYKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("frontY") > 0;
+        frontUpSlider.value = filter.getDouble("frontUp", position);
+        frontUpKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("frontUp") > 0;
+        backXSlider.value = filter.getDouble("backX", position);
+        backXKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("backX") > 0;
+        backYSlider.value = filter.getDouble("backY", position);
+        backYKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("backY") > 0;
+        backUpSlider.value = filter.getDouble("backUp", position);
+        backUpKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("backUp") > 0;
+        fovSlider.value = filter.getDouble("fov", position);
+        fovKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("fov") > 0;
+        radiusSlider.value = filter.getDouble("radius", position);
+        radiusKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("radius") > 0;
+        nadirRadiusSlider.value = filter.getDouble("nadirRadius", position);
+        nadirRadiusKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("nadirRadius") > 0;
+        nadirCorrectionStartSlider.value = filter.getDouble("nadirCorrectionStart", position);
+        nadirCorrectionStartKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("nadirCorrectionStart") > 0;
+        interpolationComboBox.currentIndex = filter.get("interpolation");
+        projectionComboBox.currentIndex = filter.get("projection");
+        blockUpdate = false;
     }
 
-    function updateProperty_yaw (position) { if (blockUpdate) return; var value = yawSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { yawStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { yawEnd = value; } else { yawMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("yaw"); yawKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("yaw", yawStart, 0); filter.set("yaw", yawMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("yaw", yawMiddle, filter.duration - filter.animateOut); filter.set("yaw", yawEnd, filter.duration - 1); } } else if (!yawKeyframesButton.checked) { filter.resetProperty("yaw"); filter.set("yaw", yawMiddle); } else if (position !== null) { filter.set("yaw", value, position); } }
-    function updateProperty_pitch (position) { if (blockUpdate) return; var value = pitchSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { pitchStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { pitchEnd = value; } else { pitchMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("pitch"); pitchKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("pitch", pitchStart, 0); filter.set("pitch", pitchMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("pitch", pitchMiddle, filter.duration - filter.animateOut); filter.set("pitch", pitchEnd, filter.duration - 1); } } else if (!pitchKeyframesButton.checked) { filter.resetProperty("pitch"); filter.set("pitch", pitchMiddle); } else if (position !== null) { filter.set("pitch", value, position); } }
-    function updateProperty_roll (position) { if (blockUpdate) return; var value = rollSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { rollStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { rollEnd = value; } else { rollMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("roll"); rollKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("roll", rollStart, 0); filter.set("roll", rollMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("roll", rollMiddle, filter.duration - filter.animateOut); filter.set("roll", rollEnd, filter.duration - 1); } } else if (!rollKeyframesButton.checked) { filter.resetProperty("roll"); filter.set("roll", rollMiddle); } else if (position !== null) { filter.set("roll", value, position); } }
+    function updateProperty_yaw(position) {
+        if (blockUpdate)
+            return ;
 
-    function updateProperty_frontX (position) { if (blockUpdate) return; var value = frontXSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { frontXStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { frontXEnd = value; } else { frontXMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("frontX"); frontXKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("frontX", frontXStart, 0); filter.set("frontX", frontXMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("frontX", frontXMiddle, filter.duration - filter.animateOut); filter.set("frontX", frontXEnd, filter.duration - 1); } } else if (!frontXKeyframesButton.checked) { filter.resetProperty("frontX"); filter.set("frontX", frontXMiddle); } else if (position !== null) { filter.set("frontX", value, position); } }
-    function updateProperty_frontY (position) { if (blockUpdate) return; var value = frontYSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { frontYStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { frontYEnd = value; } else { frontYMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("frontY"); frontYKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("frontY", frontYStart, 0); filter.set("frontY", frontYMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("frontY", frontYMiddle, filter.duration - filter.animateOut); filter.set("frontY", frontYEnd, filter.duration - 1); } } else if (!frontYKeyframesButton.checked) { filter.resetProperty("frontY"); filter.set("frontY", frontYMiddle); } else if (position !== null) { filter.set("frontY", value, position); } }
-    function updateProperty_frontUp (position) { if (blockUpdate) return; var value = frontUpSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { frontUpStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { frontUpEnd = value; } else { frontUpMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("frontUp"); frontUpKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("frontUp", frontUpStart, 0); filter.set("frontUp", frontUpMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("frontUp", frontUpMiddle, filter.duration - filter.animateOut); filter.set("frontUp", frontUpEnd, filter.duration - 1); } } else if (!frontUpKeyframesButton.checked) { filter.resetProperty("frontUp"); filter.set("frontUp", frontUpMiddle); } else if (position !== null) { filter.set("frontUp", value, position); } }
+        var value = yawSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                yawStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                yawEnd = value;
+            else
+                yawMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("yaw");
+            yawKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("yaw", yawStart, 0);
+                filter.set("yaw", yawMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("yaw", yawMiddle, filter.duration - filter.animateOut);
+                filter.set("yaw", yawEnd, filter.duration - 1);
+            }
+        } else if (!yawKeyframesButton.checked) {
+            filter.resetProperty("yaw");
+            filter.set("yaw", yawMiddle);
+        } else if (position !== null) {
+            filter.set("yaw", value, position);
+        }
+    }
 
-    function updateProperty_backX (position) { if (blockUpdate) return; var value = backXSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { backXStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { backXEnd = value; } else { backXMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("backX"); backXKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("backX", backXStart, 0); filter.set("backX", backXMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("backX", backXMiddle, filter.duration - filter.animateOut); filter.set("backX", backXEnd, filter.duration - 1); } } else if (!backXKeyframesButton.checked) { filter.resetProperty("backX"); filter.set("backX", backXMiddle); } else if (position !== null) { filter.set("backX", value, position); } }
-    function updateProperty_backY (position) { if (blockUpdate) return; var value = backYSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { backYStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { backYEnd = value; } else { backYMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("backY"); backYKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("backY", backYStart, 0); filter.set("backY", backYMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("backY", backYMiddle, filter.duration - filter.animateOut); filter.set("backY", backYEnd, filter.duration - 1); } } else if (!backYKeyframesButton.checked) { filter.resetProperty("backY"); filter.set("backY", backYMiddle); } else if (position !== null) { filter.set("backY", value, position); } }
-    function updateProperty_backUp (position) { if (blockUpdate) return; var value = backUpSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { backUpStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { backUpEnd = value; } else { backUpMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("backUp"); backUpKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("backUp", backUpStart, 0); filter.set("backUp", backUpMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("backUp", backUpMiddle, filter.duration - filter.animateOut); filter.set("backUp", backUpEnd, filter.duration - 1); } } else if (!backUpKeyframesButton.checked) { filter.resetProperty("backUp"); filter.set("backUp", backUpMiddle); } else if (position !== null) { filter.set("backUp", value, position); } }
+    function updateProperty_pitch(position) {
+        if (blockUpdate)
+            return ;
 
-    function updateProperty_fov (position) { if (blockUpdate) return; var value = fovSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { fovStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { fovEnd = value; } else { fovMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("fov"); fovKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("fov", fovStart, 0); filter.set("fov", fovMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("fov", fovMiddle, filter.duration - filter.animateOut); filter.set("fov", fovEnd, filter.duration - 1); } } else if (!fovKeyframesButton.checked) { filter.resetProperty("fov"); filter.set("fov", fovMiddle); } else if (position !== null) { filter.set("fov", value, position); } }
-    function updateProperty_radius (position) { if (blockUpdate) return; var value = radiusSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { radiusStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { radiusEnd = value; } else { radiusMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("radius"); radiusKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("radius", radiusStart, 0); filter.set("radius", radiusMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("radius", radiusMiddle, filter.duration - filter.animateOut); filter.set("radius", radiusEnd, filter.duration - 1); } } else if (!radiusKeyframesButton.checked) { filter.resetProperty("radius"); filter.set("radius", radiusMiddle); } else if (position !== null) { filter.set("radius", value, position); } }
-    function updateProperty_nadirRadius (position) { if (blockUpdate) return; var value = nadirRadiusSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { nadirRadiusStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { nadirRadiusEnd = value; } else { nadirRadiusMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("nadirRadius"); nadirRadiusKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("nadirRadius", nadirRadiusStart, 0); filter.set("nadirRadius", nadirRadiusMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("nadirRadius", nadirRadiusMiddle, filter.duration - filter.animateOut); filter.set("nadirRadius", nadirRadiusEnd, filter.duration - 1); } } else if (!nadirRadiusKeyframesButton.checked) { filter.resetProperty("nadirRadius"); filter.set("nadirRadius", nadirRadiusMiddle); } else if (position !== null) { filter.set("nadirRadius", value, position); } }
-    function updateProperty_nadirCorrectionStart (position) { if (blockUpdate) return; var value = nadirCorrectionStartSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { nadirCorrectionStartStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { nadirCorrectionStartEnd = value; } else { nadirCorrectionStartMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("nadirCorrectionStart"); nadirCorrectionStartKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("nadirCorrectionStart", nadirCorrectionStartStart, 0); filter.set("nadirCorrectionStart", nadirCorrectionStartMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("nadirCorrectionStart", nadirCorrectionStartMiddle, filter.duration - filter.animateOut); filter.set("nadirCorrectionStart", nadirCorrectionStartEnd, filter.duration - 1); } } else if (!nadirCorrectionStartKeyframesButton.checked) { filter.resetProperty("nadirCorrectionStart"); filter.set("nadirCorrectionStart", nadirCorrectionStartMiddle); } else if (position !== null) { filter.set("nadirCorrectionStart", value, position); } }
+        var value = pitchSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                pitchStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                pitchEnd = value;
+            else
+                pitchMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("pitch");
+            pitchKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("pitch", pitchStart, 0);
+                filter.set("pitch", pitchMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("pitch", pitchMiddle, filter.duration - filter.animateOut);
+                filter.set("pitch", pitchEnd, filter.duration - 1);
+            }
+        } else if (!pitchKeyframesButton.checked) {
+            filter.resetProperty("pitch");
+            filter.set("pitch", pitchMiddle);
+        } else if (position !== null) {
+            filter.set("pitch", value, position);
+        }
+    }
 
-    function updateProperty_interpolation () { if (blockUpdate) return; var value = interpolationComboBox.currentIndex; filter.set("interpolation", value); }
-    function updateProperty_projection () { if (blockUpdate) return; var value = projectionComboBox.currentIndex; filter.set("projection", value); }
+    function updateProperty_roll(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = rollSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                rollStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                rollEnd = value;
+            else
+                rollMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("roll");
+            rollKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("roll", rollStart, 0);
+                filter.set("roll", rollMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("roll", rollMiddle, filter.duration - filter.animateOut);
+                filter.set("roll", rollEnd, filter.duration - 1);
+            }
+        } else if (!rollKeyframesButton.checked) {
+            filter.resetProperty("roll");
+            filter.set("roll", rollMiddle);
+        } else if (position !== null) {
+            filter.set("roll", value, position);
+        }
+    }
+
+    function updateProperty_frontX(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = frontXSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                frontXStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                frontXEnd = value;
+            else
+                frontXMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("frontX");
+            frontXKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("frontX", frontXStart, 0);
+                filter.set("frontX", frontXMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("frontX", frontXMiddle, filter.duration - filter.animateOut);
+                filter.set("frontX", frontXEnd, filter.duration - 1);
+            }
+        } else if (!frontXKeyframesButton.checked) {
+            filter.resetProperty("frontX");
+            filter.set("frontX", frontXMiddle);
+        } else if (position !== null) {
+            filter.set("frontX", value, position);
+        }
+    }
+
+    function updateProperty_frontY(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = frontYSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                frontYStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                frontYEnd = value;
+            else
+                frontYMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("frontY");
+            frontYKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("frontY", frontYStart, 0);
+                filter.set("frontY", frontYMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("frontY", frontYMiddle, filter.duration - filter.animateOut);
+                filter.set("frontY", frontYEnd, filter.duration - 1);
+            }
+        } else if (!frontYKeyframesButton.checked) {
+            filter.resetProperty("frontY");
+            filter.set("frontY", frontYMiddle);
+        } else if (position !== null) {
+            filter.set("frontY", value, position);
+        }
+    }
+
+    function updateProperty_frontUp(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = frontUpSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                frontUpStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                frontUpEnd = value;
+            else
+                frontUpMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("frontUp");
+            frontUpKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("frontUp", frontUpStart, 0);
+                filter.set("frontUp", frontUpMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("frontUp", frontUpMiddle, filter.duration - filter.animateOut);
+                filter.set("frontUp", frontUpEnd, filter.duration - 1);
+            }
+        } else if (!frontUpKeyframesButton.checked) {
+            filter.resetProperty("frontUp");
+            filter.set("frontUp", frontUpMiddle);
+        } else if (position !== null) {
+            filter.set("frontUp", value, position);
+        }
+    }
+
+    function updateProperty_backX(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = backXSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                backXStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                backXEnd = value;
+            else
+                backXMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("backX");
+            backXKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("backX", backXStart, 0);
+                filter.set("backX", backXMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("backX", backXMiddle, filter.duration - filter.animateOut);
+                filter.set("backX", backXEnd, filter.duration - 1);
+            }
+        } else if (!backXKeyframesButton.checked) {
+            filter.resetProperty("backX");
+            filter.set("backX", backXMiddle);
+        } else if (position !== null) {
+            filter.set("backX", value, position);
+        }
+    }
+
+    function updateProperty_backY(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = backYSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                backYStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                backYEnd = value;
+            else
+                backYMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("backY");
+            backYKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("backY", backYStart, 0);
+                filter.set("backY", backYMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("backY", backYMiddle, filter.duration - filter.animateOut);
+                filter.set("backY", backYEnd, filter.duration - 1);
+            }
+        } else if (!backYKeyframesButton.checked) {
+            filter.resetProperty("backY");
+            filter.set("backY", backYMiddle);
+        } else if (position !== null) {
+            filter.set("backY", value, position);
+        }
+    }
+
+    function updateProperty_backUp(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = backUpSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                backUpStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                backUpEnd = value;
+            else
+                backUpMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("backUp");
+            backUpKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("backUp", backUpStart, 0);
+                filter.set("backUp", backUpMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("backUp", backUpMiddle, filter.duration - filter.animateOut);
+                filter.set("backUp", backUpEnd, filter.duration - 1);
+            }
+        } else if (!backUpKeyframesButton.checked) {
+            filter.resetProperty("backUp");
+            filter.set("backUp", backUpMiddle);
+        } else if (position !== null) {
+            filter.set("backUp", value, position);
+        }
+    }
+
+    function updateProperty_fov(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = fovSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                fovStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                fovEnd = value;
+            else
+                fovMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("fov");
+            fovKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("fov", fovStart, 0);
+                filter.set("fov", fovMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("fov", fovMiddle, filter.duration - filter.animateOut);
+                filter.set("fov", fovEnd, filter.duration - 1);
+            }
+        } else if (!fovKeyframesButton.checked) {
+            filter.resetProperty("fov");
+            filter.set("fov", fovMiddle);
+        } else if (position !== null) {
+            filter.set("fov", value, position);
+        }
+    }
+
+    function updateProperty_radius(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = radiusSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                radiusStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                radiusEnd = value;
+            else
+                radiusMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("radius");
+            radiusKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("radius", radiusStart, 0);
+                filter.set("radius", radiusMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("radius", radiusMiddle, filter.duration - filter.animateOut);
+                filter.set("radius", radiusEnd, filter.duration - 1);
+            }
+        } else if (!radiusKeyframesButton.checked) {
+            filter.resetProperty("radius");
+            filter.set("radius", radiusMiddle);
+        } else if (position !== null) {
+            filter.set("radius", value, position);
+        }
+    }
+
+    function updateProperty_nadirRadius(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = nadirRadiusSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                nadirRadiusStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                nadirRadiusEnd = value;
+            else
+                nadirRadiusMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("nadirRadius");
+            nadirRadiusKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("nadirRadius", nadirRadiusStart, 0);
+                filter.set("nadirRadius", nadirRadiusMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("nadirRadius", nadirRadiusMiddle, filter.duration - filter.animateOut);
+                filter.set("nadirRadius", nadirRadiusEnd, filter.duration - 1);
+            }
+        } else if (!nadirRadiusKeyframesButton.checked) {
+            filter.resetProperty("nadirRadius");
+            filter.set("nadirRadius", nadirRadiusMiddle);
+        } else if (position !== null) {
+            filter.set("nadirRadius", value, position);
+        }
+    }
+
+    function updateProperty_nadirCorrectionStart(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = nadirCorrectionStartSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                nadirCorrectionStartStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                nadirCorrectionStartEnd = value;
+            else
+                nadirCorrectionStartMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("nadirCorrectionStart");
+            nadirCorrectionStartKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("nadirCorrectionStart", nadirCorrectionStartStart, 0);
+                filter.set("nadirCorrectionStart", nadirCorrectionStartMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("nadirCorrectionStart", nadirCorrectionStartMiddle, filter.duration - filter.animateOut);
+                filter.set("nadirCorrectionStart", nadirCorrectionStartEnd, filter.duration - 1);
+            }
+        } else if (!nadirCorrectionStartKeyframesButton.checked) {
+            filter.resetProperty("nadirCorrectionStart");
+            filter.set("nadirCorrectionStart", nadirCorrectionStartMiddle);
+        } else if (position !== null) {
+            filter.set("nadirCorrectionStart", value, position);
+        }
+    }
+
+    function updateProperty_interpolation() {
+        if (blockUpdate)
+            return ;
+
+        var value = interpolationComboBox.currentIndex;
+        filter.set("interpolation", value);
+    }
+
+    function updateProperty_projection() {
+        if (blockUpdate)
+            return ;
+
+        var value = projectionComboBox.currentIndex;
+        filter.set("projection", value);
+    }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
+    }
+
+    width: 350
+    height: 550
+    Component.onCompleted: {
+        if (filter.isNew) {
+            filter.set("yaw", 0);
+        } else {
+            yawMiddle = filter.getDouble("yaw", filter.animateIn);
+            if (filter.animateIn > 0)
+                yawStart = filter.getDouble("yaw", 0);
+
+            if (filter.animateOut > 0)
+                yawEnd = filter.getDouble("yaw", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("pitch", 0);
+        } else {
+            pitchMiddle = filter.getDouble("pitch", filter.animateIn);
+            if (filter.animateIn > 0)
+                pitchStart = filter.getDouble("pitch", 0);
+
+            if (filter.animateOut > 0)
+                pitchEnd = filter.getDouble("pitch", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("roll", 0);
+        } else {
+            rollMiddle = filter.getDouble("roll", filter.animateIn);
+            if (filter.animateIn > 0)
+                rollStart = filter.getDouble("roll", 0);
+
+            if (filter.animateOut > 0)
+                rollEnd = filter.getDouble("roll", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("frontX", 0.75);
+        } else {
+            frontXMiddle = filter.getDouble("frontX", filter.animateIn);
+            if (filter.animateIn > 0)
+                frontXStart = filter.getDouble("frontX", 0);
+
+            if (filter.animateOut > 0)
+                frontXEnd = filter.getDouble("frontX", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("frontY", 0.5);
+        } else {
+            frontYMiddle = filter.getDouble("frontY", filter.animateIn);
+            if (filter.animateIn > 0)
+                frontYStart = filter.getDouble("frontY", 0);
+
+            if (filter.animateOut > 0)
+                frontYEnd = filter.getDouble("frontY", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("frontUp", 90);
+        } else {
+            frontUpMiddle = filter.getDouble("frontUp", filter.animateIn);
+            if (filter.animateIn > 0)
+                frontUpStart = filter.getDouble("frontUp", 0);
+
+            if (filter.animateOut > 0)
+                frontUpEnd = filter.getDouble("frontUp", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("backX", 0.25);
+        } else {
+            backXMiddle = filter.getDouble("backX", filter.animateIn);
+            if (filter.animateIn > 0)
+                backXStart = filter.getDouble("backX", 0);
+
+            if (filter.animateOut > 0)
+                backXEnd = filter.getDouble("backX", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("backY", 0.5);
+        } else {
+            backYMiddle = filter.getDouble("backY", filter.animateIn);
+            if (filter.animateIn > 0)
+                backYStart = filter.getDouble("backY", 0);
+
+            if (filter.animateOut > 0)
+                backYEnd = filter.getDouble("backY", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("backUp", 270);
+        } else {
+            backUpMiddle = filter.getDouble("backUp", filter.animateIn);
+            if (filter.animateIn > 0)
+                backUpStart = filter.getDouble("backUp", 0);
+
+            if (filter.animateOut > 0)
+                backUpEnd = filter.getDouble("backUp", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("fov", 180);
+        } else {
+            fovMiddle = filter.getDouble("fov", filter.animateIn);
+            if (filter.animateIn > 0)
+                fovStart = filter.getDouble("fov", 0);
+
+            if (filter.animateOut > 0)
+                fovEnd = filter.getDouble("fov", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("radius", 0.25);
+        } else {
+            radiusMiddle = filter.getDouble("radius", filter.animateIn);
+            if (filter.animateIn > 0)
+                radiusStart = filter.getDouble("radius", 0);
+
+            if (filter.animateOut > 0)
+                radiusEnd = filter.getDouble("radius", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("nadirRadius", 0.2229);
+        } else {
+            nadirRadiusMiddle = filter.getDouble("nadirRadius", filter.animateIn);
+            if (filter.animateIn > 0)
+                nadirRadiusStart = filter.getDouble("nadirRadius", 0);
+
+            if (filter.animateOut > 0)
+                nadirRadiusEnd = filter.getDouble("nadirRadius", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("nadirCorrectionStart", 0.8);
+        } else {
+            nadirCorrectionStartMiddle = filter.getDouble("nadirCorrectionStart", filter.animateIn);
+            if (filter.animateIn > 0)
+                nadirCorrectionStartStart = filter.getDouble("nadirCorrectionStart", 0);
+
+            if (filter.animateOut > 0)
+                nadirCorrectionStartEnd = filter.getDouble("nadirCorrectionStart", filter.duration - 1);
+
+        }
+        if (filter.isNew)
+            filter.set("interpolation", 1);
+        else
+            interpolationValue = filter.get("interpolation");
+        if (filter.isNew)
+            filter.set("projection", 0);
+        else
+            projectionValue = filter.get("projection");
+        if (filter.isNew)
+            filter.savePreset(preset.parameters);
+
+        setControls();
     }
 
     GridLayout {
@@ -187,41 +747,121 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ["yaw", "pitch", "roll", "frontX", "frontY", "frontUp", "backX", "backY", "backUp", "fov", "radius", "nadirRadius", "nadirCorrectionStart", "interpolation", "projection"]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                filter.resetProperty('yaw')
-                filter.resetProperty('pitch')
-                filter.resetProperty('roll')
-                filter.resetProperty('frontX')
-                filter.resetProperty('frontY')
-                filter.resetProperty('frontUp')
-                filter.resetProperty('backX')
-                filter.resetProperty('backY')
-                filter.resetProperty('backUp')
-                filter.resetProperty('fov')
-                filter.resetProperty('radius')
-                filter.resetProperty('nadirRadius')
-                filter.resetProperty('nadirCorrectionStart')
-                filter.resetProperty('interpolation')
-                filter.resetProperty('projection')
+                filter.resetProperty('yaw');
+                filter.resetProperty('pitch');
+                filter.resetProperty('roll');
+                filter.resetProperty('frontX');
+                filter.resetProperty('frontY');
+                filter.resetProperty('frontUp');
+                filter.resetProperty('backX');
+                filter.resetProperty('backY');
+                filter.resetProperty('backUp');
+                filter.resetProperty('fov');
+                filter.resetProperty('radius');
+                filter.resetProperty('nadirRadius');
+                filter.resetProperty('nadirCorrectionStart');
+                filter.resetProperty('interpolation');
+                filter.resetProperty('projection');
             }
             onPresetSelected: {
-                yawMiddle = filter.getDouble("yaw", filter.animateIn); if (filter.animateIn > 0) { yawStart = filter.getDouble("yaw", 0); } if (filter.animateOut > 0) { yawEnd = filter.getDouble("yaw", filter.duration - 1); }
-                pitchMiddle = filter.getDouble("pitch", filter.animateIn); if (filter.animateIn > 0) { pitchStart = filter.getDouble("pitch", 0); } if (filter.animateOut > 0) { pitchEnd = filter.getDouble("pitch", filter.duration - 1); }
-                rollMiddle = filter.getDouble("roll", filter.animateIn); if (filter.animateIn > 0) { rollStart = filter.getDouble("roll", 0); } if (filter.animateOut > 0) { rollEnd = filter.getDouble("roll", filter.duration - 1); }
-                frontXMiddle = filter.getDouble("frontX", filter.animateIn); if (filter.animateIn > 0) { frontXStart = filter.getDouble("frontX", 0); } if (filter.animateOut > 0) { frontXEnd = filter.getDouble("frontX", filter.duration - 1); }
-                frontYMiddle = filter.getDouble("frontY", filter.animateIn); if (filter.animateIn > 0) { frontYStart = filter.getDouble("frontY", 0); } if (filter.animateOut > 0) { frontYEnd = filter.getDouble("frontY", filter.duration - 1); }
-                frontUpMiddle = filter.getDouble("frontUp", filter.animateIn); if (filter.animateIn > 0) { frontUpStart = filter.getDouble("frontUp", 0); } if (filter.animateOut > 0) { frontUpEnd = filter.getDouble("frontUp", filter.duration - 1); }
-                backXMiddle = filter.getDouble("backX", filter.animateIn); if (filter.animateIn > 0) { backXStart = filter.getDouble("backX", 0); } if (filter.animateOut > 0) { backXEnd = filter.getDouble("backX", filter.duration - 1); }
-                backYMiddle = filter.getDouble("backY", filter.animateIn); if (filter.animateIn > 0) { backYStart = filter.getDouble("backY", 0); } if (filter.animateOut > 0) { backYEnd = filter.getDouble("backY", filter.duration - 1); }
-                backUpMiddle = filter.getDouble("backUp", filter.animateIn); if (filter.animateIn > 0) { backUpStart = filter.getDouble("backUp", 0); } if (filter.animateOut > 0) { backUpEnd = filter.getDouble("backUp", filter.duration - 1); }
-                fovMiddle = filter.getDouble("fov", filter.animateIn); if (filter.animateIn > 0) { fovStart = filter.getDouble("fov", 0); } if (filter.animateOut > 0) { fovEnd = filter.getDouble("fov", filter.duration - 1); }
-                radiusMiddle = filter.getDouble("radius", filter.animateIn); if (filter.animateIn > 0) { radiusStart = filter.getDouble("radius", 0); } if (filter.animateOut > 0) { radiusEnd = filter.getDouble("radius", filter.duration - 1); }
-                nadirRadiusMiddle = filter.getDouble("nadirRadius", filter.animateIn); if (filter.animateIn > 0) { nadirRadiusStart = filter.getDouble("nadirRadius", 0); } if (filter.animateOut > 0) { nadirRadiusEnd = filter.getDouble("nadirRadius", filter.duration - 1); }
-                nadirCorrectionStartMiddle = filter.getDouble("nadirCorrectionStart", filter.animateIn); if (filter.animateIn > 0) { nadirCorrectionStartStart = filter.getDouble("nadirCorrectionStart", 0); } if (filter.animateOut > 0) { nadirCorrectionStartEnd = filter.getDouble("nadirCorrectionStart", filter.duration - 1); }
+                yawMiddle = filter.getDouble("yaw", filter.animateIn);
+                if (filter.animateIn > 0)
+                    yawStart = filter.getDouble("yaw", 0);
+
+                if (filter.animateOut > 0)
+                    yawEnd = filter.getDouble("yaw", filter.duration - 1);
+
+                pitchMiddle = filter.getDouble("pitch", filter.animateIn);
+                if (filter.animateIn > 0)
+                    pitchStart = filter.getDouble("pitch", 0);
+
+                if (filter.animateOut > 0)
+                    pitchEnd = filter.getDouble("pitch", filter.duration - 1);
+
+                rollMiddle = filter.getDouble("roll", filter.animateIn);
+                if (filter.animateIn > 0)
+                    rollStart = filter.getDouble("roll", 0);
+
+                if (filter.animateOut > 0)
+                    rollEnd = filter.getDouble("roll", filter.duration - 1);
+
+                frontXMiddle = filter.getDouble("frontX", filter.animateIn);
+                if (filter.animateIn > 0)
+                    frontXStart = filter.getDouble("frontX", 0);
+
+                if (filter.animateOut > 0)
+                    frontXEnd = filter.getDouble("frontX", filter.duration - 1);
+
+                frontYMiddle = filter.getDouble("frontY", filter.animateIn);
+                if (filter.animateIn > 0)
+                    frontYStart = filter.getDouble("frontY", 0);
+
+                if (filter.animateOut > 0)
+                    frontYEnd = filter.getDouble("frontY", filter.duration - 1);
+
+                frontUpMiddle = filter.getDouble("frontUp", filter.animateIn);
+                if (filter.animateIn > 0)
+                    frontUpStart = filter.getDouble("frontUp", 0);
+
+                if (filter.animateOut > 0)
+                    frontUpEnd = filter.getDouble("frontUp", filter.duration - 1);
+
+                backXMiddle = filter.getDouble("backX", filter.animateIn);
+                if (filter.animateIn > 0)
+                    backXStart = filter.getDouble("backX", 0);
+
+                if (filter.animateOut > 0)
+                    backXEnd = filter.getDouble("backX", filter.duration - 1);
+
+                backYMiddle = filter.getDouble("backY", filter.animateIn);
+                if (filter.animateIn > 0)
+                    backYStart = filter.getDouble("backY", 0);
+
+                if (filter.animateOut > 0)
+                    backYEnd = filter.getDouble("backY", filter.duration - 1);
+
+                backUpMiddle = filter.getDouble("backUp", filter.animateIn);
+                if (filter.animateIn > 0)
+                    backUpStart = filter.getDouble("backUp", 0);
+
+                if (filter.animateOut > 0)
+                    backUpEnd = filter.getDouble("backUp", filter.duration - 1);
+
+                fovMiddle = filter.getDouble("fov", filter.animateIn);
+                if (filter.animateIn > 0)
+                    fovStart = filter.getDouble("fov", 0);
+
+                if (filter.animateOut > 0)
+                    fovEnd = filter.getDouble("fov", filter.duration - 1);
+
+                radiusMiddle = filter.getDouble("radius", filter.animateIn);
+                if (filter.animateIn > 0)
+                    radiusStart = filter.getDouble("radius", 0);
+
+                if (filter.animateOut > 0)
+                    radiusEnd = filter.getDouble("radius", filter.duration - 1);
+
+                nadirRadiusMiddle = filter.getDouble("nadirRadius", filter.animateIn);
+                if (filter.animateIn > 0)
+                    nadirRadiusStart = filter.getDouble("nadirRadius", 0);
+
+                if (filter.animateOut > 0)
+                    nadirRadiusEnd = filter.getDouble("nadirRadius", filter.duration - 1);
+
+                nadirCorrectionStartMiddle = filter.getDouble("nadirCorrectionStart", filter.animateIn);
+                if (filter.animateIn > 0)
+                    nadirCorrectionStartStart = filter.getDouble("nadirCorrectionStart", 0);
+
+                if (filter.animateOut > 0)
+                    nadirCorrectionStartEnd = filter.getDouble("nadirCorrectionStart", filter.duration - 1);
+
                 interpolationValue = filter.get("interpolation");
                 projectionValue = filter.get("projection");
                 setControls(null);
@@ -232,17 +872,24 @@ Item {
             text: qsTr('Interpolation')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
+            id: interpolationComboBox
+
             currentIndex: 0
             model: ["Nearest-neighbor", "Bilinear"]
-            id: interpolationComboBox
             onCurrentIndexChanged: updateProperty_interpolation()
         }
+
         Shotcut.UndoButton {
             id: interpolationUndo
+
             onClicked: interpolationComboBox.currentIndex = 0
         }
-        Item { Layout.fillWidth: true }
+
+        Item {
+            Layout.fillWidth: true
+        }
 
         Label {
             text: qsTr('Alignment')
@@ -250,57 +897,138 @@ Item {
             Layout.columnSpan: 4
         }
 
-
         Label {
             text: qsTr('Yaw')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: yawSlider
+
             minimumValue: -360
             maximumValue: 360
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_yaw(getPosition())
         }
+
         Shotcut.UndoButton {
             id: yawUndo
+
             onClicked: yawSlider.value = 0
         }
-        Shotcut.KeyframesButton { id: yawKeyframesButton; onToggled: { var value = yawSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("yaw"); yawSlider.enabled = true; } filter.clearSimpleAnimation("yaw"); blockUpdate = false; filter.set("yaw", value, getPosition()); } else { filter.resetProperty("yaw"); filter.set("yaw", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: yawKeyframesButton
+
+            onToggled: {
+                var value = yawSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("yaw");
+                        yawSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("yaw");
+                    blockUpdate = false;
+                    filter.set("yaw", value, getPosition());
+                } else {
+                    filter.resetProperty("yaw");
+                    filter.set("yaw", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Pitch', 'rotation around the side-to-side axis (roll, pitch, yaw)')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: pitchSlider
+
             minimumValue: -180
             maximumValue: 180
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_pitch(getPosition())
         }
+
         Shotcut.UndoButton {
             id: pitchUndo
+
             onClicked: pitchSlider.value = 0
         }
-        Shotcut.KeyframesButton { id: pitchKeyframesButton; checked: filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("pitch") > 0; onToggled: { var value = pitchSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("pitch"); pitchSlider.enabled = true; } filter.clearSimpleAnimation("pitch"); blockUpdate = false; filter.set("pitch", value, getPosition()); } else { filter.resetProperty("pitch"); filter.set("pitch", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: pitchKeyframesButton
+
+            checked: filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("pitch") > 0
+            onToggled: {
+                var value = pitchSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("pitch");
+                        pitchSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("pitch");
+                    blockUpdate = false;
+                    filter.set("pitch", value, getPosition());
+                } else {
+                    filter.resetProperty("pitch");
+                    filter.set("pitch", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Roll')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: rollSlider
+
             minimumValue: -180
             maximumValue: 180
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_roll(getPosition())
         }
+
         Shotcut.UndoButton {
             id: rollUndo
+
             onClicked: rollSlider.value = 0
         }
-        Shotcut.KeyframesButton { id: rollKeyframesButton; onToggled: { var value = rollSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("roll"); rollSlider.enabled = true; } filter.clearSimpleAnimation("roll"); blockUpdate = false; filter.set("roll", value, getPosition()); } else { filter.resetProperty("roll"); filter.set("roll", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: rollKeyframesButton
+
+            onToggled: {
+                var value = rollSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("roll");
+                        rollSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("roll");
+                    blockUpdate = false;
+                    filter.set("roll", value, getPosition());
+                } else {
+                    filter.resetProperty("roll");
+                    filter.set("roll", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Lens')
@@ -312,24 +1040,33 @@ Item {
             text: qsTr('Projection')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
+            id: projectionComboBox
+
             currentIndex: 0
             model: ["Equidistant Fisheye"]
-            id: projectionComboBox
             onCurrentIndexChanged: updateProperty_projection()
         }
+
         Shotcut.UndoButton {
             id: projectionUndo
+
             onClicked: projectionComboBox.currentIndex = 0
         }
-        Item { Layout.fillWidth: true }
+
+        Item {
+            Layout.fillWidth: true
+        }
 
         Label {
             text: qsTr('FOV')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: fovSlider
+
             minimumValue: 0
             maximumValue: 360
             spinnerWidth: 120
@@ -338,18 +1075,42 @@ Item {
             stepSize: 0.0001
             onValueChanged: updateProperty_fov(getPosition())
         }
+
         Shotcut.UndoButton {
             id: fovUndo
+
             onClicked: fovSlider.value = 180
         }
-        Shotcut.KeyframesButton { id: fovKeyframesButton; onToggled: { var value = fovSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("fov"); fovSlider.enabled = true; } filter.clearSimpleAnimation("fov"); blockUpdate = false; filter.set("fov", value, getPosition()); } else { filter.resetProperty("fov"); filter.set("fov", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: fovKeyframesButton
+
+            onToggled: {
+                var value = fovSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("fov");
+                        fovSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("fov");
+                    blockUpdate = false;
+                    filter.set("fov", value, getPosition());
+                } else {
+                    filter.resetProperty("fov");
+                    filter.set("fov", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Radius')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: radiusSlider
+
             minimumValue: 0
             maximumValue: 1
             suffix: ' '
@@ -357,12 +1118,33 @@ Item {
             stepSize: 0.0001
             onValueChanged: updateProperty_radius(getPosition())
         }
+
         Shotcut.UndoButton {
             id: radiusUndo
+
             onClicked: radiusSlider.value = 0.25
         }
-        Shotcut.KeyframesButton { id: radiusKeyframesButton; onToggled: { var value = radiusSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("radius"); radiusSlider.enabled = true; } filter.clearSimpleAnimation("radius"); blockUpdate = false; filter.set("radius", value, getPosition()); } else { filter.resetProperty("radius"); filter.set("radius", value); } } }
 
+        Shotcut.KeyframesButton {
+            id: radiusKeyframesButton
+
+            onToggled: {
+                var value = radiusSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("radius");
+                        radiusSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("radius");
+                    blockUpdate = false;
+                    filter.set("radius", value, getPosition());
+                } else {
+                    filter.resetProperty("radius");
+                    filter.set("radius", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Front')
@@ -374,8 +1156,10 @@ Item {
             text: qsTr('X')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: frontXSlider
+
             minimumValue: 0
             maximumValue: 1
             stepSize: 0.0001
@@ -383,18 +1167,42 @@ Item {
             suffix: ' '
             onValueChanged: updateProperty_frontX(getPosition())
         }
+
         Shotcut.UndoButton {
             id: frontXUndo
+
             onClicked: frontXSlider.value = 0.25
         }
-        Shotcut.KeyframesButton { id: frontXKeyframesButton; onToggled: { var value = frontXSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("frontX"); frontXSlider.enabled = true; } filter.clearSimpleAnimation("frontX"); blockUpdate = false; filter.set("frontX", value, getPosition()); } else { filter.resetProperty("frontX"); filter.set("frontX", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: frontXKeyframesButton
+
+            onToggled: {
+                var value = frontXSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("frontX");
+                        frontXSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("frontX");
+                    blockUpdate = false;
+                    filter.set("frontX", value, getPosition());
+                } else {
+                    filter.resetProperty("frontX");
+                    filter.set("frontX", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Y')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: frontYSlider
+
             minimumValue: 0
             maximumValue: 1
             stepSize: 0.0001
@@ -402,29 +1210,78 @@ Item {
             suffix: ' '
             onValueChanged: updateProperty_frontY(getPosition())
         }
+
         Shotcut.UndoButton {
             id: frontYUndo
+
             onClicked: frontYSlider.value = 0.25
         }
-        Shotcut.KeyframesButton { id: frontYKeyframesButton; onToggled: { var value = frontYSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("frontY"); frontYSlider.enabled = true; } filter.clearSimpleAnimation("frontY"); blockUpdate = false; filter.set("frontY", value, getPosition()); } else { filter.resetProperty("frontY"); filter.set("frontY", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: frontYKeyframesButton
+
+            onToggled: {
+                var value = frontYSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("frontY");
+                        frontYSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("frontY");
+                    blockUpdate = false;
+                    filter.set("frontY", value, getPosition());
+                } else {
+                    filter.resetProperty("frontY");
+                    filter.set("frontY", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Up')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: frontUpSlider
+
             minimumValue: 0
             maximumValue: 360
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_frontUp(getPosition())
         }
+
         Shotcut.UndoButton {
             id: frontUpUndo
+
             onClicked: frontUpSlider.value = 90
         }
-        Shotcut.KeyframesButton { id: frontUpKeyframesButton; checked: filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("frontUp") > 0; onToggled: { var value = frontUpSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("frontUp"); frontUpSlider.enabled = true; } filter.clearSimpleAnimation("frontUp"); blockUpdate = false; filter.set("frontUp", value, getPosition()); } else { filter.resetProperty("frontUp"); filter.set("frontUp", value); } } }
 
+        Shotcut.KeyframesButton {
+            id: frontUpKeyframesButton
+
+            checked: filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("frontUp") > 0
+            onToggled: {
+                var value = frontUpSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("frontUp");
+                        frontUpSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("frontUp");
+                    blockUpdate = false;
+                    filter.set("frontUp", value, getPosition());
+                } else {
+                    filter.resetProperty("frontUp");
+                    filter.set("frontUp", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Back')
@@ -436,8 +1293,10 @@ Item {
             text: qsTr('X')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: backXSlider
+
             minimumValue: 0
             maximumValue: 1
             stepSize: 0.0001
@@ -445,18 +1304,42 @@ Item {
             suffix: ' '
             onValueChanged: updateProperty_backX(getPosition())
         }
+
         Shotcut.UndoButton {
             id: backXUndo
+
             onClicked: backXSlider.value = 0.25
         }
-        Shotcut.KeyframesButton { id: backXKeyframesButton; onToggled: { var value = backXSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("backX"); backXSlider.enabled = true; } filter.clearSimpleAnimation("backX"); blockUpdate = false; filter.set("backX", value, getPosition()); } else { filter.resetProperty("backX"); filter.set("backX", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: backXKeyframesButton
+
+            onToggled: {
+                var value = backXSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("backX");
+                        backXSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("backX");
+                    blockUpdate = false;
+                    filter.set("backX", value, getPosition());
+                } else {
+                    filter.resetProperty("backX");
+                    filter.set("backX", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Y')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: backYSlider
+
             minimumValue: 0
             maximumValue: 1
             stepSize: 0.0001
@@ -464,29 +1347,78 @@ Item {
             suffix: ' '
             onValueChanged: updateProperty_backY(getPosition())
         }
+
         Shotcut.UndoButton {
             id: backYUndo
+
             onClicked: backYSlider.value = 0.25
         }
-        Shotcut.KeyframesButton { id: backYKeyframesButton; onToggled: { var value = backYSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("backY"); backYSlider.enabled = true; } filter.clearSimpleAnimation("backY"); blockUpdate = false; filter.set("backY", value, getPosition()); } else { filter.resetProperty("backY"); filter.set("backY", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: backYKeyframesButton
+
+            onToggled: {
+                var value = backYSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("backY");
+                        backYSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("backY");
+                    blockUpdate = false;
+                    filter.set("backY", value, getPosition());
+                } else {
+                    filter.resetProperty("backY");
+                    filter.set("backY", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Up')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: backUpSlider
+
             minimumValue: 0
             maximumValue: 360
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_backUp(getPosition())
         }
+
         Shotcut.UndoButton {
             id: backUpUndo
+
             onClicked: backUpSlider.value = 90
         }
-        Shotcut.KeyframesButton { id: backUpKeyframesButton; checked: filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("backUp") > 0; onToggled: { var value = backUpSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("backUp"); backUpSlider.enabled = true; } filter.clearSimpleAnimation("backUp"); blockUpdate = false; filter.set("backUp", value, getPosition()); } else { filter.resetProperty("backUp"); filter.set("backUp", value); } } }
 
+        Shotcut.KeyframesButton {
+            id: backUpKeyframesButton
+
+            checked: filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("backUp") > 0
+            onToggled: {
+                var value = backUpSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("backUp");
+                        backUpSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("backUp");
+                    blockUpdate = false;
+                    filter.set("backUp", value, getPosition());
+                } else {
+                    filter.resetProperty("backUp");
+                    filter.set("backUp", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Nadir')
@@ -494,13 +1426,14 @@ Item {
             Layout.columnSpan: 4
         }
 
-
         Label {
             text: qsTr('Radius')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: nadirRadiusSlider
+
             minimumValue: 0
             maximumValue: 1
             suffix: ' '
@@ -508,18 +1441,42 @@ Item {
             stepSize: 0.0001
             onValueChanged: updateProperty_nadirRadius(getPosition())
         }
+
         Shotcut.UndoButton {
             id: nadirRadiusUndo
+
             onClicked: nadirRadiusSlider.value = 0.2229
         }
-        Shotcut.KeyframesButton { id: nadirRadiusKeyframesButton; onToggled: { var value = nadirRadiusSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("nadirRadius"); nadirRadiusSlider.enabled = true; } filter.clearSimpleAnimation("nadirRadius"); blockUpdate = false; filter.set("nadirRadius", value, getPosition()); } else { filter.resetProperty("nadirRadius"); filter.set("nadirRadius", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: nadirRadiusKeyframesButton
+
+            onToggled: {
+                var value = nadirRadiusSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("nadirRadius");
+                        nadirRadiusSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("nadirRadius");
+                    blockUpdate = false;
+                    filter.set("nadirRadius", value, getPosition());
+                } else {
+                    filter.resetProperty("nadirRadius");
+                    filter.set("nadirRadius", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Start')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: nadirCorrectionStartSlider
+
             minimumValue: 0
             maximumValue: 1
             suffix: ' '
@@ -527,28 +1484,74 @@ Item {
             stepSize: 0.0001
             onValueChanged: updateProperty_nadirCorrectionStart(getPosition())
         }
+
         Shotcut.UndoButton {
             id: nadirCorrectionStartUndo
+
             onClicked: radiusSlider.value = 0.8
         }
-        Shotcut.KeyframesButton { id: nadirCorrectionStartKeyframesButton; onToggled: { var value = nadirCorrectionStartSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("nadirCorrectionStart"); nadirCorrectionStartSlider.enabled = true; } filter.clearSimpleAnimation("nadirCorrectionStart"); blockUpdate = false; filter.set("nadirCorrectionStart", value, getPosition()); } else { filter.resetProperty("nadirCorrectionStart"); filter.set("nadirCorrectionStart", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: nadirCorrectionStartKeyframesButton
+
+            onToggled: {
+                var value = nadirCorrectionStartSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("nadirCorrectionStart");
+                        nadirCorrectionStartSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("nadirCorrectionStart");
+                    blockUpdate = false;
+                    filter.set("nadirCorrectionStart", value, getPosition());
+                } else {
+                    filter.resetProperty("nadirCorrectionStart");
+                    filter.set("nadirCorrectionStart", value);
+                }
+            }
+        }
+
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/bigsh0t_rect_to_eq/meta.qml
+++ b/src/qml/filters/bigsh0t_rect_to_eq/meta.qml
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0-or-later */
+// SPDX-License-Identifier: GPL-2.0-or-later
 import QtQuick 2.0
 import org.shotcut.qml 1.0
 
@@ -8,6 +8,7 @@ Metadata {
     mlt_service: "frei0r.bigsh0t_rect_to_eq"
     objectName: "bigsh0t_rect_to_eq"
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -29,4 +30,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/bigsh0t_rect_to_eq/ui.qml
+++ b/src/qml/filters/bigsh0t_rect_to_eq/ui.qml
@@ -1,64 +1,154 @@
-
-
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
-
 Item {
-    width: 350
-    height: 130
     property bool blockUpdate: true
-
-    property double hfovStart : 0.0; property double hfovMiddle : 0.0; property double hfovEnd : 0.0;
-    property double vfovStart : 0.0; property double vfovMiddle : 0.0; property double vfovEnd : 0.0;
-    property int interpolationValue : 0;
+    property double hfovStart: 0
+    property double hfovMiddle: 0
+    property double hfovEnd: 0
+    property double vfovStart: 0
+    property double vfovMiddle: 0
+    property double vfovEnd: 0
+    property int interpolationValue: 0
 
     function updateSimpleKeyframes() {
         if (filter.animateIn > 0 || filter.animateOut > 0) {
             // When enabling simple keyframes, initialize the keyframes with the current value
-            if (filter.keyframeCount("hfov") <= 0) {
-                hfovStart = hfovMiddle = hfovEnd = filter.getDouble("hfov")
-            }
-            if (filter.keyframeCount("vfov") <= 0) {
-                vfovStart = vfovMiddle = vfovEnd = filter.getDouble("vfov")
-            }
-        }
-        setControls()
-        updateProperty_hfov(null)
-        updateProperty_vfov(null)
-        updateProperty_interpolation()
-    }
+            if (filter.keyframeCount("hfov") <= 0)
+                hfovStart = hfovMiddle = hfovEnd = filter.getDouble("hfov");
 
-    Component.onCompleted: {
-        if (filter.isNew) { filter.set("hfov", 90); } else { hfovMiddle = filter.getDouble("hfov", filter.animateIn); if (filter.animateIn > 0) { hfovStart = filter.getDouble("hfov", 0); } if (filter.animateOut > 0) { hfovEnd = filter.getDouble("hfov", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("vfov", 60); } else { vfovMiddle = filter.getDouble("vfov", filter.animateIn); if (filter.animateIn > 0) { vfovStart = filter.getDouble("vfov", 0); } if (filter.animateOut > 0) { vfovEnd = filter.getDouble("vfov", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("interpolation", 1); } else { interpolationValue = filter.get("interpolation"); }
+            if (filter.keyframeCount("vfov") <= 0)
+                vfovStart = vfovMiddle = vfovEnd = filter.getDouble("vfov");
 
-        if (filter.isNew) {
-            filter.savePreset(preset.parameters)
         }
-        setControls()
+        setControls();
+        updateProperty_hfov(null);
+        updateProperty_vfov(null);
+        updateProperty_interpolation();
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        hfovSlider.value = filter.getDouble("hfov", position)
-        hfovKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("hfov") > 0
-        vfovSlider.value = filter.getDouble("vfov", position)
-        vfovKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("vfov") > 0
-        interpolationComboBox.currentIndex = filter.get("interpolation")
-        blockUpdate = false
+        var position = getPosition();
+        blockUpdate = true;
+        hfovSlider.value = filter.getDouble("hfov", position);
+        hfovKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("hfov") > 0;
+        vfovSlider.value = filter.getDouble("vfov", position);
+        vfovKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("vfov") > 0;
+        interpolationComboBox.currentIndex = filter.get("interpolation");
+        blockUpdate = false;
     }
 
-    function updateProperty_hfov (position) { if (blockUpdate) return; var value = hfovSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { hfovStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { hfovEnd = value; } else { hfovMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("hfov"); hfovKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("hfov", hfovStart, 0); filter.set("hfov", hfovMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("hfov", hfovMiddle, filter.duration - filter.animateOut); filter.set("hfov", hfovEnd, filter.duration - 1); } } else if (!hfovKeyframesButton.checked) { filter.resetProperty("hfov"); filter.set("hfov", hfovMiddle); } else if (position !== null) { filter.set("hfov", value, position); } }
-    function updateProperty_vfov (position) { if (blockUpdate) return; var value = vfovSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { vfovStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { vfovEnd = value; } else { vfovMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("vfov"); vfovKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("vfov", vfovStart, 0); filter.set("vfov", vfovMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("vfov", vfovMiddle, filter.duration - filter.animateOut); filter.set("vfov", vfovEnd, filter.duration - 1); } } else if (!vfovKeyframesButton.checked) { filter.resetProperty("vfov"); filter.set("vfov", vfovMiddle); } else if (position !== null) { filter.set("vfov", value, position); } }
-    function updateProperty_interpolation () { if (blockUpdate) return; var value = interpolationComboBox.currentIndex; filter.set("interpolation", value); }
+    function updateProperty_hfov(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = hfovSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                hfovStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                hfovEnd = value;
+            else
+                hfovMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("hfov");
+            hfovKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("hfov", hfovStart, 0);
+                filter.set("hfov", hfovMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("hfov", hfovMiddle, filter.duration - filter.animateOut);
+                filter.set("hfov", hfovEnd, filter.duration - 1);
+            }
+        } else if (!hfovKeyframesButton.checked) {
+            filter.resetProperty("hfov");
+            filter.set("hfov", hfovMiddle);
+        } else if (position !== null) {
+            filter.set("hfov", value, position);
+        }
+    }
+
+    function updateProperty_vfov(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = vfovSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                vfovStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                vfovEnd = value;
+            else
+                vfovMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("vfov");
+            vfovKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("vfov", vfovStart, 0);
+                filter.set("vfov", vfovMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("vfov", vfovMiddle, filter.duration - filter.animateOut);
+                filter.set("vfov", vfovEnd, filter.duration - 1);
+            }
+        } else if (!vfovKeyframesButton.checked) {
+            filter.resetProperty("vfov");
+            filter.set("vfov", vfovMiddle);
+        } else if (position !== null) {
+            filter.set("vfov", value, position);
+        }
+    }
+
+    function updateProperty_interpolation() {
+        if (blockUpdate)
+            return ;
+
+        var value = interpolationComboBox.currentIndex;
+        filter.set("interpolation", value);
+    }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
+    }
+
+    width: 350
+    height: 130
+    Component.onCompleted: {
+        if (filter.isNew) {
+            filter.set("hfov", 90);
+        } else {
+            hfovMiddle = filter.getDouble("hfov", filter.animateIn);
+            if (filter.animateIn > 0)
+                hfovStart = filter.getDouble("hfov", 0);
+
+            if (filter.animateOut > 0)
+                hfovEnd = filter.getDouble("hfov", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("vfov", 60);
+        } else {
+            vfovMiddle = filter.getDouble("vfov", filter.animateIn);
+            if (filter.animateIn > 0)
+                vfovStart = filter.getDouble("vfov", 0);
+
+            if (filter.animateOut > 0)
+                vfovEnd = filter.getDouble("vfov", filter.duration - 1);
+
+        }
+        if (filter.isNew)
+            filter.set("interpolation", 1);
+        else
+            interpolationValue = filter.get("interpolation");
+        if (filter.isNew)
+            filter.savePreset(preset.parameters);
+
+        setControls();
     }
 
     GridLayout {
@@ -70,18 +160,32 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ["hfov", "vfov", "interpolation"]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                filter.resetProperty('hfov')
-                filter.resetProperty('vfov')
-                filter.resetProperty('interpolation')
+                filter.resetProperty('hfov');
+                filter.resetProperty('vfov');
+                filter.resetProperty('interpolation');
             }
             onPresetSelected: {
-                hfovMiddle = filter.getDouble("hfov", filter.animateIn); if (filter.animateIn > 0) { hfovStart = filter.getDouble("hfov", 0); } if (filter.animateOut > 0) { hfovEnd = filter.getDouble("hfov", filter.duration - 1); }
-                vfovMiddle = filter.getDouble("vfov", filter.animateIn); if (filter.animateIn > 0) { vfovStart = filter.getDouble("vfov", 0); } if (filter.animateOut > 0) { vfovEnd = filter.getDouble("vfov", filter.duration - 1); }
+                hfovMiddle = filter.getDouble("hfov", filter.animateIn);
+                if (filter.animateIn > 0)
+                    hfovStart = filter.getDouble("hfov", 0);
+
+                if (filter.animateOut > 0)
+                    hfovEnd = filter.getDouble("hfov", filter.duration - 1);
+
+                vfovMiddle = filter.getDouble("vfov", filter.animateIn);
+                if (filter.animateIn > 0)
+                    vfovStart = filter.getDouble("vfov", 0);
+
+                if (filter.animateOut > 0)
+                    vfovEnd = filter.getDouble("vfov", filter.duration - 1);
+
                 interpolationValue = filter.get("interpolation");
                 setControls(null);
             }
@@ -91,68 +195,153 @@ Item {
             text: qsTr('Interpolation')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
+            id: interpolationComboBox
+
             currentIndex: 0
             model: ["Nearest-neighbor", "Bilinear"]
-            id: interpolationComboBox
             onCurrentIndexChanged: updateProperty_interpolation()
         }
+
         Shotcut.UndoButton {
             id: interpolationUndo
+
             onClicked: interpolationComboBox.currentIndex = 0
         }
-        Item { Layout.fillWidth: true }
+
+        Item {
+            Layout.fillWidth: true
+        }
 
         Label {
             text: qsTr('Horizontal')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: hfovSlider
+
             minimumValue: 0
             maximumValue: 180
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_hfov(getPosition())
         }
+
         Shotcut.UndoButton {
             id: hfovUndo
+
             onClicked: hfovSlider.value = 90
         }
-        Shotcut.KeyframesButton { id: hfovKeyframesButton; onToggled: { var value = hfovSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("hfov"); hfovSlider.enabled = true; } filter.clearSimpleAnimation("hfov"); blockUpdate = false; filter.set("hfov", value, getPosition()); } else { filter.resetProperty("hfov"); filter.set("hfov", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: hfovKeyframesButton
+
+            onToggled: {
+                var value = hfovSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("hfov");
+                        hfovSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("hfov");
+                    blockUpdate = false;
+                    filter.set("hfov", value, getPosition());
+                } else {
+                    filter.resetProperty("hfov");
+                    filter.set("hfov", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Vertical')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: vfovSlider
+
             minimumValue: 0
             maximumValue: 180
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_vfov(getPosition())
         }
+
         Shotcut.UndoButton {
             id: vfovUndo
+
             onClicked: vfovSlider.value = 60
         }
-        Shotcut.KeyframesButton { id: vfovKeyframesButton; onToggled: { var value = vfovSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("vfov"); vfovSlider.enabled = true; } filter.clearSimpleAnimation("vfov"); blockUpdate = false; filter.set("vfov", value, getPosition()); } else { filter.resetProperty("vfov"); filter.set("vfov", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: vfovKeyframesButton
+
+            onToggled: {
+                var value = vfovSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("vfov");
+                        vfovSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("vfov");
+                    blockUpdate = false;
+                    filter.set("vfov", value, getPosition());
+                } else {
+                    filter.resetProperty("vfov");
+                    filter.set("vfov", value);
+                }
+            }
+        }
+
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/bigsh0t_stabilize_360/meta.qml
+++ b/src/qml/filters/bigsh0t_stabilize_360/meta.qml
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0-or-later */
+// SPDX-License-Identifier: GPL-2.0-or-later
 import QtQuick 2.0
 import org.shotcut.qml 1.0
 

--- a/src/qml/filters/bigsh0t_stabilize_360/ui.qml
+++ b/src/qml/filters/bigsh0t_stabilize_360/ui.qml
@@ -1,120 +1,309 @@
-
 import QtQuick 2.12
 import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
 import QtQuick.Dialogs 1.3
+import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 350
-    height: 625
     property bool blockUpdate: true
-
-    property int interpolationValue : 0;
-    property bool analyzeValue : false;
-    property bool transformWhenAnalyzingValue: false;
-    property double sampleRadiusValue : 0.0;
-    property double searchRadiusValue : 0.0;
-    property double offsetValue : 0.0;
-    property string analysisFileValue : "";
-    property bool useBackTrackpointsValue : false;
-    property double stabilizeYawValue : 0.0;
-    property double stabilizePitchValue : 0.0;
-    property double stabilizeRollValue : 0.0;
-    property double smoothYawValue : 0.0;
-    property double smoothPitchValue : 0.0;
-    property double smoothRollValue : 0.0;
-    property double timeBiasYawValue : 0.0;
-    property double timeBiasPitchValue : 0.0;
-    property double timeBiasRollValue : 0.0;
-    property double clipOffsetValue: 0.0;
-
-    Component.onCompleted: {
-        if (filter.isNew) { filter.set("analyze", false); } else { analyzeValue = filter.get("analyze"); }
-        if (filter.isNew) { filter.set("transformWhenAnalyzing", true); } else { transformWhenAnalyzingValue = filter.get("transformWhenAnalyzing"); }
-        if (filter.isNew) { filter.set("interpolation", 1); } else { interpolationValue = filter.get("interpolation"); }
-        if (filter.isNew) { filter.set("sampleRadius", 16); } else { sampleRadiusValue = filter.getDouble("sampleRadius");}
-        if (filter.isNew) { filter.set("searchRadius", 24); } else { searchRadiusValue = filter.getDouble("searchRadius");}
-        if (filter.isNew) { filter.set("offset", 64); } else { offsetValue = filter.getDouble("offset");}
-        if (filter.isNew) { filter.set("analysisFile", ""); } else { analysisFileValue = filter.get("analysisFile"); }
-        if (filter.isNew) { filter.set("useBackTrackpoints", false); } else { useBackTrackpointsValue = filter.get("useBackTrackpoints"); }
-
-        if (filter.isNew) { filter.set("stabilizeYaw", 100); } else { stabilizeYawValue = filter.getDouble("stabilizeYaw");}
-        if (filter.isNew) { filter.set("stabilizePitch", 100); } else { stabilizePitchValue = filter.getDouble("stabilizePitch");}
-        if (filter.isNew) { filter.set("stabilizeRoll", 100); } else { stabilizeRollValue = filter.getDouble("stabilizeRoll");}
-        if (filter.isNew) { filter.set("smoothYaw", 120); } else { smoothYawValue = filter.getDouble("smoothYaw");}
-        if (filter.isNew) { filter.set("smoothPitch", 120); } else { smoothPitchValue = filter.getDouble("smoothPitch");}
-        if (filter.isNew) { filter.set("smoothRoll", 120); } else { smoothRollValue = filter.getDouble("smoothRoll");}
-        if (filter.isNew) { filter.set("timeBiasYaw", 0); } else { timeBiasYawValue = filter.getDouble("timeBiasYaw");}
-        if (filter.isNew) { filter.set("timeBiasPitch", 0); } else { timeBiasPitchValue = filter.getDouble("timeBiasPitch");}
-        if (filter.isNew) { filter.set("timeBiasRoll", 0); } else { timeBiasRollValue = filter.getDouble("timeBiasRoll");}
-        if (filter.isNew) { filter.set("clipOffset", 0); } else { clipOffsetValue = filter.getDouble("clipOffset");}
-
-        if (filter.isNew) {
-            filter.savePreset(preset.parameters)
-        }
-        setControls()
-    }
+    property int interpolationValue: 0
+    property bool analyzeValue: false
+    property bool transformWhenAnalyzingValue: false
+    property double sampleRadiusValue: 0
+    property double searchRadiusValue: 0
+    property double offsetValue: 0
+    property string analysisFileValue: ""
+    property bool useBackTrackpointsValue: false
+    property double stabilizeYawValue: 0
+    property double stabilizePitchValue: 0
+    property double stabilizeRollValue: 0
+    property double smoothYawValue: 0
+    property double smoothPitchValue: 0
+    property double smoothRollValue: 0
+    property double timeBiasYawValue: 0
+    property double timeBiasPitchValue: 0
+    property double timeBiasRollValue: 0
+    property double clipOffsetValue: 0
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
+        var position = getPosition();
+        blockUpdate = true;
         analyzeCheckBox.checked = filter.get("analyze") == '1';
         transformWhenAnalyzingCheckBox.checked = filter.get("transformWhenAnalyzing") == '1';
-        interpolationComboBox.currentIndex = filter.get("interpolation")
-        sampleRadiusSlider.value = filter.getDouble("sampleRadius")
-        searchRadiusSlider.value = filter.getDouble("searchRadius")
-        offsetSlider.value = filter.getDouble("offset")
-        analysisFileTextField.text = filter.get("analysisFile")
+        interpolationComboBox.currentIndex = filter.get("interpolation");
+        sampleRadiusSlider.value = filter.getDouble("sampleRadius");
+        searchRadiusSlider.value = filter.getDouble("searchRadius");
+        offsetSlider.value = filter.getDouble("offset");
+        analysisFileTextField.text = filter.get("analysisFile");
         useBackTrackpointsCheckBox.checked = filter.get("useBackTrackpoints") == '1';
-        stabilizeYawSlider.value = filter.getDouble("stabilizeYaw")
-        stabilizePitchSlider.value = filter.getDouble("stabilizePitch")
-        stabilizeRollSlider.value = filter.getDouble("stabilizeRoll")
-        smoothYawSlider.value = filter.getDouble("smoothYaw")
-        smoothPitchSlider.value = filter.getDouble("smoothPitch")
-        smoothRollSlider.value = filter.getDouble("smoothRoll")
-        timeBiasYawSlider.value = filter.getDouble("timeBiasYaw")
-        timeBiasPitchSlider.value = filter.getDouble("timeBiasPitch")
-        timeBiasRollSlider.value = filter.getDouble("timeBiasRoll")
-        clipOffsetTextField.text = filter.getDouble("clipOffset").toFixed(4)
-
-        blockUpdate = false
+        stabilizeYawSlider.value = filter.getDouble("stabilizeYaw");
+        stabilizePitchSlider.value = filter.getDouble("stabilizePitch");
+        stabilizeRollSlider.value = filter.getDouble("stabilizeRoll");
+        smoothYawSlider.value = filter.getDouble("smoothYaw");
+        smoothPitchSlider.value = filter.getDouble("smoothPitch");
+        smoothRollSlider.value = filter.getDouble("smoothRoll");
+        timeBiasYawSlider.value = filter.getDouble("timeBiasYaw");
+        timeBiasPitchSlider.value = filter.getDouble("timeBiasPitch");
+        timeBiasRollSlider.value = filter.getDouble("timeBiasRoll");
+        clipOffsetTextField.text = filter.getDouble("clipOffset").toFixed(4);
+        blockUpdate = false;
     }
 
-    function updateProperty_analyze () { if (blockUpdate) return; var value = analyzeCheckBox.checked; filter.set("analyze", value); }
-    function updateProperty_transformWhenAnalyzing() { if (blockUpdate) return; var value = transformWhenAnalyzingCheckBox.checked; filter.set("transformWhenAnalyzing", value); }
-    function updateProperty_interpolation () { if (blockUpdate) return; var value = interpolationComboBox.currentIndex; filter.set("interpolation", value); }
-    function updateProperty_sampleRadius (position) { if (blockUpdate) return; var value = sampleRadiusSlider.value; filter.set("sampleRadius", value); }
-    function updateProperty_searchRadius (position) { if (blockUpdate) return; var value = searchRadiusSlider.value; filter.set("searchRadius", value); }
-    function updateProperty_offset (position) { if (blockUpdate) return; var value = offsetSlider.value; filter.set("offset", value); }
-    function updateProperty_analysisFile () { if (blockUpdate) return; var value = analysisFileTextField.text; filter.set("analysisFile", value); }
-    function updateProperty_useBackTrackpoints () { if (blockUpdate) return; var value = useBackTrackpointsCheckBox.checked; filter.set("useBackTrackpoints", value); }
-    function updateProperty_stabilizeYaw (position) { if (blockUpdate) return; var value = stabilizeYawSlider.value; filter.set("stabilizeYaw", value); }
-    function updateProperty_stabilizePitch (position) { if (blockUpdate) return; var value = stabilizePitchSlider.value; filter.set("stabilizePitch", value); }
-    function updateProperty_stabilizeRoll (position) { if (blockUpdate) return; var value = stabilizeRollSlider.value; filter.set("stabilizeRoll", value); }
-    function updateProperty_smoothYaw (position) { if (blockUpdate) return; var value = smoothYawSlider.value; filter.set("smoothYaw", value); }
-    function updateProperty_smoothPitch (position) { if (blockUpdate) return; var value = smoothPitchSlider.value; filter.set("smoothPitch", value); }
-    function updateProperty_smoothRoll (position) { if (blockUpdate) return; var value = smoothRollSlider.value; filter.set("smoothRoll", value); }
-    function updateProperty_timeBiasYaw (position) { if (blockUpdate) return; var value = timeBiasYawSlider.value; filter.set("timeBiasYaw", value); }
-    function updateProperty_timeBiasPitch (position) { if (blockUpdate) return; var value = timeBiasPitchSlider.value; filter.set("timeBiasPitch", value); }
-    function updateProperty_timeBiasRoll (position) { if (blockUpdate) return; var value = timeBiasRollSlider.value; filter.set("timeBiasRoll", value); }
-    function updateProperty_clipOffset (position) { if (blockUpdate) return; var value = parseFloat(clipOffsetTextField.text); filter.set("clipOffset", value); }
+    function updateProperty_analyze() {
+        if (blockUpdate)
+            return ;
 
+        var value = analyzeCheckBox.checked;
+        filter.set("analyze", value);
+    }
+
+    function updateProperty_transformWhenAnalyzing() {
+        if (blockUpdate)
+            return ;
+
+        var value = transformWhenAnalyzingCheckBox.checked;
+        filter.set("transformWhenAnalyzing", value);
+    }
+
+    function updateProperty_interpolation() {
+        if (blockUpdate)
+            return ;
+
+        var value = interpolationComboBox.currentIndex;
+        filter.set("interpolation", value);
+    }
+
+    function updateProperty_sampleRadius(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = sampleRadiusSlider.value;
+        filter.set("sampleRadius", value);
+    }
+
+    function updateProperty_searchRadius(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = searchRadiusSlider.value;
+        filter.set("searchRadius", value);
+    }
+
+    function updateProperty_offset(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = offsetSlider.value;
+        filter.set("offset", value);
+    }
+
+    function updateProperty_analysisFile() {
+        if (blockUpdate)
+            return ;
+
+        var value = analysisFileTextField.text;
+        filter.set("analysisFile", value);
+    }
+
+    function updateProperty_useBackTrackpoints() {
+        if (blockUpdate)
+            return ;
+
+        var value = useBackTrackpointsCheckBox.checked;
+        filter.set("useBackTrackpoints", value);
+    }
+
+    function updateProperty_stabilizeYaw(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = stabilizeYawSlider.value;
+        filter.set("stabilizeYaw", value);
+    }
+
+    function updateProperty_stabilizePitch(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = stabilizePitchSlider.value;
+        filter.set("stabilizePitch", value);
+    }
+
+    function updateProperty_stabilizeRoll(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = stabilizeRollSlider.value;
+        filter.set("stabilizeRoll", value);
+    }
+
+    function updateProperty_smoothYaw(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = smoothYawSlider.value;
+        filter.set("smoothYaw", value);
+    }
+
+    function updateProperty_smoothPitch(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = smoothPitchSlider.value;
+        filter.set("smoothPitch", value);
+    }
+
+    function updateProperty_smoothRoll(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = smoothRollSlider.value;
+        filter.set("smoothRoll", value);
+    }
+
+    function updateProperty_timeBiasYaw(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = timeBiasYawSlider.value;
+        filter.set("timeBiasYaw", value);
+    }
+
+    function updateProperty_timeBiasPitch(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = timeBiasPitchSlider.value;
+        filter.set("timeBiasPitch", value);
+    }
+
+    function updateProperty_timeBiasRoll(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = timeBiasRollSlider.value;
+        filter.set("timeBiasRoll", value);
+    }
+
+    function updateProperty_clipOffset(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = parseFloat(clipOffsetTextField.text);
+        filter.set("clipOffset", value);
+    }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function getFrameRate() {
-        return producer.getDouble("meta.media.frame_rate_num", getPosition()) / producer.getDouble("meta.media.frame_rate_den", getPosition())
+        return producer.getDouble("meta.media.frame_rate_num", getPosition()) / producer.getDouble("meta.media.frame_rate_den", getPosition());
     }
 
     function getClipOffset() {
-        return filter.in
+        return filter.in;
+    }
+
+    function toggleMode() {
+        if (blockUpdate)
+            return ;
+
+        if (analyzeCheckBox.checked && analysisFileTextField.text == "")
+            selectAnalysisFile.open();
+
+        updateProperty_analyze();
+    }
+
+    function onClipOffsetUndo() {
+        clipOffsetTextField.text = (getClipOffset() / getFrameRate()).toFixed(4);
+        updateProperty_clipOffset();
+    }
+
+    width: 350
+    height: 625
+    Component.onCompleted: {
+        if (filter.isNew)
+            filter.set("analyze", false);
+        else
+            analyzeValue = filter.get("analyze");
+        if (filter.isNew)
+            filter.set("transformWhenAnalyzing", true);
+        else
+            transformWhenAnalyzingValue = filter.get("transformWhenAnalyzing");
+        if (filter.isNew)
+            filter.set("interpolation", 1);
+        else
+            interpolationValue = filter.get("interpolation");
+        if (filter.isNew)
+            filter.set("sampleRadius", 16);
+        else
+            sampleRadiusValue = filter.getDouble("sampleRadius");
+        if (filter.isNew)
+            filter.set("searchRadius", 24);
+        else
+            searchRadiusValue = filter.getDouble("searchRadius");
+        if (filter.isNew)
+            filter.set("offset", 64);
+        else
+            offsetValue = filter.getDouble("offset");
+        if (filter.isNew)
+            filter.set("analysisFile", "");
+        else
+            analysisFileValue = filter.get("analysisFile");
+        if (filter.isNew)
+            filter.set("useBackTrackpoints", false);
+        else
+            useBackTrackpointsValue = filter.get("useBackTrackpoints");
+        if (filter.isNew)
+            filter.set("stabilizeYaw", 100);
+        else
+            stabilizeYawValue = filter.getDouble("stabilizeYaw");
+        if (filter.isNew)
+            filter.set("stabilizePitch", 100);
+        else
+            stabilizePitchValue = filter.getDouble("stabilizePitch");
+        if (filter.isNew)
+            filter.set("stabilizeRoll", 100);
+        else
+            stabilizeRollValue = filter.getDouble("stabilizeRoll");
+        if (filter.isNew)
+            filter.set("smoothYaw", 120);
+        else
+            smoothYawValue = filter.getDouble("smoothYaw");
+        if (filter.isNew)
+            filter.set("smoothPitch", 120);
+        else
+            smoothPitchValue = filter.getDouble("smoothPitch");
+        if (filter.isNew)
+            filter.set("smoothRoll", 120);
+        else
+            smoothRollValue = filter.getDouble("smoothRoll");
+        if (filter.isNew)
+            filter.set("timeBiasYaw", 0);
+        else
+            timeBiasYawValue = filter.getDouble("timeBiasYaw");
+        if (filter.isNew)
+            filter.set("timeBiasPitch", 0);
+        else
+            timeBiasPitchValue = filter.getDouble("timeBiasPitch");
+        if (filter.isNew)
+            filter.set("timeBiasRoll", 0);
+        else
+            timeBiasRollValue = filter.getDouble("timeBiasRoll");
+        if (filter.isNew)
+            filter.set("clipOffset", 0);
+        else
+            clipOffsetValue = filter.getDouble("clipOffset");
+        if (filter.isNew)
+            filter.savePreset(preset.parameters);
+
+        setControls();
     }
 
     FileDialog {
         id: selectAnalysisFile
+
         title: "File for motion analysis"
         folder: shortcuts.home
         modality: application.dialogModality
@@ -122,30 +311,14 @@ Item {
         selectExisting: false
         selectFolder: false
         nameFilters: ['Motion Analysis Files (*.bigsh0t360motion)', 'All Files (*)']
-
         onAccepted: {
-            var urlString = selectAnalysisFile.fileUrl.toString()
-            analysisFileTextField.text = urlString
-
-            updateProperty_analysisFile()
+            var urlString = selectAnalysisFile.fileUrl.toString();
+            analysisFileTextField.text = urlString;
+            updateProperty_analysisFile();
         }
         onRejected: {
         }
     }
-
-    function toggleMode() {
-        if (blockUpdate) return;
-        if (analyzeCheckBox.checked && analysisFileTextField.text == "") {
-            selectAnalysisFile.open()
-        }
-        updateProperty_analyze()
-    }
-
-    function onClipOffsetUndo() {
-        clipOffsetTextField.text = (getClipOffset() / getFrameRate()).toFixed(4)
-        updateProperty_clipOffset()
-    }
-
 
     GridLayout {
         columns: 4
@@ -156,25 +329,27 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ["sampleRadius", "searchRadius", "offset", "interpolation", "stabilizeYaw", "stabilizePitch", "stabilizeRoll", "smoothYaw", "smoothPitch", "smoothRoll", "timeBiasYaw", "timeBiasPitch", "timeBiasRoll"]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                filter.resetProperty("sampleRadius")
-                filter.resetProperty("searchRadius")
-                filter.resetProperty("offset")
-                filter.resetProperty("interpolation")
-                filter.resetProperty("stabilizeYaw")
-                filter.resetProperty("stabilizePitch")
-                filter.resetProperty("stabilizeRoll")
-                filter.resetProperty("smoothYaw")
-                filter.resetProperty("smoothPitch")
-                filter.resetProperty("smoothRoll")
-                filter.resetProperty("timeBiasYaw")
-                filter.resetProperty("timeBiasPitch")
-                filter.resetProperty("timeBiasRoll")
-                filter.resetProperty("clipOffset")
+                filter.resetProperty("sampleRadius");
+                filter.resetProperty("searchRadius");
+                filter.resetProperty("offset");
+                filter.resetProperty("interpolation");
+                filter.resetProperty("stabilizeYaw");
+                filter.resetProperty("stabilizePitch");
+                filter.resetProperty("stabilizeRoll");
+                filter.resetProperty("smoothYaw");
+                filter.resetProperty("smoothPitch");
+                filter.resetProperty("smoothRoll");
+                filter.resetProperty("timeBiasYaw");
+                filter.resetProperty("timeBiasPitch");
+                filter.resetProperty("timeBiasRoll");
+                filter.resetProperty("clipOffset");
             }
             onPresetSelected: {
                 sampleRadiusValue = filter.getDouble("sampleRadius");
@@ -191,7 +366,6 @@ Item {
                 timeBiasPitchValue = filter.getDouble("timeBiasPitch");
                 timeBiasRollValue = filter.getDouble("timeBiasRoll");
                 clipOffsetValue = filter.get("clipOffset");
-
                 setControls(null);
             }
         }
@@ -200,10 +374,12 @@ Item {
             text: qsTr('Mode')
             Layout.alignment: Qt.AlignRight
         }
+
         CheckBox {
+            id: analyzeCheckBox
+
             text: qsTr('Analyze')
             checked: false
-            id: analyzeCheckBox
             Layout.columnSpan: 3
             onCheckedChanged: toggleMode()
         }
@@ -212,39 +388,51 @@ Item {
             text: qsTr('File')
             Layout.alignment: Qt.AlignRight
         }
+
         TextField {
-            text: qsTr("")
             id: analysisFileTextField
+
+            text: qsTr("")
             Layout.columnSpan: 2
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignLeft
             selectByMouse: true
             onEditingFinished: updateProperty_analysisFile()
         }
+
         Shotcut.Button {
             icon.name: 'document-open'
             icon.source: 'qrc:///icons/oxygen/32x32/actions/document-open.png'
-            Shotcut.HoverTip { text: qsTr('Browse...') }
             implicitWidth: 20
             implicitHeight: 20
             onClicked: selectAnalysisFile.open()
+
+            Shotcut.HoverTip {
+                text: qsTr('Browse...')
+            }
+
         }
 
         Label {
             text: qsTr('Start Offset')
             Layout.alignment: Qt.AlignRight
         }
+
         TextField {
             id: clipOffsetTextField
+
             selectByMouse: true
             onEditingFinished: updateProperty_clipOffset()
         }
+
         Label {
             text: qsTr('seconds')
             Layout.fillWidth: true
         }
+
         Shotcut.UndoButton {
             id: clipOffsetUndo
+
             onClicked: onClipOffsetUndo()
         }
 
@@ -252,18 +440,21 @@ Item {
             text: qsTr('Interpolation')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
+            id: interpolationComboBox
+
             currentIndex: 0
             model: ["Nearest-neighbor", "Bilinear"]
-            id: interpolationComboBox
             Layout.columnSpan: 2
             onCurrentIndexChanged: updateProperty_interpolation()
         }
+
         Shotcut.UndoButton {
             id: interpolationUndo
+
             onClicked: interpolationComboBox.currentIndex = 0
         }
-
 
         Label {
             text: qsTr('Analysis')
@@ -271,10 +462,13 @@ Item {
             Layout.columnSpan: 4
         }
 
-        Label {}
+        Label {
+        }
+
         CheckBox {
-            text: qsTr('Apply transform')
             id: transformWhenAnalyzingCheckBox
+
+            text: qsTr('Apply transform')
             Layout.columnSpan: 3
             onCheckedChanged: updateProperty_transformWhenAnalyzing()
         }
@@ -283,8 +477,10 @@ Item {
             text: qsTr('Sample Radius')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sampleRadiusSlider
+
             minimumValue: 1
             maximumValue: 64
             suffix: ' px'
@@ -293,8 +489,10 @@ Item {
             Layout.columnSpan: 2
             onValueChanged: updateProperty_sampleRadius(getPosition())
         }
+
         Shotcut.UndoButton {
             id: sampleRadiusUndo
+
             onClicked: sampleRadiusSlider.value = 16
         }
 
@@ -302,8 +500,10 @@ Item {
             text: qsTr('Search Radius')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: searchRadiusSlider
+
             minimumValue: 1
             maximumValue: 128
             suffix: ' px'
@@ -312,8 +512,10 @@ Item {
             Layout.columnSpan: 2
             onValueChanged: updateProperty_searchRadius(getPosition())
         }
+
         Shotcut.UndoButton {
             id: searchRadiusUndo
+
             onClicked: searchRadiusSlider.value = 24
         }
 
@@ -321,8 +523,10 @@ Item {
             text: qsTr('Offset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: offsetSlider
+
             minimumValue: 1
             maximumValue: 256
             suffix: ' px'
@@ -331,8 +535,10 @@ Item {
             Layout.columnSpan: 2
             onValueChanged: updateProperty_offset(getPosition())
         }
+
         Shotcut.UndoButton {
             id: offsetUndo
+
             onClicked: offsetSlider.value = 64
         }
 
@@ -340,14 +546,15 @@ Item {
             text: qsTr('Track Points')
             Layout.alignment: Qt.AlignRight
         }
+
         CheckBox {
+            id: useBackTrackpointsCheckBox
+
             text: qsTr('Use backwards-facing track points')
             checked: false
-            id: useBackTrackpointsCheckBox
             Layout.columnSpan: 3
             onCheckedChanged: updateProperty_useBackTrackpoints()
         }
-
 
         Label {
             text: qsTr('Yaw')
@@ -359,8 +566,10 @@ Item {
             text: qsTr('Amount')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: stabilizeYawSlider
+
             minimumValue: 0
             maximumValue: 100
             suffix: ' %'
@@ -369,16 +578,21 @@ Item {
             Layout.columnSpan: 2
             onValueChanged: updateProperty_stabilizeYaw(getPosition())
         }
+
         Shotcut.UndoButton {
             id: stabilizeYawUndo
+
             onClicked: stabilizeYawSlider.value = 100
         }
+
         Label {
             text: qsTr('Smoothing')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: smoothYawSlider
+
             minimumValue: 1
             maximumValue: 300
             suffix: ' frames'
@@ -387,16 +601,21 @@ Item {
             Layout.columnSpan: 2
             onValueChanged: updateProperty_smoothYaw(getPosition())
         }
+
         Shotcut.UndoButton {
             id: smoothYawUndo
+
             onClicked: smoothYawSlider.value = 120
         }
+
         Label {
             text: qsTr('Time Bias')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: timeBiasYawSlider
+
             minimumValue: -100
             maximumValue: 100
             suffix: ' %'
@@ -405,8 +624,10 @@ Item {
             Layout.columnSpan: 2
             onValueChanged: updateProperty_timeBiasYaw(getPosition())
         }
+
         Shotcut.UndoButton {
             id: timeBiasYawUndo
+
             onClicked: timeBiasYawSlider.value = 0
         }
 
@@ -415,12 +636,15 @@ Item {
             Layout.alignment: Qt.AlignLeft
             Layout.columnSpan: 4
         }
+
         Label {
             text: qsTr('Amount')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: stabilizePitchSlider
+
             minimumValue: 0
             maximumValue: 100
             suffix: ' %'
@@ -429,16 +653,21 @@ Item {
             Layout.columnSpan: 2
             onValueChanged: updateProperty_stabilizePitch(getPosition())
         }
+
         Shotcut.UndoButton {
             id: stabilizePitchUndo
+
             onClicked: stabilizePitchSlider.value = 100
         }
+
         Label {
             text: qsTr('Smoothing')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: smoothPitchSlider
+
             minimumValue: 1
             maximumValue: 300
             suffix: ' frames'
@@ -447,16 +676,21 @@ Item {
             Layout.columnSpan: 2
             onValueChanged: updateProperty_smoothPitch(getPosition())
         }
+
         Shotcut.UndoButton {
             id: smoothPitchUndo
+
             onClicked: smoothPitchSlider.value = 120
         }
+
         Label {
             text: qsTr('Time Bias')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: timeBiasPitchSlider
+
             minimumValue: -100
             maximumValue: 100
             suffix: ' %'
@@ -465,8 +699,10 @@ Item {
             Layout.columnSpan: 2
             onValueChanged: updateProperty_timeBiasPitch(getPosition())
         }
+
         Shotcut.UndoButton {
             id: timeBiasPitchUndo
+
             onClicked: timeBiasPitchSlider.value = 0
         }
 
@@ -475,12 +711,15 @@ Item {
             Layout.alignment: Qt.AlignLeft
             Layout.columnSpan: 4
         }
+
         Label {
             text: qsTr('Amount')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: stabilizeRollSlider
+
             minimumValue: 0
             maximumValue: 100
             suffix: ' %'
@@ -489,16 +728,21 @@ Item {
             Layout.columnSpan: 2
             onValueChanged: updateProperty_stabilizeRoll(getPosition())
         }
+
         Shotcut.UndoButton {
             id: stabilizeRollUndo
+
             onClicked: stabilizeRollSlider.value = 100
         }
+
         Label {
             text: qsTr('Smoothing')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: smoothRollSlider
+
             minimumValue: 1
             maximumValue: 300
             suffix: ' frames'
@@ -507,8 +751,10 @@ Item {
             Layout.columnSpan: 2
             onValueChanged: updateProperty_smoothRoll(getPosition())
         }
+
         Shotcut.UndoButton {
             id: smoothRollUndo
+
             onClicked: smoothRollSlider.value = 120
         }
 
@@ -516,8 +762,10 @@ Item {
             text: qsTr('Time Bias')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: timeBiasRollSlider
+
             minimumValue: -100
             maximumValue: 100
             suffix: ' %'
@@ -526,27 +774,53 @@ Item {
             Layout.columnSpan: 2
             onValueChanged: updateProperty_timeBiasRoll(getPosition())
         }
+
         Shotcut.UndoButton {
             id: timeBiasRollUndo
+
             onClicked: timeBiasRollSlider.value = 0
         }
+
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            setControls();
+        }
+
+        function onOutChanged() {
+            setControls();
+        }
+
+        function onAnimateInChanged() {
+            setControls();
+        }
+
+        function onAnimateOutChanged() {
+            setControls();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { setControls() }
-        function onOutChanged() { setControls() }
-        function onAnimateInChanged() { setControls() }
-        function onAnimateOutChanged() { setControls() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/bigsh0t_transform_360/meta.qml
+++ b/src/qml/filters/bigsh0t_transform_360/meta.qml
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0-or-later */
+// SPDX-License-Identifier: GPL-2.0-or-later
 import QtQuick 2.0
 import org.shotcut.qml 1.0
 
@@ -9,6 +9,7 @@ Metadata {
     objectName: "bigsh0t_transform_360"
     qml: "ui.qml"
     vui: "vui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -37,4 +38,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/bigsh0t_transform_360/ui.qml
+++ b/src/qml/filters/bigsh0t_transform_360/ui.qml
@@ -1,77 +1,220 @@
-
-
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
-
 Item {
-    width: 350
-    height: 180
     property bool blockUpdate: true
-
-    property double yawStart : 0.0; property double yawMiddle : 0.0; property double yawEnd : 0.0;
-    property double pitchStart : 0.0; property double pitchMiddle : 0.0; property double pitchEnd : 0.0;
-    property double rollStart : 0.0; property double rollMiddle : 0.0; property double rollEnd : 0.0;
-    property int interpolationValue : 0;
+    property double yawStart: 0
+    property double yawMiddle: 0
+    property double yawEnd: 0
+    property double pitchStart: 0
+    property double pitchMiddle: 0
+    property double pitchEnd: 0
+    property double rollStart: 0
+    property double rollMiddle: 0
+    property double rollEnd: 0
+    property int interpolationValue: 0
     property bool gridValue: false
 
     function updateSimpleKeyframes() {
         if (filter.animateIn > 0 || filter.animateOut > 0) {
             // When enabling simple keyframes, initialize the keyframes with the current value
-            if (filter.keyframeCount("yaw") <= 0) {
-                yawStart = yawMiddle = yawEnd = filter.getDouble("yaw")
-            }
-            if (filter.keyframeCount("pitch") <= 0) {
-                pitchStart = pitchMiddle = pitchEnd = filter.getDouble("pitch")
-            }
-            if (filter.keyframeCount("roll") <= 0) {
-                rollStart = rollMiddle = rollEnd = filter.getDouble("roll")
-            }
-        }
-        setControls()
-        updateProperty_yaw (null)
-        updateProperty_pitch (null)
-        updateProperty_roll (null)
-        updateProperty_interpolation ()
-    }
+            if (filter.keyframeCount("yaw") <= 0)
+                yawStart = yawMiddle = yawEnd = filter.getDouble("yaw");
 
-    Component.onCompleted: {
-        if (filter.isNew) { filter.set("yaw", 0); } else { yawMiddle = filter.getDouble("yaw", filter.animateIn); if (filter.animateIn > 0) { yawStart = filter.getDouble("yaw", 0); } if (filter.animateOut > 0) { yawEnd = filter.getDouble("yaw", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("pitch", 0); } else { pitchMiddle = filter.getDouble("pitch", filter.animateIn); if (filter.animateIn > 0) { pitchStart = filter.getDouble("pitch", 0); } if (filter.animateOut > 0) { pitchEnd = filter.getDouble("pitch", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("roll", 0); } else { rollMiddle = filter.getDouble("roll", filter.animateIn); if (filter.animateIn > 0) { rollStart = filter.getDouble("roll", 0); } if (filter.animateOut > 0) { rollEnd = filter.getDouble("roll", filter.duration - 1); } }
-        if (filter.isNew) { filter.set("interpolation", 1); } else { interpolationValue = filter.get("interpolation"); }
-        if (filter.isNew) { filter.set("grid", false); } else { gridValue = filter.get("grid") == '1'; }
+            if (filter.keyframeCount("pitch") <= 0)
+                pitchStart = pitchMiddle = pitchEnd = filter.getDouble("pitch");
 
-        if (filter.isNew) {
-            filter.savePreset(preset.parameters)
+            if (filter.keyframeCount("roll") <= 0)
+                rollStart = rollMiddle = rollEnd = filter.getDouble("roll");
+
         }
-        setControls()
+        setControls();
+        updateProperty_yaw(null);
+        updateProperty_pitch(null);
+        updateProperty_roll(null);
+        updateProperty_interpolation();
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        yawSlider.value = filter.getDouble("yaw", position)
-        yawKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("yaw") > 0
-        pitchSlider.value = filter.getDouble("pitch", position)
-        pitchKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("pitch") > 0
-        rollSlider.value = filter.getDouble("roll", position)
-        rollKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("roll") > 0
-        interpolationComboBox.currentIndex = filter.get("interpolation")
+        var position = getPosition();
+        blockUpdate = true;
+        yawSlider.value = filter.getDouble("yaw", position);
+        yawKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("yaw") > 0;
+        pitchSlider.value = filter.getDouble("pitch", position);
+        pitchKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("pitch") > 0;
+        rollSlider.value = filter.getDouble("roll", position);
+        rollKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount("roll") > 0;
+        interpolationComboBox.currentIndex = filter.get("interpolation");
         gridCheckBox.checked = filter.get("grid") == '1';
-        blockUpdate = false
+        blockUpdate = false;
     }
 
-    function updateProperty_yaw (position) { if (blockUpdate) return; var value = yawSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { yawStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { yawEnd = value; } else { yawMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("yaw"); yawKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("yaw", yawStart, 0); filter.set("yaw", yawMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("yaw", yawMiddle, filter.duration - filter.animateOut); filter.set("yaw", yawEnd, filter.duration - 1); } } else if (!yawKeyframesButton.checked) { filter.resetProperty("yaw"); filter.set("yaw", yawMiddle); } else if (position !== null) { filter.set("yaw", value, position); } }
-    function updateProperty_pitch (position) { if (blockUpdate) return; var value = pitchSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { pitchStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { pitchEnd = value; } else { pitchMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("pitch"); pitchKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("pitch", pitchStart, 0); filter.set("pitch", pitchMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("pitch", pitchMiddle, filter.duration - filter.animateOut); filter.set("pitch", pitchEnd, filter.duration - 1); } } else if (!pitchKeyframesButton.checked) { filter.resetProperty("pitch"); filter.set("pitch", pitchMiddle); } else if (position !== null) { filter.set("pitch", value, position); } }
-    function updateProperty_roll (position) { if (blockUpdate) return; var value = rollSlider.value; if (position !== null) { if (position <= 0 && filter.animateIn > 0) { rollStart = value; } else if (position >= filter.duration - 1 && filter.animateOut > 0) { rollEnd = value; } else { rollMiddle = value; } } if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("roll"); rollKeyframesButton.checked = false; if (filter.animateIn > 0) { filter.set("roll", rollStart, 0); filter.set("roll", rollMiddle, filter.animateIn - 1); } if (filter.animateOut > 0) { filter.set("roll", rollMiddle, filter.duration - filter.animateOut); filter.set("roll", rollEnd, filter.duration - 1); } } else if (!rollKeyframesButton.checked) { filter.resetProperty("roll"); filter.set("roll", rollMiddle); } else if (position !== null) { filter.set("roll", value, position); } }
-    function updateProperty_interpolation () { if (blockUpdate) return; var value = interpolationComboBox.currentIndex; filter.set("interpolation", value); }
-    function updateProperty_grid () { if (blockUpdate) return; var value = gridCheckBox.checked; filter.set("grid", value); }
+    function updateProperty_yaw(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = yawSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                yawStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                yawEnd = value;
+            else
+                yawMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("yaw");
+            yawKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("yaw", yawStart, 0);
+                filter.set("yaw", yawMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("yaw", yawMiddle, filter.duration - filter.animateOut);
+                filter.set("yaw", yawEnd, filter.duration - 1);
+            }
+        } else if (!yawKeyframesButton.checked) {
+            filter.resetProperty("yaw");
+            filter.set("yaw", yawMiddle);
+        } else if (position !== null) {
+            filter.set("yaw", value, position);
+        }
+    }
+
+    function updateProperty_pitch(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = pitchSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                pitchStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                pitchEnd = value;
+            else
+                pitchMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("pitch");
+            pitchKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("pitch", pitchStart, 0);
+                filter.set("pitch", pitchMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("pitch", pitchMiddle, filter.duration - filter.animateOut);
+                filter.set("pitch", pitchEnd, filter.duration - 1);
+            }
+        } else if (!pitchKeyframesButton.checked) {
+            filter.resetProperty("pitch");
+            filter.set("pitch", pitchMiddle);
+        } else if (position !== null) {
+            filter.set("pitch", value, position);
+        }
+    }
+
+    function updateProperty_roll(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = rollSlider.value;
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                rollStart = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                rollEnd = value;
+            else
+                rollMiddle = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty("roll");
+            rollKeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                filter.set("roll", rollStart, 0);
+                filter.set("roll", rollMiddle, filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set("roll", rollMiddle, filter.duration - filter.animateOut);
+                filter.set("roll", rollEnd, filter.duration - 1);
+            }
+        } else if (!rollKeyframesButton.checked) {
+            filter.resetProperty("roll");
+            filter.set("roll", rollMiddle);
+        } else if (position !== null) {
+            filter.set("roll", value, position);
+        }
+    }
+
+    function updateProperty_interpolation() {
+        if (blockUpdate)
+            return ;
+
+        var value = interpolationComboBox.currentIndex;
+        filter.set("interpolation", value);
+    }
+
+    function updateProperty_grid() {
+        if (blockUpdate)
+            return ;
+
+        var value = gridCheckBox.checked;
+        filter.set("grid", value);
+    }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
+    }
+
+    width: 350
+    height: 180
+    Component.onCompleted: {
+        if (filter.isNew) {
+            filter.set("yaw", 0);
+        } else {
+            yawMiddle = filter.getDouble("yaw", filter.animateIn);
+            if (filter.animateIn > 0)
+                yawStart = filter.getDouble("yaw", 0);
+
+            if (filter.animateOut > 0)
+                yawEnd = filter.getDouble("yaw", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("pitch", 0);
+        } else {
+            pitchMiddle = filter.getDouble("pitch", filter.animateIn);
+            if (filter.animateIn > 0)
+                pitchStart = filter.getDouble("pitch", 0);
+
+            if (filter.animateOut > 0)
+                pitchEnd = filter.getDouble("pitch", filter.duration - 1);
+
+        }
+        if (filter.isNew) {
+            filter.set("roll", 0);
+        } else {
+            rollMiddle = filter.getDouble("roll", filter.animateIn);
+            if (filter.animateIn > 0)
+                rollStart = filter.getDouble("roll", 0);
+
+            if (filter.animateOut > 0)
+                rollEnd = filter.getDouble("roll", filter.duration - 1);
+
+        }
+        if (filter.isNew)
+            filter.set("interpolation", 1);
+        else
+            interpolationValue = filter.get("interpolation");
+        if (filter.isNew)
+            filter.set("grid", false);
+        else
+            gridValue = filter.get("grid") == '1';
+        if (filter.isNew)
+            filter.savePreset(preset.parameters);
+
+        setControls();
     }
 
     GridLayout {
@@ -83,20 +226,40 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ["yaw", "pitch", "roll", "interpolation"]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                filter.resetProperty('yaw')
-                filter.resetProperty('pitch')
-                filter.resetProperty('roll')
-                filter.resetProperty('interpolation')
+                filter.resetProperty('yaw');
+                filter.resetProperty('pitch');
+                filter.resetProperty('roll');
+                filter.resetProperty('interpolation');
             }
             onPresetSelected: {
-                yawMiddle = filter.getDouble("yaw", filter.animateIn); if (filter.animateIn > 0) { yawStart = filter.getDouble("yaw", 0); } if (filter.animateOut > 0) { yawEnd = filter.getDouble("yaw", filter.duration - 1); }
-                pitchMiddle = filter.getDouble("pitch", filter.animateIn); if (filter.animateIn > 0) { pitchStart = filter.getDouble("pitch", 0); } if (filter.animateOut > 0) { pitchEnd = filter.getDouble("pitch", filter.duration - 1); }
-                rollMiddle = filter.getDouble("roll", filter.animateIn); if (filter.animateIn > 0) { rollStart = filter.getDouble("roll", 0); } if (filter.animateOut > 0) { rollEnd = filter.getDouble("roll", filter.duration - 1); }
+                yawMiddle = filter.getDouble("yaw", filter.animateIn);
+                if (filter.animateIn > 0)
+                    yawStart = filter.getDouble("yaw", 0);
+
+                if (filter.animateOut > 0)
+                    yawEnd = filter.getDouble("yaw", filter.duration - 1);
+
+                pitchMiddle = filter.getDouble("pitch", filter.animateIn);
+                if (filter.animateIn > 0)
+                    pitchStart = filter.getDouble("pitch", 0);
+
+                if (filter.animateOut > 0)
+                    pitchEnd = filter.getDouble("pitch", filter.duration - 1);
+
+                rollMiddle = filter.getDouble("roll", filter.animateIn);
+                if (filter.animateIn > 0)
+                    rollStart = filter.getDouble("roll", 0);
+
+                if (filter.animateOut > 0)
+                    rollEnd = filter.getDouble("roll", filter.duration - 1);
+
                 interpolationValue = filter.get("interpolation");
                 setControls(null);
             }
@@ -106,94 +269,209 @@ Item {
             text: qsTr('Interpolation')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
+            id: interpolationComboBox
+
             currentIndex: 0
             model: ["Nearest-neighbor", "Bilinear"]
-            id: interpolationComboBox
             onCurrentIndexChanged: updateProperty_interpolation()
         }
+
         Shotcut.UndoButton {
             id: interpolationUndo
+
             onClicked: interpolationComboBox.currentIndex = 0
         }
-        Item { Layout.fillWidth: true }
+
+        Item {
+            Layout.fillWidth: true
+        }
 
         Label {
             text: qsTr('Yaw')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: yawSlider
+
             minimumValue: -360
             maximumValue: 360
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_yaw(getPosition())
         }
+
         Shotcut.UndoButton {
             id: yawUndo
+
             onClicked: yawSlider.value = 0
         }
-        Shotcut.KeyframesButton { id: yawKeyframesButton; onToggled: { var value = yawSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("yaw"); yawSlider.enabled = true; } filter.clearSimpleAnimation("yaw"); blockUpdate = false; filter.set("yaw", value, getPosition()); } else { filter.resetProperty("yaw"); filter.set("yaw", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: yawKeyframesButton
+
+            onToggled: {
+                var value = yawSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("yaw");
+                        yawSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("yaw");
+                    blockUpdate = false;
+                    filter.set("yaw", value, getPosition());
+                } else {
+                    filter.resetProperty("yaw");
+                    filter.set("yaw", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Pitch', 'rotation around the side-to-side axis (roll, pitch, yaw)')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: pitchSlider
+
             minimumValue: -180
             maximumValue: 180
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_pitch(getPosition())
         }
+
         Shotcut.UndoButton {
             id: pitchUndo
+
             onClicked: pitchSlider.value = 0
         }
-        Shotcut.KeyframesButton { id: pitchKeyframesButton; onToggled: { var value = pitchSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("pitch"); pitchSlider.enabled = true; } filter.clearSimpleAnimation("pitch"); blockUpdate = false; filter.set("pitch", value, getPosition()); } else { filter.resetProperty("pitch"); filter.set("pitch", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: pitchKeyframesButton
+
+            onToggled: {
+                var value = pitchSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("pitch");
+                        pitchSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("pitch");
+                    blockUpdate = false;
+                    filter.set("pitch", value, getPosition());
+                } else {
+                    filter.resetProperty("pitch");
+                    filter.set("pitch", value);
+                }
+            }
+        }
 
         Label {
             text: qsTr('Roll')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: rollSlider
+
             minimumValue: -180
             maximumValue: 180
-            spinnerWidth: 120; suffix: ' deg'; decimals: 3; stepSize: 1;
+            spinnerWidth: 120
+            suffix: ' deg'
+            decimals: 3
+            stepSize: 1
             onValueChanged: updateProperty_roll(getPosition())
         }
+
         Shotcut.UndoButton {
             id: rollUndo
+
             onClicked: rollSlider.value = 0
         }
-        Shotcut.KeyframesButton { id: rollKeyframesButton; onToggled: { var value = rollSlider.value; if (checked) { blockUpdate = true; if (filter.animateIn > 0 || filter.animateOut > 0) { filter.resetProperty("roll"); rollSlider.enabled = true; } filter.clearSimpleAnimation("roll"); blockUpdate = false; filter.set("roll", value, getPosition()); } else { filter.resetProperty("roll"); filter.set("roll", value); } } }
+
+        Shotcut.KeyframesButton {
+            id: rollKeyframesButton
+
+            onToggled: {
+                var value = rollSlider.value;
+                if (checked) {
+                    blockUpdate = true;
+                    if (filter.animateIn > 0 || filter.animateOut > 0) {
+                        filter.resetProperty("roll");
+                        rollSlider.enabled = true;
+                    }
+                    filter.clearSimpleAnimation("roll");
+                    blockUpdate = false;
+                    filter.set("roll", value, getPosition());
+                } else {
+                    filter.resetProperty("roll");
+                    filter.set("roll", value);
+                }
+            }
+        }
+
         Item {
             Layout.fillHeight: true
         }
 
-        Label {}
+        Label {
+        }
+
         CheckBox {
+            id: gridCheckBox
+
             text: qsTr('Show grid')
             checked: false
-            id: gridCheckBox
             Layout.columnSpan: 3
             onCheckedChanged: updateProperty_grid()
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/bigsh0t_transform_360/vui.qml
+++ b/src/qml/filters/bigsh0t_transform_360/vui.qml
@@ -24,72 +24,76 @@ Shotcut.VuiBase {
     property var middleValues: []
     property var endValues: []
 
+    function clamp(x, min, max) {
+        return Math.max(min, Math.min(max, x));
+    }
+
+    function getPosition() {
+        return Math.max(producer.position - (filter.in - producer.in), 0);
+    }
+
+    function updateProperty(name, value) {
+        var index = keyframableParameters.indexOf(name);
+        var position = getPosition();
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                startValues[index] = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                endValues[index] = value;
+            else
+                middleValues[index] = value;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            filter.resetProperty(name);
+            if (filter.animateIn > 0) {
+                filter.set(name, startValues[index], 0);
+                filter.set(name, middleValues[index], filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                filter.set(name, middleValues[index], filter.duration - filter.animateOut);
+                filter.set(name, endValues[index], filter.duration - 1);
+            }
+        } else if (filter.keyframeCount(name) <= 0) {
+            filter.resetProperty(name);
+            filter.set(name, middleValues[index]);
+        } else if (position !== null) {
+            filter.set(name, value, position);
+        }
+    }
+
     Connections {
+        function onChanged() {
+            mouseArea.enabled = filter.get('disable') !== '1';
+        }
+
         target: filter
-        function onChanged() { mouseArea.enabled = filter.get('disable') !== '1' }
     }
 
     MouseArea {
         id: mouseArea
-        anchors.fill: parent
 
         property double startYaw
         property double startPitch
         property double startRoll
         property int startX
         property int startY
+
+        anchors.fill: parent
         onPressed: {
-            startX = mouse.x
-            startY = mouse.y
-            startYaw = filter.getDouble('yaw', getPosition())
-            startPitch = filter.getDouble('pitch', getPosition())
-            startRoll = filter.getDouble('roll', getPosition())
+            startX = mouse.x;
+            startY = mouse.y;
+            startYaw = filter.getDouble('yaw', getPosition());
+            startPitch = filter.getDouble('pitch', getPosition());
+            startRoll = filter.getDouble('roll', getPosition());
         }
         onPositionChanged: {
             if (mouse.modifiers == Qt.ControlModifier) {
-                updateProperty('roll', clamp(startRoll + 0.5 * (startY - mouse.y), -180, 180))
+                updateProperty('roll', clamp(startRoll + 0.5 * (startY - mouse.y), -180, 180));
             } else {
-                updateProperty('yaw', clamp(startYaw + 0.2 * (startX - mouse.x), -360, 360))
-                updateProperty('pitch', clamp(startPitch + 0.1 * (mouse.y - startY), -180, 180))
+                updateProperty('yaw', clamp(startYaw + 0.2 * (startX - mouse.x), -360, 360));
+                updateProperty('pitch', clamp(startPitch + 0.1 * (mouse.y - startY), -180, 180));
             }
         }
     }
 
-    function clamp(x, min, max) {
-        return Math.max(min, Math.min(max, x))
-    }
-
-    function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
-    }
-
-    function updateProperty(name, value) {
-        var index = keyframableParameters.indexOf(name)
-        var position = getPosition()
-
-        if (position !== null) {
-            if (position <= 0 && filter.animateIn > 0) {
-                startValues[index] = value
-            } else if (position >= filter.duration - 1 && filter.animateOut > 0) {
-                endValues[index] = value
-            } else {
-                middleValues[index] = value
-            }
-        } if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(name)
-            if (filter.animateIn > 0) {
-                filter.set(name, startValues[index], 0)
-                filter.set(name, middleValues[index], filter.animateIn - 1)
-            }
-            if (filter.animateOut > 0) {
-                filter.set(name, middleValues[index], filter.duration - filter.animateOut)
-                filter.set(name, endValues[index], filter.duration - 1)
-            }
-        } else if (filter.keyframeCount(name) <= 0) {
-            filter.resetProperty(name)
-            filter.set(name, middleValues[index])
-        } else if (position !== null) {
-            filter.set(name, value, position)
-        }
-    }
 }

--- a/src/qml/filters/blend_mode/ui.qml
+++ b/src/qml/filters/blend_mode/ui.qml
@@ -22,20 +22,21 @@ import Shotcut.Controls 1.0 as Shotcut
 
 Item {
     property string propertyName: 'mode'
+
     width: 100
     height: 50
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            combo.currentIndex = 0
-            filter.set(propertyName, comboItems.get(0).value)
+            combo.currentIndex = 0;
+            filter.set(propertyName, comboItems.get(0).value);
         } else {
             // Initialize parameter values
-            var value = filter.get(propertyName)
+            var value = filter.get(propertyName);
             for (var i = 0; i < comboItems.count; i++) {
                 if (value === comboItems.get(i).value) {
-                    combo.currentIndex = i
-                    break
+                    combo.currentIndex = i;
+                    break;
                 }
             }
         }
@@ -46,41 +47,122 @@ Item {
         anchors.margins: 8
         columns: 4
 
-        Label { text: qsTr('Blend mode') }
+        Label {
+            text: qsTr('Blend mode')
+        }
+
         Shotcut.ComboBox {
             id: combo
-            model: ListModel {
-                id: comboItems
-                ListElement { text: qsTr('Over'); value: 'normal' }
-                ListElement { text: qsTr('None'); value: '' }
-                ListElement { text: qsTr('Add'); value: 'add' }
-                ListElement { text: qsTr('Saturate'); value: 'saturate' }
-                ListElement { text: qsTr('Multiply'); value: 'multiply' }
-                ListElement { text: qsTr('Screen'); value: 'screen' }
-                ListElement { text: qsTr('Overlay'); value: 'overlay' }
-                ListElement { text: qsTr('Darken'); value: 'darken' }
-                ListElement { text: qsTr('Dodge'); value: 'colordodge' }
-                ListElement { text: qsTr('Burn'); value: 'colorburn' }
-                ListElement { text: qsTr('Hard Light'); value: 'hardlight' }
-                ListElement { text: qsTr('Soft Light'); value: 'softlight' }
-                ListElement { text: qsTr('Difference'); value: 'difference' }
-                ListElement { text: qsTr('Exclusion'); value: 'exclusion' }
-                ListElement { text: qsTr('HSL Hue'); value: 'hslhue' }
-                ListElement { text: qsTr('HSL Saturation'); value: 'hslsaturatation' }
-                ListElement { text: qsTr('HSL Color'); value: 'hslcolor' }
-                ListElement { text: qsTr('HSL Luminosity'); value: 'hslluminocity' }
-            }
+
             textRole: 'text'
             onActivated: {
-                filter.set(propertyName, comboItems.get(currentIndex).value)
+                filter.set(propertyName, comboItems.get(currentIndex).value);
             }
+
+            model: ListModel {
+                id: comboItems
+
+                ListElement {
+                    text: qsTr('Over')
+                    value: 'normal'
+                }
+
+                ListElement {
+                    text: qsTr('None')
+                    value: ''
+                }
+
+                ListElement {
+                    text: qsTr('Add')
+                    value: 'add'
+                }
+
+                ListElement {
+                    text: qsTr('Saturate')
+                    value: 'saturate'
+                }
+
+                ListElement {
+                    text: qsTr('Multiply')
+                    value: 'multiply'
+                }
+
+                ListElement {
+                    text: qsTr('Screen')
+                    value: 'screen'
+                }
+
+                ListElement {
+                    text: qsTr('Overlay')
+                    value: 'overlay'
+                }
+
+                ListElement {
+                    text: qsTr('Darken')
+                    value: 'darken'
+                }
+
+                ListElement {
+                    text: qsTr('Dodge')
+                    value: 'colordodge'
+                }
+
+                ListElement {
+                    text: qsTr('Burn')
+                    value: 'colorburn'
+                }
+
+                ListElement {
+                    text: qsTr('Hard Light')
+                    value: 'hardlight'
+                }
+
+                ListElement {
+                    text: qsTr('Soft Light')
+                    value: 'softlight'
+                }
+
+                ListElement {
+                    text: qsTr('Difference')
+                    value: 'difference'
+                }
+
+                ListElement {
+                    text: qsTr('Exclusion')
+                    value: 'exclusion'
+                }
+
+                ListElement {
+                    text: qsTr('HSL Hue')
+                    value: 'hslhue'
+                }
+
+                ListElement {
+                    text: qsTr('HSL Saturation')
+                    value: 'hslsaturatation'
+                }
+
+                ListElement {
+                    text: qsTr('HSL Color')
+                    value: 'hslcolor'
+                }
+
+                ListElement {
+                    text: qsTr('HSL Luminosity')
+                    value: 'hslluminocity'
+                }
+
+            }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filter.set(propertyName, comboItems.get(0).value)
-                combo.currentIndex = 0
+                filter.set(propertyName, comboItems.get(0).value);
+                combo.currentIndex = 0;
             }
         }
+
         Item {
             Layout.fillWidth: true
         }
@@ -88,5 +170,7 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/bluescreen0r/ui.qml
+++ b/src/qml/filters/bluescreen0r/ui.qml
@@ -26,19 +26,20 @@ Item {
     property string distanceParam: '1'
     property double distanceDefault: 28.8
     property var defaultParameters: [colorParam, distanceParam]
+
     width: 350
     height: 50
     Component.onCompleted: {
-        presetItem.parameters = defaultParameters
-        filter.set('threads', 0)
+        presetItem.parameters = defaultParameters;
+        filter.set('threads', 0);
         if (filter.isNew) {
             // Set default parameter values
-            filter.set(colorParam, colorDefault)
-            filter.set(distanceParam, distanceDefault / 100)
-            filter.savePreset(defaultParameters)
+            filter.set(colorParam, colorDefault);
+            filter.set(distanceParam, distanceDefault / 100);
+            filter.savePreset(defaultParameters);
         }
-        colorPicker.value = filter.get(colorParam)
-        distanceSlider.value = filter.getDouble(distanceParam) * 100
+        colorPicker.value = filter.get(colorParam);
+        distanceSlider.value = filter.getDouble(distanceParam) * 100;
     }
 
     GridLayout {
@@ -50,12 +51,14 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: presetItem
+
             Layout.columnSpan: 2
             onPresetSelected: {
-                colorPicker.value = filter.get(colorParam)
-                distanceSlider.value = filter.getDouble(distanceParam) * 100
+                colorPicker.value = filter.get(colorParam);
+                distanceSlider.value = filter.getDouble(distanceParam) * 100;
             }
         }
 
@@ -64,15 +67,18 @@ Item {
             text: qsTr('Key color')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ColorPicker {
             id: colorPicker
+
             onValueChanged: {
-                filter.set(colorParam, value)
-                filter.set('disable', 0)
+                filter.set(colorParam, value);
+                filter.set('disable', 0);
             }
             onPickStarted: filter.set('disable', 1)
             onPickCancelled: filter.set('disable', 0)
         }
+
         Shotcut.UndoButton {
             onClicked: colorPicker.value = colorDefault
         }
@@ -82,8 +88,10 @@ Item {
             text: qsTr('Distance')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: distanceSlider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -91,6 +99,7 @@ Item {
             value: filter.getDouble(distanceParam) * 100
             onValueChanged: filter.set(distanceParam, value / 100)
         }
+
         Shotcut.UndoButton {
             onClicked: distanceSlider.value = distanceDefault
         }
@@ -98,5 +107,7 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/blur/meta_box_blur.qml
+++ b/src/qml/filters/blur/meta_box_blur.qml
@@ -7,6 +7,7 @@ Metadata {
     mlt_service: "box_blur"
     qml: "ui_box_blur.qml"
     gpuAlt: "movit.blur"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -28,4 +29,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/blur/meta_boxblur.qml
+++ b/src/qml/filters/blur/meta_boxblur.qml
@@ -8,6 +8,7 @@ Metadata {
     qml: "ui_boxblur.qml"
     gpuAlt: "movit.blur"
     isHidden: true
+
     keyframes {
         minimumVersion: '3'
         allowAnimateIn: true
@@ -30,4 +31,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/blur/meta_movit.qml
+++ b/src/qml/filters/blur/meta_movit.qml
@@ -7,6 +7,7 @@ Metadata {
     mlt_service: "movit.blur"
     needsGPU: true
     qml: "ui_movit.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -21,4 +22,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/blur/ui_box_blur.qml
+++ b/src/qml/filters/blur/ui_box_blur.qml
@@ -21,45 +21,44 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Shotcut.KeyframableFilter {
+    function getPosition() {
+        return Math.max(producer.position - (filter.in - producer.in), 0);
+    }
+
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        wslider.value = filter.getDouble('hradius', position);
+        widthKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('hradius') > 0;
+        hslider.value = filter.getDouble('vradius', position);
+        heightKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('vradius') > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        wslider.enabled = hslider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        updateFilter('hradius', wslider.value, widthKeyframesButton, null);
+        updateFilter('vradius', hslider.value, heightKeyframesButton, null);
+    }
+
     width: 200
     height: 50
     keyframableParameters: ['hradius', 'vradius']
     startValues: [0, 0]
     middleValues: [5, 5]
     endValues: [0, 0]
-
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set('hradius', 5)
-            filter.set('vradius', 5)
-            filter.savePreset(preset.parameters)
+            filter.set('hradius', 5);
+            filter.set('vradius', 5);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
-    }
-    
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        wslider.value = filter.getDouble('hradius', position)
-        widthKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('hradius') > 0
-        hslider.value = filter.getDouble('vradius', position)
-        heightKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('vradius') > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        wslider.enabled = hslider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        updateFilter('hradius', wslider.value, widthKeyframesButton, null)
-        updateFilter('vradius', hslider.value, heightKeyframesButton, null)
+        setControls();
     }
 
     GridLayout {
@@ -71,17 +70,19 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: parent.columns - 1
             parameters: ['hradius', 'vradius']
             onBeforePresetLoaded: {
-                filter.resetProperty('hradius')
-                filter.resetProperty('vradius')
+                filter.resetProperty('hradius');
+                filter.resetProperty('vradius');
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -89,23 +90,28 @@ Shotcut.KeyframableFilter {
             text: qsTr('Width')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: wslider
+
             minimumValue: 0
             maximumValue: 100
-            stepSize: .1
+            stepSize: 0.1
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter('hradius', wslider.value, widthKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: wslider.value = 5
         }
+
         Shotcut.KeyframesButton {
             id: widthKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, 'hradius', wslider.value)
+                enableControls(true);
+                toggleKeyframes(checked, 'hradius', wslider.value);
             }
         }
 
@@ -113,43 +119,71 @@ Shotcut.KeyframableFilter {
             text: qsTr('Height')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: hslider
+
             minimumValue: 0
             maximumValue: 100
-            stepSize: .1
+            stepSize: 0.1
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter('vradius', hslider.value, heightKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: hslider.value = 5
         }
+
         Shotcut.KeyframesButton {
             id: heightKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, 'vradius', hslider.value)
+                enableControls(true);
+                toggleKeyframes(checked, 'vradius', hslider.value);
             }
         }
 
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/blur/ui_boxblur.qml
+++ b/src/qml/filters/blur/ui_boxblur.qml
@@ -21,8 +21,6 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 200
-    height: 50
     property bool blockUpdate: true
     property int startWidthValue: 1
     property int middleWidthValue: 2
@@ -31,105 +29,107 @@ Item {
     property int middleHeightValue: 2
     property int endHeightValue: 1
 
-    Component.onCompleted: {
-        filter.set('start', 1)
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set('hori', 2)
-            filter.set('vert', 2)
-            filter.savePreset(preset.parameters)
-        } else {
-            middleWidthValue = filter.getDouble('hori', filter.animateIn)
-            middleHeightValue = filter.getDouble('vert', filter.animateIn)
-            if (filter.animateIn > 0) {
-                startWidthValue = filter.getDouble('hori', 0)
-                startHeightValue = filter.getDouble('vert', 0)
-            }
-            if (filter.animateOut > 0) {
-                endWidthValue = filter.getDouble('hori', filter.duration - 1)
-                endHeightValue = filter.getDouble('vert', filter.duration - 1)
-            }
-        }
-        setControls()
-    }
-
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        wslider.value = filter.getDouble('hori', position)
-        widthKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('hori') > 0
-        hslider.value = filter.getDouble('vert', position)
-        heightKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('vert') > 0
-        blockUpdate = false
-        wslider.enabled = hslider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        wslider.value = filter.getDouble('hori', position);
+        widthKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('hori') > 0;
+        hslider.value = filter.getDouble('vert', position);
+        heightKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('vert') > 0;
+        blockUpdate = false;
+        wslider.enabled = hslider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function updateFilterWidth(position) {
-        if (blockUpdate) return
-        var value = wslider.value
+        if (blockUpdate)
+            return ;
 
+        var value = wslider.value;
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startWidthValue = value
+                startWidthValue = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endWidthValue = value
+                endWidthValue = value;
             else
-                middleWidthValue = value
+                middleWidthValue = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty('hori')
-            widthKeyframesButton.checked = false
+            filter.resetProperty('hori');
+            widthKeyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set('hori', startWidthValue, 0)
-                filter.set('hori', middleWidthValue, filter.animateIn - 1)
+                filter.set('hori', startWidthValue, 0);
+                filter.set('hori', middleWidthValue, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set('hori', middleWidthValue, filter.duration - filter.animateOut)
-                filter.set('hori', endWidthValue, filter.duration - 1)
+                filter.set('hori', middleWidthValue, filter.duration - filter.animateOut);
+                filter.set('hori', endWidthValue, filter.duration - 1);
             }
         } else if (!widthKeyframesButton.checked) {
-            filter.resetProperty('hori')
-            filter.set('hori', middleWidthValue)
+            filter.resetProperty('hori');
+            filter.set('hori', middleWidthValue);
         } else if (position !== null) {
-            filter.set('hori', value, position)
+            filter.set('hori', value, position);
         }
     }
 
     function updateFilterHeight(position) {
-        if (blockUpdate) return
-        var value = hslider.value
+        if (blockUpdate)
+            return ;
 
+        var value = hslider.value;
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startHeightValue = value
+                startHeightValue = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endHeightValue = value
+                endHeightValue = value;
             else
-                middleHeightValue = value
+                middleHeightValue = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty('vert')
-            heightKeyframesButton.checked = false
+            filter.resetProperty('vert');
+            heightKeyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set('vert', startHeightValue, 0)
-                filter.set('vert', middleHeightValue, filter.animateIn - 1)
+                filter.set('vert', startHeightValue, 0);
+                filter.set('vert', middleHeightValue, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set('vert', middleHeightValue, filter.duration - filter.animateOut)
-                filter.set('vert', endHeightValue, filter.duration - 1)
+                filter.set('vert', middleHeightValue, filter.duration - filter.animateOut);
+                filter.set('vert', endHeightValue, filter.duration - 1);
             }
         } else if (!heightKeyframesButton.checked) {
-            filter.resetProperty('vert')
-            filter.set('vert', middleHeightValue)
+            filter.resetProperty('vert');
+            filter.set('vert', middleHeightValue);
         } else if (position !== null) {
-            filter.set('vert', value, position)
+            filter.set('vert', value, position);
         }
+    }
+
+    width: 200
+    height: 50
+    Component.onCompleted: {
+        filter.set('start', 1);
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set('hori', 2);
+            filter.set('vert', 2);
+            filter.savePreset(preset.parameters);
+        } else {
+            middleWidthValue = filter.getDouble('hori', filter.animateIn);
+            middleHeightValue = filter.getDouble('vert', filter.animateIn);
+            if (filter.animateIn > 0) {
+                startWidthValue = filter.getDouble('hori', 0);
+                startHeightValue = filter.getDouble('vert', 0);
+            }
+            if (filter.animateOut > 0) {
+                endWidthValue = filter.getDouble('hori', filter.duration - 1);
+                endHeightValue = filter.getDouble('vert', filter.duration - 1);
+            }
+        }
+        setControls();
     }
 
     GridLayout {
@@ -141,60 +141,68 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: parent.columns - 1
             parameters: ['hori', 'vert']
             onBeforePresetLoaded: {
-                filter.resetProperty('hori')
-                filter.resetProperty('vert')
+                filter.resetProperty('hori');
+                filter.resetProperty('vert');
             }
             onPresetSelected: {
-                setControls()
-                widthKeyframesButton.checked = filter.keyframeCount('hori') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-                heightKeyframesButton.checked = filter.keyframeCount('vert') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-                middleWidthValue = filter.getDouble('hori', filter.animateIn)
-                middleHeightValue = filter.getDouble('vert', filter.animateIn)
+                setControls();
+                widthKeyframesButton.checked = filter.keyframeCount('hori') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+                heightKeyframesButton.checked = filter.keyframeCount('vert') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+                middleWidthValue = filter.getDouble('hori', filter.animateIn);
+                middleHeightValue = filter.getDouble('vert', filter.animateIn);
                 if (filter.animateIn > 0) {
-                    startWidthValue = filter.getDouble('hori', 0)
-                    startHeightValue = filter.getDouble('vert', 0)
+                    startWidthValue = filter.getDouble('hori', 0);
+                    startHeightValue = filter.getDouble('vert', 0);
                 }
                 if (filter.animateOut > 0) {
-                    endWidthValue = filter.getDouble('hori', filter.duration - 1)
-                    endHeightValue = filter.getDouble('vert', filter.duration - 1)
+                    endWidthValue = filter.getDouble('hori', filter.duration - 1);
+                    endHeightValue = filter.getDouble('vert', filter.duration - 1);
                 }
             }
         }
+
         Label {
             text: qsTr('Width')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: wslider
+
             minimumValue: 0
             maximumValue: 99
             suffix: ' px'
             onValueChanged: updateFilterWidth(getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: wslider.value = 2
         }
+
         Shotcut.KeyframesButton {
             id: widthKeyframesButton
+
             onToggled: {
                 if (checked) {
-                    blockUpdate = true
+                    blockUpdate = true;
                     if (filter.animateIn > 0 || filter.animateOut > 0) {
-                        filter.resetProperty('vert')
-                        filter.set('vert', middleHeightValue)
-                        hslider.enabled = true
+                        filter.resetProperty('vert');
+                        filter.set('vert', middleHeightValue);
+                        hslider.enabled = true;
                     }
-                    filter.clearSimpleAnimation('hori')
-                    blockUpdate = false
-                    filter.set('hori', wslider.value, getPosition())
+                    filter.clearSimpleAnimation('hori');
+                    blockUpdate = false;
+                    filter.set('hori', wslider.value, getPosition());
                 } else {
-                    filter.resetProperty('hori')
-                    filter.set('hori', wslider.value)
+                    filter.resetProperty('hori');
+                    filter.set('hori', wslider.value);
                 }
             }
         }
@@ -203,32 +211,37 @@ Item {
             text: qsTr('Height')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: hslider
+
             minimumValue: 0
             maximumValue: 99
             suffix: ' px'
             onValueChanged: updateFilterHeight(getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: hslider.value = 2
         }
+
         Shotcut.KeyframesButton {
             id: heightKeyframesButton
+
             onToggled: {
                 if (checked) {
-                    blockUpdate = true
+                    blockUpdate = true;
                     if (filter.animateIn > 0 || filter.animateOut > 0) {
-                        filter.resetProperty('hori')
-                        filter.set('hori', middleWidthValue)
-                        wslider.enabled = true
+                        filter.resetProperty('hori');
+                        filter.set('hori', middleWidthValue);
+                        wslider.enabled = true;
                     }
-                    filter.clearSimpleAnimation('vert')
-                    blockUpdate = false
-                    filter.set('vert', hslider.value, getPosition())
+                    filter.clearSimpleAnimation('vert');
+                    blockUpdate = false;
+                    filter.set('vert', hslider.value, getPosition());
                 } else {
-                    filter.resetProperty('vert')
-                    filter.set('vert', hslider.value)
+                    filter.resetProperty('vert');
+                    filter.set('vert', hslider.value);
                 }
             }
         }
@@ -236,31 +249,52 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
-        target: producer
         function onPositionChanged() {
             if (filter.animateIn > 0 || filter.animateOut > 0) {
-                setControls()
+                setControls();
             } else {
-                blockUpdate = true
-                wslider.value = filter.getDouble('hori', getPosition())
-                hslider.value = filter.getDouble('vert', getPosition())
-                blockUpdate = false
-                wslider.enabled = true
-                hslider.enabled = true
+                blockUpdate = true;
+                wslider.value = filter.getDouble('hori', getPosition());
+                hslider.value = filter.getDouble('vert', getPosition());
+                blockUpdate = false;
+                wslider.enabled = true;
+                hslider.enabled = true;
             }
         }
+
+        target: producer
     }
+
 }

--- a/src/qml/filters/blur/ui_movit.qml
+++ b/src/qml/filters/blur/ui_movit.qml
@@ -21,73 +21,74 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 200
-    height: 50
-
     property bool blockUpdate: true
-    property double startValue: 0.0
-    property double middleValue: 3.0
-    property double endValue: 0.0
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set('radius', 3.0)
-            filter.savePreset(preset.parameters)
-        } else {
-            middleValue = filter.getDouble('radius', filter.animateIn)
-            if (filter.animateIn > 0)
-                startValue = filter.getDouble('radius', 0)
-            if (filter.animateOut > 0)
-                endValue = filter.getDouble('radius', filter.duration - 1)
-        }
-        setControls()
-    }
+    property double startValue: 0
+    property double middleValue: 3
+    property double endValue: 0
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        slider.value = filter.getDouble('radius', position)
-        keyframesButton.checked = filter.keyframeCount('radius') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-        blockUpdate = false
-        slider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        slider.value = filter.getDouble('radius', position);
+        keyframesButton.checked = filter.keyframeCount('radius') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+        blockUpdate = false;
+        slider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function updateFilter(position) {
-        if (blockUpdate) return
-        setControls()
-        var value = slider.value
+        if (blockUpdate)
+            return ;
 
+        setControls();
+        var value = slider.value;
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValue = value
+                startValue = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValue = value
+                endValue = value;
             else
-                middleValue = value
+                middleValue = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty('radius')
-            keyframesButton.checked = false
+            filter.resetProperty('radius');
+            keyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set('radius', startValue, 0)
-                filter.set('radius', middleValue, filter.animateIn - 1)
+                filter.set('radius', startValue, 0);
+                filter.set('radius', middleValue, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set('radius', middleValue, filter.duration - filter.animateOut)
-                filter.set('radius', endValue, filter.duration - 1)
+                filter.set('radius', middleValue, filter.duration - filter.animateOut);
+                filter.set('radius', endValue, filter.duration - 1);
             }
         } else if (!keyframesButton.checked) {
-            filter.resetProperty('radius')
-            filter.set('radius', middleValue)
+            filter.resetProperty('radius');
+            filter.set('radius', middleValue);
         } else if (position !== null) {
-            filter.set('radius', value, position)
+            filter.set('radius', value, position);
         }
+    }
+
+    width: 200
+    height: 50
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set('radius', 3);
+            filter.savePreset(preset.parameters);
+        } else {
+            middleValue = filter.getDouble('radius', filter.animateIn);
+            if (filter.animateIn > 0)
+                startValue = filter.getDouble('radius', 0);
+
+            if (filter.animateOut > 0)
+                endValue = filter.getDouble('radius', filter.duration - 1);
+
+        }
+        setControls();
     }
 
     GridLayout {
@@ -99,45 +100,56 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: parent.columns - 1
             parameters: ['radius']
             onBeforePresetLoaded: {
-                filter.resetProperty(parameters[0])
+                filter.resetProperty(parameters[0]);
             }
             onPresetSelected: {
-                setControls()
-                middleValue = filter.getDouble(parameters[0], filter.animateIn)
+                setControls();
+                middleValue = filter.getDouble(parameters[0], filter.animateIn);
                 if (filter.animateIn > 0)
-                    startValue = filter.getDouble(parameters[0], 0)
+                    startValue = filter.getDouble(parameters[0], 0);
+
                 if (filter.animateOut > 0)
-                    endValue = filter.getDouble(parameters[0], filter.duration - 1)
+                    endValue = filter.getDouble(parameters[0], filter.duration - 1);
+
             }
         }
 
-        Label { text: qsTr('Radius') }
+        Label {
+            text: qsTr('Radius')
+        }
+
         Shotcut.SliderSpinner {
             id: slider
+
             minimumValue: 0
             maximumValue: 99.99
             decimals: 2
             onValueChanged: updateFilter(getPosition())
         }
+
         Shotcut.UndoButton {
-            onClicked: slider.value = 3.0
+            onClicked: slider.value = 3
         }
+
         Shotcut.KeyframesButton {
             id: keyframesButton
+
             onToggled: {
                 if (checked) {
-                    blockUpdate = true
-                    filter.clearSimpleAnimation('radius')
-                    blockUpdate = false
-                    filter.set('radius', slider.value, getPosition())
+                    blockUpdate = true;
+                    filter.clearSimpleAnimation('radius');
+                    blockUpdate = false;
+                    filter.set('radius', slider.value, getPosition());
                 } else {
-                    filter.resetProperty('radius')
-                    filter.set('radius', slider.value)
+                    filter.resetProperty('radius');
+                    filter.set('radius', slider.value);
                 }
             }
         }
@@ -145,29 +157,50 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateFilter(null);
+        }
+
+        function onOutChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateInChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateOutChanged() {
+            updateFilter(null);
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateFilter(null) }
-        function onOutChanged() { updateFilter(null) }
-        function onAnimateInChanged() { updateFilter(null) }
-        function onAnimateOutChanged() { updateFilter(null) }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
-        target: producer
         function onPositionChanged() {
             if (filter.animateIn > 0 || filter.animateOut > 0) {
-                setControls()
+                setControls();
             } else {
-                blockUpdate = true
-                slider.value = filter.getDouble('radius', getPosition())
-                blockUpdate = false
-                slider.enabled = true
+                blockUpdate = true;
+                slider.value = filter.getDouble('radius', getPosition());
+                blockUpdate = false;
+                slider.enabled = true;
             }
         }
+
+        target: producer
     }
+
 }

--- a/src/qml/filters/blur_exponential/meta.qml
+++ b/src/qml/filters/blur_exponential/meta.qml
@@ -24,6 +24,7 @@ Metadata {
     objectName: 'blur_exponential'
     mlt_service: "frei0r.IIRblur"
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -38,4 +39,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/blur_exponential/ui.qml
+++ b/src/qml/filters/blur_exponential/ui.qml
@@ -22,42 +22,39 @@ import Shotcut.Controls 1.0 as Shotcut
 
 Shotcut.KeyframableFilter {
     property string amount: '0'
-    property double amountDefault: 0.20
-    
+    property double amountDefault: 0.2
+
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        amountSlider.value = filter.getDouble(amount, position) * amountSlider.maximumValue;
+        amountKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(amount) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        amountSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        updateFilter(amount, amountSlider.value / amountSlider.maximumValue, amountKeyframesButton, null);
+    }
+
     keyframableParameters: [amount]
     startValues: [0.5]
     middleValues: [amountDefault]
     endValues: [0.5]
-
     width: 350
     height: 100
-
     Component.onCompleted: {
         if (filter.isNew) {
             // Property 1 sets the type of blur: [0, 0.33] = Exponential, [0.34, 0.66] = Lowpass, [0.67, 0.99] = Gaussian
-            filter.set('1', '0')
-            filter.set(amount, amountDefault)
-            filter.savePreset(preset.parameters)
+            filter.set('1', '0');
+            filter.set(amount, amountDefault);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        amountSlider.value = filter.getDouble(amount, position) * amountSlider.maximumValue
-        amountKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(amount) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        amountSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        updateFilter(amount, amountSlider.value / amountSlider.maximumValue, amountKeyframesButton, null)
-        
+        setControls();
     }
 
     GridLayout {
@@ -69,16 +66,18 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [amount]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -86,43 +85,71 @@ Shotcut.KeyframableFilter {
             text: qsTr('Amount')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: amountSlider
+
             minimumValue: 0
-            maximumValue: 100.0
-            stepSize: .1
+            maximumValue: 100
+            stepSize: 0.1
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter(amount, amountSlider.value / amountSlider.maximumValue, amountKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: amountSlider.value = amountDefault * amountSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: amountKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, amount, amountSlider.value / amountSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, amount, amountSlider.value / amountSlider.maximumValue);
             }
         }
-        
+
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/blur_gaussian/meta.qml
+++ b/src/qml/filters/blur_gaussian/meta.qml
@@ -25,6 +25,7 @@ Metadata {
     mlt_service: "frei0r.IIRblur"
     qml: "ui_frei0r.qml"
     isHidden: true
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -39,4 +40,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/blur_gaussian/meta_av.qml
+++ b/src/qml/filters/blur_gaussian/meta_av.qml
@@ -24,6 +24,7 @@ Metadata {
     objectName: 'blur_gaussian_av'
     mlt_service: "avfilter.gblur"
     qml: "ui_av.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -39,4 +40,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/blur_gaussian/ui_av.qml
+++ b/src/qml/filters/blur_gaussian/ui_av.qml
@@ -27,39 +27,37 @@ Shotcut.KeyframableFilter {
     property double amountSliderMax: 100
     property double amountSliderDefault: 4
 
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        amountSlider.value = filter.getDouble(amountH, position);
+        amountKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(amountH) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        amountSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        updateFilter(amountH, amountSlider.value, amountKeyframesButton, null);
+        updateFilter(amountV, amountSlider.value, amountKeyframesButton, null);
+    }
+
     keyframableParameters: [amountH, amountV]
     startValues: [0, 0]
     middleValues: [amountSliderDefault, amountSliderDefault]
     endValues: [0, 0]
-
     width: 350
     height: 100
-
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set(amountH, amountSliderDefault)
-            filter.set(amountV, amountSliderDefault)
-            filter.savePreset(preset.parameters)
+            filter.set(amountH, amountSliderDefault);
+            filter.set(amountV, amountSliderDefault);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        amountSlider.value = filter.getDouble(amountH, position)
-        amountKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(amountH) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        amountSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        updateFilter(amountH, amountSlider.value, amountKeyframesButton, null)
-        updateFilter(amountV, amountSlider.value, amountKeyframesButton, null)
+        setControls();
     }
 
     GridLayout {
@@ -71,16 +69,18 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: keyframableParameters
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -88,47 +88,75 @@ Shotcut.KeyframableFilter {
             text: qsTr('Amount')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: amountSlider
+
             minimumValue: amountSliderMin
             maximumValue: amountSliderMax
-            stepSize: .1
+            stepSize: 0.1
             decimals: 1
             suffix: ' %'
             onValueChanged: {
-                updateFilter(amountH, amountSlider.value, amountKeyframesButton, getPosition())
-                updateFilter(amountV, amountSlider.value, amountKeyframesButton, getPosition())
+                updateFilter(amountH, amountSlider.value, amountKeyframesButton, getPosition());
+                updateFilter(amountV, amountSlider.value, amountKeyframesButton, getPosition());
             }
         }
+
         Shotcut.UndoButton {
             onClicked: amountSlider.value = amountSliderDefault
         }
+
         Shotcut.KeyframesButton {
             id: amountKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, amountH, amountSlider.value)
-                toggleKeyframes(checked, amountV, amountSlider.value)
+                enableControls(true);
+                toggleKeyframes(checked, amountH, amountSlider.value);
+                toggleKeyframes(checked, amountV, amountSlider.value);
             }
         }
-        
+
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/blur_gaussian/ui_frei0r.qml
+++ b/src/qml/filters/blur_gaussian/ui_frei0r.qml
@@ -22,42 +22,39 @@ import Shotcut.Controls 1.0 as Shotcut
 
 Shotcut.KeyframableFilter {
     property string amount: '0'
-    property double amountDefault: 0.20
-    
+    property double amountDefault: 0.2
+
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        amountSlider.value = filter.getDouble(amount, position) * amountSlider.maximumValue;
+        amountKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(amount) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        amountSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        updateFilter(amount, amountSlider.value / amountSlider.maximumValue, amountKeyframesButton, null);
+    }
+
     keyframableParameters: [amount]
     startValues: [0.5]
     middleValues: [amountDefault]
     endValues: [0.5]
-
     width: 350
     height: 100
-
     Component.onCompleted: {
         if (filter.isNew) {
             // Property 1 sets the type of blur: [0, 0.33] = Exponential, [0.34, 0.66] = Lowpass, [0.67, 0.99] = Gaussian
-            filter.set('1', '0.99')
-            filter.set(amount, amountDefault)
-            filter.savePreset(preset.parameters)
+            filter.set('1', '0.99');
+            filter.set(amount, amountDefault);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        amountSlider.value = filter.getDouble(amount, position) * amountSlider.maximumValue
-        amountKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(amount) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        amountSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        updateFilter(amount, amountSlider.value / amountSlider.maximumValue, amountKeyframesButton, null)
-        
+        setControls();
     }
 
     GridLayout {
@@ -69,16 +66,18 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [amount]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -86,43 +85,71 @@ Shotcut.KeyframableFilter {
             text: qsTr('Amount')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: amountSlider
+
             minimumValue: 0
-            maximumValue: 100.0
-            stepSize: .1
+            maximumValue: 100
+            stepSize: 0.1
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter(amount, amountSlider.value / amountSlider.maximumValue, amountKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: amountSlider.value = amountDefault * amountSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: amountKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, amount, amountSlider.value / amountSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, amount, amountSlider.value / amountSlider.maximumValue);
             }
         }
-        
+
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/blur_lowpass/meta.qml
+++ b/src/qml/filters/blur_lowpass/meta.qml
@@ -24,6 +24,7 @@ Metadata {
     objectName: 'blur_lowpass'
     mlt_service: "frei0r.IIRblur"
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -38,4 +39,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/blur_lowpass/ui.qml
+++ b/src/qml/filters/blur_lowpass/ui.qml
@@ -22,42 +22,39 @@ import Shotcut.Controls 1.0 as Shotcut
 
 Shotcut.KeyframableFilter {
     property string amount: '0'
-    property double amountDefault: 0.20
-    
+    property double amountDefault: 0.2
+
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        amountSlider.value = filter.getDouble(amount, position) * amountSlider.maximumValue;
+        amountKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(amount) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        amountSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        updateFilter(amount, amountSlider.value / amountSlider.maximumValue, amountKeyframesButton, null);
+    }
+
     keyframableParameters: [amount]
     startValues: [0.5]
     middleValues: [amountDefault]
     endValues: [0.5]
-
     width: 350
     height: 100
-
     Component.onCompleted: {
         if (filter.isNew) {
             // Property 1 sets the type of blur: [0, 0.33] = Exponential, [0.34, 0.66] = Lowpass, [0.67, 0.99] = Gaussian
-            filter.set('1', '0.5')
-            filter.set(amount, amountDefault)
-            filter.savePreset(preset.parameters)
+            filter.set('1', '0.5');
+            filter.set(amount, amountDefault);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        amountSlider.value = filter.getDouble(amount, position) * amountSlider.maximumValue
-        amountKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(amount) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        amountSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        updateFilter(amount, amountSlider.value / amountSlider.maximumValue, amountKeyframesButton, null)
-        
+        setControls();
     }
 
     GridLayout {
@@ -69,16 +66,18 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [amount]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -86,43 +85,71 @@ Shotcut.KeyframableFilter {
             text: qsTr('Amount')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: amountSlider
+
             minimumValue: 0
-            maximumValue: 100.0
-            stepSize: .1
+            maximumValue: 100
+            stepSize: 0.1
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter(amount, amountSlider.value / amountSlider.maximumValue, amountKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: amountSlider.value = amountDefault * amountSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: amountKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, amount, amountSlider.value / amountSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, amount, amountSlider.value / amountSlider.maximumValue);
             }
         }
-        
+
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/brightness/meta.qml
+++ b/src/qml/filters/brightness/meta.qml
@@ -8,6 +8,7 @@ Metadata {
     qml: "ui.qml"
     isFavorite: true
     gpuAlt: "movit.opacity"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -22,4 +23,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/brightness/meta_movit.qml
+++ b/src/qml/filters/brightness/meta_movit.qml
@@ -9,6 +9,7 @@ Metadata {
     needsGPU: true
     qml: "ui_movit.qml"
     isFavorite: true
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -23,4 +24,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/brightness/ui.qml
+++ b/src/qml/filters/brightness/ui.qml
@@ -21,96 +21,118 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 200
-    height: 50
+    //        console.log('level: ' + filter.get('level'))
+
     property bool blockUpdate: true
-    property double startValue: 1.0
-    property double middleValue: 1.0
-    property double endValue: 1.0
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set('level', 1.0)
-            filter.savePreset(preset.parameters)
-        } else {
-            middleValue = filter.getDouble('level', filter.animateIn)
-            if (filter.animateIn > 0)
-                startValue = filter.getDouble('level', 0)
-            if (filter.animateOut > 0)
-                endValue = filter.getDouble('level', filter.duration - 1)
-        }
-        setControls()
-    }
-
-    Connections {
-        target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateFilter(null) }
-        function onOutChanged() { updateFilter(null) }
-        function onAnimateInChanged() { updateFilter(null) }
-        function onAnimateOutChanged() { updateFilter(null) }
-        function onPropertyChanged(name) { setControls() }
-    }
-
-    Connections {
-        target: producer
-        function onPositionChanged() {
-            if (filter.animateIn > 0 || filter.animateOut > 0) {
-                setControls()
-            } else {
-                blockUpdate = true
-                brightnessSlider.value = filter.getDouble('level', getPosition()) * 100.0
-                blockUpdate = false
-                brightnessSlider.enabled = true
-            }
-        }
-    }
+    property double startValue: 1
+    property double middleValue: 1
+    property double endValue: 1
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        brightnessSlider.value = filter.getDouble('level', position) * 100.0
-        brightnessKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('level') > 0
-        blockUpdate = false
-        brightnessSlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        brightnessSlider.value = filter.getDouble('level', position) * 100;
+        brightnessKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('level') > 0;
+        blockUpdate = false;
+        brightnessSlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function updateFilter(position) {
-        if (blockUpdate) return
-        var value = brightnessSlider.value / 100.0
+        if (blockUpdate)
+            return ;
 
+        var value = brightnessSlider.value / 100;
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValue = value
+                startValue = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValue = value
+                endValue = value;
             else
-                middleValue = value
+                middleValue = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty('level')
-            brightnessKeyframesButton.checked = false
+            filter.resetProperty('level');
+            brightnessKeyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set('level', startValue, 0)
-                filter.set('level', middleValue, filter.animateIn - 1)
+                filter.set('level', startValue, 0);
+                filter.set('level', middleValue, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set('level', middleValue, filter.duration - filter.animateOut)
-                filter.set('level', endValue, filter.duration - 1)
+                filter.set('level', middleValue, filter.duration - filter.animateOut);
+                filter.set('level', endValue, filter.duration - 1);
             }
         } else if (!brightnessKeyframesButton.checked) {
-            filter.resetProperty('level')
-            filter.set('level', middleValue)
+            filter.resetProperty('level');
+            filter.set('level', middleValue);
         } else if (position !== null) {
-            filter.set('level', value, position)
+            filter.set('level', value, position);
         }
-//        console.log('level: ' + filter.get('level'))
+    }
+
+    width: 200
+    height: 50
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set('level', 1);
+            filter.savePreset(preset.parameters);
+        } else {
+            middleValue = filter.getDouble('level', filter.animateIn);
+            if (filter.animateIn > 0)
+                startValue = filter.getDouble('level', 0);
+
+            if (filter.animateOut > 0)
+                endValue = filter.getDouble('level', filter.duration - 1);
+
+        }
+        setControls();
+    }
+
+    Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateFilter(null);
+        }
+
+        function onOutChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateInChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateOutChanged() {
+            updateFilter(null);
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
+        target: filter
+    }
+
+    Connections {
+        function onPositionChanged() {
+            if (filter.animateIn > 0 || filter.animateOut > 0) {
+                setControls();
+            } else {
+                blockUpdate = true;
+                brightnessSlider.value = filter.getDouble('level', getPosition()) * 100;
+                blockUpdate = false;
+                brightnessSlider.enabled = true;
+            }
+        }
+
+        target: producer
     }
 
     GridLayout {
@@ -122,20 +144,24 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: parent.columns - 1
             parameters: ['level']
             onBeforePresetLoaded: {
-                filter.resetProperty(parameters[0])
+                filter.resetProperty(parameters[0]);
             }
             onPresetSelected: {
-                setControls()
-                middleValue = filter.getDouble(parameters[0], filter.animateIn)
+                setControls();
+                middleValue = filter.getDouble(parameters[0], filter.animateIn);
                 if (filter.animateIn > 0)
-                    startValue = filter.getDouble(parameters[0], 0)
+                    startValue = filter.getDouble(parameters[0], 0);
+
                 if (filter.animateOut > 0)
-                    endValue = filter.getDouble(parameters[0], filter.duration - 1)
+                    endValue = filter.getDouble(parameters[0], filter.duration - 1);
+
             }
         }
 
@@ -143,29 +169,34 @@ Item {
             text: qsTr('Level')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: brightnessSlider
-            minimumValue: 0.0
-            maximumValue: 200.0
+
+            minimumValue: 0
+            maximumValue: 200
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter(getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: brightnessSlider.value = 100
         }
+
         Shotcut.KeyframesButton {
             id: brightnessKeyframesButton
+
             onToggled: {
-                var value = brightnessSlider.value / 100.0
+                var value = brightnessSlider.value / 100;
                 if (checked) {
-                    blockUpdate = true
-                    filter.clearSimpleAnimation('level')
-                    blockUpdate = false
-                    filter.set('level', value, getPosition())
+                    blockUpdate = true;
+                    filter.clearSimpleAnimation('level');
+                    blockUpdate = false;
+                    filter.set('level', value, getPosition());
                 } else {
-                    filter.resetProperty('level')
-                    filter.set('level', value)
+                    filter.resetProperty('level');
+                    filter.set('level', value);
                 }
             }
         }
@@ -173,5 +204,7 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/brightness/ui_movit.qml
+++ b/src/qml/filters/brightness/ui_movit.qml
@@ -21,96 +21,117 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 200
-    height: 50
     property bool blockUpdate: true
-    property double startValue: 1.0
-    property double middleValue: 1.0
-    property double endValue: 1.0
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set('alpha', 1.0)
-            filter.set('opacity', 1.0)
-            filter.savePreset(preset.parameters)
-        } else {
-            middleValue = filter.getDouble('opacity', filter.animateIn)
-            if (filter.animateIn > 0)
-                startValue = filter.getDouble('opacity', 0)
-            if (filter.animateOut > 0)
-                endValue = filter.getDouble('opacity', filter.duration - 1)
-        }
-        setControls()
-    }
-
-    Connections {
-        target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateFilter(null) }
-        function onOutChanged() { updateFilter(null) }
-        function onAnimateInChanged() { updateFilter(null) }
-        function onAnimateOutChanged() { updateFilter(null) }
-        function onPropertyChanged(name) { setControls() }
-    }
-
-    Connections {
-        target: producer
-        function onPositionChanged() {
-            if (filter.animateIn > 0 || filter.animateOut > 0) {
-                setControls()
-            } else {
-                blockUpdate = true
-                brightnessSlider.value = filter.getDouble('opacity', getPosition()) * 100.0
-                blockUpdate = false
-                brightnessSlider.enabled = true
-            }
-        }
-    }
+    property double startValue: 1
+    property double middleValue: 1
+    property double endValue: 1
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        brightnessSlider.value = filter.getDouble('opacity', position) * 100.0
-        brightnessKeyframesButton.checked = filter.keyframeCount('opacity') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-        blockUpdate = false
-        brightnessSlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        brightnessSlider.value = filter.getDouble('opacity', position) * 100;
+        brightnessKeyframesButton.checked = filter.keyframeCount('opacity') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+        blockUpdate = false;
+        brightnessSlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function updateFilter(position) {
-        if (blockUpdate) return
-        var value = brightnessSlider.value / 100.0
+        if (blockUpdate)
+            return ;
 
+        var value = brightnessSlider.value / 100;
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValue = value
+                startValue = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValue = value
+                endValue = value;
             else
-                middleValue = value
+                middleValue = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty('opacity')
-            brightnessKeyframesButton.checked = false
+            filter.resetProperty('opacity');
+            brightnessKeyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set('opacity', startValue, 0)
-                filter.set('opacity', middleValue, filter.animateIn - 1)
+                filter.set('opacity', startValue, 0);
+                filter.set('opacity', middleValue, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set('opacity', middleValue, filter.duration - filter.animateOut)
-                filter.set('opacity', endValue, filter.duration - 1)
+                filter.set('opacity', middleValue, filter.duration - filter.animateOut);
+                filter.set('opacity', endValue, filter.duration - 1);
             }
         } else if (!brightnessKeyframesButton.checked) {
-            filter.resetProperty('opacity')
-            filter.set('opacity', middleValue)
+            filter.resetProperty('opacity');
+            filter.set('opacity', middleValue);
         } else if (position !== null) {
-            filter.set('opacity', value, position)
+            filter.set('opacity', value, position);
         }
+    }
+
+    width: 200
+    height: 50
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set('alpha', 1);
+            filter.set('opacity', 1);
+            filter.savePreset(preset.parameters);
+        } else {
+            middleValue = filter.getDouble('opacity', filter.animateIn);
+            if (filter.animateIn > 0)
+                startValue = filter.getDouble('opacity', 0);
+
+            if (filter.animateOut > 0)
+                endValue = filter.getDouble('opacity', filter.duration - 1);
+
+        }
+        setControls();
+    }
+
+    Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateFilter(null);
+        }
+
+        function onOutChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateInChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateOutChanged() {
+            updateFilter(null);
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
+        target: filter
+    }
+
+    Connections {
+        function onPositionChanged() {
+            if (filter.animateIn > 0 || filter.animateOut > 0) {
+                setControls();
+            } else {
+                blockUpdate = true;
+                brightnessSlider.value = filter.getDouble('opacity', getPosition()) * 100;
+                blockUpdate = false;
+                brightnessSlider.enabled = true;
+            }
+        }
+
+        target: producer
     }
 
     GridLayout {
@@ -122,20 +143,24 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: parent.columns - 1
             parameters: ['opacity']
             onBeforePresetLoaded: {
-                filter.resetProperty(parameters[0])
+                filter.resetProperty(parameters[0]);
             }
             onPresetSelected: {
-                setControls()
-                middleValue = filter.getDouble(parameters[0], filter.animateIn)
+                setControls();
+                middleValue = filter.getDouble(parameters[0], filter.animateIn);
                 if (filter.animateIn > 0)
-                    startValue = filter.getDouble(parameters[0], 0)
+                    startValue = filter.getDouble(parameters[0], 0);
+
                 if (filter.animateOut > 0)
-                    endValue = filter.getDouble(parameters[0], filter.duration - 1)
+                    endValue = filter.getDouble(parameters[0], filter.duration - 1);
+
             }
         }
 
@@ -143,36 +168,42 @@ Item {
             text: qsTr('Level')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: brightnessSlider
-            minimumValue: 0.0
-            maximumValue: 200.0
+
+            minimumValue: 0
+            maximumValue: 200
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter(getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: brightnessSlider.value = 100
         }
+
         Shotcut.KeyframesButton {
             id: brightnessKeyframesButton
+
             onToggled: {
-                var value = brightnessSlider.value / 100.0
+                var value = brightnessSlider.value / 100;
                 if (checked) {
-                    blockUpdate = true
-                    filter.clearSimpleAnimation('opacity')
-                    blockUpdate = false
-                    filter.set('opacity', value, getPosition())
+                    blockUpdate = true;
+                    filter.clearSimpleAnimation('opacity');
+                    blockUpdate = false;
+                    filter.set('opacity', value, getPosition());
                 } else {
-                    filter.resetProperty('opacity')
-                    filter.set('opacity', value)
+                    filter.resetProperty('opacity');
+                    filter.set('opacity', value);
                 }
             }
         }
 
-
         Item {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/choppy/meta.qml
+++ b/src/qml/filters/choppy/meta.qml
@@ -6,6 +6,7 @@ Metadata {
     name: qsTr('Choppy')
     mlt_service: 'choppy'
     qml: 'ui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -20,4 +21,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/choppy/ui.qml
+++ b/src/qml/filters/choppy/ui.qml
@@ -24,36 +24,34 @@ Shotcut.KeyframableFilter {
     property string amount: 'amount'
     property int amountDefault: 5
 
+    function setControls() {
+        blockUpdate = true;
+        amountSlider.value = filter.getDouble(amount, getPosition());
+        amountKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(amount) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        amountSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        updateFilter(amount, amountSlider.value, amountKeyframesButton, null);
+    }
+
     keyframableParameters: [amount]
     startValues: [0]
     middleValues: [amountDefault]
     endValues: [0]
-
-    width : 350
+    width: 350
     height: 100
-
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set(amount, amountDefault)
-            filter.savePreset(preset.parameters)
+            filter.set(amount, amountDefault);
+            filter.savePreset(preset.parameters);
         }
         setControls();
-    }
-
-    function setControls() {
-        blockUpdate = true
-        amountSlider.value = filter.getDouble(amount, getPosition())
-        amountKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(amount) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        amountSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        updateFilter(amount, amountSlider.value, amountKeyframesButton, null)
     }
 
     GridLayout {
@@ -68,14 +66,15 @@ Shotcut.KeyframableFilter {
 
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: parent.columns - 1
             parameters: [amount]
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -83,8 +82,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Repeat')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: amountSlider
+
             minimumValue: 0
             maximumValue: Math.round(profile.fps)
             stepSize: 1
@@ -92,32 +93,60 @@ Shotcut.KeyframableFilter {
             spinnerWidth: 110
             onValueChanged: updateFilter(amount, amountSlider.value, amountKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: amountSlider.value = amountDefault
         }
+
         Shotcut.KeyframesButton {
             id: amountKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, amount, amountSlider.value)
+                enableControls(true);
+                toggleKeyframes(checked, amount, amountSlider.value);
             }
         }
 
-        Item { Layout.fillHeight: true }
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/chromahold/meta.qml
+++ b/src/qml/filters/chromahold/meta.qml
@@ -23,6 +23,7 @@ Metadata {
     name: qsTr("Chroma Hold")
     mlt_service: 'avfilter.chromahold'
     qml: 'ui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -37,4 +38,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/chromahold/ui.qml
+++ b/src/qml/filters/chromahold/ui.qml
@@ -27,39 +27,38 @@ Shotcut.KeyframableFilter {
     property double distanceDefault: 10
     property var defaultParameters: [colorParam, distanceParam]
 
+    function setControls() {
+        colorPicker.value = filter.get(colorParam);
+        blockUpdate = true;
+        distanceSlider.value = filter.getDouble(distanceParam, getPosition()) * 100;
+        distanceKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(distanceParam) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        distanceSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        updateFilter(distanceParam, distanceSlider.value / 100, distanceKeyframesButton, null);
+    }
+
     keyframableParameters: [distanceParam]
     startValues: [1]
     middleValues: [distanceDefault / 100]
     endValues: [1]
-
     width: 350
     height: 50
     Component.onCompleted: {
-        presetItem.parameters = defaultParameters
+        presetItem.parameters = defaultParameters;
         if (filter.isNew) {
             // Set default parameter values
-            filter.set(colorParam, colorDefault)
-            filter.set(distanceParam, distanceDefault / 100)
-            filter.savePreset(defaultParameters)
+            filter.set(colorParam, colorDefault);
+            filter.set(distanceParam, distanceDefault / 100);
+            filter.savePreset(defaultParameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        colorPicker.value = filter.get(colorParam)
-        blockUpdate = true
-        distanceSlider.value = filter.getDouble(distanceParam, getPosition()) * 100
-        distanceKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(distanceParam) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        distanceSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        updateFilter(distanceParam, distanceSlider.value / 100, distanceKeyframesButton, null)
+        setControls();
     }
 
     GridLayout {
@@ -71,13 +70,15 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: presetItem
+
             Layout.columnSpan: 3
             onBeforePresetLoaded: resetSimpleKeyframes()
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -86,61 +87,95 @@ Shotcut.KeyframableFilter {
             text: qsTr('Color')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ColorPicker {
             id: colorPicker
+
             onValueChanged: {
-                filter.set(colorParam, value)
-                filter.set('disable', 0)
+                filter.set(colorParam, value);
+                filter.set('disable', 0);
             }
             onPickStarted: filter.set('disable', 1)
             onPickCancelled: filter.set('disable', 0)
         }
+
         Shotcut.UndoButton {
             onClicked: colorPicker.value = colorDefault
         }
-        Item { Layout.fillWidth: true }
+
+        Item {
+            Layout.fillWidth: true
+        }
 
         // Row 2
         Label {
             text: qsTr('Distance')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: distanceSlider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter(distanceParam, value / 100, distanceKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: distanceSlider.value = distanceDefault
         }
+
         Shotcut.KeyframesButton {
             id: distanceKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, distanceParam, distanceSlider.value / 100)
+                enableControls(true);
+                toggleKeyframes(checked, distanceParam, distanceSlider.value / 100);
             }
         }
 
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/color/meta.qml
+++ b/src/qml/filters/color/meta.qml
@@ -8,6 +8,7 @@ Metadata {
     qml: "ui.qml"
     isFavorite: true
     gpuAlt: "movit.lift_gamma_gain"
+
     keyframes {
         parameters: [
             Parameter {
@@ -27,4 +28,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/color/meta_movit.qml
+++ b/src/qml/filters/color/meta_movit.qml
@@ -8,6 +8,7 @@ Metadata {
     needsGPU: true
     qml: "ui.qml"
     isFavorite: true
+
     keyframes {
         parameters: [
             Parameter {
@@ -27,4 +28,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/color/ui.qml
+++ b/src/qml/filters/color/ui.qml
@@ -21,54 +21,38 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    property var defaultParameters: ['lift_r', 'lift_g', 'lift_b', 'gamma_r', 'gamma_g', 'gamma_b', 'gain_r', 'gain_g', 'gain_b']
-    property double gammaFactor: 2.0
-    property double gainFactor: 4.0
-    property bool blockUpdate: true
-    width: 620
-    height: 350
+    // For a = 0, the function is linear
+    // The solution to the quadratic formula reduces to:
 
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set("lift_r", 0.0);
-            filter.set("lift_g", 0.0);
-            filter.set("lift_b", 0.0);
-            filter.set("gamma_r", 1.0);
-            filter.set("gamma_g", 1.0);
-            filter.set("gamma_b", 1.0);
-            filter.set("gain_r", 1.0);
-            filter.set("gain_g", 1.0);
-            filter.set("gain_b", 1.0);
-            filter.savePreset(defaultParameters)
-        }
-        loadValues()
-    }
+    property var defaultParameters: ['lift_r', 'lift_g', 'lift_b', 'gamma_r', 'gamma_g', 'gamma_b', 'gain_r', 'gain_g', 'gain_b']
+    property double gammaFactor: 2
+    property double gainFactor: 4
+    property bool blockUpdate: true
 
     function loadValues() {
-        var position = getPosition()
-        blockUpdate = true
+        var position = getPosition();
+        blockUpdate = true;
         // Force a color change to make sure the color wheel is updated.
-        liftRedSpinner.value = 1.0
-        gammaRedSpinner.value = 1.0
-        gainRedSpinner.value = 1.0
-        liftRedSpinner.value = filter.getDouble("lift_r", position) * 100.0
-        liftGreenSpinner.value = filter.getDouble("lift_g", position) * 100.0
-        liftBlueSpinner.value = filter.getDouble("lift_b", position) * 100.0
-        gammaRedSpinner.value = wheelToSpinner(scaleValueToWheel(filter.getDouble("gamma_r", position), gammaFactor))
-        gammaGreenSpinner.value = wheelToSpinner(scaleValueToWheel(filter.getDouble("gamma_g", position), gammaFactor))
-        gammaBlueSpinner.value = wheelToSpinner(scaleValueToWheel(filter.getDouble("gamma_b", position), gammaFactor))
-        gainRedSpinner.value = wheelToSpinner(scaleValueToWheel(filter.getDouble("gain_r", position), gainFactor))
-        gainGreenSpinner.value = wheelToSpinner(scaleValueToWheel(filter.getDouble("gain_g", position), gainFactor))
-        gainBlueSpinner.value = wheelToSpinner(scaleValueToWheel(filter.getDouble("gain_b", position), gainFactor))
-        liftKeyframesButton.checked = filter.keyframeCount('lift_r') > 0
-        gammaKeyframesButton.checked = filter.keyframeCount('gamma_r') > 0
-        gainKeyframesButton.checked = filter.keyframeCount('gain_r') > 0
-        blockUpdate = false
+        liftRedSpinner.value = 1;
+        gammaRedSpinner.value = 1;
+        gainRedSpinner.value = 1;
+        liftRedSpinner.value = filter.getDouble("lift_r", position) * 100;
+        liftGreenSpinner.value = filter.getDouble("lift_g", position) * 100;
+        liftBlueSpinner.value = filter.getDouble("lift_b", position) * 100;
+        gammaRedSpinner.value = wheelToSpinner(scaleValueToWheel(filter.getDouble("gamma_r", position), gammaFactor));
+        gammaGreenSpinner.value = wheelToSpinner(scaleValueToWheel(filter.getDouble("gamma_g", position), gammaFactor));
+        gammaBlueSpinner.value = wheelToSpinner(scaleValueToWheel(filter.getDouble("gamma_b", position), gammaFactor));
+        gainRedSpinner.value = wheelToSpinner(scaleValueToWheel(filter.getDouble("gain_r", position), gainFactor));
+        gainGreenSpinner.value = wheelToSpinner(scaleValueToWheel(filter.getDouble("gain_g", position), gainFactor));
+        gainBlueSpinner.value = wheelToSpinner(scaleValueToWheel(filter.getDouble("gain_b", position), gainFactor));
+        liftKeyframesButton.checked = filter.keyframeCount('lift_r') > 0;
+        gammaKeyframesButton.checked = filter.keyframeCount('gamma_r') > 0;
+        gainKeyframesButton.checked = filter.keyframeCount('gain_r') > 0;
+        blockUpdate = false;
     }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function scaleWheelToValue(w, f) {
@@ -86,32 +70,48 @@ Item {
         //    a = 2f - 4
         //    b = f - a
         //    c = 0
-        var a = (2*f) - 4
-        var b = f - a
-        return a * (w*w) + b*w
+        var a = (2 * f) - 4;
+        var b = f - a;
+        return a * (w * w) + b * w;
     }
 
     function scaleValueToWheel(v, f) {
-       // Do the opposite of scaleWheelToValue
-       var a = (2*f) - 4
-       var b = f - a
-       if (a == 0) {
-           // For a = 0, the function is linear
-           return v / f
-       } else {
-           // The solution to the quadratic formula reduces to:
-           return ((b*-1.0) + Math.sqrt((b*b) + (4*a*v))) / (2*a)
-       }
-   }
+        // Do the opposite of scaleWheelToValue
+        var a = (2 * f) - 4;
+        var b = f - a;
+        if (a == 0)
+            return v / f;
+        else
+            return ((b * -1) + Math.sqrt((b * b) + (4 * a * v))) / (2 * a);
+    }
 
     function wheelToSpinner(w) {
         // Convert a wheel value [0.0 - 1.0] to a spinner value [-100.0 - 100.0]
-        return (w * 2.0 - 1.0) * 100.0
+        return (w * 2 - 1) * 100;
     }
 
     function spinnerToWheel(s) {
         // Convert a spinner value [-100.0 - 100.0] to wheel value [0.0 - 1.0]
-        return (s / 100.0 + 1.0) / 2.0
+        return (s / 100 + 1) / 2;
+    }
+
+    width: 620
+    height: 350
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set("lift_r", 0);
+            filter.set("lift_g", 0);
+            filter.set("lift_b", 0);
+            filter.set("gamma_r", 1);
+            filter.set("gamma_g", 1);
+            filter.set("gamma_b", 1);
+            filter.set("gain_r", 1);
+            filter.set("gain_g", 1);
+            filter.set("gain_b", 1);
+            filter.savePreset(defaultParameters);
+        }
+        loadValues();
     }
 
     GridLayout {
@@ -124,110 +124,128 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             Layout.columnSpan: 8
             parameters: defaultParameters
             onBeforePresetLoaded: {
-                filter.resetProperty('lift_r')
-                filter.resetProperty('lift_g')
-                filter.resetProperty('lift_b')
-                filter.resetProperty('gamma_r')
-                filter.resetProperty('gamma_g')
-                filter.resetProperty('gamma_b')
-                filter.resetProperty('gain_r')
-                filter.resetProperty('gain_g')
-                filter.resetProperty('gain_b')
+                filter.resetProperty('lift_r');
+                filter.resetProperty('lift_g');
+                filter.resetProperty('lift_b');
+                filter.resetProperty('gamma_r');
+                filter.resetProperty('gamma_g');
+                filter.resetProperty('gamma_b');
+                filter.resetProperty('gain_r');
+                filter.resetProperty('gain_g');
+                filter.resetProperty('gain_b');
             }
             onPresetSelected: {
-                loadValues()
+                loadValues();
             }
         }
 
         // Row 2
-        Label { text: qsTr('Shadows (Lift)') }
+        Label {
+            text: qsTr('Shadows (Lift)')
+        }
+
         Shotcut.UndoButton {
             Layout.alignment: Qt.AlignRight
             onClicked: {
                 // Force a color change to make sure the color wheel is updated.
-                liftRedSpinner.value = 1.0
-                liftRedSpinner.value = 0.0
-                liftGreenSpinner.value = 0.0
-                liftBlueSpinner.value = 0.0
+                liftRedSpinner.value = 1;
+                liftRedSpinner.value = 0;
+                liftGreenSpinner.value = 0;
+                liftBlueSpinner.value = 0;
             }
         }
+
         Shotcut.KeyframesButton {
             id: liftKeyframesButton
+
             Layout.alignment: Qt.AlignLeft
             onToggled: {
                 if (checked) {
-                    filter.set('lift_r', liftwheel.redF * 2.0 - 1.0, getPosition())
-                    filter.set('lift_g', liftwheel.greenF * 2.0 - 1.0, getPosition())
-                    filter.set('lift_b', liftwheel.blueF * 2.0 - 1.0, getPosition())
+                    filter.set('lift_r', liftwheel.redF * 2 - 1, getPosition());
+                    filter.set('lift_g', liftwheel.greenF * 2 - 1, getPosition());
+                    filter.set('lift_b', liftwheel.blueF * 2 - 1, getPosition());
                 } else {
-                    filter.resetProperty('lift_r')
-                    filter.resetProperty('lift_g')
-                    filter.resetProperty('lift_b')
-                    filter.set('lift_r', liftwheel.redF * 2.0 - 1.0)
-                    filter.set('lift_g', liftwheel.greenF * 2.0 - 1.0)
-                    filter.set('lift_b', liftwheel.blueF * 2.0 - 1.0)
+                    filter.resetProperty('lift_r');
+                    filter.resetProperty('lift_g');
+                    filter.resetProperty('lift_b');
+                    filter.set('lift_r', liftwheel.redF * 2 - 1);
+                    filter.set('lift_g', liftwheel.greenF * 2 - 1);
+                    filter.set('lift_b', liftwheel.blueF * 2 - 1);
                 }
             }
         }
-        Label { text: qsTr('Midtones (Gamma)') }
+
+        Label {
+            text: qsTr('Midtones (Gamma)')
+        }
+
         Shotcut.UndoButton {
             Layout.alignment: Qt.AlignRight
             onClicked: {
                 // Force a color change to make sure the color wheel is updated.
-                gammaRedSpinner.value = 100.0
-                gammaRedSpinner.value = 0.0
-                gammaGreenSpinner.value = 0.0
-                gammaBlueSpinner.value = 0.0
+                gammaRedSpinner.value = 100;
+                gammaRedSpinner.value = 0;
+                gammaGreenSpinner.value = 0;
+                gammaBlueSpinner.value = 0;
             }
         }
+
         Shotcut.KeyframesButton {
             id: gammaKeyframesButton
+
             Layout.alignment: Qt.AlignLeft
             onToggled: {
                 if (checked) {
-                    filter.set('gamma_r', scaleWheelToValue(gammawheel.redF, gammaFactor), getPosition())
-                    filter.set('gamma_g', scaleWheelToValue(gammawheel.greenF, gammaFactor), getPosition())
-                    filter.set('gamma_b', scaleWheelToValue(gammawheel.blueF, gammaFactor), getPosition())
+                    filter.set('gamma_r', scaleWheelToValue(gammawheel.redF, gammaFactor), getPosition());
+                    filter.set('gamma_g', scaleWheelToValue(gammawheel.greenF, gammaFactor), getPosition());
+                    filter.set('gamma_b', scaleWheelToValue(gammawheel.blueF, gammaFactor), getPosition());
                 } else {
-                    filter.resetProperty('gamma_r')
-                    filter.resetProperty('gamma_g')
-                    filter.resetProperty('gamma_b')
-                    filter.set('gamma_r', scaleWheelToValue(gammawheel.redF, gammaFactor))
-                    filter.set('gamma_g', scaleWheelToValue(gammawheel.greenF, gammaFactor))
-                    filter.set('gamma_b', scaleWheelToValue(gammawheel.blueF, gammaFactor))
+                    filter.resetProperty('gamma_r');
+                    filter.resetProperty('gamma_g');
+                    filter.resetProperty('gamma_b');
+                    filter.set('gamma_r', scaleWheelToValue(gammawheel.redF, gammaFactor));
+                    filter.set('gamma_g', scaleWheelToValue(gammawheel.greenF, gammaFactor));
+                    filter.set('gamma_b', scaleWheelToValue(gammawheel.blueF, gammaFactor));
                 }
             }
         }
-        Label { text: qsTr('Highlights (Gain)') }
+
+        Label {
+            text: qsTr('Highlights (Gain)')
+        }
+
         Shotcut.UndoButton {
             Layout.alignment: Qt.AlignRight
             onClicked: {
                 // Force a color change to make sure the color wheel is updated.
-                gainRedSpinner.value = 100.0
-                gainRedSpinner.value = 0.0
-                gainGreenSpinner.value = 0.0
-                gainBlueSpinner.value = 0.0
+                gainRedSpinner.value = 100;
+                gainRedSpinner.value = 0;
+                gainGreenSpinner.value = 0;
+                gainBlueSpinner.value = 0;
             }
         }
+
         Shotcut.KeyframesButton {
             id: gainKeyframesButton
+
             Layout.alignment: Qt.AlignLeft
             onToggled: {
                 if (checked) {
-                    filter.set('gain_r', scaleWheelToValue(gainwheel.redF, gainFactor), getPosition())
-                    filter.set('gain_g', scaleWheelToValue(gainwheel.greenF, gainFactor), getPosition())
-                    filter.set('gain_b', scaleWheelToValue(gainwheel.blueF, gainFactor), getPosition())
+                    filter.set('gain_r', scaleWheelToValue(gainwheel.redF, gainFactor), getPosition());
+                    filter.set('gain_g', scaleWheelToValue(gainwheel.greenF, gainFactor), getPosition());
+                    filter.set('gain_b', scaleWheelToValue(gainwheel.blueF, gainFactor), getPosition());
                 } else {
-                    filter.resetProperty('gain_r')
-                    filter.resetProperty('gain_g')
-                    filter.resetProperty('gain_b')
-                    filter.set('gain_r', scaleWheelToValue(gainwheel.redF, gainFactor))
-                    filter.set('gain_g', scaleWheelToValue(gainwheel.greenF, gainFactor))
-                    filter.set('gain_b', scaleWheelToValue(gainwheel.blueF, gainFactor))
+                    filter.resetProperty('gain_r');
+                    filter.resetProperty('gain_g');
+                    filter.resetProperty('gain_b');
+                    filter.set('gain_r', scaleWheelToValue(gainwheel.redF, gainFactor));
+                    filter.set('gain_g', scaleWheelToValue(gainwheel.greenF, gainFactor));
+                    filter.set('gain_b', scaleWheelToValue(gainwheel.blueF, gainFactor));
                 }
             }
         }
@@ -235,108 +253,113 @@ Item {
         // Row 3
         Shotcut.ColorWheelItem {
             id: liftwheel
+
             Layout.columnSpan: 3
             implicitWidth: parent.width / 3 - parent.columnSpacing
             implicitHeight: implicitWidth / 1.1
-            Layout.alignment : Qt.AlignCenter | Qt.AlignTop
+            Layout.alignment: Qt.AlignCenter | Qt.AlignTop
             Layout.minimumHeight: 75
             Layout.maximumHeight: 300
             step: 0.0005
             onColorChanged: {
-                if( liftRedSpinner.value != wheelToSpinner(liftwheel.redF) ) {
-                    liftRedSpinner.value = wheelToSpinner(liftwheel.redF)
-                }
-                if( liftGreenSpinner.value != wheelToSpinner(liftwheel.greenF) ) {
-                    liftGreenSpinner.value = wheelToSpinner(liftwheel.greenF)
-                }
-                if( liftBlueSpinner.value != wheelToSpinner(liftwheel.blueF) ) {
-                    liftBlueSpinner.value = wheelToSpinner(liftwheel.blueF)
-                }
+                if (liftRedSpinner.value != wheelToSpinner(liftwheel.redF))
+                    liftRedSpinner.value = wheelToSpinner(liftwheel.redF);
+
+                if (liftGreenSpinner.value != wheelToSpinner(liftwheel.greenF))
+                    liftGreenSpinner.value = wheelToSpinner(liftwheel.greenF);
+
+                if (liftBlueSpinner.value != wheelToSpinner(liftwheel.blueF))
+                    liftBlueSpinner.value = wheelToSpinner(liftwheel.blueF);
+
                 if (!blockUpdate) {
                     if (!liftKeyframesButton.checked) {
-                        filter.resetProperty('lift_r')
-                        filter.resetProperty('lift_g')
-                        filter.resetProperty('lift_b')
-                        filter.set('lift_r', liftwheel.redF * 2.0 - 1.0)
-                        filter.set('lift_g', liftwheel.greenF * 2.0 - 1.0)
-                        filter.set('lift_b', liftwheel.blueF * 2.0 - 1.0)
+                        filter.resetProperty('lift_r');
+                        filter.resetProperty('lift_g');
+                        filter.resetProperty('lift_b');
+                        filter.set('lift_r', liftwheel.redF * 2 - 1);
+                        filter.set('lift_g', liftwheel.greenF * 2 - 1);
+                        filter.set('lift_b', liftwheel.blueF * 2 - 1);
                     } else {
-                        var position = getPosition()
-                        filter.set('lift_r', liftwheel.redF * 2.0 - 1.0, position)
-                        filter.set('lift_g', liftwheel.greenF * 2.0 - 1.0, position)
-                        filter.set('lift_b', liftwheel.blueF * 2.0 - 1.0, position)
+                        var position = getPosition();
+                        filter.set('lift_r', liftwheel.redF * 2 - 1, position);
+                        filter.set('lift_g', liftwheel.greenF * 2 - 1, position);
+                        filter.set('lift_b', liftwheel.blueF * 2 - 1, position);
                     }
                 }
             }
         }
+
         Shotcut.ColorWheelItem {
             id: gammawheel
+
             Layout.columnSpan: 3
             implicitWidth: parent.width / 3 - parent.columnSpacing
             implicitHeight: implicitWidth / 1.1
-            Layout.alignment : Qt.AlignCenter | Qt.AlignTop
+            Layout.alignment: Qt.AlignCenter | Qt.AlignTop
             Layout.minimumHeight: 75
             Layout.maximumHeight: 300
             step: 0.0005
             onColorChanged: {
-                if( gammaRedSpinner.value != wheelToSpinner(gammawheel.redF) ) {
-                    gammaRedSpinner.value = wheelToSpinner(gammawheel.redF)
-                }
-                if( gammaGreenSpinner.value != wheelToSpinner(gammawheel.greenF) ) {
-                    gammaGreenSpinner.value = wheelToSpinner(gammawheel.greenF)
-                }
-                if( gammaBlueSpinner.value != wheelToSpinner(gammawheel.blueF) ) {
-                    gammaBlueSpinner.value = wheelToSpinner(gammawheel.blueF)
-                }
+                if (gammaRedSpinner.value != wheelToSpinner(gammawheel.redF))
+                    gammaRedSpinner.value = wheelToSpinner(gammawheel.redF);
+
+                if (gammaGreenSpinner.value != wheelToSpinner(gammawheel.greenF))
+                    gammaGreenSpinner.value = wheelToSpinner(gammawheel.greenF);
+
+                if (gammaBlueSpinner.value != wheelToSpinner(gammawheel.blueF))
+                    gammaBlueSpinner.value = wheelToSpinner(gammawheel.blueF);
+
                 if (!blockUpdate) {
                     if (!gammaKeyframesButton.checked) {
-                        filter.resetProperty('gamma_r')
-                        filter.resetProperty('gamma_g')
-                        filter.resetProperty('gamma_b')
-                        filter.set('gamma_r', scaleWheelToValue(gammawheel.redF, gammaFactor))
-                        filter.set('gamma_g', scaleWheelToValue(gammawheel.greenF, gammaFactor))
-                        filter.set('gamma_b', scaleWheelToValue(gammawheel.blueF, gammaFactor))
+                        filter.resetProperty('gamma_r');
+                        filter.resetProperty('gamma_g');
+                        filter.resetProperty('gamma_b');
+                        filter.set('gamma_r', scaleWheelToValue(gammawheel.redF, gammaFactor));
+                        filter.set('gamma_g', scaleWheelToValue(gammawheel.greenF, gammaFactor));
+                        filter.set('gamma_b', scaleWheelToValue(gammawheel.blueF, gammaFactor));
                     } else {
-                        var position = getPosition()
-                        filter.set('gamma_r', scaleWheelToValue(gammawheel.redF, gammaFactor), position)
-                        filter.set('gamma_g', scaleWheelToValue(gammawheel.greenF, gammaFactor), position)
-                        filter.set('gamma_b', scaleWheelToValue(gammawheel.blueF, gammaFactor), position)
+                        var position = getPosition();
+                        filter.set('gamma_r', scaleWheelToValue(gammawheel.redF, gammaFactor), position);
+                        filter.set('gamma_g', scaleWheelToValue(gammawheel.greenF, gammaFactor), position);
+                        filter.set('gamma_b', scaleWheelToValue(gammawheel.blueF, gammaFactor), position);
                     }
                 }
             }
         }
+
         Shotcut.ColorWheelItem {
             id: gainwheel
+
             Layout.columnSpan: 3
             implicitWidth: parent.width / 3 - parent.columnSpacing
             implicitHeight: implicitWidth / 1.1
-            Layout.alignment : Qt.AlignCenter | Qt.AlignTop
+            Layout.alignment: Qt.AlignCenter | Qt.AlignTop
             Layout.minimumHeight: 75
             Layout.maximumHeight: 300
             step: 0.0005
             onColorChanged: {
-                if( gainRedSpinner.value != wheelToSpinner(gainwheel.redF) ) {
-                    gainRedSpinner.value = wheelToSpinner(gainwheel.redF)
-                }
-                if( gainGreenSpinner.value != wheelToSpinner(gainwheel.greenF) ) {
-                    gainGreenSpinner.value = wheelToSpinner(gainwheel.greenF)
-                }
-                if( gainBlueSpinner.value != wheelToSpinner(gainwheel.blueF) ) {
-                    gainBlueSpinner.value = wheelToSpinner(gainwheel.blueF)
-                }
+                if (gainRedSpinner.value != wheelToSpinner(gainwheel.redF))
+                    gainRedSpinner.value = wheelToSpinner(gainwheel.redF);
+
+                if (gainGreenSpinner.value != wheelToSpinner(gainwheel.greenF))
+                    gainGreenSpinner.value = wheelToSpinner(gainwheel.greenF);
+
+                if (gainBlueSpinner.value != wheelToSpinner(gainwheel.blueF))
+                    gainBlueSpinner.value = wheelToSpinner(gainwheel.blueF);
+
                 if (!blockUpdate) {
                     if (!gainKeyframesButton.checked) {
-                        filter.resetProperty('gain_r')
-                        filter.resetProperty('gain_g')
-                        filter.resetProperty('gain_b')
-                        filter.set('gain_r', scaleWheelToValue(gainwheel.redF, gainFactor))
-                        filter.set('gain_g', scaleWheelToValue(gainwheel.greenF, gainFactor))
-                        filter.set('gain_b', scaleWheelToValue(gainwheel.blueF, gainFactor))
+                        filter.resetProperty('gain_r');
+                        filter.resetProperty('gain_g');
+                        filter.resetProperty('gain_b');
+                        filter.set('gain_r', scaleWheelToValue(gainwheel.redF, gainFactor));
+                        filter.set('gain_g', scaleWheelToValue(gainwheel.greenF, gainFactor));
+                        filter.set('gain_b', scaleWheelToValue(gainwheel.blueF, gainFactor));
                     } else {
-                        var position = getPosition()
-                        filter.set('gain_r', scaleWheelToValue(gainwheel.redF, gainFactor), position)
-                        filter.set('gain_g', scaleWheelToValue(gainwheel.greenF, gainFactor), position)
-                        filter.set('gain_b', scaleWheelToValue(gainwheel.blueF, gainFactor), position)
+                        var position = getPosition();
+                        filter.set('gain_r', scaleWheelToValue(gainwheel.redF, gainFactor), position);
+                        filter.set('gain_g', scaleWheelToValue(gainwheel.greenF, gainFactor), position);
+                        filter.set('gain_b', scaleWheelToValue(gainwheel.blueF, gainFactor), position);
                     }
                 }
             }
@@ -346,10 +369,15 @@ Item {
         RowLayout {
             Layout.columnSpan: 3
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            Label { text: 'R' }
+
+            Label {
+                text: 'R'
+            }
+
             Shotcut.DoubleSpinBox {
-                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 id: liftRedSpinner
+
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 width: 115
                 from: -100
                 to: 100
@@ -357,19 +385,26 @@ Item {
                 stepSize: 0.1
                 suffix: ' %'
                 onValueChanged: {
-                    if( liftwheel.redF != spinnerToWheel(value) ) {
-                        liftwheel.redF = spinnerToWheel(value)
-                    }
+                    if (liftwheel.redF != spinnerToWheel(value))
+                        liftwheel.redF = spinnerToWheel(value);
+
                 }
             }
+
         }
+
         RowLayout {
             Layout.columnSpan: 3
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            Label { text: 'R' }
+
+            Label {
+                text: 'R'
+            }
+
             Shotcut.DoubleSpinBox {
-                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 id: gammaRedSpinner
+
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 width: 115
                 from: -100
                 to: 100
@@ -377,19 +412,26 @@ Item {
                 stepSize: 0.1
                 suffix: ' %'
                 onValueChanged: {
-                    if( gammawheel.redF != spinnerToWheel(value) ) {
-                        gammawheel.redF = spinnerToWheel(value)
-                    }
+                    if (gammawheel.redF != spinnerToWheel(value))
+                        gammawheel.redF = spinnerToWheel(value);
+
                 }
             }
+
         }
+
         RowLayout {
             Layout.columnSpan: 3
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            Label { text: 'R' }
+
+            Label {
+                text: 'R'
+            }
+
             Shotcut.DoubleSpinBox {
-                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 id: gainRedSpinner
+
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 width: 115
                 from: -100
                 to: 100
@@ -397,21 +439,27 @@ Item {
                 stepSize: 0.1
                 suffix: ' %'
                 onValueChanged: {
-                    if( gainwheel.redF != spinnerToWheel(value) ) {
-                        gainwheel.redF = spinnerToWheel(value)
-                    }
+                    if (gainwheel.redF != spinnerToWheel(value))
+                        gainwheel.redF = spinnerToWheel(value);
+
                 }
             }
+
         }
 
         // Row 5
         RowLayout {
             Layout.columnSpan: 3
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            Label { text: 'G' }
+
+            Label {
+                text: 'G'
+            }
+
             Shotcut.DoubleSpinBox {
-                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 id: liftGreenSpinner
+
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 width: 115
                 from: -100
                 to: 100
@@ -419,19 +467,26 @@ Item {
                 stepSize: 0.1
                 suffix: ' %'
                 onValueChanged: {
-                    if( liftwheel.greenF != spinnerToWheel(value) ) {
-                        liftwheel.greenF = spinnerToWheel(value)
-                    }
+                    if (liftwheel.greenF != spinnerToWheel(value))
+                        liftwheel.greenF = spinnerToWheel(value);
+
                 }
             }
+
         }
+
         RowLayout {
             Layout.columnSpan: 3
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            Label { text: 'G' }
+
+            Label {
+                text: 'G'
+            }
+
             Shotcut.DoubleSpinBox {
-                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 id: gammaGreenSpinner
+
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 width: 115
                 from: -100
                 to: 100
@@ -439,19 +494,26 @@ Item {
                 stepSize: 0.1
                 suffix: ' %'
                 onValueChanged: {
-                    if( gammawheel.greenF != spinnerToWheel(value) ) {
-                        gammawheel.greenF = spinnerToWheel(value)
-                    }
+                    if (gammawheel.greenF != spinnerToWheel(value))
+                        gammawheel.greenF = spinnerToWheel(value);
+
                 }
             }
+
         }
+
         RowLayout {
             Layout.columnSpan: 3
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            Label { text: 'G' }
+
+            Label {
+                text: 'G'
+            }
+
             Shotcut.DoubleSpinBox {
-                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 id: gainGreenSpinner
+
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 width: 115
                 from: -100
                 to: 100
@@ -459,21 +521,27 @@ Item {
                 stepSize: 0.1
                 suffix: ' %'
                 onValueChanged: {
-                    if( gainwheel.greenF != spinnerToWheel(value) ) {
-                        gainwheel.greenF = spinnerToWheel(value)
-                    }
+                    if (gainwheel.greenF != spinnerToWheel(value))
+                        gainwheel.greenF = spinnerToWheel(value);
+
                 }
             }
+
         }
 
         // Row 6
         RowLayout {
             Layout.columnSpan: 3
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            Label { text: 'B' }
+
+            Label {
+                text: 'B'
+            }
+
             Shotcut.DoubleSpinBox {
-                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 id: liftBlueSpinner
+
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 width: 115
                 from: -100
                 to: 100
@@ -481,19 +549,26 @@ Item {
                 stepSize: 0.1
                 suffix: ' %'
                 onValueChanged: {
-                    if( liftwheel.blueF != spinnerToWheel(value) ) {
-                        liftwheel.blueF = spinnerToWheel(value)
-                    }
+                    if (liftwheel.blueF != spinnerToWheel(value))
+                        liftwheel.blueF = spinnerToWheel(value);
+
                 }
             }
+
         }
+
         RowLayout {
             Layout.columnSpan: 3
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            Label { text: 'B' }
+
+            Label {
+                text: 'B'
+            }
+
             Shotcut.DoubleSpinBox {
-                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 id: gammaBlueSpinner
+
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 width: 115
                 from: -100
                 to: 100
@@ -501,19 +576,26 @@ Item {
                 stepSize: 0.1
                 suffix: ' %'
                 onValueChanged: {
-                    if( gammawheel.blueF != spinnerToWheel(value) ) {
-                        gammawheel.blueF = spinnerToWheel(value)
-                    }
+                    if (gammawheel.blueF != spinnerToWheel(value))
+                        gammawheel.blueF = spinnerToWheel(value);
+
                 }
             }
+
         }
+
         RowLayout {
             Layout.columnSpan: 3
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            Label { text: 'B' }
+
+            Label {
+                text: 'B'
+            }
+
             Shotcut.DoubleSpinBox {
-                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 id: gainBlueSpinner
+
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 width: 115
                 from: -100
                 to: 100
@@ -521,41 +603,50 @@ Item {
                 stepSize: 0.1
                 suffix: ' %'
                 onValueChanged: {
-                    if( gainwheel.blueF != spinnerToWheel(value) ) {
-                        gainwheel.blueF = spinnerToWheel(value)
-                    }
+                    if (gainwheel.blueF != spinnerToWheel(value))
+                        gainwheel.blueF = spinnerToWheel(value);
+
                 }
             }
+
         }
 
-        Item { Layout.fillHeight: true }
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
 
     Connections {
+        function onPositionChanged() {
+            loadValues();
+        }
+
         target: producer
-        function onPositionChanged() { loadValues() }
     }
 
     Connections {
-        target: parameters
         function onKeyframeAdded(parameter, position) {
             switch (parameter) {
             case 'lift_r':
-                filter.set('lift_r', liftwheel.redF * 2.0 - 1.0, position)
-                filter.set('lift_g', liftwheel.greenF * 2.0 - 1.0, position)
-                filter.set('lift_b', liftwheel.blueF * 2.0 - 1.0, position)
+                filter.set('lift_r', liftwheel.redF * 2 - 1, position);
+                filter.set('lift_g', liftwheel.greenF * 2 - 1, position);
+                filter.set('lift_b', liftwheel.blueF * 2 - 1, position);
                 break;
             case 'gamma_r':
-                filter.set('gamma_r', scaleWheelToValue(gammawheel.redF, gammaFactor), position)
-                filter.set('gamma_g', scaleWheelToValue(gammawheel.greenF, gammaFactor), position)
-                filter.set('gamma_b', scaleWheelToValue(gammawheel.blueF, gammaFactor), position)
+                filter.set('gamma_r', scaleWheelToValue(gammawheel.redF, gammaFactor), position);
+                filter.set('gamma_g', scaleWheelToValue(gammawheel.greenF, gammaFactor), position);
+                filter.set('gamma_b', scaleWheelToValue(gammawheel.blueF, gammaFactor), position);
                 break;
             case 'gain_r':
-                filter.set('gain_r', scaleWheelToValue(gainwheel.redF, gainFactor), position)
-                filter.set('gain_g', scaleWheelToValue(gainwheel.greenF, gainFactor), position)
-                filter.set('gain_b', scaleWheelToValue(gainwheel.blueF, gainFactor), position)
+                filter.set('gain_r', scaleWheelToValue(gainwheel.redF, gainFactor), position);
+                filter.set('gain_g', scaleWheelToValue(gainwheel.greenF, gainFactor), position);
+                filter.set('gain_b', scaleWheelToValue(gainwheel.blueF, gainFactor), position);
                 break;
             }
         }
+
+        target: parameters
     }
+
 }

--- a/src/qml/filters/color/ui_frei0r_coloradj.qml
+++ b/src/qml/filters/color/ui_frei0r_coloradj.qml
@@ -26,21 +26,19 @@ Item {
     property string paramBlue: '2'
     property string paramAction: '3'
     property var defaultParameters: [paramRed, paramGreen, paramBlue, paramAction]
+
+    function loadWheels() {
+        wheel.color = Qt.rgba(filter.getDouble(paramRed), filter.getDouble(paramGreen), filter.getDouble(paramBlue), 1);
+    }
+
     width: 450
     height: 250
-    
-    function loadWheels() {
-        wheel.color = Qt.rgba(filter.getDouble(paramRed),
-                              filter.getDouble(paramGreen),
-                              filter.getDouble(paramBlue),
-                              1.0)
-    }
-    
     Component.onCompleted: {
         if (filter.isNew)
-            filter.savePreset(defaultParameters)
-        modeCombo.currentIndex = Math.round(filter.getDouble(paramAction) * 2)
-        loadWheels()
+            filter.savePreset(defaultParameters);
+
+        modeCombo.currentIndex = Math.round(filter.getDouble(paramAction) * 2);
+        loadWheels();
     }
 
     ColumnLayout {
@@ -50,38 +48,46 @@ Item {
         Shotcut.Preset {
             parameters: defaultParameters
             onPresetSelected: {
-                modeCombo.currentIndex = Math.round(filter.getDouble(paramAction) * 2)
-                loadWheels()
+                modeCombo.currentIndex = Math.round(filter.getDouble(paramAction) * 2);
+                loadWheels();
             }
         }
 
         RowLayout {
-            Label { text: qsTr('Mode') }
+            Label {
+                text: qsTr('Mode')
+            }
+
             Shotcut.ComboBox {
                 id: modeCombo
+
                 Layout.minimumWidth: 200
                 model: [qsTr('Shadows (Lift)'), qsTr('Midtones (Gamma)'), qsTr('Highlights (Gain)')]
                 onActivated: filter.set(paramAction, currentIndex / 2)
             }
+
         }
 
         Shotcut.ColorWheelItem {
             id: wheel
+
             Layout.columnSpan: 2
             implicitWidth: (Math.min(parent.width, parent.height) - 60) * 1.1
             implicitHeight: Math.min(parent.width, parent.height) - 60
-            Layout.alignment : Qt.AlignCenter | Qt.AlignTop
+            Layout.alignment: Qt.AlignCenter | Qt.AlignTop
             Layout.minimumHeight: 75
             Layout.maximumHeight: 300
             onColorChanged: {
-                filter.set(paramRed, wheel.red / 255.0);
-                filter.set(paramGreen, wheel.green / 255.0);
-                filter.set(paramBlue, wheel.blue / 255.0);
+                filter.set(paramRed, wheel.red / 255);
+                filter.set(paramGreen, wheel.green / 255);
+                filter.set(paramBlue, wheel.blue / 255);
             }
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/contrast/meta.qml
+++ b/src/qml/filters/contrast/meta.qml
@@ -9,6 +9,7 @@ Metadata {
     qml: "ui.qml"
     isFavorite: true
     gpuAlt: "movit.lift_gamma_gain"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -21,4 +22,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/contrast/meta_movit.qml
+++ b/src/qml/filters/contrast/meta_movit.qml
@@ -9,6 +9,7 @@ Metadata {
     needsGPU: true
     qml: "ui.qml"
     isFavorite: true
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -21,4 +22,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/contrast/ui.qml
+++ b/src/qml/filters/contrast/ui.qml
@@ -22,118 +22,120 @@ import Shotcut.Controls 1.0 as Shotcut
 
 Item {
     property var defaultParameters: ['gamma_r', 'gamma_g', 'gamma_b', 'gain_r', 'gain_g', 'gain_b']
-    property double gammaFactor: 2.0
-    property double gainFactor: 2.0
+    property double gammaFactor: 2
+    property double gainFactor: 2
     property bool blockUpdate: true
     property double startValue: 0.5
     property double middleValue: 0.5
     property double endValue: 0.5
-    width: 200
-    height: 50
-    
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set("gamma_r", 1.0);
-            filter.set("gamma_g", 1.0);
-            filter.set("gamma_b", 1.0);
-            filter.set("gain_r", 1.0);
-            filter.set("gain_g", 1.0);
-            filter.set("gain_b", 1.0);
-            filter.savePreset(defaultParameters)
-        } else {
-            middleValue = filter.getDouble('gain_r', filter.animateIn) / gainFactor
-            if (filter.animateIn > 0)
-                startValue = filter.getDouble('gain_r', 0) / gainFactor
-            if (filter.animateOut > 0)
-                endValue = filter.getDouble('gain_r', filter.duration - 1) / gainFactor
-        }
-        setControls()
-    }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        contrastSlider.value = filter.getDouble("gain_r", position) / gainFactor * 100.0
-        keyframesButton.checked = filter.keyframeCount('gain_r') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-        blockUpdate = false
-        contrastSlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        contrastSlider.value = filter.getDouble("gain_r", position) / gainFactor * 100;
+        keyframesButton.checked = filter.keyframeCount('gain_r') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+        blockUpdate = false;
+        contrastSlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function updateFilter(position) {
-        if (blockUpdate) return
-        var value = contrastSlider.value / 100.0
+        if (blockUpdate)
+            return ;
 
+        var value = contrastSlider.value / 100;
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValue = value
+                startValue = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValue = value
+                endValue = value;
             else
-                middleValue = value
+                middleValue = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty('gamma_r')
-            filter.resetProperty('gamma_g')
-            filter.resetProperty('gamma_b')
-            filter.resetProperty('gain_r')
-            filter.resetProperty('gain_g')
-            filter.resetProperty('gain_b')
-            keyframesButton.checked = false
+            filter.resetProperty('gamma_r');
+            filter.resetProperty('gamma_g');
+            filter.resetProperty('gamma_b');
+            filter.resetProperty('gain_r');
+            filter.resetProperty('gain_g');
+            filter.resetProperty('gain_b');
+            keyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set("gamma_r", (1.0 - startValue) * gammaFactor, 0)
-                filter.set("gamma_g", (1.0 - startValue) * gammaFactor, 0)
-                filter.set("gamma_b", (1.0 - startValue) * gammaFactor, 0)
-                filter.set("gain_r",  startValue * gainFactor, 0)
-                filter.set("gain_g",  startValue * gainFactor, 0)
-                filter.set("gain_b",  startValue * gainFactor, 0)
-                filter.set("gamma_r", (1.0 - middleValue) * gammaFactor, filter.animateIn - 1)
-                filter.set("gamma_g", (1.0 - middleValue) * gammaFactor, filter.animateIn - 1)
-                filter.set("gamma_b", (1.0 - middleValue) * gammaFactor, filter.animateIn - 1)
-                filter.set("gain_r",  middleValue * gainFactor, filter.animateIn - 1)
-                filter.set("gain_g",  middleValue * gainFactor, filter.animateIn - 1)
-                filter.set("gain_b",  middleValue * gainFactor, filter.animateIn - 1)
+                filter.set("gamma_r", (1 - startValue) * gammaFactor, 0);
+                filter.set("gamma_g", (1 - startValue) * gammaFactor, 0);
+                filter.set("gamma_b", (1 - startValue) * gammaFactor, 0);
+                filter.set("gain_r", startValue * gainFactor, 0);
+                filter.set("gain_g", startValue * gainFactor, 0);
+                filter.set("gain_b", startValue * gainFactor, 0);
+                filter.set("gamma_r", (1 - middleValue) * gammaFactor, filter.animateIn - 1);
+                filter.set("gamma_g", (1 - middleValue) * gammaFactor, filter.animateIn - 1);
+                filter.set("gamma_b", (1 - middleValue) * gammaFactor, filter.animateIn - 1);
+                filter.set("gain_r", middleValue * gainFactor, filter.animateIn - 1);
+                filter.set("gain_g", middleValue * gainFactor, filter.animateIn - 1);
+                filter.set("gain_b", middleValue * gainFactor, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set("gamma_r", (1.0 - middleValue) * gammaFactor, filter.duration - filter.animateOut)
-                filter.set("gamma_g", (1.0 - middleValue) * gammaFactor, filter.duration - filter.animateOut)
-                filter.set("gamma_b", (1.0 - middleValue) * gammaFactor, filter.duration - filter.animateOut)
-                filter.set("gain_r",  middleValue * gainFactor, filter.duration - filter.animateOut)
-                filter.set("gain_g",  middleValue * gainFactor, filter.duration - filter.animateOut)
-                filter.set("gain_b",  middleValue * gainFactor, filter.duration - filter.animateOut)
-                filter.set("gamma_r", (1.0 - endValue) * gammaFactor, filter.duration - 1)
-                filter.set("gamma_g", (1.0 - endValue) * gammaFactor, filter.duration - 1)
-                filter.set("gamma_b", (1.0 - endValue) * gammaFactor, filter.duration - 1)
-                filter.set("gain_r",  endValue * gainFactor, filter.duration - 1)
-                filter.set("gain_g",  endValue * gainFactor, filter.duration - 1)
-                filter.set("gain_b",  endValue * gainFactor, filter.duration - 1)
+                filter.set("gamma_r", (1 - middleValue) * gammaFactor, filter.duration - filter.animateOut);
+                filter.set("gamma_g", (1 - middleValue) * gammaFactor, filter.duration - filter.animateOut);
+                filter.set("gamma_b", (1 - middleValue) * gammaFactor, filter.duration - filter.animateOut);
+                filter.set("gain_r", middleValue * gainFactor, filter.duration - filter.animateOut);
+                filter.set("gain_g", middleValue * gainFactor, filter.duration - filter.animateOut);
+                filter.set("gain_b", middleValue * gainFactor, filter.duration - filter.animateOut);
+                filter.set("gamma_r", (1 - endValue) * gammaFactor, filter.duration - 1);
+                filter.set("gamma_g", (1 - endValue) * gammaFactor, filter.duration - 1);
+                filter.set("gamma_b", (1 - endValue) * gammaFactor, filter.duration - 1);
+                filter.set("gain_r", endValue * gainFactor, filter.duration - 1);
+                filter.set("gain_g", endValue * gainFactor, filter.duration - 1);
+                filter.set("gain_b", endValue * gainFactor, filter.duration - 1);
             }
         } else if (!keyframesButton.checked) {
-            filter.resetProperty('gamma_r')
-            filter.resetProperty('gamma_g')
-            filter.resetProperty('gamma_b')
-            filter.resetProperty('gain_r')
-            filter.resetProperty('gain_g')
-            filter.resetProperty('gain_b')
-            filter.set("gamma_r", (1.0 - middleValue) * gammaFactor)
-            filter.set("gamma_g", (1.0 - middleValue) * gammaFactor)
-            filter.set("gamma_b", (1.0 - middleValue) * gammaFactor)
-            filter.set("gain_r",  middleValue * gainFactor)
-            filter.set("gain_g",  middleValue * gainFactor)
-            filter.set("gain_b",  middleValue * gainFactor)
+            filter.resetProperty('gamma_r');
+            filter.resetProperty('gamma_g');
+            filter.resetProperty('gamma_b');
+            filter.resetProperty('gain_r');
+            filter.resetProperty('gain_g');
+            filter.resetProperty('gain_b');
+            filter.set("gamma_r", (1 - middleValue) * gammaFactor);
+            filter.set("gamma_g", (1 - middleValue) * gammaFactor);
+            filter.set("gamma_b", (1 - middleValue) * gammaFactor);
+            filter.set("gain_r", middleValue * gainFactor);
+            filter.set("gain_g", middleValue * gainFactor);
+            filter.set("gain_b", middleValue * gainFactor);
         } else if (position !== null) {
-            filter.set("gamma_r", (1.0 - value) * gammaFactor, position)
-            filter.set("gamma_g", (1.0 - value) * gammaFactor, position)
-            filter.set("gamma_b", (1.0 - value) * gammaFactor, position)
-            filter.set("gain_r",  value * gainFactor, position)
-            filter.set("gain_g",  value * gainFactor, position)
-            filter.set("gain_b",  value * gainFactor, position)
+            filter.set("gamma_r", (1 - value) * gammaFactor, position);
+            filter.set("gamma_g", (1 - value) * gammaFactor, position);
+            filter.set("gamma_b", (1 - value) * gammaFactor, position);
+            filter.set("gain_r", value * gainFactor, position);
+            filter.set("gain_g", value * gainFactor, position);
+            filter.set("gain_b", value * gainFactor, position);
         }
+    }
+
+    width: 200
+    height: 50
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set("gamma_r", 1);
+            filter.set("gamma_g", 1);
+            filter.set("gamma_b", 1);
+            filter.set("gain_r", 1);
+            filter.set("gain_g", 1);
+            filter.set("gain_b", 1);
+            filter.savePreset(defaultParameters);
+        } else {
+            middleValue = filter.getDouble('gain_r', filter.animateIn) / gainFactor;
+            if (filter.animateIn > 0)
+                startValue = filter.getDouble('gain_r', 0) / gainFactor;
+
+            if (filter.animateOut > 0)
+                endValue = filter.getDouble('gain_r', filter.duration - 1) / gainFactor;
+
+        }
+        setControls();
     }
 
     GridLayout {
@@ -145,20 +147,21 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             Layout.columnSpan: 3
             parameters: defaultParameters
             onBeforePresetLoaded: {
-                filter.resetProperty('gamma_r')
-                filter.resetProperty('gamma_g')
-                filter.resetProperty('gamma_b')
-                filter.resetProperty('gain_r')
-                filter.resetProperty('gain_g')
-                filter.resetProperty('gain_b')
+                filter.resetProperty('gamma_r');
+                filter.resetProperty('gamma_g');
+                filter.resetProperty('gamma_b');
+                filter.resetProperty('gain_r');
+                filter.resetProperty('gain_g');
+                filter.resetProperty('gain_b');
             }
             onPresetSelected: {
-                setControls()
-                updateFilter(getPosition())
+                setControls();
+                updateFilter(getPosition());
             }
         }
 
@@ -166,46 +169,51 @@ Item {
             text: qsTr('Level')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: contrastSlider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter(getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: contrastSlider.value = 50
         }
+
         Shotcut.KeyframesButton {
-            id:keyframesButton
+            id: keyframesButton
+
             onToggled: {
-                var value = contrastSlider.value / 100.0
-                blockUpdate = true
-                filter.resetProperty('gamma_r')
-                filter.resetProperty('gamma_g')
-                filter.resetProperty('gamma_b')
-                filter.resetProperty('gain_r')
-                filter.resetProperty('gain_g')
-                filter.resetProperty('gain_b')
+                var value = contrastSlider.value / 100;
+                blockUpdate = true;
+                filter.resetProperty('gamma_r');
+                filter.resetProperty('gamma_g');
+                filter.resetProperty('gamma_b');
+                filter.resetProperty('gain_r');
+                filter.resetProperty('gain_g');
+                filter.resetProperty('gain_b');
                 if (checked) {
-                    filter.animateIn = filter.animateOut = 0
-                    blockUpdate = false
-                    var position = getPosition()
-                    filter.set("gamma_r", (1.0 - value) * gammaFactor, position)
-                    filter.set("gamma_g", (1.0 - value) * gammaFactor, position)
-                    filter.set("gamma_b", (1.0 - value) * gammaFactor, position)
-                    filter.set("gain_r",  value * gainFactor, position)
-                    filter.set("gain_g",  value * gainFactor, position)
-                    filter.set("gain_b",  value * gainFactor, position)
+                    filter.animateIn = filter.animateOut = 0;
+                    blockUpdate = false;
+                    var position = getPosition();
+                    filter.set("gamma_r", (1 - value) * gammaFactor, position);
+                    filter.set("gamma_g", (1 - value) * gammaFactor, position);
+                    filter.set("gamma_b", (1 - value) * gammaFactor, position);
+                    filter.set("gain_r", value * gainFactor, position);
+                    filter.set("gain_g", value * gainFactor, position);
+                    filter.set("gain_b", value * gainFactor, position);
                 } else {
-                    blockUpdate = false
-                    filter.set("gamma_r", (1.0 - value) * gammaFactor)
-                    filter.set("gamma_g", (1.0 - value) * gammaFactor)
-                    filter.set("gamma_b", (1.0 - value) * gammaFactor)
-                    filter.set("gain_r",  value * gainFactor)
-                    filter.set("gain_g",  value * gainFactor)
-                    filter.set("gain_b",  value * gainFactor)
+                    blockUpdate = false;
+                    filter.set("gamma_r", (1 - value) * gammaFactor);
+                    filter.set("gamma_g", (1 - value) * gammaFactor);
+                    filter.set("gamma_b", (1 - value) * gammaFactor);
+                    filter.set("gain_r", value * gainFactor);
+                    filter.set("gain_g", value * gainFactor);
+                    filter.set("gain_b", value * gainFactor);
                 }
             }
         }
@@ -213,34 +221,58 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
-        target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateFilter(null) }
-        function onOutChanged() { updateFilter(null) }
-        function onAnimateInChanged() { updateFilter(null) }
-        function onAnimateOutChanged() { updateFilter(null) }
-        function onPropertyChanged(name) { setControls() }
-    }
-
-    Connections {
-        target: producer
-        function onPositionChanged() { setControls() }
-    }
-
-    Connections {
-        target: parameters
-        function onKeyframeAdded(parameter, position) {
-            middleValue = filter.getDouble(parameter, position) / gainFactor
-            filter.set("gain_r", middleValue * gainFactor, position)
-            filter.set("gain_g", middleValue * gainFactor, position)
-            filter.set("gain_b", middleValue * gainFactor, position)
-            var gamma = (1.0 - middleValue) * gammaFactor
-            filter.set("gamma_r", gamma, position)
-            filter.set("gamma_g", gamma, position)
-            filter.set("gamma_b", gamma, position)
+        function onChanged() {
+            setControls();
         }
+
+        function onInChanged() {
+            updateFilter(null);
+        }
+
+        function onOutChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateInChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateOutChanged() {
+            updateFilter(null);
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
+        target: filter
     }
+
+    Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
+        target: producer
+    }
+
+    Connections {
+        function onKeyframeAdded(parameter, position) {
+            middleValue = filter.getDouble(parameter, position) / gainFactor;
+            filter.set("gain_r", middleValue * gainFactor, position);
+            filter.set("gain_g", middleValue * gainFactor, position);
+            filter.set("gain_b", middleValue * gainFactor, position);
+            var gamma = (1 - middleValue) * gammaFactor;
+            filter.set("gamma_r", gamma, position);
+            filter.set("gamma_g", gamma, position);
+            filter.set("gamma_b", gamma, position);
+        }
+
+        target: parameters
+    }
+
 }

--- a/src/qml/filters/corners/meta.qml
+++ b/src/qml/filters/corners/meta.qml
@@ -24,6 +24,7 @@ Metadata {
     mlt_service: 'frei0r.c0rners'
     qml: 'ui.qml'
     vui: 'vui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -40,21 +41,22 @@ Metadata {
                 isCurve: true
                 minimum: 0
                 maximum: 1
-             },
-             Parameter {
+            },
+            Parameter {
                 name: qsTr('Stretch Y')
                 property: '10'
                 isCurve: true
                 minimum: 0
                 maximum: 1
-             },
-             Parameter {
+            },
+            Parameter {
                 name: qsTr('Feathering')
                 property: '13'
                 isCurve: true
                 minimum: 0
                 maximum: 1
-             }
+            }
         ]
     }
+
 }

--- a/src/qml/filters/corners/ui.qml
+++ b/src/qml/filters/corners/ui.qml
@@ -36,223 +36,196 @@ Shotcut.KeyframableFilter {
     property string transparentProperty: '12'
     property string featherProperty: '13'
     property string alphaOpProperty: '14'
-
-    property double corner1xDefault: 1/3
-    property double corner1yDefault: 1/3
-    property double corner2xDefault: 2/3
-    property double corner2yDefault: 1/3
-    property double corner3xDefault: 2/3
-    property double corner3yDefault: 2/3
-    property double corner4xDefault: 1/3
-    property double corner4yDefault: 2/3
+    property double corner1xDefault: 1 / 3
+    property double corner1yDefault: 1 / 3
+    property double corner2xDefault: 2 / 3
+    property double corner2yDefault: 1 / 3
+    property double corner3xDefault: 2 / 3
+    property double corner3yDefault: 2 / 3
+    property double corner4xDefault: 1 / 3
+    property double corner4yDefault: 2 / 3
     property double stretchxDefault: 0.5
     property double stretchyDefault: 0.5
-    property double interpolatorDefault: 2/6
+    property double interpolatorDefault: 2 / 6
     property double featheralphaDefault: 0.01
     property double alphaoperationDefault: 0
-
     property var cornerProperties: ['shotcut:corner1', 'shotcut:corner2', 'shotcut:corner3', 'shotcut:corner4']
-    property var corners: [
-        Qt.rect(corner1xDefault, corner1yDefault, 0, 0),
-        Qt.rect(corner2xDefault, corner2yDefault, 0, 0),
-        Qt.rect(corner3xDefault, corner3yDefault, 0, 0),
-        Qt.rect(corner4xDefault, corner4yDefault, 0, 0)]
+    property var corners: [Qt.rect(corner1xDefault, corner1yDefault, 0, 0), Qt.rect(corner2xDefault, corner2yDefault, 0, 0), Qt.rect(corner3xDefault, corner3yDefault, 0, 0), Qt.rect(corner4xDefault, corner4yDefault, 0, 0)]
     property var cornerStartValues: ['_shotcut:corner1StartValue', '_shotcut:corner2StartValue', '_shotcut:corner3StartValue', '_shotcut:corner4StartValue']
     property var cornerMiddleValues: ['_shotcut:corner1MiddleValue', '_shotcut:corner2MiddleValue', '_shotcut:corner3MiddleValue', '_shotcut:corner4MiddleValue']
     property var cornerEndValues: ['_shotcut:corner1EndValue', '_shotcut:corner2EndValue', '_shotcut:corner3EndValue', '_shotcut:corner4EndValue']
+
+    function sliderValue(slider) {
+        return (slider.value - slider.minimumValue) / (slider.maximumValue - slider.minimumValue);
+    }
+
+    function setSliderValue(slider, value) {
+        slider.value = value * (slider.maximumValue - slider.minimumValue) + slider.minimumValue;
+    }
+
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        stretchxSlider.value = (1 - filter.getDouble(stretchxProperty, position)) * stretchxSlider.maximumValue;
+        stretchySlider.value = (1 - filter.getDouble(stretchyProperty, position)) * stretchySlider.maximumValue;
+        interpolatorCombo.currentIndex = Math.round(filter.getDouble(interpolatorProperty) * 6);
+        alphaoperationCombo.currentIndex = filter.get(transparentProperty) === '1' ? Math.round(filter.getDouble(alphaOpProperty) * 4) + 1 : 0;
+        featheralphaSlider.value = filter.getDouble(featherProperty, position) * featheralphaSlider.maximumValue;
+        for (var i in corners) corners[i] = filter.getRect(cornerProperties[i], position)
+        setSliderValue(corner1xSlider, corners[0].x);
+        setSliderValue(corner1ySlider, corners[0].y);
+        setSliderValue(corner2xSlider, corners[1].x);
+        setSliderValue(corner2ySlider, corners[1].y);
+        setSliderValue(corner3xSlider, corners[2].x);
+        setSliderValue(corner3ySlider, corners[2].y);
+        setSliderValue(corner4xSlider, corners[3].x);
+        setSliderValue(corner4ySlider, corners[3].y);
+        corner1KeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(corner1xProperty) > 0;
+        stretchxKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(stretchxProperty) > 0;
+        stretchyKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(stretchyProperty) > 0;
+        featheralphaKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(featherProperty) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        corner1xSlider.enabled = corner1ySlider.enabled = corner2xSlider.enabled = corner2ySlider.enabled = corner3xSlider.enabled = corner3ySlider.enabled = corner4xSlider.enabled = corner4ySlider.enabled = stretchxSlider.enabled = stretchySlider.enabled = featheralphaSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        setControls();
+        updateFilter(corner1xProperty, sliderValue(corner1xSlider), corner1KeyframesButton, null);
+        updateFilter(corner1yProperty, sliderValue(corner1ySlider), corner1KeyframesButton, null);
+        updateFilter(corner2xProperty, sliderValue(corner2xSlider), corner1KeyframesButton, null);
+        updateFilter(corner2yProperty, sliderValue(corner2ySlider), corner1KeyframesButton, null);
+        updateFilter(corner3xProperty, sliderValue(corner3xSlider), corner1KeyframesButton, null);
+        updateFilter(corner3yProperty, sliderValue(corner3ySlider), corner1KeyframesButton, null);
+        updateFilter(corner4xProperty, sliderValue(corner4xSlider), corner1KeyframesButton, null);
+        updateFilter(corner4yProperty, sliderValue(corner4ySlider), corner1KeyframesButton, null);
+        updateFilter(stretchxProperty, 1 - stretchxSlider.value / stretchxSlider.maximumValue, stretchxKeyframesButton, null);
+        updateFilter(stretchyProperty, 1 - stretchySlider.value / stretchySlider.maximumValue, stretchyKeyframesButton, null);
+        updateFilter(featherProperty, featheralphaSlider.value / featheralphaSlider.maximumValue, featheralphaKeyframesButton, null);
+        updateFilterCorners(null);
+    }
+
+    function resetFilter() {
+        filter.resetProperty(corner1xProperty);
+        filter.resetProperty(corner1yProperty);
+        filter.resetProperty(corner2xProperty);
+        filter.resetProperty(corner2yProperty);
+        filter.resetProperty(corner3xProperty);
+        filter.resetProperty(corner3yProperty);
+        filter.resetProperty(corner4xProperty);
+        filter.resetProperty(corner4yProperty);
+        for (var i in cornerProperties) filter.resetProperty(cornerProperties[i])
+    }
+
+    function setFilterCorners(corners, position) {
+        for (var i in cornerProperties) filter.set(cornerProperties[i], corners[i], position)
+        filter.set(corner1xProperty, corners[0].x, position);
+        filter.set(corner1yProperty, corners[0].y, position);
+        filter.set(corner2xProperty, corners[1].x, position);
+        filter.set(corner2yProperty, corners[1].y, position);
+        filter.set(corner3xProperty, corners[2].x, position);
+        filter.set(corner3yProperty, corners[2].y, position);
+        filter.set(corner4xProperty, corners[3].x, position);
+        filter.set(corner4yProperty, corners[3].y, position);
+    }
+
+    function updateFilterCorners(position) {
+        if (blockUpdate)
+            return ;
+
+        if (position !== null) {
+            filter.blockSignals = true;
+            if (position <= 0 && filter.animateIn > 0) {
+                for (var i in cornerStartValues) filter.set(cornerStartValues[i], corners[i])
+            } else if (position >= filter.duration - 1 && filter.animateOut > 0) {
+                for (i in cornerEndValues) filter.set(cornerEndValues[i], corners[i])
+            } else {
+                for (i in cornerMiddleValues) filter.set(cornerMiddleValues[i], corners[i])
+            }
+            filter.blockSignals = false;
+        }
+        if (filter.animateIn > 0 || filter.animateOut > 0) {
+            resetFilter();
+            corner1KeyframesButton.checked = false;
+            if (filter.animateIn > 0) {
+                setFilterCorners([filter.getRect(cornerStartValues[0]), filter.getRect(cornerStartValues[1]), filter.getRect(cornerStartValues[2]), filter.getRect(cornerStartValues[3])], 0);
+                setFilterCorners([filter.getRect(cornerMiddleValues[0]), filter.getRect(cornerMiddleValues[1]), filter.getRect(cornerMiddleValues[2]), filter.getRect(cornerMiddleValues[3])], filter.animateIn - 1);
+            }
+            if (filter.animateOut > 0) {
+                setFilterCorners([filter.getRect(cornerMiddleValues[0]), filter.getRect(cornerMiddleValues[1]), filter.getRect(cornerMiddleValues[2]), filter.getRect(cornerMiddleValues[3])], filter.duration - filter.animateOut);
+                setFilterCorners([filter.getRect(cornerEndValues[0]), filter.getRect(cornerEndValues[1]), filter.getRect(cornerEndValues[2]), filter.getRect(cornerEndValues[3])], filter.duration - 1);
+            }
+        } else if (!corner1KeyframesButton.checked) {
+            resetFilter();
+            setFilterCorners([filter.getRect(cornerMiddleValues[0]), filter.getRect(cornerMiddleValues[1]), filter.getRect(cornerMiddleValues[2]), filter.getRect(cornerMiddleValues[3])], -1);
+        } else if (position !== null) {
+            setFilterCorners(corners, position);
+        }
+    }
 
     keyframableParameters: [corner1xProperty, corner1yProperty, corner2xProperty, corner2yProperty, corner3xProperty, corner3yProperty, corner4xProperty, corner4yProperty, stretchxProperty, stretchyProperty, featherProperty]
     startValues: [corner1xDefault, corner1yDefault, corner2xDefault, corner2yDefault, corner3xDefault, corner3yDefault, corner4xDefault, corner4yDefault, stretchxDefault, stretchyDefault, featheralphaDefault]
     middleValues: [corner1xDefault, corner1yDefault, corner2xDefault, corner2yDefault, corner3xDefault, corner3yDefault, corner4xDefault, corner4yDefault, stretchxDefault, stretchyDefault, featheralphaDefault]
     endValues: [corner1xDefault, corner1yDefault, corner2xDefault, corner2yDefault, corner3xDefault, corner3yDefault, corner4xDefault, corner4yDefault, stretchxDefault, stretchyDefault, featheralphaDefault]
-
     width: 350
     height: 450
-
     Component.onCompleted: {
-        filter.blockSignals = true
-        var cornersString = JSON.stringify(corners)
-        for (var i in cornerStartValues)
-            filter.set(cornerStartValues[i], corners[i])
-        for (i in cornerMiddleValues)
-            filter.set(cornerMiddleValues[i], corners[i])
-        for (i in cornerEndValues)
-            filter.set(cornerEndValues[i], corners[i])
+        filter.blockSignals = true;
+        var cornersString = JSON.stringify(corners);
+        for (var i in cornerStartValues) filter.set(cornerStartValues[i], corners[i])
+        for (i in cornerMiddleValues) filter.set(cornerMiddleValues[i], corners[i])
+        for (i in cornerEndValues) filter.set(cornerEndValues[i], corners[i])
         if (filter.isNew) {
-            filter.set(corner1xProperty, corner1xDefault)
-            filter.set(corner1yProperty, corner1yDefault)
-            filter.set(corner2xProperty, corner2xDefault)
-            filter.set(corner2yProperty, corner2yDefault)
-            filter.set(corner3xProperty, corner3xDefault)
-            filter.set(corner3yProperty, corner3yDefault)
-            filter.set(corner4xProperty, corner4xDefault)
-            filter.set(corner4yProperty, corner4yDefault)
-            filter.set(enablestretchProperty, 1)
-            filter.set(stretchxProperty, stretchxDefault)
-            filter.set(stretchyProperty, stretchyDefault)
-            filter.set(interpolatorProperty, interpolatorDefault)
-            filter.set(transparentProperty, 1)
-            filter.set(alphaOpProperty, alphaoperationDefault)
-            filter.set(featherProperty, featheralphaDefault)
-            for (i in corners)
-                filter.set(cornerProperties[i], '' + corners[i].x + ' ' + corners[i].y)
-            filter.savePreset(preset.parameters)
+            filter.set(corner1xProperty, corner1xDefault);
+            filter.set(corner1yProperty, corner1yDefault);
+            filter.set(corner2xProperty, corner2xDefault);
+            filter.set(corner2yProperty, corner2yDefault);
+            filter.set(corner3xProperty, corner3xDefault);
+            filter.set(corner3yProperty, corner3yDefault);
+            filter.set(corner4xProperty, corner4xDefault);
+            filter.set(corner4yProperty, corner4yDefault);
+            filter.set(enablestretchProperty, 1);
+            filter.set(stretchxProperty, stretchxDefault);
+            filter.set(stretchyProperty, stretchyDefault);
+            filter.set(interpolatorProperty, interpolatorDefault);
+            filter.set(transparentProperty, 1);
+            filter.set(alphaOpProperty, alphaoperationDefault);
+            filter.set(featherProperty, featheralphaDefault);
+            for (i in corners) filter.set(cornerProperties[i], '' + corners[i].x + ' ' + corners[i].y)
+            filter.savePreset(preset.parameters);
         } else {
-            initializeSimpleKeyframes()
-
-            var position = getPosition()
-            cornersString = filter.get(cornerProperties[0])
+            initializeSimpleKeyframes();
+            var position = getPosition();
+            cornersString = filter.get(cornerProperties[0]);
             if (cornersString) {
-                for (i in corners)
-                    corners[i] = filter.getRect(cornerProperties[i], position)
+                for (i in corners) corners[i] = filter.getRect(cornerProperties[i], position)
             } else {
-                corners[0].x = filter.getDouble(corner1xProperty, position)
-                corners[0].y = filter.getDouble(corner1yProperty, position)
-                corners[1].x = filter.getDouble(corner2xProperty, position)
-                corners[1].y = filter.getDouble(corner2yProperty, position)
-                corners[2].x = filter.getDouble(corner3xProperty, position)
-                corners[2].y = filter.getDouble(corner3yProperty, position)
-                corners[3].x = filter.getDouble(corner4xProperty, position)
-                corners[3].y = filter.getDouble(corner4yProperty, position)
-                for (i in cornerProperties)
-                    filter.set(cornerProperties[i], corners[i])
+                corners[0].x = filter.getDouble(corner1xProperty, position);
+                corners[0].y = filter.getDouble(corner1yProperty, position);
+                corners[1].x = filter.getDouble(corner2xProperty, position);
+                corners[1].y = filter.getDouble(corner2yProperty, position);
+                corners[2].x = filter.getDouble(corner3xProperty, position);
+                corners[2].y = filter.getDouble(corner3yProperty, position);
+                corners[3].x = filter.getDouble(corner4xProperty, position);
+                corners[3].y = filter.getDouble(corner4yProperty, position);
+                for (i in cornerProperties) filter.set(cornerProperties[i], corners[i])
             }
-            for (i in cornerMiddleValues)
-                filter.set(cornerMiddleValues[i], filter.getRect(cornerProperties[i], filter.animateIn + 1))
+            for (i in cornerMiddleValues) filter.set(cornerMiddleValues[i], filter.getRect(cornerProperties[i], filter.animateIn + 1))
             if (filter.animateIn > 0) {
-                for (i in cornerStartValues)
-                    filter.set(cornerStartValues[i], filter.getRect(cornerProperties[i], 0))
+                for (i in cornerStartValues) filter.set(cornerStartValues[i], filter.getRect(cornerProperties[i], 0))
             }
             if (filter.animateOut > 0) {
-                for (i in cornerEndValues)
-                    filter.set(cornerEndValues[i], filter.getRect(cornerProperties[i], filter.duration - 1))
+                for (i in cornerEndValues) filter.set(cornerEndValues[i], filter.getRect(cornerProperties[i], filter.duration - 1))
             }
         }
-        filter.blockSignals = false
-        setControls()
-        if (filter.isNew) {
-            filter.set(cornerProperties[0], filter.getRect(cornerProperties[0]))
-        }
-    }
+        filter.blockSignals = false;
+        setControls();
+        if (filter.isNew)
+            filter.set(cornerProperties[0], filter.getRect(cornerProperties[0]));
 
-    function sliderValue(slider) {
-        return (slider.value - slider.minimumValue) / (slider.maximumValue - slider.minimumValue)
-    }
-
-    function setSliderValue(slider, value) {
-        slider.value = value * (slider.maximumValue - slider.minimumValue) + slider.minimumValue
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        stretchxSlider.value = (1.0 - filter.getDouble(stretchxProperty, position)) * stretchxSlider.maximumValue
-        stretchySlider.value = (1.0 - filter.getDouble(stretchyProperty, position)) * stretchySlider.maximumValue
-        interpolatorCombo.currentIndex = Math.round(filter.getDouble(interpolatorProperty) * 6)
-        alphaoperationCombo.currentIndex = filter.get(transparentProperty) === '1'?
-                    Math.round(filter.getDouble(alphaOpProperty) * 4) + 1 : 0
-        featheralphaSlider.value = filter.getDouble(featherProperty, position) * featheralphaSlider.maximumValue
-
-        for (var i in corners)
-            corners[i] = filter.getRect(cornerProperties[i], position)
-        setSliderValue(corner1xSlider, corners[0].x)
-        setSliderValue(corner1ySlider, corners[0].y)
-        setSliderValue(corner2xSlider, corners[1].x)
-        setSliderValue(corner2ySlider, corners[1].y)
-        setSliderValue(corner3xSlider, corners[2].x)
-        setSliderValue(corner3ySlider, corners[2].y)
-        setSliderValue(corner4xSlider, corners[3].x)
-        setSliderValue(corner4ySlider, corners[3].y)
-
-        corner1KeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(corner1xProperty) > 0
-        stretchxKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(stretchxProperty) > 0
-        stretchyKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(stretchyProperty) > 0
-        featheralphaKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(featherProperty) > 0
-
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        corner1xSlider.enabled = corner1ySlider.enabled = corner2xSlider.enabled = corner2ySlider.enabled = corner3xSlider.enabled = corner3ySlider.enabled = corner4xSlider.enabled = corner4ySlider.enabled = stretchxSlider.enabled = stretchySlider.enabled = featheralphaSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        setControls()
-        updateFilter(corner1xProperty, sliderValue(corner1xSlider), corner1KeyframesButton, null)
-        updateFilter(corner1yProperty, sliderValue(corner1ySlider), corner1KeyframesButton, null)
-        updateFilter(corner2xProperty, sliderValue(corner2xSlider), corner1KeyframesButton, null)
-        updateFilter(corner2yProperty, sliderValue(corner2ySlider), corner1KeyframesButton, null)
-        updateFilter(corner3xProperty, sliderValue(corner3xSlider), corner1KeyframesButton, null)
-        updateFilter(corner3yProperty, sliderValue(corner3ySlider), corner1KeyframesButton, null)
-        updateFilter(corner4xProperty, sliderValue(corner4xSlider), corner1KeyframesButton, null)
-        updateFilter(corner4yProperty, sliderValue(corner4ySlider), corner1KeyframesButton, null)
-        updateFilter(stretchxProperty, 1.0 - stretchxSlider.value / stretchxSlider.maximumValue, stretchxKeyframesButton, null)
-        updateFilter(stretchyProperty, 1.0 - stretchySlider.value / stretchySlider.maximumValue, stretchyKeyframesButton, null)
-        updateFilter(featherProperty, featheralphaSlider.value / featheralphaSlider.maximumValue, featheralphaKeyframesButton, null)
-        updateFilterCorners(null)
-    }
-
-    function resetFilter() {
-        filter.resetProperty(corner1xProperty)
-        filter.resetProperty(corner1yProperty)
-        filter.resetProperty(corner2xProperty)
-        filter.resetProperty(corner2yProperty)
-        filter.resetProperty(corner3xProperty)
-        filter.resetProperty(corner3yProperty)
-        filter.resetProperty(corner4xProperty)
-        filter.resetProperty(corner4yProperty)
-        for (var i in cornerProperties)
-            filter.resetProperty(cornerProperties[i])
-    }
-
-    function setFilterCorners(corners, position) {
-        for (var i in cornerProperties)
-            filter.set(cornerProperties[i], corners[i], position)
-        filter.set(corner1xProperty, corners[0].x, position)
-        filter.set(corner1yProperty, corners[0].y, position)
-        filter.set(corner2xProperty, corners[1].x, position)
-        filter.set(corner2yProperty, corners[1].y, position)
-        filter.set(corner3xProperty, corners[2].x, position)
-        filter.set(corner3yProperty, corners[2].y, position)
-        filter.set(corner4xProperty, corners[3].x, position)
-        filter.set(corner4yProperty, corners[3].y, position)
-    }
-
-    function updateFilterCorners(position) {
-        if (blockUpdate) return
-        if (position !== null) {
-            filter.blockSignals = true
-            if (position <= 0 && filter.animateIn > 0) {
-                for (var i in cornerStartValues)
-                    filter.set(cornerStartValues[i], corners[i])
-            } else if (position >= filter.duration - 1 && filter.animateOut > 0) {
-                for (i in cornerEndValues)
-                    filter.set(cornerEndValues[i], corners[i])
-            } else {
-                for (i in cornerMiddleValues)
-                    filter.set(cornerMiddleValues[i], corners[i])
-            }
-            filter.blockSignals = false
-        }
-
-        if (filter.animateIn > 0 || filter.animateOut > 0) {
-            resetFilter()
-            corner1KeyframesButton.checked = false
-            if (filter.animateIn > 0) {
-                setFilterCorners([filter.getRect(cornerStartValues[0]),filter.getRect(cornerStartValues[1]),filter.getRect(cornerStartValues[2]),filter.getRect(cornerStartValues[3])], 0)
-                setFilterCorners([filter.getRect(cornerMiddleValues[0]),filter.getRect(cornerMiddleValues[1]),filter.getRect(cornerMiddleValues[2]),filter.getRect(cornerMiddleValues[3])], filter.animateIn - 1)
-            }
-            if (filter.animateOut > 0) {
-                setFilterCorners([filter.getRect(cornerMiddleValues[0]),filter.getRect(cornerMiddleValues[1]),filter.getRect(cornerMiddleValues[2]),filter.getRect(cornerMiddleValues[3])], filter.duration - filter.animateOut)
-                setFilterCorners([filter.getRect(cornerEndValues[0]),filter.getRect(cornerEndValues[1]),filter.getRect(cornerEndValues[2]),filter.getRect(cornerEndValues[3])], filter.duration - 1)
-            }
-        } else if (!corner1KeyframesButton.checked) {
-            resetFilter()
-            setFilterCorners([filter.getRect(cornerMiddleValues[0]),filter.getRect(cornerMiddleValues[1]),filter.getRect(cornerMiddleValues[2]),filter.getRect(cornerMiddleValues[3])], -1)
-        } else if (position !== null) {
-            setFilterCorners(corners, position)
-        }
     }
 
     GridLayout {
@@ -264,111 +237,123 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [corner1xProperty, corner1yProperty, corner2xProperty, corner2yProperty, corner3xProperty, corner3yProperty, corner4xProperty, corner4yProperty, stretchxProperty, stretchyProperty, interpolatorProperty, transparentProperty, featherProperty, alphaOpProperty, cornerProperties[0], cornerProperties[1], cornerProperties[2], cornerProperties[3]]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
-                corner1KeyframesButton.checked = filter.keyframeCount(corner1xProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-                filter.blockSignals = true
-                for (var i in cornerMiddleValues)
-                    filter.set(cornerMiddleValues[i], filter.getRect(cornerProperties[i], filter.animateIn + 1))
+                setControls();
+                initializeSimpleKeyframes();
+                corner1KeyframesButton.checked = filter.keyframeCount(corner1xProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+                filter.blockSignals = true;
+                for (var i in cornerMiddleValues) filter.set(cornerMiddleValues[i], filter.getRect(cornerProperties[i], filter.animateIn + 1))
                 if (filter.animateIn > 0) {
-                    for (i in cornerStartValues)
-                        filter.set(cornerStartValues[i], filter.getRect(cornerProperties[i], 0))
+                    for (i in cornerStartValues) filter.set(cornerStartValues[i], filter.getRect(cornerProperties[i], 0))
                 }
                 if (filter.animateOut > 0) {
-                    for (i in cornerEndValues)
-                        filter.set(cornerEndValues[i], filter.getRect(cornerProperties[i], filter.duration - 1))
+                    for (i in cornerEndValues) filter.set(cornerEndValues[i], filter.getRect(cornerProperties[i], filter.duration - 1))
                 }
-                filter.blockSignals = false
+                filter.blockSignals = false;
             }
         }
 
         Label {
             text: qsTr('Corner 1 X')
             Layout.alignment: Qt.AlignRight
-
         }
+
         Shotcut.SliderSpinner {
             id: corner1xSlider
+
             minimumValue: -100
             maximumValue: 200
             stepSize: 0.1
             decimals: 2
             suffix: ' %'
             onValueChanged: {
-                var newValue = sliderValue(corner1xSlider)
+                var newValue = sliderValue(corner1xSlider);
                 if (corners[0].x !== newValue) {
-                    corners[0].x = newValue
-                    updateFilterCorners(getPosition())
+                    corners[0].x = newValue;
+                    updateFilterCorners(getPosition());
                 }
             }
         }
+
         Shotcut.UndoButton {
             onClicked: setSliderValue(corner1xSlider, corner1xDefault)
         }
+
         ColumnLayout {
             Layout.rowSpan: 8
             height: corner1KeyframesButton.height * Layout.rowSpan
-            SystemPalette { id: activePalette }
+
+            SystemPalette {
+                id: activePalette
+            }
+
             Rectangle {
                 color: activePalette.text
                 width: 1
                 height: parent.height / 2
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             }
+
             Shotcut.KeyframesButton {
                 id: corner1KeyframesButton
+
                 onToggled: {
-                    toggleKeyframes(checked, corner1xProperty, corners[0].x)
-                    toggleKeyframes(checked, corner1yProperty, corners[0].y)
-                    toggleKeyframes(checked, corner2xProperty, corners[1].x)
-                    toggleKeyframes(checked, corner2yProperty, corners[1].y)
-                    toggleKeyframes(checked, corner3xProperty, corners[2].x)
-                    toggleKeyframes(checked, corner3yProperty, corners[2].y)
-                    toggleKeyframes(checked, corner4xProperty, corners[3].x)
-                    toggleKeyframes(checked, corner4yProperty, corners[3].y)
-                    toggleKeyframes(checked, cornerProperties[0], corners[0])
-                    toggleKeyframes(checked, cornerProperties[1], corners[1])
-                    toggleKeyframes(checked, cornerProperties[2], corners[2])
-                    toggleKeyframes(checked, cornerProperties[3], corners[3])
-                    setControls()
+                    toggleKeyframes(checked, corner1xProperty, corners[0].x);
+                    toggleKeyframes(checked, corner1yProperty, corners[0].y);
+                    toggleKeyframes(checked, corner2xProperty, corners[1].x);
+                    toggleKeyframes(checked, corner2yProperty, corners[1].y);
+                    toggleKeyframes(checked, corner3xProperty, corners[2].x);
+                    toggleKeyframes(checked, corner3yProperty, corners[2].y);
+                    toggleKeyframes(checked, corner4xProperty, corners[3].x);
+                    toggleKeyframes(checked, corner4yProperty, corners[3].y);
+                    toggleKeyframes(checked, cornerProperties[0], corners[0]);
+                    toggleKeyframes(checked, cornerProperties[1], corners[1]);
+                    toggleKeyframes(checked, cornerProperties[2], corners[2]);
+                    toggleKeyframes(checked, cornerProperties[3], corners[3]);
+                    setControls();
                 }
             }
+
             Rectangle {
                 color: activePalette.text
                 width: 1
                 height: parent.height / 2
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             }
+
         }
 
         Label {
             text: qsTr('Y')
             Layout.alignment: Qt.AlignRight
-
         }
+
         Shotcut.SliderSpinner {
             id: corner1ySlider
+
             minimumValue: -100
             maximumValue: 200
             stepSize: 0.1
             decimals: 2
             suffix: ' %'
             onValueChanged: {
-                var newValue = sliderValue(corner1ySlider)
+                var newValue = sliderValue(corner1ySlider);
                 if (corners[0].y !== newValue) {
-                    corners[0].y = newValue
-                    updateFilterCorners(getPosition())
+                    corners[0].y = newValue;
+                    updateFilterCorners(getPosition());
                 }
             }
         }
+
         Shotcut.UndoButton {
             onClicked: setSliderValue(corner1ySlider, corner1yDefault)
         }
@@ -376,23 +361,25 @@ Shotcut.KeyframableFilter {
         Label {
             text: qsTr('Corner 2 X')
             Layout.alignment: Qt.AlignRight
-
         }
+
         Shotcut.SliderSpinner {
             id: corner2xSlider
+
             minimumValue: -100
             maximumValue: 200
             stepSize: 0.1
             decimals: 2
             suffix: ' %'
             onValueChanged: {
-                var newValue = sliderValue(corner2xSlider)
+                var newValue = sliderValue(corner2xSlider);
                 if (corners[1].x !== newValue) {
-                    corners[1].x = newValue
-                    updateFilterCorners(getPosition())
+                    corners[1].x = newValue;
+                    updateFilterCorners(getPosition());
                 }
             }
         }
+
         Shotcut.UndoButton {
             onClicked: setSliderValue(corner2xSlider, corner2xDefault)
         }
@@ -400,23 +387,25 @@ Shotcut.KeyframableFilter {
         Label {
             text: qsTr('Y')
             Layout.alignment: Qt.AlignRight
-
         }
+
         Shotcut.SliderSpinner {
             id: corner2ySlider
+
             minimumValue: -100
             maximumValue: 200
             stepSize: 0.1
             decimals: 2
             suffix: ' %'
             onValueChanged: {
-                var newValue = sliderValue(corner2ySlider)
+                var newValue = sliderValue(corner2ySlider);
                 if (corners[1].y !== newValue) {
-                    corners[1].y = newValue
-                    updateFilterCorners(getPosition())
+                    corners[1].y = newValue;
+                    updateFilterCorners(getPosition());
                 }
             }
         }
+
         Shotcut.UndoButton {
             onClicked: setSliderValue(corner2ySlider, corner2yDefault)
         }
@@ -424,23 +413,25 @@ Shotcut.KeyframableFilter {
         Label {
             text: qsTr('Corner 3 X')
             Layout.alignment: Qt.AlignRight
-
         }
+
         Shotcut.SliderSpinner {
             id: corner3xSlider
+
             minimumValue: -100
             maximumValue: 200
             stepSize: 0.1
             decimals: 2
             suffix: ' %'
             onValueChanged: {
-                var newValue = sliderValue(corner3xSlider)
+                var newValue = sliderValue(corner3xSlider);
                 if (corners[2].x !== newValue) {
-                    corners[2].x = newValue
-                    updateFilterCorners(getPosition())
+                    corners[2].x = newValue;
+                    updateFilterCorners(getPosition());
                 }
             }
         }
+
         Shotcut.UndoButton {
             onClicked: setSliderValue(corner3xSlider, corner3xDefault)
         }
@@ -448,23 +439,25 @@ Shotcut.KeyframableFilter {
         Label {
             text: qsTr('Y')
             Layout.alignment: Qt.AlignRight
-
         }
+
         Shotcut.SliderSpinner {
             id: corner3ySlider
+
             minimumValue: -100
             maximumValue: 200
             stepSize: 0.1
             decimals: 2
             suffix: ' %'
             onValueChanged: {
-                var newValue = sliderValue(corner3ySlider)
+                var newValue = sliderValue(corner3ySlider);
                 if (corners[2].y !== newValue) {
-                    corners[2].y = newValue
-                    updateFilterCorners(getPosition())
+                    corners[2].y = newValue;
+                    updateFilterCorners(getPosition());
                 }
             }
         }
+
         Shotcut.UndoButton {
             onClicked: setSliderValue(corner3ySlider, corner3yDefault)
         }
@@ -472,23 +465,25 @@ Shotcut.KeyframableFilter {
         Label {
             text: qsTr('Corner 4 X')
             Layout.alignment: Qt.AlignRight
-
         }
+
         Shotcut.SliderSpinner {
             id: corner4xSlider
+
             minimumValue: -100
             maximumValue: 200
             stepSize: 0.1
             decimals: 2
             suffix: ' %'
             onValueChanged: {
-                var newValue = sliderValue(corner4xSlider)
+                var newValue = sliderValue(corner4xSlider);
                 if (corners[3].x !== newValue) {
-                    corners[3].x = newValue
-                    updateFilterCorners(getPosition())
+                    corners[3].x = newValue;
+                    updateFilterCorners(getPosition());
                 }
             }
         }
+
         Shotcut.UndoButton {
             onClicked: setSliderValue(corner4xSlider, corner4xDefault)
         }
@@ -496,23 +491,25 @@ Shotcut.KeyframableFilter {
         Label {
             text: qsTr('Y')
             Layout.alignment: Qt.AlignRight
-
         }
+
         Shotcut.SliderSpinner {
             id: corner4ySlider
+
             minimumValue: -100
             maximumValue: 200
             stepSize: 0.1
             decimals: 2
             suffix: ' %'
             onValueChanged: {
-                var newValue = sliderValue(corner4ySlider)
+                var newValue = sliderValue(corner4ySlider);
                 if (corners[3].y !== newValue) {
-                    corners[3].y = newValue
-                    updateFilterCorners(getPosition())
+                    corners[3].y = newValue;
+                    updateFilterCorners(getPosition());
                 }
             }
         }
+
         Shotcut.UndoButton {
             onClicked: setSliderValue(corner4ySlider, corner4yDefault)
         }
@@ -521,23 +518,28 @@ Shotcut.KeyframableFilter {
             text: qsTr('Stretch X')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: stretchxSlider
+
             minimumValue: 0
             maximumValue: 100
             stepSize: 0.1
             decimals: 2
             suffix: ' %'
-            onValueChanged: updateFilter(stretchxProperty, 1.0 - stretchxSlider.value / stretchxSlider.maximumValue, stretchxKeyframesButton, getPosition())
+            onValueChanged: updateFilter(stretchxProperty, 1 - stretchxSlider.value / stretchxSlider.maximumValue, stretchxKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: stretchxSlider.value = stretchxDefault * stretchxSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: stretchxKeyframesButton
+
             onToggled: {
-                toggleKeyframes(checked, stretchxProperty, 1.0 - stretchxSlider.value / stretchxSlider.maximumValue)
-                setControls()
+                toggleKeyframes(checked, stretchxProperty, 1 - stretchxSlider.value / stretchxSlider.maximumValue);
+                setControls();
             }
         }
 
@@ -545,23 +547,28 @@ Shotcut.KeyframableFilter {
             text: qsTr('Y')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: stretchySlider
+
             minimumValue: 0
             maximumValue: 100
             stepSize: 0.1
             decimals: 2
             suffix: ' %'
-            onValueChanged: updateFilter(stretchyProperty, 1.0 - stretchySlider.value / stretchySlider.maximumValue, stretchyKeyframesButton, getPosition())
+            onValueChanged: updateFilter(stretchyProperty, 1 - stretchySlider.value / stretchySlider.maximumValue, stretchyKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: stretchySlider.value = stretchyDefault * stretchySlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: stretchyKeyframesButton
+
             onToggled: {
-                toggleKeyframes(checked, stretchyProperty, 1.0 - stretchySlider.value / stretchySlider.maximumValue)
-                setControls()
+                toggleKeyframes(checked, stretchyProperty, 1 - stretchySlider.value / stretchySlider.maximumValue);
+                setControls();
             }
         }
 
@@ -569,16 +576,19 @@ Shotcut.KeyframableFilter {
             text: qsTr('Interpolator')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: interpolatorCombo
+
             implicitWidth: 180
             model: [qsTr('Nearest Neighbor'), qsTr('Bilinear'), qsTr('Bicubic Smooth'), qsTr('Bicubic Sharp'), qsTr('Spline 4x4'), qsTr('Spline 6x6'), 'Lanczos']
             onActivated: {
-                enabled = false
-                filter.set(interpolatorProperty, index / 6)
-                enabled = true
+                enabled = false;
+                filter.set(interpolatorProperty, index / 6);
+                enabled = true;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: filter.set(interpolatorProperty, interpolatorDefault)
             Layout.columnSpan: 2
@@ -588,34 +598,37 @@ Shotcut.KeyframableFilter {
             text: qsTr('Alpha Operation')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: alphaoperationCombo
+
             implicitWidth: 180
             model: [qsTr('Opaque'), qsTr('Overwrite'), qsTr('Maximum'), qsTr('Minimum'), qsTr('Add'), qsTr('Subtract')]
             onActivated: {
-                enabled = false
-                filter.set(transparentProperty, index > 0)
-                filter.set(alphaOpProperty, (index - 1) / 4)
-                enabled = true
+                enabled = false;
+                filter.set(transparentProperty, index > 0);
+                filter.set(alphaOpProperty, (index - 1) / 4);
+                enabled = true;
             }
         }
+
         Shotcut.UndoButton {
             Layout.columnSpan: 2
             onClicked: {
-                alphaoperationCombo.currentIndex = filter.get(transparentProperty) === '1'?
-                    Math.round(alphaoperationDefault * 4) + 1 : 0
-                filter.set(transparentProperty, alphaoperationCombo.currentIndex > 0)
-                filter.set(alphaOpProperty, (alphaoperationCombo.currentIndex - 1) / 4)
+                alphaoperationCombo.currentIndex = filter.get(transparentProperty) === '1' ? Math.round(alphaoperationDefault * 4) + 1 : 0;
+                filter.set(transparentProperty, alphaoperationCombo.currentIndex > 0);
+                filter.set(alphaOpProperty, (alphaoperationCombo.currentIndex - 1) / 4);
             }
         }
 
         Label {
             text: qsTr('Feathering')
             Layout.alignment: Qt.AlignRight
-
         }
+
         Shotcut.SliderSpinner {
             id: featheralphaSlider
+
             enabled: alphaoperationCombo.currentIndex > 0
             minimumValue: 0
             maximumValue: 100
@@ -624,43 +637,70 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(featherProperty, featheralphaSlider.value / featheralphaSlider.maximumValue, featheralphaKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: featheralphaSlider.value = featheralphaDefault * featheralphaSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: featheralphaKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, featherProperty, featheralphaSlider.value / featheralphaSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, featherProperty, featheralphaSlider.value / featheralphaSlider.maximumValue);
             }
         }
 
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
-        target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
-    }
-
-    Connections {
-        target: producer
-        function onPositionChanged() { setControls() }
-    }
-
-    Connections {
-        target: parameters
-        function onKeyframeAdded(parameter, position) {
-            if (parameter == cornerProperties[0]) {
-                updateFilterCorners(getPosition())
-            }
+        function onChanged() {
+            setControls();
         }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
+        target: filter
     }
+
+    Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
+        target: producer
+    }
+
+    Connections {
+        function onKeyframeAdded(parameter, position) {
+            if (parameter == cornerProperties[0])
+                updateFilterCorners(getPosition());
+
+        }
+
+        target: parameters
+    }
+
 }

--- a/src/qml/filters/corners/vui.qml
+++ b/src/qml/filters/corners/vui.qml
@@ -18,8 +18,12 @@
 import QtQuick 2.1
 import Shotcut.Controls 1.0 as Shotcut
 
-
 Shotcut.VuiBase {
+    // 80/90% Safe Areas
+    // EBU R95 Safe Areas
+    // 80/90% Safe Areas
+    // EBU R95 Safe Areas
+
     property string corner1xProperty: '0'
     property string corner1yProperty: '1'
     property string corner2xProperty: '2'
@@ -28,15 +32,13 @@ Shotcut.VuiBase {
     property string corner3yProperty: '5'
     property string corner4xProperty: '6'
     property string corner4yProperty: '7'
-
     property var cornerProperties: ['shotcut:corner1', 'shotcut:corner2', 'shotcut:corner3', 'shotcut:corner4']
     property var corners: [Qt.rect(0, 0, 0, 0), Qt.rect(profile.width, 0, 0, 0), Qt.rect(profile.width, profile.height, 0, 0), Qt.rect(0, profile.height, 0, 0)]
     property var cornerStartValues: ['_shotcut:corner1StartValue', '_shotcut:corner2StartValue', '_shotcut:corner3StartValue', '_shotcut:corner4StartValue']
     property var cornerMiddleValues: ['_shotcut:corner1MiddleValue', '_shotcut:corner2MiddleValue', '_shotcut:corner3MiddleValue', '_shotcut:corner4MiddleValue']
     property var cornerEndValues: ['_shotcut:corner1EndValue', '_shotcut:corner2EndValue', '_shotcut:corner3EndValue', '_shotcut:corner4EndValue']
-
     property bool blockUpdate: false
-    property real zoom: (video.zoom > 0)? video.zoom : 1.0
+    property real zoom: (video.zoom > 0) ? video.zoom : 1
     property int handleSize: Math.max(Math.round(20 / zoom), 8)
     property real handleOffset: handleSize / 2
     property int borderSize: Math.max(Math.round(4 / zoom), 3)
@@ -44,183 +46,170 @@ Shotcut.VuiBase {
     property color borderColor: 'black'
     property int snapMargin: 10
 
-    Component.onCompleted: {
-        setCornersControl()
-    }
-
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setCornersControl() {
-        var position = getPosition()
-        blockUpdate = true
-        for (var i in corners)
-            corners[i] = filter.getRect(cornerProperties[i], position)
-        setHandles()
-        cornersControl.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
-        blockUpdate = false
+        var position = getPosition();
+        blockUpdate = true;
+        for (var i in corners) corners[i] = filter.getRect(cornerProperties[i], position)
+        setHandles();
+        cornersControl.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
+        blockUpdate = false;
     }
 
     function resetFilter() {
-        filter.resetProperty(corner1xProperty)
-        filter.resetProperty(corner1yProperty)
-        filter.resetProperty(corner2xProperty)
-        filter.resetProperty(corner2yProperty)
-        filter.resetProperty(corner3xProperty)
-        filter.resetProperty(corner3yProperty)
-        filter.resetProperty(corner4xProperty)
-        filter.resetProperty(corner4yProperty)
-        for (var i in cornerProperties)
-            filter.resetProperty(cornerProperties[i])
+        filter.resetProperty(corner1xProperty);
+        filter.resetProperty(corner1yProperty);
+        filter.resetProperty(corner2xProperty);
+        filter.resetProperty(corner2yProperty);
+        filter.resetProperty(corner3xProperty);
+        filter.resetProperty(corner3yProperty);
+        filter.resetProperty(corner4xProperty);
+        filter.resetProperty(corner4yProperty);
+        for (var i in cornerProperties) filter.resetProperty(cornerProperties[i])
     }
 
     function setFilterCorners(corners, position) {
-        for (var i in cornerProperties)
-            filter.set(cornerProperties[i], corners[i], position)
-        filter.set(corner1xProperty, corners[0].x, position)
-        filter.set(corner1yProperty, corners[0].y, position)
-        filter.set(corner2xProperty, corners[1].x, position)
-        filter.set(corner2yProperty, corners[1].y, position)
-        filter.set(corner3xProperty, corners[2].x, position)
-        filter.set(corner3yProperty, corners[2].y, position)
-        filter.set(corner4xProperty, corners[3].x, position)
-        filter.set(corner4yProperty, corners[3].y, position)
+        for (var i in cornerProperties) filter.set(cornerProperties[i], corners[i], position)
+        filter.set(corner1xProperty, corners[0].x, position);
+        filter.set(corner1yProperty, corners[0].y, position);
+        filter.set(corner2xProperty, corners[1].x, position);
+        filter.set(corner2yProperty, corners[1].y, position);
+        filter.set(corner3xProperty, corners[2].x, position);
+        filter.set(corner3yProperty, corners[2].y, position);
+        filter.set(corner4xProperty, corners[3].x, position);
+        filter.set(corner4yProperty, corners[3].y, position);
     }
 
-
     function updateFilterCorners(position) {
-        if (blockUpdate) return
+        if (blockUpdate)
+            return ;
 
-        corners[0].x = mapValueBack((corner1Handle.x + handleOffset) / video.rect.width)
-        corners[0].y = mapValueBack((corner1Handle.y + handleOffset) / video.rect.height)
-        corners[1].x = mapValueBack((corner2Handle.x + handleOffset) / video.rect.width)
-        corners[1].y = mapValueBack((corner2Handle.y + handleOffset) / video.rect.height)
-        corners[2].x = mapValueBack((corner3Handle.x + handleOffset) / video.rect.width)
-        corners[2].y = mapValueBack((corner3Handle.y + handleOffset) / video.rect.height)
-        corners[3].x = mapValueBack((corner4Handle.x + handleOffset) / video.rect.width)
-        corners[3].y = mapValueBack((corner4Handle.y + handleOffset) / video.rect.height)
-
+        corners[0].x = mapValueBack((corner1Handle.x + handleOffset) / video.rect.width);
+        corners[0].y = mapValueBack((corner1Handle.y + handleOffset) / video.rect.height);
+        corners[1].x = mapValueBack((corner2Handle.x + handleOffset) / video.rect.width);
+        corners[1].y = mapValueBack((corner2Handle.y + handleOffset) / video.rect.height);
+        corners[2].x = mapValueBack((corner3Handle.x + handleOffset) / video.rect.width);
+        corners[2].y = mapValueBack((corner3Handle.y + handleOffset) / video.rect.height);
+        corners[3].x = mapValueBack((corner4Handle.x + handleOffset) / video.rect.width);
+        corners[3].y = mapValueBack((corner4Handle.y + handleOffset) / video.rect.height);
         if (position !== null) {
-            filter.blockSignals = true
+            filter.blockSignals = true;
             if (position <= 0 && filter.animateIn > 0) {
-                for (var i in cornerStartValues)
-                    filter.set(cornerStartValues[i], corners[i])
+                for (var i in cornerStartValues) filter.set(cornerStartValues[i], corners[i])
             } else if (position >= filter.duration - 1 && filter.animateOut > 0) {
-                for (i in cornerEndValues)
-                    filter.set(cornerEndValues[i], corners[i])
+                for (i in cornerEndValues) filter.set(cornerEndValues[i], corners[i])
             } else {
-                for (i in cornerMiddleValues)
-                    filter.set(cornerMiddleValues[i], corners[i])
+                for (i in cornerMiddleValues) filter.set(cornerMiddleValues[i], corners[i])
             }
-            filter.blockSignals = false
+            filter.blockSignals = false;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            resetFilter()
+            resetFilter();
             if (filter.animateIn > 0) {
-                setFilterCorners([filter.getRect(cornerStartValues[0]),filter.getRect(cornerStartValues[1]),filter.getRect(cornerStartValues[2]),filter.getRect(cornerStartValues[3])], 0)
-                setFilterCorners([filter.getRect(cornerMiddleValues[0]),filter.getRect(cornerMiddleValues[1]),filter.getRect(cornerMiddleValues[2]),filter.getRect(cornerMiddleValues[3])], filter.animateIn - 1)
+                setFilterCorners([filter.getRect(cornerStartValues[0]), filter.getRect(cornerStartValues[1]), filter.getRect(cornerStartValues[2]), filter.getRect(cornerStartValues[3])], 0);
+                setFilterCorners([filter.getRect(cornerMiddleValues[0]), filter.getRect(cornerMiddleValues[1]), filter.getRect(cornerMiddleValues[2]), filter.getRect(cornerMiddleValues[3])], filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                setFilterCorners([filter.getRect(cornerMiddleValues[0]),filter.getRect(cornerMiddleValues[1]),filter.getRect(cornerMiddleValues[2]),filter.getRect(cornerMiddleValues[3])], filter.duration - filter.animateOut)
-                setFilterCorners([filter.getRect(cornerEndValues[0]),filter.getRect(cornerEndValues[1]),filter.getRect(cornerEndValues[2]),filter.getRect(cornerEndValues[3])], filter.duration - 1)
+                setFilterCorners([filter.getRect(cornerMiddleValues[0]), filter.getRect(cornerMiddleValues[1]), filter.getRect(cornerMiddleValues[2]), filter.getRect(cornerMiddleValues[3])], filter.duration - filter.animateOut);
+                setFilterCorners([filter.getRect(cornerEndValues[0]), filter.getRect(cornerEndValues[1]), filter.getRect(cornerEndValues[2]), filter.getRect(cornerEndValues[3])], filter.duration - 1);
             }
         } else if (filter.keyframeCount(corner1xProperty) <= 0) {
-            resetFilter()
-            setFilterCorners([filter.getRect(cornerMiddleValues[0]),filter.getRect(cornerMiddleValues[1]),filter.getRect(cornerMiddleValues[2]),filter.getRect(cornerMiddleValues[3])], -1)
+            resetFilter();
+            setFilterCorners([filter.getRect(cornerMiddleValues[0]), filter.getRect(cornerMiddleValues[1]), filter.getRect(cornerMiddleValues[2]), filter.getRect(cornerMiddleValues[3])], -1);
         } else if (position !== null) {
-            setFilterCorners(corners, position)
+            setFilterCorners(corners, position);
         }
     }
 
     function mapValueForward(value) {
-        var min = -1
-        var max = 2
-        return min + (max - min) * value
+        var min = -1;
+        var max = 2;
+        return min + (max - min) * value;
     }
 
     function mapValueBack(value) {
-        var min = -1
-        var max = 2
-        return (value - min) / (max - min)
+        var min = -1;
+        var max = 2;
+        return (value - min) / (max - min);
     }
 
     function setHandles() {
-        corner1Handle.x = mapValueForward(corners[0].x) * video.rect.width - handleOffset
-        corner1Handle.y = mapValueForward(corners[0].y) * video.rect.height - handleOffset
-        corner2Handle.x = mapValueForward(corners[1].x) * video.rect.width - handleOffset
-        corner2Handle.y = mapValueForward(corners[1].y) * video.rect.height - handleOffset
-        corner3Handle.x = mapValueForward(corners[2].x) * video.rect.width - handleSize/2
-        corner3Handle.y = mapValueForward(corners[2].y) * video.rect.height - handleOffset
-        corner4Handle.x = mapValueForward(corners[3].x) * video.rect.width - handleOffset
-        corner4Handle.y = mapValueForward(corners[3].y) * video.rect.height - handleOffset
+        corner1Handle.x = mapValueForward(corners[0].x) * video.rect.width - handleOffset;
+        corner1Handle.y = mapValueForward(corners[0].y) * video.rect.height - handleOffset;
+        corner2Handle.x = mapValueForward(corners[1].x) * video.rect.width - handleOffset;
+        corner2Handle.y = mapValueForward(corners[1].y) * video.rect.height - handleOffset;
+        corner3Handle.x = mapValueForward(corners[2].x) * video.rect.width - handleSize / 2;
+        corner3Handle.y = mapValueForward(corners[2].y) * video.rect.height - handleOffset;
+        corner4Handle.x = mapValueForward(corners[3].x) * video.rect.width - handleOffset;
+        corner4Handle.y = mapValueForward(corners[3].y) * video.rect.height - handleOffset;
     }
 
     function snapGrid(v, gridSize) {
-        var polarity = (v < 0) ? -1 : 1
-        v = v * polarity
-        var delta = v % gridSize
-        if (delta < snapMargin) {
-            v = v - delta
-        } else if ((gridSize - delta) < snapMargin) {
-            v = v + gridSize - delta
-        }
-        return v * polarity
+        var polarity = (v < 0) ? -1 : 1;
+        v = v * polarity;
+        var delta = v % gridSize;
+        if (delta < snapMargin)
+            v = v - delta;
+        else if ((gridSize - delta) < snapMargin)
+            v = v + gridSize - delta;
+        return v * polarity;
     }
 
     function snapX(x) {
-        if (!video.snapToGrid || video.grid === 0) {
-            return x
-        }
+        if (!video.snapToGrid || video.grid === 0)
+            return x;
+
         if (video.grid !== 95 && video.grid !== 8090) {
-            var n = (video.grid > 10000) ? cornersControl.width / (profile.width / (video.grid - 10000)) : cornersControl.width / video.grid
-            return snapGrid(x, n)
+            var n = (video.grid > 10000) ? cornersControl.width / (profile.width / (video.grid - 10000)) : cornersControl.width / video.grid;
+            return snapGrid(x, n);
         } else {
-            var deltas = null
-            if (video.grid === 8090) {
-                // 80/90% Safe Areas
-                deltas = [0.0, 0.05, 0.1, 0.9, 0.95, 1.0]
-            } else if (video.grid === 95) {
-                // EBU R95 Safe Areas
-                deltas = [0.0, 0.035, 0.05, 0.95, 0.965, 1.0]
-            }
+            var deltas = null;
+            if (video.grid === 8090)
+                deltas = [0, 0.05, 0.1, 0.9, 0.95, 1];
+            else if (video.grid === 95)
+                deltas = [0, 0.035, 0.05, 0.95, 0.965, 1];
             if (deltas) {
                 for (var i = 0; i < deltas.length; i++) {
-                    var delta = x - deltas[i] * cornersControl.width
+                    var delta = x - deltas[i] * cornersControl.width;
                     if (Math.abs(delta) < snapMargin)
-                        return x - delta
+                        return x - delta;
+
                 }
             }
         }
-        return x
+        return x;
     }
 
     function snapY(y) {
-        if (!video.snapToGrid || video.grid === 0) {
-            return y
-        }
+        if (!video.snapToGrid || video.grid === 0)
+            return y;
+
         if (video.grid !== 95 && video.grid !== 8090) {
-            var n = (video.grid > 10000) ? cornersControl.height / (profile.height / (video.grid - 10000)) : cornersControl.height / video.grid
-            return snapGrid(y, n)
+            var n = (video.grid > 10000) ? cornersControl.height / (profile.height / (video.grid - 10000)) : cornersControl.height / video.grid;
+            return snapGrid(y, n);
         } else {
-            var deltas = null
-            if (video.grid === 8090) {
-                // 80/90% Safe Areas
-                deltas = [0.0, 0.05, 0.1, 0.9, 0.95, 1.0]
-            } else if (video.grid === 95) {
-                // EBU R95 Safe Areas
-                deltas = [0.0, 0.035, 0.05, 0.95, 0.965, 1.0]
-            }
+            var deltas = null;
+            if (video.grid === 8090)
+                deltas = [0, 0.05, 0.1, 0.9, 0.95, 1];
+            else if (video.grid === 95)
+                deltas = [0, 0.035, 0.05, 0.95, 0.965, 1];
             if (deltas) {
                 for (var i = 0; i < deltas.length; i++) {
-                    var delta = y - deltas[i] * cornersControl.height
+                    var delta = y - deltas[i] * cornersControl.height;
                     if (Math.abs(delta) < snapMargin)
-                        return y - delta
+                        return y - delta;
+
                 }
             }
         }
-        return y
+        return y;
+    }
+
+    Component.onCompleted: {
+        setCornersControl();
     }
 
     Flickable {
@@ -234,6 +223,7 @@ Shotcut.VuiBase {
 
         Item {
             id: videoItem
+
             x: video.rect.x
             y: video.rect.y
             width: video.rect.width
@@ -242,128 +232,155 @@ Shotcut.VuiBase {
 
             Item {
                 id: cornersControl
+
                 anchors.fill: parent
-                opacity: enabled? 0.8 : 0.2
+                opacity: enabled ? 0.8 : 0.2
 
                 Rectangle {
                     id: corner1Handle
+
                     color: handleColor
                     border.color: borderColor
                     width: handleSize
                     height: handleSize
-                    radius: handleSize/2
+                    radius: handleSize / 2
+
                     MouseArea {
                         anchors.fill: parent
                         acceptedButtons: Qt.LeftButton
                         cursorShape: Qt.SizeFDiagCursor
                         drag.target: parent
                         onPositionChanged: {
-                            corner1Handle.x = snapX(corner1Handle.x + handleOffset) - handleOffset
-                            corner1Handle.y = snapY(corner1Handle.y + handleOffset) - handleOffset
-                            updateFilterCorners(getPosition())
+                            corner1Handle.x = snapX(corner1Handle.x + handleOffset) - handleOffset;
+                            corner1Handle.y = snapY(corner1Handle.y + handleOffset) - handleOffset;
+                            updateFilterCorners(getPosition());
                         }
                     }
+
                     Text {
                         text: qsTr('1')
                         font.pixelSize: handleSize * 0.8
                         anchors.centerIn: parent
                     }
+
                 }
 
                 Rectangle {
                     id: corner2Handle
+
                     color: handleColor
                     border.color: borderColor
                     width: handleSize
                     height: handleSize
-                    radius: handleSize/2
+                    radius: handleSize / 2
+
                     MouseArea {
                         anchors.fill: parent
                         acceptedButtons: Qt.LeftButton
                         cursorShape: Qt.SizeBDiagCursor
                         drag.target: parent
                         onPositionChanged: {
-                            corner2Handle.x = snapX(corner2Handle.x + handleOffset) - handleOffset
-                            corner2Handle.y = snapY(corner2Handle.y + handleOffset) - handleOffset
-                            updateFilterCorners(getPosition())
+                            corner2Handle.x = snapX(corner2Handle.x + handleOffset) - handleOffset;
+                            corner2Handle.y = snapY(corner2Handle.y + handleOffset) - handleOffset;
+                            updateFilterCorners(getPosition());
                         }
                     }
+
                     Text {
                         text: qsTr('2')
                         font.pixelSize: handleSize * 0.8
                         anchors.centerIn: parent
                     }
+
                 }
 
                 Rectangle {
                     id: corner3Handle
+
                     color: handleColor
                     border.color: borderColor
                     width: handleSize
                     height: handleSize
-                    radius: handleSize/2
+                    radius: handleSize / 2
+
                     MouseArea {
                         anchors.fill: parent
                         acceptedButtons: Qt.LeftButton
                         cursorShape: Qt.SizeFDiagCursor
                         drag.target: parent
                         onPositionChanged: {
-                            corner3Handle.x = snapX(corner3Handle.x + handleOffset) - handleOffset
-                            corner3Handle.y = snapY(corner3Handle.y + handleOffset) - handleOffset
-                            updateFilterCorners(getPosition())
+                            corner3Handle.x = snapX(corner3Handle.x + handleOffset) - handleOffset;
+                            corner3Handle.y = snapY(corner3Handle.y + handleOffset) - handleOffset;
+                            updateFilterCorners(getPosition());
                         }
                     }
+
                     Text {
                         text: qsTr('3')
                         font.pixelSize: handleSize * 0.8
                         anchors.centerIn: parent
                     }
+
                 }
 
                 Rectangle {
                     id: corner4Handle
+
                     color: handleColor
                     border.color: borderColor
                     width: handleSize
                     height: handleSize
-                    radius: handleSize/2
+                    radius: handleSize / 2
+
                     MouseArea {
                         anchors.fill: parent
                         acceptedButtons: Qt.LeftButton
                         cursorShape: Qt.SizeBDiagCursor
                         drag.target: parent
                         onPositionChanged: {
-                            corner4Handle.x = snapX(corner4Handle.x + handleOffset) - handleOffset
-                            corner4Handle.y = snapY(corner4Handle.y + handleOffset) - handleOffset
-                            updateFilterCorners(getPosition())
+                            corner4Handle.x = snapX(corner4Handle.x + handleOffset) - handleOffset;
+                            corner4Handle.y = snapY(corner4Handle.y + handleOffset) - handleOffset;
+                            updateFilterCorners(getPosition());
                         }
                     }
+
                     Text {
                         text: qsTr('4')
                         font.pixelSize: handleSize * 0.8
                         anchors.centerIn: parent
                     }
+
                 }
+
             }
+
         }
+
     }
 
     Connections {
-        target: filter
         function onChanged() {
-            setCornersControl()
-            videoItem.enabled = filter.get('disable') !== '1'
+            setCornersControl();
+            videoItem.enabled = filter.get('disable') !== '1';
         }
+
+        target: filter
     }
 
     Connections {
+        function onPositionChanged() {
+            setCornersControl();
+        }
+
         target: producer
-        function onPositionChanged() { setCornersControl() }
     }
-    
-    Connections {
-        target: video
-        function onRectChanged() { setCornersControl() }
-    }
-}
 
+    Connections {
+        function onRectChanged() {
+            setCornersControl();
+        }
+
+        target: video
+    }
+
+}

--- a/src/qml/filters/crop/ui.qml
+++ b/src/qml/filters/crop/ui.qml
@@ -21,75 +21,74 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    property int producerWidth: (producer.get('meta.media.width') === null)? profile.width :producer.get('meta.media.width')
-    property int producerHeight: (producer.get('meta.media.height') === null)? profile.height : producer.get('meta.media.height')
+    property int producerWidth: (producer.get('meta.media.width') === null) ? profile.width : producer.get('meta.media.width')
+    property int producerHeight: (producer.get('meta.media.height') === null) ? profile.height : producer.get('meta.media.height')
     property double widthScaleFactor: profile.width / producerWidth
     property double heightScaleFactor: profile.height / producerHeight
     property var defaultParameters: ['left', 'right', 'top', 'bottom', 'center', 'center_bias']
 
-    width: 350
-    height: 200
-    
     function setEnabled() {
         if (filter.get('center') === '1') {
-            biasslider.enabled = true
-            biasundo.enabled = true
-            topslider.enabled = false
-            topundo.enabled = false
-            bottomslider.enabled = false
-            bottomundo.enabled = false
-            leftslider.enabled = false
-            leftundo.enabled = false
-            rightslider.enabled = false
-            rightundo.enabled = false
+            biasslider.enabled = true;
+            biasundo.enabled = true;
+            topslider.enabled = false;
+            topundo.enabled = false;
+            bottomslider.enabled = false;
+            bottomundo.enabled = false;
+            leftslider.enabled = false;
+            leftundo.enabled = false;
+            rightslider.enabled = false;
+            rightundo.enabled = false;
         } else {
-            biasslider.enabled = false
-            biasundo.enabled = false
-            topslider.enabled = true
-            topundo.enabled = true
-            bottomslider.enabled = true
-            bottomundo.enabled = true
-            leftslider.enabled = true
-            leftundo.enabled = true
-            rightslider.enabled = true
-            rightundo.enabled = true
+            biasslider.enabled = false;
+            biasundo.enabled = false;
+            topslider.enabled = true;
+            topundo.enabled = true;
+            bottomslider.enabled = true;
+            bottomundo.enabled = true;
+            leftslider.enabled = true;
+            leftundo.enabled = true;
+            rightslider.enabled = true;
+            rightundo.enabled = true;
         }
     }
 
     function setControls() {
-        centerCheckBox.checked = filter.get('center') === '1'
-        biasslider.value = filter.get('center_bias')
-        topslider.value = filter.get('top')
-        bottomslider.value = filter.get('bottom')
-        leftslider.value = filter.get('left')
-        rightslider.value = filter.get('right')
+        centerCheckBox.checked = filter.get('center') === '1';
+        biasslider.value = filter.get('center_bias');
+        topslider.value = filter.get('top');
+        bottomslider.value = filter.get('bottom');
+        leftslider.value = filter.get('left');
+        rightslider.value = filter.get('right');
     }
-    
+
+    width: 350
+    height: 200
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set('use_profile', '1')
+            filter.set('use_profile', '1');
             filter.set("center", 0);
             filter.set("center_bias", 0);
             filter.set("top", 0);
             filter.set("bottom", 0);
             filter.set("left", 0);
             filter.set("right", 0);
-            centerCheckBox.checked = false
-            filter.savePreset(defaultParameters)
+            centerCheckBox.checked = false;
+            filter.savePreset(defaultParameters);
         } else {
             if (filter.get('use_profile') !== '1') {
-                filter.blockSignals = true
-                filter.set('use_profile', '1')
-                filter.set('top', Math.round(filter.getDouble('top') * heightScaleFactor))
-                filter.set('bottom', Math.round(filter.getDouble('bottom') * heightScaleFactor))
-                filter.set('left', Math.round(filter.getDouble('left') * widthScaleFactor))
-                filter.blockSignals = false
-                filter.set('right', Math.round(filter.getDouble('right') * widthScaleFactor))
+                filter.blockSignals = true;
+                filter.set('use_profile', '1');
+                filter.set('top', Math.round(filter.getDouble('top') * heightScaleFactor));
+                filter.set('bottom', Math.round(filter.getDouble('bottom') * heightScaleFactor));
+                filter.set('left', Math.round(filter.getDouble('left') * widthScaleFactor));
+                filter.blockSignals = false;
+                filter.set('right', Math.round(filter.getDouble('right') * widthScaleFactor));
             }
         }
-        setControls()
-        setEnabled()
+        setControls();
+        setEnabled();
     }
 
     GridLayout {
@@ -101,35 +100,40 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             Layout.columnSpan: 2
             parameters: defaultParameters
             onPresetSelected: {
-                setControls()
-                setEnabled()
+                setControls();
+                setEnabled();
             }
         }
 
         CheckBox {
             id: centerCheckBox
-            text: qsTr('Center')
+
             property bool isReady: false
+
+            text: qsTr('Center')
             Component.onCompleted: isReady = true
             onClicked: {
                 if (isReady) {
-                    filter.set('center', checked)
-                    setEnabled()
+                    filter.set('center', checked);
+                    setEnabled();
                 }
             }
         }
+
         Item {
             width: 1
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                centerCheckBox.checked = false
-                filter.set('center', false)
-                setEnabled()
+                centerCheckBox.checked = false;
+                filter.set('center', false);
+                setEnabled();
             }
         }
 
@@ -137,15 +141,19 @@ Item {
             text: qsTr('Center bias')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: biasslider
+
             minimumValue: Math.round(-Math.max(profile.width, profile.height) / 2)
             maximumValue: Math.round(Math.max(profile.width, profile.height) / 2)
             suffix: ' px'
             onValueChanged: filter.set('center_bias', value)
         }
+
         Shotcut.UndoButton {
             id: biasundo
+
             onClicked: biasslider.value = 0
         }
 
@@ -153,15 +161,19 @@ Item {
             text: qsTr('Top')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: topslider
+
             minimumValue: 0
             maximumValue: profile.height
             suffix: ' px'
             onValueChanged: filter.set('top', value)
         }
+
         Shotcut.UndoButton {
             id: topundo
+
             onClicked: topslider.value = 0
         }
 
@@ -169,15 +181,19 @@ Item {
             text: qsTr('Bottom')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: bottomslider
+
             minimumValue: 0
             maximumValue: profile.height
             suffix: ' px'
             onValueChanged: filter.set('bottom', value)
         }
+
         Shotcut.UndoButton {
             id: bottomundo
+
             onClicked: bottomslider.value = 0
         }
 
@@ -185,15 +201,19 @@ Item {
             text: qsTr('Left')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: leftslider
+
             minimumValue: 0
             maximumValue: profile.width
             suffix: ' px'
             onValueChanged: filter.set('left', value)
         }
+
         Shotcut.UndoButton {
             id: leftundo
+
             onClicked: leftslider.value = 0
         }
 
@@ -201,20 +221,26 @@ Item {
             text: qsTr('Right')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: rightslider
+
             minimumValue: 0
             maximumValue: profile.width
             suffix: ' px'
             onValueChanged: filter.set('right', value)
         }
+
         Shotcut.UndoButton {
             id: rightundo
+
             onClicked: rightslider.value = 0
         }
-        
+
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/crop_circle/meta.qml
+++ b/src/qml/filters/crop_circle/meta.qml
@@ -7,6 +7,7 @@ Metadata {
     name: qsTr('Crop: Circle')
     mlt_service: 'qtcrop'
     qml: 'ui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -21,4 +22,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/crop_circle/ui.qml
+++ b/src/qml/filters/crop_circle/ui.qml
@@ -21,73 +21,75 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 400
-    height: 100
     property bool blockUpdate: true
     property double startValue: 0.5
     property double middleValue: 0.5
     property double endValue: 0.5
 
-    Component.onCompleted: {
-        filter.set('circle', 1)
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set('color', '#ff000000')
-            filter.set('radius', 0.5)
-        } else {
-            middleValue = filter.getDouble('radius', filter.animateIn)
-            if (filter.animateIn > 0)
-                startValue = filter.getDouble('radius', 0)
-            if (filter.animateOut > 0)
-                endValue = filter.getDouble('radius', filter.duration - 1)
-        }
-        setControls()
-        colorSwatch.value = filter.get('color')
-    }
-
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        slider.value = filter.getDouble('radius', position) * slider.maximumValue
-        keyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('radius') > 0
-        blockUpdate = false
-        slider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        slider.value = filter.getDouble('radius', position) * slider.maximumValue;
+        keyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('radius') > 0;
+        blockUpdate = false;
+        slider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function updateFilter(position) {
-        if (blockUpdate) return
-        var value = slider.value / 100.0
+        if (blockUpdate)
+            return ;
 
+        var value = slider.value / 100;
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValue = value
+                startValue = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValue = value
+                endValue = value;
             else
-                middleValue = value
+                middleValue = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty('radius')
-            keyframesButton.checked = false
+            filter.resetProperty('radius');
+            keyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set('radius', startValue, 0)
-                filter.set('radius', middleValue, filter.animateIn - 1)
+                filter.set('radius', startValue, 0);
+                filter.set('radius', middleValue, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set('radius', middleValue, filter.duration - filter.animateOut)
-                filter.set('radius', endValue, filter.duration - 1)
+                filter.set('radius', middleValue, filter.duration - filter.animateOut);
+                filter.set('radius', endValue, filter.duration - 1);
             }
         } else if (!keyframesButton.checked) {
-            filter.resetProperty('radius')
-            filter.set('radius', middleValue)
+            filter.resetProperty('radius');
+            filter.set('radius', middleValue);
         } else if (position !== null) {
-            filter.set('radius', value, position)
+            filter.set('radius', value, position);
         }
+    }
+
+    width: 400
+    height: 100
+    Component.onCompleted: {
+        filter.set('circle', 1);
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set('color', '#ff000000');
+            filter.set('radius', 0.5);
+        } else {
+            middleValue = filter.getDouble('radius', filter.animateIn);
+            if (filter.animateIn > 0)
+                startValue = filter.getDouble('radius', 0);
+
+            if (filter.animateOut > 0)
+                endValue = filter.getDouble('radius', filter.duration - 1);
+
+        }
+        setControls();
+        colorSwatch.value = filter.get('color');
     }
 
     GridLayout {
@@ -99,47 +101,54 @@ Item {
             text: qsTr('Radius')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter(getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: slider.value = 50
         }
+
         Shotcut.KeyframesButton {
             id: keyframesButton
+
             onToggled: {
-                var value = slider.value / 100.0
+                var value = slider.value / 100;
                 if (checked) {
-                    blockUpdate = true
-                    filter.clearSimpleAnimation('radius')
-                    blockUpdate = false
-                    filter.set('radius', value, getPosition())
+                    blockUpdate = true;
+                    filter.clearSimpleAnimation('radius');
+                    blockUpdate = false;
+                    filter.set('radius', value, getPosition());
                 } else {
-                    filter.resetProperty('radius')
-                    filter.set('radius', value)
+                    filter.resetProperty('radius');
+                    filter.set('radius', value);
                 }
             }
         }
-
 
         Label {
             text: qsTr('Color')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Shotcut.ColorPicker {
                 id: colorSwatch
-                alpha: true
+
                 property bool isReady: false
+
+                alpha: true
                 Component.onCompleted: isReady = true
                 onValueChanged: {
                     if (isReady) {
-                        filter.set('color', value)
+                        filter.set('color', value);
                         filter.set("disable", 0);
                     }
                 }
@@ -148,42 +157,69 @@ Item {
                 }
                 onPickCancelled: filter.set('disable', 0)
             }
+
             Shotcut.Button {
                 text: qsTr('Transparent')
                 onClicked: colorSwatch.value = '#00000000'
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: colorSwatch.value = '#FF000000'
         }
-        Item { width: 1 }
+
+        Item {
+            width: 1
+        }
 
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateFilter(null);
+        }
+
+        function onOutChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateInChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateOutChanged() {
+            updateFilter(null);
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateFilter(null) }
-        function onOutChanged() { updateFilter(null) }
-        function onAnimateInChanged() { updateFilter(null) }
-        function onAnimateOutChanged() { updateFilter(null) }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
-        target: producer
         function onPositionChanged() {
             if (filter.animateIn > 0 || filter.animateOut > 0) {
-                setControls()
+                setControls();
             } else {
-                blockUpdate = true
-                slider.value = filter.getDouble('radius', getPosition()) * slider.maximumValue
-                blockUpdate = false
-                slider.enabled = true
+                blockUpdate = true;
+                slider.value = filter.getDouble('radius', getPosition()) * slider.maximumValue;
+                blockUpdate = false;
+                slider.enabled = true;
             }
         }
+
+        target: producer
     }
+
 }

--- a/src/qml/filters/crop_rectangle/meta.qml
+++ b/src/qml/filters/crop_rectangle/meta.qml
@@ -8,6 +8,7 @@ Metadata {
     mlt_service: 'qtcrop'
     qml: 'ui.qml'
     vui: 'vui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -27,4 +28,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/crop_rectangle/ui.qml
+++ b/src/qml/filters/crop_rectangle/ui.qml
@@ -21,149 +21,153 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 400
-    height: 150
     property bool blockUpdate: true
     property double startValueRadius: 0
     property double middleValueRadius: 0
     property double endValueRadius: 0
     property string startValueRect: '_shotcut:startValue'
     property string middleValueRect: '_shotcut:middleValue'
-    property string endValueRect:  '_shotcut:endValue'
+    property string endValueRect: '_shotcut:endValue'
     property string rectProperty: 'rect'
     property rect filterRect
 
-    Component.onCompleted: {
-        filter.blockSignals = true
-        filter.set(startValueRect, Qt.rect(0, 0, profile.width, profile.height))
-        filter.set(middleValueRect, Qt.rect(0, 0, profile.width, profile.height))
-        filter.set(endValueRect, Qt.rect(0, 0, profile.width, profile.height))
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set('color', '#ff000000')
-            filter.set('radius', 0)
-            filter.set(rectProperty, '0%/0%:100%x100%')
-            filter.savePreset(preset.parameters)
-        } else {
-            middleValueRadius = filter.getDouble('radius', filter.animateIn)
-            filter.set(middleValueRect, filter.getRect(rectProperty, filter.animateIn + 1))
-            if (filter.animateIn > 0) {
-                startValueRadius = filter.getDouble('radius', 0)
-                filter.set(startValueRect, filter.getRect(rectProperty, 0))
-            }
-            if (filter.animateOut > 0) {
-                endValueRadius = filter.getDouble('radius', filter.duration - 1)
-                filter.set(endValueRect, filter.getRect(rectProperty, filter.duration - 1))
-            }
-        }
-        filter.blockSignals = false
-        setRatioControls()
-        setRectControls()
-        colorSwatch.value = filter.get('color')
-        if (filter.isNew)
-            filter.set(rectProperty, filter.getRect(rectProperty))
-    }
-
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setRatioControls() {
-        var position = getPosition()
-        blockUpdate = true
-        slider.value = filter.getDouble('radius', position) * slider.maximumValue
-        blockUpdate = false
-        slider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
-        radiusKeyframesButton.checked = filter.keyframeCount('radius') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
+        var position = getPosition();
+        blockUpdate = true;
+        slider.value = filter.getDouble('radius', position) * slider.maximumValue;
+        blockUpdate = false;
+        slider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
+        radiusKeyframesButton.checked = filter.keyframeCount('radius') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
     }
 
     function setRectControls() {
-        var position = getPosition()
-        var newValue = filter.getRect(rectProperty, position)
+        var position = getPosition();
+        var newValue = filter.getRect(rectProperty, position);
         if (filterRect !== newValue) {
-            filterRect = newValue
-            rectX.value = filterRect.x.toFixed()
-            rectY.value = filterRect.y.toFixed()
-            rectW.value = filterRect.width.toFixed()
-            rectH.value = filterRect.height.toFixed()
+            filterRect = newValue;
+            rectX.value = filterRect.x.toFixed();
+            rectY.value = filterRect.y.toFixed();
+            rectW.value = filterRect.width.toFixed();
+            rectH.value = filterRect.height.toFixed();
         }
-        var enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
-        rectX.enabled = enabled
-        rectY.enabled = enabled
-        rectW.enabled = enabled
-        rectH.enabled = enabled
-        positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
+        var enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
+        rectX.enabled = enabled;
+        rectY.enabled = enabled;
+        rectW.enabled = enabled;
+        rectH.enabled = enabled;
+        positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
     }
-    
-    function updateFilterRatio(position) {
-        if (blockUpdate) return
-        var value = slider.value / 100.0
-        setRatioControls()
-        if (position !== null) {
-            if (position <= 0 && filter.animateIn > 0) {
-                startValueRadius = value
-            } else if (position >= filter.duration - 1 && filter.animateOut > 0) {
-                endValueRadius = value
-            } else {
-                middleValueRadius = value
-            }
-        }
 
+    function updateFilterRatio(position) {
+        if (blockUpdate)
+            return ;
+
+        var value = slider.value / 100;
+        setRatioControls();
+        if (position !== null) {
+            if (position <= 0 && filter.animateIn > 0)
+                startValueRadius = value;
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                endValueRadius = value;
+            else
+                middleValueRadius = value;
+        }
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty('radius')
-            radiusKeyframesButton.checked = false
+            filter.resetProperty('radius');
+            radiusKeyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set('radius', startValueRadius, 0)
-                filter.set('radius', middleValueRadius, filter.animateIn - 1)
+                filter.set('radius', startValueRadius, 0);
+                filter.set('radius', middleValueRadius, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set('radius', middleValueRadius, filter.duration - filter.animateOut)
-                filter.set('radius', endValueRadius, filter.duration - 1)
+                filter.set('radius', middleValueRadius, filter.duration - filter.animateOut);
+                filter.set('radius', endValueRadius, filter.duration - 1);
             }
         } else if (!radiusKeyframesButton.checked) {
-            filter.resetProperty('radius')
-            filter.set('radius', middleValueRadius)
+            filter.resetProperty('radius');
+            filter.set('radius', middleValueRadius);
         } else if (position !== null) {
-            filter.set('radius', value, position)
+            filter.set('radius', value, position);
         }
     }
 
     function updateFilterRect(position) {
-        var rect
+        var rect;
         if (position !== null) {
-            filter.blockSignals = true
-            if (position <= 0 && filter.animateIn > 0) {
-                filter.set(startValueRect, filterRect)
-            } else if (position >= filter.duration - 1 && filter.animateOut > 0) {
-                filter.set(endValueRect, filterRect)
-            } else {
-                filter.set(middleValueRect, filterRect)
-            }
-            filter.blockSignals = false
+            filter.blockSignals = true;
+            if (position <= 0 && filter.animateIn > 0)
+                filter.set(startValueRect, filterRect);
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                filter.set(endValueRect, filterRect);
+            else
+                filter.set(middleValueRect, filterRect);
+            filter.blockSignals = false;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(rectProperty)
-            positionKeyframesButton.checked = false
+            filter.resetProperty(rectProperty);
+            positionKeyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                rect = filter.getRect(startValueRect)
-                filter.set(rectProperty, rect, 0)
-                rect = filter.getRect(middleValueRect)
-                filter.set(rectProperty, rect, filter.animateIn - 1)
+                rect = filter.getRect(startValueRect);
+                filter.set(rectProperty, rect, 0);
+                rect = filter.getRect(middleValueRect);
+                filter.set(rectProperty, rect, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                rect = filter.getRect(middleValueRect)
-                filter.set(rectProperty, rect, filter.duration - filter.animateOut)
-                rect = filter.getRect(endValueRect)
-                filter.set(rectProperty, rect, filter.duration - 1)
+                rect = filter.getRect(middleValueRect);
+                filter.set(rectProperty, rect, filter.duration - filter.animateOut);
+                rect = filter.getRect(endValueRect);
+                filter.set(rectProperty, rect, filter.duration - 1);
             }
         } else if (!positionKeyframesButton.checked) {
-            filter.resetProperty(rectProperty)
-            rect = filter.getRect(middleValueRect)
-            filter.set(rectProperty, rect)
+            filter.resetProperty(rectProperty);
+            rect = filter.getRect(middleValueRect);
+            filter.set(rectProperty, rect);
         } else if (position !== null) {
-            filter.set(rectProperty, filterRect, position)
+            filter.set(rectProperty, filterRect, position);
         }
+    }
+
+    function updateFilter() {
+        updateFilterRatio(null);
+        updateFilterRect(null);
+    }
+
+    width: 400
+    height: 150
+    Component.onCompleted: {
+        filter.blockSignals = true;
+        filter.set(startValueRect, Qt.rect(0, 0, profile.width, profile.height));
+        filter.set(middleValueRect, Qt.rect(0, 0, profile.width, profile.height));
+        filter.set(endValueRect, Qt.rect(0, 0, profile.width, profile.height));
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set('color', '#ff000000');
+            filter.set('radius', 0);
+            filter.set(rectProperty, '0%/0%:100%x100%');
+            filter.savePreset(preset.parameters);
+        } else {
+            middleValueRadius = filter.getDouble('radius', filter.animateIn);
+            filter.set(middleValueRect, filter.getRect(rectProperty, filter.animateIn + 1));
+            if (filter.animateIn > 0) {
+                startValueRadius = filter.getDouble('radius', 0);
+                filter.set(startValueRect, filter.getRect(rectProperty, 0));
+            }
+            if (filter.animateOut > 0) {
+                endValueRadius = filter.getDouble('radius', filter.duration - 1);
+                filter.set(endValueRect, filter.getRect(rectProperty, filter.duration - 1));
+            }
+        }
+        filter.blockSignals = false;
+        setRatioControls();
+        setRectControls();
+        colorSwatch.value = filter.get('color');
+        if (filter.isNew)
+            filter.set(rectProperty, filter.getRect(rectProperty));
+
     }
 
     GridLayout {
@@ -175,31 +179,33 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [rectProperty, 'radius', 'color']
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                filterRect = Qt.rect(0, 0, 0, 0)
-                filter.resetProperty(rectProperty)
-                filter.resetProperty('radius')
+                filterRect = Qt.rect(0, 0, 0, 0);
+                filter.resetProperty(rectProperty);
+                filter.resetProperty('radius');
             }
             onPresetSelected: {
-                setRatioControls()
-                setRectControls()
-                colorSwatch.value = filter.get('color')
-                filter.blockSignals = true
-                middleValueRadius = filter.getDouble('radius', filter.animateIn)
-                filter.set(middleValueRect, filter.getRect(rectProperty, filter.animateIn + 1))
+                setRatioControls();
+                setRectControls();
+                colorSwatch.value = filter.get('color');
+                filter.blockSignals = true;
+                middleValueRadius = filter.getDouble('radius', filter.animateIn);
+                filter.set(middleValueRect, filter.getRect(rectProperty, filter.animateIn + 1));
                 if (filter.animateIn > 0) {
-                    startValueRadius = filter.getDouble('radius', 0)
-                    filter.set(startValueRect, filter.getRect(rectProperty, 0))
+                    startValueRadius = filter.getDouble('radius', 0);
+                    filter.set(startValueRect, filter.getRect(rectProperty, 0));
                 }
                 if (filter.animateOut > 0) {
-                    endValueRadius = filter.getDouble('radius', filter.duration - 1)
-                    filter.set(endValueRect, filter.getRect(rectProperty, filter.duration - 1))
+                    endValueRadius = filter.getDouble('radius', filter.duration - 1);
+                    filter.set(endValueRect, filter.getRect(rectProperty, filter.duration - 1));
                 }
-                filter.blockSignals = false
+                filter.blockSignals = false;
             }
         }
 
@@ -207,146 +213,185 @@ Item {
             text: qsTr('Position')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Shotcut.DoubleSpinBox {
                 id: rectX
+
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.x !== value) {
-                    filterRect.x = value
-                    updateFilterRect(getPosition(), true)
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.x !== value) {
+                        filterRect.x = value;
+                        updateFilterRect(getPosition(), true);
+                    }
                 }
             }
-            Label { text: ','; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: ','
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectY
+
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.y !== value) {
-                    filterRect.y = value
-                    updateFilterRect(getPosition(), true)
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.y !== value) {
+                        filterRect.y = value;
+                        updateFilterRect(getPosition(), true);
+                    }
                 }
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                rectX.value = rectY.value = 0
-                filterRect.x = filterRect.y = 0
-                updateFilterRect(getPosition(), true)
+                rectX.value = rectY.value = 0;
+                filterRect.x = filterRect.y = 0;
+                updateFilterRect(getPosition(), true);
             }
         }
+
         Shotcut.KeyframesButton {
             id: positionKeyframesButton
+
             Layout.rowSpan: 2
             onToggled: {
                 if (checked) {
-                    filter.blockSignals = true
-                    filter.clearSimpleAnimation(rectProperty)
-                    filter.blockSignals = false
-                    filter.set(rectProperty, filterRect, getPosition())
+                    filter.blockSignals = true;
+                    filter.clearSimpleAnimation(rectProperty);
+                    filter.blockSignals = false;
+                    filter.set(rectProperty, filterRect, getPosition());
                 } else {
-                    filter.resetProperty(rectProperty)
-                    filter.set(rectProperty, filterRect)
+                    filter.resetProperty(rectProperty);
+                    filter.set(rectProperty, filterRect);
                 }
-                checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
+                checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
             }
         }
-    
+
         Label {
             text: qsTr('Size')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Shotcut.DoubleSpinBox {
                 id: rectW
+
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.width !== value) {
-                    filterRect.width = value
-                    updateFilterRect(getPosition(), true)
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.width !== value) {
+                        filterRect.width = value;
+                        updateFilterRect(getPosition(), true);
+                    }
                 }
             }
-            Label { text: 'x'; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: 'x'
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectH
+
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.height !== value) {
-                    filterRect.height = value
-                    updateFilterRect(getPosition(), true)
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.height !== value) {
+                        filterRect.height = value;
+                        updateFilterRect(getPosition(), true);
+                    }
                 }
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                rectW.value = profile.width
-                rectH.value = profile.height
-                filterRect.width = profile.width
-                filterRect.height = profile.height
-                updateFilterRect(getPosition(), true)
+                rectW.value = profile.width;
+                rectH.value = profile.height;
+                filterRect.width = profile.width;
+                filterRect.height = profile.height;
+                updateFilterRect(getPosition(), true);
             }
         }
-    
+
         Label {
             text: qsTr('Corner radius')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilterRatio(getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: slider.value = 0
         }
+
         Shotcut.KeyframesButton {
             id: radiusKeyframesButton
+
             onToggled: {
-                var value = slider.value / 100.0
+                var value = slider.value / 100;
                 if (checked) {
-                    filter.clearSimpleAnimation('radius')
-                    filter.set('radius', value, getPosition())
+                    filter.clearSimpleAnimation('radius');
+                    filter.set('radius', value, getPosition());
                 } else {
-                    filter.resetProperty('radius')
-                    filter.set('radius', value)
+                    filter.resetProperty('radius');
+                    filter.set('radius', value);
                 }
-                checked = filter.keyframeCount('radius') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
+                checked = filter.keyframeCount('radius') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
             }
         }
-
 
         Label {
             text: qsTr('Padding color')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Shotcut.ColorPicker {
                 id: colorSwatch
-                alpha: true
+
                 property bool isReady: false
+
+                alpha: true
                 Component.onCompleted: isReady = true
                 onValueChanged: {
                     if (isReady) {
-                        filter.set('color', value)
+                        filter.set('color', value);
                         filter.set("disable", 0);
                     }
                 }
@@ -355,47 +400,65 @@ Item {
                 }
                 onPickCancelled: filter.set('disable', 0)
             }
+
             Shotcut.Button {
                 text: qsTr('Transparent')
                 onClicked: colorSwatch.value = '#00000000'
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: colorSwatch.value = '#FF000000'
         }
-        Item { width: 1 }
+
+        Item {
+            width: 1
+        }
 
         Item {
             Layout.fillHeight: true
         }
+
     }
 
-    function updateFilter() {
-        updateFilterRatio(null)
-        updateFilterRect(null)
-    }
-    
     Connections {
-        target: filter
         function onChanged() {
-            setRectControls()
-            setRatioControls()
+            setRectControls();
+            setRatioControls();
         }
-        function onInChanged() { updateFilter(null) }
-        function onOutChanged() { updateFilter(null) }
-        function onAnimateInChanged() { updateFilter(null) }
-        function onAnimateOutChanged() { updateFilter(null) }
+
+        function onInChanged() {
+            updateFilter(null);
+        }
+
+        function onOutChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateInChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateOutChanged() {
+            updateFilter(null);
+        }
+
         function onPropertyChanged(name) {
-            setRectControls()
-            setRatioControls()
+            setRectControls();
+            setRatioControls();
         }
+
+        target: filter
     }
 
     Connections {
-        target: producer
         function onPositionChanged() {
-            setRatioControls()
-            setRectControls()
+            setRatioControls();
+            setRectControls();
         }
+
+        target: producer
     }
+
 }

--- a/src/qml/filters/dance/ui_dance.qml
+++ b/src/qml/filters/dance/ui_dance.qml
@@ -25,43 +25,42 @@ Item {
     property int _minFreqDelta: 100
     property bool _disableUpdate: false
 
-    width: 350
-    height: 350
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            filter.set('osc', '5')
-            filter.set('initial_zoom', '100')
-            filter.set('zoom', '10')
-            filter.set('up', '0')
-            filter.set('down', '0')
-            filter.set('left', '0')
-            filter.set('right', '0')
-            filter.set('clockwise', '0')
-            filter.set('counterclockwise', '0')
-            filter.set('frequency_low', '20')
-            filter.set('frequency_high', '20000')
-            filter.set('threshold', '-30')
-            filter.savePreset(defaultParameters)
-        }
-        setControls()
+    function setControls() {
+        _disableUpdate = true;
+        oscSlider.value = filter.getDouble('osc');
+        initialZoomSlider.value = filter.getDouble('initial_zoom');
+        zoomSlider.value = filter.getDouble('zoom');
+        upSlider.value = filter.getDouble('up');
+        downSlider.value = filter.getDouble('down');
+        leftSlider.value = filter.getDouble('left');
+        rightSlider.value = filter.getDouble('right');
+        clockwiseSlider.value = filter.getDouble('clockwise');
+        counterclockwiseSlider.value = filter.getDouble('counterclockwise');
+        freqLowSlider.value = filter.getDouble('frequency_low');
+        freqHighSlider.value = filter.getDouble('frequency_high');
+        thresholdSlider.value = filter.getDouble('threshold');
+        _disableUpdate = false;
     }
 
-    function setControls() {
-        _disableUpdate = true
-        oscSlider.value = filter.getDouble('osc')
-        initialZoomSlider.value = filter.getDouble('initial_zoom')
-        zoomSlider.value = filter.getDouble('zoom')
-        upSlider.value = filter.getDouble('up')
-        downSlider.value = filter.getDouble('down')
-        leftSlider.value = filter.getDouble('left')
-        rightSlider.value = filter.getDouble('right')
-        clockwiseSlider.value = filter.getDouble('clockwise')
-        counterclockwiseSlider.value = filter.getDouble('counterclockwise')
-        freqLowSlider.value = filter.getDouble('frequency_low')
-        freqHighSlider.value = filter.getDouble('frequency_high')
-        thresholdSlider.value = filter.getDouble('threshold')
-        _disableUpdate = false
+    width: 350
+    height: 350
+    Component.onCompleted: {
+        if (filter.isNew) {
+            filter.set('osc', '5');
+            filter.set('initial_zoom', '100');
+            filter.set('zoom', '10');
+            filter.set('up', '0');
+            filter.set('down', '0');
+            filter.set('left', '0');
+            filter.set('right', '0');
+            filter.set('clockwise', '0');
+            filter.set('counterclockwise', '0');
+            filter.set('frequency_low', '20');
+            filter.set('frequency_high', '20000');
+            filter.set('threshold', '-30');
+            filter.savePreset(defaultParameters);
+        }
+        setControls();
     }
 
     GridLayout {
@@ -73,8 +72,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: defaultParameters
             Layout.columnSpan: 4
             onPresetSelected: setControls()
@@ -83,17 +84,24 @@ Item {
         Label {
             text: qsTr('Initial Zoom')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The amount to zoom the image before any motion occurs.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The amount to zoom the image before any motion occurs.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: initialZoomSlider
+
+            Layout.columnSpan: 3
             minimumValue: 0
             maximumValue: 200
             decimals: 0
             suffix: ' %'
             onValueChanged: filter.set("initial_zoom", value)
         }
+
         Shotcut.UndoButton {
             onClicked: initialZoomSlider.value = 100
         }
@@ -101,17 +109,24 @@ Item {
         Label {
             text: qsTr('Oscillation')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Oscillation can be useful to make the image move back and forth during long periods of sound.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Oscillation can be useful to make the image move back and forth during long periods of sound.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: oscSlider
+
+            Layout.columnSpan: 3
             minimumValue: 0
             maximumValue: 10
             decimals: 0
             suffix: ' Hz'
             onValueChanged: filter.set("osc", value)
         }
+
         Shotcut.UndoButton {
             onClicked: oscSlider.value = 5
         }
@@ -119,17 +134,24 @@ Item {
         Label {
             text: qsTr('Zoom')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The amount that the audio affects the zoom of the image.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The amount that the audio affects the zoom of the image.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: zoomSlider
+
+            Layout.columnSpan: 3
             minimumValue: -100
             maximumValue: 100
             decimals: 0
             suffix: ' %'
             onValueChanged: filter.set("zoom", value)
         }
+
         Shotcut.UndoButton {
             onClicked: zoomSlider.value = 10
         }
@@ -137,17 +159,24 @@ Item {
         Label {
             text: qsTr('Up')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The amount that the audio affects the upward offset of the image.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The amount that the audio affects the upward offset of the image.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: upSlider
+
+            Layout.columnSpan: 3
             minimumValue: 0
             maximumValue: 100
             decimals: 0
             suffix: ' %'
             onValueChanged: filter.set("up", value)
         }
+
         Shotcut.UndoButton {
             onClicked: upSlider.value = 0
         }
@@ -155,17 +184,24 @@ Item {
         Label {
             text: qsTr('Down')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The amount that the audio affects the downward offset of the image.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The amount that the audio affects the downward offset of the image.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: downSlider
+
+            Layout.columnSpan: 3
             minimumValue: 0
             maximumValue: 100
             decimals: 0
             suffix: ' %'
             onValueChanged: filter.set("down", value)
         }
+
         Shotcut.UndoButton {
             onClicked: downSlider.value = 0
         }
@@ -173,17 +209,24 @@ Item {
         Label {
             text: qsTr('Left')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The amount that the audio affects the left offset of the image.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The amount that the audio affects the left offset of the image.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: leftSlider
+
+            Layout.columnSpan: 3
             minimumValue: 0
             maximumValue: 100
             decimals: 0
             suffix: ' %'
             onValueChanged: filter.set("left", value)
         }
+
         Shotcut.UndoButton {
             onClicked: leftSlider.value = 0
         }
@@ -191,17 +234,24 @@ Item {
         Label {
             text: qsTr('Right')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The amount that the audio affects the right offset of the image.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The amount that the audio affects the right offset of the image.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: rightSlider
+
+            Layout.columnSpan: 3
             minimumValue: 0
             maximumValue: 100
             decimals: 0
             suffix: ' %'
             onValueChanged: filter.set("right", value)
         }
+
         Shotcut.UndoButton {
             onClicked: rightSlider.value = 0
         }
@@ -209,17 +259,24 @@ Item {
         Label {
             text: qsTr('Clockwise')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The amount that the audio affects the clockwise rotation of the image.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The amount that the audio affects the clockwise rotation of the image.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: clockwiseSlider
+
+            Layout.columnSpan: 3
             minimumValue: 0
             maximumValue: 360
             decimals: 0
             suffix: qsTr(' deg')
             onValueChanged: filter.set("clockwise", value)
         }
+
         Shotcut.UndoButton {
             onClicked: clockwiseSlider.value = 0
         }
@@ -227,17 +284,24 @@ Item {
         Label {
             text: qsTr('Counterclockwise')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The amount that the audio affects the counterclockwise rotation of the image.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The amount that the audio affects the counterclockwise rotation of the image.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: counterclockwiseSlider
+
+            Layout.columnSpan: 3
             minimumValue: 0
             maximumValue: 360
             decimals: 0
             suffix: qsTr(' deg')
             onValueChanged: filter.set("counterclockwise", value)
         }
+
         Shotcut.UndoButton {
             onClicked: counterclockwiseSlider.value = 0
         }
@@ -245,22 +309,29 @@ Item {
         Label {
             text: qsTr('Low Frequency')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The low end of the frequency range to be used to influence the image motion.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The low end of the frequency range to be used to influence the image motion.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: freqLowSlider
+
+            Layout.columnSpan: 3
             minimumValue: 20
             maximumValue: 20000 - _minFreqDelta
             decimals: 0
             suffix: ' Hz'
             onValueChanged: {
-                filter.set("frequency_low", value)
-                if (!_disableUpdate && (value + _minFreqDelta) > freqHighSlider.value) {
-                    freqHighSlider.value = value + _minFreqDelta
-                }
+                filter.set("frequency_low", value);
+                if (!_disableUpdate && (value + _minFreqDelta) > freqHighSlider.value)
+                    freqHighSlider.value = value + _minFreqDelta;
+
             }
         }
+
         Shotcut.UndoButton {
             onClicked: freqLowSlider.value = 20
         }
@@ -268,22 +339,29 @@ Item {
         Label {
             text: qsTr('High Frequency')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The high end of the frequency range to be used to influence the image motion.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The high end of the frequency range to be used to influence the image motion.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: freqHighSlider
+
+            Layout.columnSpan: 3
             minimumValue: 20 + _minFreqDelta
             maximumValue: 20000
             decimals: 0
             suffix: ' Hz'
             onValueChanged: {
-                filter.set("frequency_high", value)
-                if (!_disableUpdate && (value - _minFreqDelta) < freqLowSlider.value) {
-                    freqLowSlider.value = value - _minFreqDelta
-                }
+                filter.set("frequency_high", value);
+                if (!_disableUpdate && (value - _minFreqDelta) < freqLowSlider.value)
+                    freqLowSlider.value = value - _minFreqDelta;
+
             }
         }
+
         Shotcut.UndoButton {
             onClicked: freqHighSlider.value = 20000
         }
@@ -291,21 +369,32 @@ Item {
         Label {
             text: qsTr('Threshold')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The minimum amplitude of sound that must occur within the frequency range to cause the image to move.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The minimum amplitude of sound that must occur within the frequency range to cause the image to move.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: thresholdSlider
+
+            Layout.columnSpan: 3
             minimumValue: -60
             maximumValue: 0
             decimals: 0
             suffix: ' dB'
             onValueChanged: filter.set("threshold", value)
         }
+
         Shotcut.UndoButton {
             onClicked: thresholdSlider.value = -30
         }
-        
-        Item { Layout.fillHeight: true }
+
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
+
 }

--- a/src/qml/filters/deband/meta.qml
+++ b/src/qml/filters/deband/meta.qml
@@ -16,10 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 import QtQuick 2.12
 import org.shotcut.qml 1.0
-
 
 Metadata {
     type: Metadata.Filter

--- a/src/qml/filters/deband/ui.qml
+++ b/src/qml/filters/deband/ui.qml
@@ -16,423 +16,441 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 import QtQuick.Window 2.12
 import Shotcut.Controls 1.0 as Shotcut
 
-
 Item {
     // Constants
-
-    property double thresholdMin: 0.00003
-    property double thresholdMax: 0.5
-    property double directionMax: 6.28319
-
-
     // Parameters
-
-    property string thr1Param: 'av.1thr'
-    property double thr1Default: 0.0100294
-
-    property string thr2Param: 'av.2thr'
-    property double thr2Default: 0.0100294
-
-    property string thr3Param: 'av.3thr'
-    property double thr3Default: 0.0100294
-
-    property string thr4Param: 'av.4thr'
-    property double thr4Default: 0.0100294
-
-    property string linkParam: 'ui.link'
-    property bool linkDefault: true
-
-    property string rangeParam: 'av.range'
-    property int rangeDefault: 23
-
-    property string directionParam: 'av.direction'
-    property double directionDefault: directionMax
-
-    property string blurParam: 'av.blur'
-    property bool blurDefault: true
-
-    property string couplingParam: 'av.coupling'
-    property bool couplingDefault: false
-
-    property var allParams: [thr1Param, thr2Param, thr3Param, thr4Param, linkParam, rangeParam, directionParam, blurParam, couplingParam]
-
-
     // Conversion functions between filter and UI units
-
-    function pctToThr (value) {
-        return (thresholdMax - thresholdMin) * (value / 100) + thresholdMin
-    }
-
-
-    function thrToPct (value) {
-        return Math.round(((value - thresholdMin) / (thresholdMax - thresholdMin) + Number.EPSILON) * 1000) / 10
-    }
-
-
-    function sqrToRoot (value) {
-        return Math.round((Math.sqrt(Math.abs(value)) + Number.EPSILON) * 10) / 10
-    }
-
-
-    function rootToSqr (value) {
-        return Math.round(value * value + Number.EPSILON)
-    }
-
-
-    function radToDeg (value) {
-        return Math.round(Math.abs(value / directionMax * 360) + Number.EPSILON)
-    }
-
-
-    function degToRad (value) {
-        return value / 360 * directionMax
-    }
-
-
     // UI management functions
 
-    function setThreshold (param, pct) {
+    property double thresholdMin: 3e-05
+    property double thresholdMax: 0.5
+    property double directionMax: 6.28319
+    property string thr1Param: 'av.1thr'
+    property double thr1Default: 0.0100294
+    property string thr2Param: 'av.2thr'
+    property double thr2Default: 0.0100294
+    property string thr3Param: 'av.3thr'
+    property double thr3Default: 0.0100294
+    property string thr4Param: 'av.4thr'
+    property double thr4Default: 0.0100294
+    property string linkParam: 'ui.link'
+    property bool linkDefault: true
+    property string rangeParam: 'av.range'
+    property int rangeDefault: 23
+    property string directionParam: 'av.direction'
+    property double directionDefault: directionMax
+    property string blurParam: 'av.blur'
+    property bool blurDefault: true
+    property string couplingParam: 'av.coupling'
+    property bool couplingDefault: false
+    property var allParams: [thr1Param, thr2Param, thr3Param, thr4Param, linkParam, rangeParam, directionParam, blurParam, couplingParam]
+
+    function pctToThr(value) {
+        return (thresholdMax - thresholdMin) * (value / 100) + thresholdMin;
+    }
+
+    function thrToPct(value) {
+        return Math.round(((value - thresholdMin) / (thresholdMax - thresholdMin) + Number.EPSILON) * 1000) / 10;
+    }
+
+    function sqrToRoot(value) {
+        return Math.round((Math.sqrt(Math.abs(value)) + Number.EPSILON) * 10) / 10;
+    }
+
+    function rootToSqr(value) {
+        return Math.round(value * value + Number.EPSILON);
+    }
+
+    function radToDeg(value) {
+        return Math.round(Math.abs(value / directionMax * 360) + Number.EPSILON);
+    }
+
+    function degToRad(value) {
+        return value / 360 * directionMax;
+    }
+
+    function setThreshold(param, pct) {
         if (idLink.checked) {
-            var thr = pctToThr(pct)
-
-            filter.set(thr1Param, thr)
-            filter.set(thr2Param, thr)
-            filter.set(thr3Param, thr)
-            filter.set(thr4Param, thr)
-
-            idThr1.value = pct
-            idThr2.value = pct
-            idThr3.value = pct
-            idThr4.value = pct
-        }
-        else {
-            filter.set(param, pctToThr(pct))
+            var thr = pctToThr(pct);
+            filter.set(thr1Param, thr);
+            filter.set(thr2Param, thr);
+            filter.set(thr3Param, thr);
+            filter.set(thr4Param, thr);
+            idThr1.value = pct;
+            idThr2.value = pct;
+            idThr3.value = pct;
+            idThr4.value = pct;
+        } else {
+            filter.set(param, pctToThr(pct));
         }
     }
 
-
-    function setControls () {
-        idLink.checked = false
-        idThr1.value = thrToPct(filter.getDouble(thr1Param))
-        idThr2.value = thrToPct(filter.getDouble(thr2Param))
-        idThr3.value = thrToPct(filter.getDouble(thr3Param))
-        idThr4.value = thrToPct(filter.getDouble(thr4Param))
-        idLink.checked = parseInt(filter.get(linkParam))
-
+    function setControls() {
+        idLink.checked = false;
+        idThr1.value = thrToPct(filter.getDouble(thr1Param));
+        idThr2.value = thrToPct(filter.getDouble(thr2Param));
+        idThr3.value = thrToPct(filter.getDouble(thr3Param));
+        idThr4.value = thrToPct(filter.getDouble(thr4Param));
+        idLink.checked = parseInt(filter.get(linkParam));
         // The Randomize checkboxes must be set first or else sign inversion will happen.
-        idRangeRand.checked = parseInt(filter.get(rangeParam)) >= 0 ? true : false
-        idRange.value = sqrToRoot(parseInt(filter.get(rangeParam)))
-        idDirectionRand.checked = filter.getDouble(directionParam) >= 0 ? true : false
-        idDirection.value = radToDeg(filter.getDouble(directionParam))
-
-        idBlur.checked = parseInt(filter.get(blurParam))
-        idCoupling.checked = parseInt(filter.get(couplingParam))
+        idRangeRand.checked = parseInt(filter.get(rangeParam)) >= 0 ? true : false;
+        idRange.value = sqrToRoot(parseInt(filter.get(rangeParam)));
+        idDirectionRand.checked = filter.getDouble(directionParam) >= 0 ? true : false;
+        idDirection.value = radToDeg(filter.getDouble(directionParam));
+        idBlur.checked = parseInt(filter.get(blurParam));
+        idCoupling.checked = parseInt(filter.get(couplingParam));
     }
-
 
     Component.onCompleted: {
-        filter.blockSignals = true
+        filter.blockSignals = true;
         if (filter.isNew) {
             // Custom preset
-            filter.set(thr1Param, 0.0100294)
-            filter.set(thr2Param, 0.0100294)
-            filter.set(thr3Param, 0.0100294)
-            filter.set(thr4Param, 0.0100294)
-            filter.set(linkParam, true)
-            filter.set(rangeParam, 23)
-            filter.set(directionParam, directionMax)
-            filter.set(blurParam, true)
-            filter.set(couplingParam, false)
-            filter.savePreset(allParams, qsTr('Minimal strength'))
-
+            filter.set(thr1Param, 0.0100294);
+            filter.set(thr2Param, 0.0100294);
+            filter.set(thr3Param, 0.0100294);
+            filter.set(thr4Param, 0.0100294);
+            filter.set(linkParam, true);
+            filter.set(rangeParam, 23);
+            filter.set(directionParam, directionMax);
+            filter.set(blurParam, true);
+            filter.set(couplingParam, false);
+            filter.savePreset(allParams, qsTr('Minimal strength'));
             // Custom preset
-            filter.set(thr1Param, 0.02)
-            filter.set(thr2Param, 0.02)
-            filter.set(thr3Param, 0.02)
-            filter.set(thr4Param, 0.02)
-            filter.set(linkParam, true)
-            filter.set(rangeParam, 16)
-            filter.set(directionParam, directionMax)
-            filter.set(blurParam, true)
-            filter.set(couplingParam, false)
-            filter.savePreset(allParams, qsTr('Average strength'))
-
+            filter.set(thr1Param, 0.02);
+            filter.set(thr2Param, 0.02);
+            filter.set(thr3Param, 0.02);
+            filter.set(thr4Param, 0.02);
+            filter.set(linkParam, true);
+            filter.set(rangeParam, 16);
+            filter.set(directionParam, directionMax);
+            filter.set(blurParam, true);
+            filter.set(couplingParam, false);
+            filter.savePreset(allParams, qsTr('Average strength'));
             // Custom preset
-            filter.set(thr1Param, 0.0150291)
-            filter.set(thr2Param, 0.03994)
-            filter.set(thr3Param, 0.0150291)
-            filter.set(thr4Param, 0.0150291)
-            filter.set(linkParam, false)
-            filter.set(rangeParam, 90)
-            filter.set(directionParam, directionMax)
-            filter.set(blurParam, true)
-            filter.set(couplingParam, false)
-            filter.savePreset(allParams, qsTr('Blue sky'))
-
+            filter.set(thr1Param, 0.0150291);
+            filter.set(thr2Param, 0.03994);
+            filter.set(thr3Param, 0.0150291);
+            filter.set(thr4Param, 0.0150291);
+            filter.set(linkParam, false);
+            filter.set(rangeParam, 90);
+            filter.set(directionParam, directionMax);
+            filter.set(blurParam, true);
+            filter.set(couplingParam, false);
+            filter.savePreset(allParams, qsTr('Blue sky'));
             // Custom preset
-            filter.set(thr1Param, 0.0150291)
-            filter.set(thr2Param, 0.0150291)
-            filter.set(thr3Param, 0.03994)
-            filter.set(thr4Param, 0.0150291)
-            filter.set(linkParam, false)
-            filter.set(rangeParam, 44)
-            filter.set(directionParam, directionMax)
-            filter.set(blurParam, true)
-            filter.set(couplingParam, false)
-            filter.savePreset(allParams, qsTr('Red sky'))
-
+            filter.set(thr1Param, 0.0150291);
+            filter.set(thr2Param, 0.0150291);
+            filter.set(thr3Param, 0.03994);
+            filter.set(thr4Param, 0.0150291);
+            filter.set(linkParam, false);
+            filter.set(rangeParam, 44);
+            filter.set(directionParam, directionMax);
+            filter.set(blurParam, true);
+            filter.set(couplingParam, false);
+            filter.savePreset(allParams, qsTr('Red sky'));
             // Custom preset
-            filter.set(thr1Param, thr1Default)
-            filter.set(thr2Param, thr2Default)
-            filter.set(thr3Param, thr3Default)
-            filter.set(thr4Param, thr4Default)
-            filter.set(linkParam, linkDefault)
-            filter.set(rangeParam, rangeDefault)
-            filter.set(directionParam, directionDefault)
-            filter.set(blurParam, blurDefault)
-            filter.set(couplingParam, couplingDefault)
-            filter.savePreset(allParams, qsTr('Full range to limited range'))
-
+            filter.set(thr1Param, thr1Default);
+            filter.set(thr2Param, thr2Default);
+            filter.set(thr3Param, thr3Default);
+            filter.set(thr4Param, thr4Default);
+            filter.set(linkParam, linkDefault);
+            filter.set(rangeParam, rangeDefault);
+            filter.set(directionParam, directionDefault);
+            filter.set(blurParam, blurDefault);
+            filter.set(couplingParam, couplingDefault);
+            filter.savePreset(allParams, qsTr('Full range to limited range'));
             // Default preset
             // Same as "Full to limited" preset; assumed most common use case
-            filter.savePreset(allParams)
+            filter.savePreset(allParams);
         }
-        filter.blockSignals = false
-
-        setControls()
+        filter.blockSignals = false;
+        setControls();
     }
-
-
     width: 500
     height: 360
 
-
     GridLayout {
+        // Row split
+        // Row split
+        // Row split
+        // Row split
+        // Row split
+        // Row split
+        // Row split
+        // Row split
+        // Row split
+        // Row split
+        // Row split
+        // Row split
+        // Filler
+
         columns: 3
         anchors.fill: parent
         anchors.margins: 8
-
-        // Row split
 
         Label {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: idPreset
+
             Layout.columnSpan: 2
             parameters: allParams
             onPresetSelected: setControls()
         }
 
-        // Row split
-
         Label {
             text: qsTr('Contrast threshold')
-            Shotcut.HoverTip { text: qsTr('Banding similarity within first component\nY (luma) in YCbCr mode\nRed in RGB mode') }
             Layout.alignment: Qt.AlignRight
+
+            Shotcut.HoverTip {
+                text: qsTr('Banding similarity within first component\nY (luma) in YCbCr mode\nRed in RGB mode')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: idThr1
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
             suffix: ' %'
             onValueChanged: setThreshold(thr1Param, value)
         }
+
         Shotcut.UndoButton {
             onClicked: idThr1.value = thrToPct(thr1Default)
         }
 
-        // Row split
-
         Label {
             text: qsTr('Blue threshold')
-            Shotcut.HoverTip { text: qsTr('Banding similarity within second component\nCb (blue) in YCbCr mode\nGreen in RGB mode') }
             Layout.alignment: Qt.AlignRight
+
+            Shotcut.HoverTip {
+                text: qsTr('Banding similarity within second component\nCb (blue) in YCbCr mode\nGreen in RGB mode')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: idThr2
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
             suffix: ' %'
             onValueChanged: setThreshold(thr2Param, value)
         }
+
         Shotcut.UndoButton {
             onClicked: idThr2.value = thrToPct(thr2Default)
         }
 
-        // Row split
-
         Label {
             text: qsTr('Red threshold')
-            Shotcut.HoverTip { text: qsTr('Banding similarity within third component\nCr (red) in YCbCr mode\nBlue in RGB mode') }
             Layout.alignment: Qt.AlignRight
+
+            Shotcut.HoverTip {
+                text: qsTr('Banding similarity within third component\nCr (red) in YCbCr mode\nBlue in RGB mode')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: idThr3
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
             suffix: ' %'
             onValueChanged: setThreshold(thr3Param, value)
         }
+
         Shotcut.UndoButton {
             onClicked: idThr3.value = thrToPct(thr3Default)
         }
 
-        // Row split
-
         Label {
             text: qsTr('Alpha threshold')
-            Shotcut.HoverTip { text: qsTr('Banding similarity within fourth component') }
             Layout.alignment: Qt.AlignRight
+
+            Shotcut.HoverTip {
+                text: qsTr('Banding similarity within fourth component')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: idThr4
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
             suffix: ' %'
             onValueChanged: setThreshold(thr4Param, value)
         }
+
         Shotcut.UndoButton {
             onClicked: idThr4.value = thrToPct(thr4Default)
         }
 
-        // Row split
-
         Item {
             Layout.fillWidth: true
         }
+
         CheckBox {
             id: idLink
+
             text: qsTr('Link thresholds')
             onClicked: filter.set(linkParam, checked)
         }
+
         Item {
             Layout.fillWidth: true
         }
 
-        // Row split
-
         Label {
             text: qsTr('Pixel range')
-            Shotcut.HoverTip { text: qsTr('The size of bands being targeted') }
             Layout.alignment: Qt.AlignRight
+
+            Shotcut.HoverTip {
+                text: qsTr('The size of bands being targeted')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: idRange
+
             minimumValue: 0
             maximumValue: 64
             decimals: 1
             onValueChanged: filter.set(rangeParam, idRangeRand.checked ? rootToSqr(value) : -rootToSqr(value))
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filter.set(rangeParam, rangeDefault)
-                setControls()
+                filter.set(rangeParam, rangeDefault);
+                setControls();
             }
         }
 
-        // Row split
-
         Item {
             Layout.fillWidth: true
         }
+
         CheckBox {
             id: idRangeRand
+
             text: qsTr('Randomize pixel range between zero and value')
             onClicked: filter.set(rangeParam, checked ? rootToSqr(idRange.value) : -rootToSqr(idRange.value))
         }
+
         Item {
             Layout.fillWidth: true
         }
 
-        // Row split
-
         Label {
             text: qsTr('Direction')
-            Shotcut.HoverTip { text: qsTr('Up = 270°\nDown = 90°\nLeft = 180°\nRight = 0° or 360°\nAll = 360° + Randomize') }
             Layout.alignment: Qt.AlignRight
+
+            Shotcut.HoverTip {
+                text: qsTr('Up = 270°\nDown = 90°\nLeft = 180°\nRight = 0° or 360°\nAll = 360° + Randomize')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: idDirection
+
             minimumValue: 0
             maximumValue: 360
             suffix: ' °'
             onValueChanged: filter.set(directionParam, idDirectionRand.checked ? degToRad(value) : -degToRad(value))
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filter.set(directionParam, directionDefault)
-                setControls()
+                filter.set(directionParam, directionDefault);
+                setControls();
             }
         }
-
-        // Row split
 
         Item {
             Layout.fillWidth: true
         }
+
         CheckBox {
             id: idDirectionRand
+
             text: qsTr('Randomize direction between zero degrees and value')
             onClicked: filter.set(directionParam, checked ? degToRad(idDirection.value) : -degToRad(idDirection.value))
         }
-        Item {
-            Layout.fillWidth: true
-        }
-
-        // Row split
 
         Item {
             Layout.fillWidth: true
         }
+
+        Item {
+            Layout.fillWidth: true
+        }
+
         CheckBox {
             id: idBlur
+
             text: qsTr('Measure similarity using average of neighbors')
-            Shotcut.HoverTip { text: qsTr('Compare to thresholds using average versus exact neighbor values') }
             onClicked: filter.set(blurParam, checked)
-        }
-        Shotcut.UndoButton {
-            onClicked: {
-                filter.set(blurParam, blurDefault)
-                idBlur.checked = blurDefault
+
+            Shotcut.HoverTip {
+                text: qsTr('Compare to thresholds using average versus exact neighbor values')
             }
+
         }
 
-        // Row split
+        Shotcut.UndoButton {
+            onClicked: {
+                filter.set(blurParam, blurDefault);
+                idBlur.checked = blurDefault;
+            }
+        }
 
         Item {
             Layout.fillWidth: true
         }
+
         CheckBox {
             id: idCoupling
+
             text: qsTr('All components required to trigger deband')
-            Shotcut.HoverTip { text: qsTr('Deband only if all pixel components (including alpha) are within thresholds') }
             onClicked: filter.set(couplingParam, checked)
-        }
-        Shotcut.UndoButton {
-            onClicked: {
-                filter.set(couplingParam, couplingDefault)
-                idCoupling.checked = couplingDefault
+
+            Shotcut.HoverTip {
+                text: qsTr('Deband only if all pixel components (including alpha) are within thresholds')
             }
+
         }
 
-        // Filler
+        Shotcut.UndoButton {
+            onClicked: {
+                filter.set(couplingParam, couplingDefault);
+                idCoupling.checked = couplingDefault;
+            }
+        }
 
         Item {
             Layout.columnSpan: 3
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/distort/meta.qml
+++ b/src/qml/filters/distort/meta.qml
@@ -23,6 +23,7 @@ Metadata {
     name: qsTr("Distort")
     mlt_service: "frei0r.distort0r"
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -51,4 +52,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/distort/ui.qml
+++ b/src/qml/filters/distort/ui.qml
@@ -21,7 +21,6 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Shotcut.KeyframableFilter {
-    
     property string amplitude: '0'
     property string frequency: '1'
     property string useVelocity: '2'
@@ -30,46 +29,44 @@ Shotcut.KeyframableFilter {
     property double frequencyDefault: 0.005
     property double velocityDefault: 0.5
 
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        amplitudeSlider.value = filter.getDouble(amplitude, position) * amplitudeSlider.maximumValue;
+        amplitudeKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(amplitude) > 0;
+        frequencySlider.value = filter.getDouble(frequency, position) * frequencySlider.maximumValue;
+        frequencyKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(frequency) > 0;
+        velocitySlider.value = filter.getDouble(velocity, position) * velocitySlider.maximumValue;
+        velocityKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(velocity) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        amplitudeSlider.enabled = frequencySlider.enabled = velocitySlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        updateFilter(amplitude, amplitudeSlider.value / amplitudeSlider.maximumValue, amplitudeKeyframesButton, null);
+        updateFilter(frequency, frequencySlider.value / frequencySlider.maximumValue, frequencyKeyframesButton, null);
+        updateFilter(velocity, velocitySlider.value / velocitySlider.maximumValue, velocityKeyframesButton, null);
+    }
+
     keyframableParameters: [amplitude, frequency, velocity]
     startValues: [0, 0, 0]
     middleValues: [amplitudeDefault, frequencyDefault, velocityDefault]
     endValues: [0, 0, 0]
-
     width: 350
     height: 150
-    
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set(amplitude, amplitudeDefault)
-            filter.set(frequency, frequencyDefault)
-            filter.set(useVelocity, 1)
-            filter.set(velocity, velocityDefault)
-            filter.savePreset(preset.parameters)
+            filter.set(amplitude, amplitudeDefault);
+            filter.set(frequency, frequencyDefault);
+            filter.set(useVelocity, 1);
+            filter.set(velocity, velocityDefault);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        amplitudeSlider.value = filter.getDouble(amplitude, position) * amplitudeSlider.maximumValue
-        amplitudeKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(amplitude) > 0
-        frequencySlider.value = filter.getDouble(frequency, position) * frequencySlider.maximumValue
-        frequencyKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(frequency) > 0
-        velocitySlider.value = filter.getDouble(velocity, position) * velocitySlider.maximumValue
-        velocityKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(velocity) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        amplitudeSlider.enabled = frequencySlider.enabled = velocitySlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        updateFilter(amplitude, amplitudeSlider.value / amplitudeSlider.maximumValue, amplitudeKeyframesButton, null)
-        updateFilter(frequency, frequencySlider.value / frequencySlider.maximumValue, frequencyKeyframesButton, null)
-        updateFilter(velocity, velocitySlider.value / velocitySlider.maximumValue, velocityKeyframesButton, null)
+        setControls();
     }
 
     GridLayout {
@@ -81,16 +78,18 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [amplitude, frequency, useVelocity, velocity]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -98,8 +97,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Amplitude')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: amplitudeSlider
+
             minimumValue: 0
             maximumValue: 100
             stepSize: 0.1
@@ -107,14 +108,17 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(amplitude, value / maximumValue, amplitudeKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: amplitudeSlider.value = amplitudeDefault * amplitudeSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: amplitudeKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, amplitude, amplitudeSlider.value / amplitudeSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, amplitude, amplitudeSlider.value / amplitudeSlider.maximumValue);
             }
         }
 
@@ -122,8 +126,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Frequency')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: frequencySlider
+
             minimumValue: 0
             maximumValue: 100
             stepSize: 0.1
@@ -131,14 +137,17 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(frequency, value / maximumValue, frequencyKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: frequencySlider.value = frequencyDefault * frequencySlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: frequencyKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, frequency, frequencySlider.value / frequencySlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, frequency, frequencySlider.value / frequencySlider.maximumValue);
             }
         }
 
@@ -146,8 +155,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Velocity')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: velocitySlider
+
             minimumValue: 0
             maximumValue: 100
             stepSize: 0.1
@@ -155,34 +166,60 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(velocity, value / maximumValue, velocityKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: velocitySlider.value = velocityDefault * velocitySlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: velocityKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, velocity, velocitySlider.value / velocitySlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, velocity, velocitySlider.value / velocitySlider.maximumValue);
             }
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/dither/meta.qml
+++ b/src/qml/filters/dither/meta.qml
@@ -7,6 +7,7 @@ Metadata {
     objectName: 'dither'
     mlt_service: "frei0r.dither"
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -21,4 +22,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/dither/ui.qml
+++ b/src/qml/filters/dither/ui.qml
@@ -26,39 +26,37 @@ Shotcut.KeyframableFilter {
     property double levelsDefault: 0.1
     property double matrixidDefault: 0
 
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        levelsSlider.value = filter.getDouble(levels, position) * levelsSlider.maximumValue;
+        levelKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(levels) > 0;
+        matrixCombo.currentIndex = filter.getDouble(matrixid) * 9;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        levelsSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        updateFilter(levels, levelsSlider.value / levelsSlider.maximumValue, levelKeyframesButton, null);
+    }
+
     keyframableParameters: [levels]
     startValues: [0.5]
     middleValues: [levelsDefault]
     endValues: [0.5]
-
     width: 350
     height: 100
-
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set(levels, levelsDefault)
-            filter.set(matrixid, matrixidDefault)
-            filter.savePreset(preset.parameters)
+            filter.set(levels, levelsDefault);
+            filter.set(matrixid, matrixidDefault);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        levelsSlider.value = filter.getDouble(levels, position) * levelsSlider.maximumValue
-        levelKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(levels) > 0
-        matrixCombo.currentIndex = filter.getDouble(matrixid) * 9
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        levelsSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        updateFilter(levels, levelsSlider.value / levelsSlider.maximumValue, levelKeyframesButton, null)
+        setControls();
     }
 
     GridLayout {
@@ -70,16 +68,18 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [levels, matrixid]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -87,23 +87,28 @@ Shotcut.KeyframableFilter {
             text: qsTr('Levels', 'Dither video filter')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: levelsSlider
-            minimumValue: 0.0
+
+            minimumValue: 0
             maximumValue: 100
             stepSize: 0.1
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter(levels, levelsSlider.value / levelsSlider.maximumValue, levelKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: levelsSlider.value = levelsDefault * levelsSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: levelKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, levels, levelsSlider.value / levelsSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, levels, levelsSlider.value / levelsSlider.maximumValue);
             }
         }
 
@@ -111,18 +116,19 @@ Shotcut.KeyframableFilter {
             text: qsTr('Matrix')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: matrixCombo
+
             implicitWidth: 180
-            model: [qsTr('2x2 Magic Square'), qsTr('4x4 Magic Square'), qsTr('4x4 Ordered'), qsTr('4x4 Lines'),
-                qsTr('6x6 90 Degree Halftone'), qsTr('6x6 Ordered'), qsTr('8x8 Ordered'),
-                qsTr('Order-3 Clustered'), qsTr('Order-4 Ordered'), qsTr('Order-8 Ordered')]
+            model: [qsTr('2x2 Magic Square'), qsTr('4x4 Magic Square'), qsTr('4x4 Ordered'), qsTr('4x4 Lines'), qsTr('6x6 90 Degree Halftone'), qsTr('6x6 Ordered'), qsTr('8x8 Ordered'), qsTr('Order-3 Clustered'), qsTr('Order-4 Ordered'), qsTr('Order-8 Ordered')]
             onActivated: {
-                enabled = false
-                filter.set(matrixid, index / 9)
-                enabled = true
+                enabled = false;
+                filter.set(matrixid, index / 9);
+                enabled = true;
             }
         }
+
         Shotcut.UndoButton {
             onClicked: matrixCombo.currentIndex = matrixidDefault * 9
             Layout.columnSpan: 2
@@ -131,20 +137,43 @@ Shotcut.KeyframableFilter {
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/dust/ui.qml
+++ b/src/qml/filters/dust/ui.qml
@@ -22,21 +22,21 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
+    function setControls() {
+        sizeSlider.value = filter.get('maxdiameter');
+        amountSlider.value = filter.get('maxcount');
+    }
+
     width: 350
     height: 100
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set('maxdiameter', 2)
-            filter.set('maxcount', 10)
-            filter.savePreset(preset.parameters)
+            filter.set('maxdiameter', 2);
+            filter.set('maxcount', 10);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        sizeSlider.value = filter.get('maxdiameter')
-        amountSlider.value = filter.get('maxcount')
+        setControls();
     }
 
     GridLayout {
@@ -48,8 +48,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ['maxdiameter', 'maxcount']
             Layout.columnSpan: 2
             onPresetSelected: setControls()
@@ -59,14 +61,17 @@ Item {
             text: qsTr('Size')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sizeSlider
+
             minimumValue: 1
             maximumValue: 100
             suffix: ' %'
             value: filter.get('maxdiameter')
             onValueChanged: filter.set('maxdiameter', value)
         }
+
         Shotcut.UndoButton {
             onClicked: sizeSlider.value = 2
         }
@@ -75,19 +80,24 @@ Item {
             text: qsTr('Amount')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: amountSlider
+
             minimumValue: 1
             maximumValue: 400
             value: filter.get('maxcount')
             onValueChanged: filter.set('maxcount', value)
         }
+
         Shotcut.UndoButton {
             onClicked: amountSlider.value = 10
         }
-        
+
         Item {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/dynamictext/meta.qml
+++ b/src/qml/filters/dynamictext/meta.qml
@@ -9,6 +9,7 @@ Metadata {
     qml: "ui.qml"
     vui: 'vui.qml'
     isGpuCompatible: false
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -21,4 +22,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/dynamictext/ui.qml
+++ b/src/qml/filters/dynamictext/ui.qml
@@ -21,132 +21,129 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 500
-    height: 380
-
-    Component.onCompleted: {
-        filter.blockSignals = true
-        filter.set(textFilterUi.middleValue, Qt.rect(0, 0, profile.width, profile.height))
-        filter.set(textFilterUi.startValue, Qt.rect(0, 0, profile.width, profile.height))
-        filter.set(textFilterUi.endValue, Qt.rect(0, 0, profile.width, profile.height))
-        if (filter.isNew) {
-            var presetParams = preset.parameters.slice()
-            var index = presetParams.indexOf('argument')
-            if (index > -1)
-                presetParams.splice(index, 1)
-
-            if (application.OS === 'Windows')
-                filter.set('family', 'Verdana')
-            filter.set('fgcolour', '#ffffffff')
-            filter.set('bgcolour', '#00000000')
-            filter.set('olcolour', '#aa000000')
-            filter.set('outline', 3)
-            filter.set('weight', 10 * Font.Normal)
-            filter.set('style', 'normal')
-            filter.set(textFilterUi.useFontSizeProperty, false)
-            filter.set('size', profile.height)
-
-            filter.set(textFilterUi.rectProperty,   '0%/50%:50%x50%')
-            filter.set(textFilterUi.valignProperty, 'bottom')
-            filter.set(textFilterUi.halignProperty, 'left')
-            filter.savePreset(presetParams, qsTr('Bottom Left'))
-
-            filter.set(textFilterUi.rectProperty,   '50%/50%:50%x50%')
-            filter.set(textFilterUi.valignProperty, 'bottom')
-            filter.set(textFilterUi.halignProperty, 'right')
-            filter.savePreset(presetParams, qsTr('Bottom Right'))
-
-            filter.set(textFilterUi.rectProperty,   '0%/0%:50%x50%')
-            filter.set(textFilterUi.valignProperty, 'top')
-            filter.set(textFilterUi.halignProperty, 'left')
-            filter.savePreset(presetParams, qsTr('Top Left'))
-
-            filter.set(textFilterUi.rectProperty,   '50%/0%:50%x50%')
-            filter.set(textFilterUi.valignProperty, 'top')
-            filter.set(textFilterUi.halignProperty, 'right')
-            filter.savePreset(presetParams, qsTr('Top Right'))
-
-            filter.set(textFilterUi.rectProperty,   '0%/76%:100%x14%')
-            filter.set(textFilterUi.valignProperty, 'bottom')
-            filter.set(textFilterUi.halignProperty, 'center')
-            filter.savePreset(presetParams, qsTr('Lower Third'))
-
-            // Add some animated presets.
-            filter.animateIn = Math.round(profile.fps)
-            filter.set(textFilterUi.rectProperty,   '0=-100%/0%:100%x100%; :1.0=0%/0%:100%x100%')
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slide In From Left'))
-            filter.set(textFilterUi.rectProperty,   '0=100%/0%:100%x100%; :1.0=0%/0%:100%x100%')
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slide In From Right'))
-            filter.set(textFilterUi.rectProperty,   '0=0%/-100%:100%x100%; :1.0=0%/0%:100%x100%')
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slide In From Top'))
-            filter.set(textFilterUi.rectProperty,   '0=0%/100%:100%x100%; :1.0=0%/0%:100%x100%')
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slide In From Bottom'))
-            filter.animateIn = 0
-            filter.animateOut = Math.round(profile.fps)
-            filter.set(textFilterUi.rectProperty,   ':-1.0=0%/0%:100%x100%; -1=-100%/0%:100%x100%')
-            filter.savePreset(presetParams.concat('shotcut:animOut'), qsTr('Slide Out Left'))
-            filter.set(textFilterUi.rectProperty,   ':-1.0=0%/0%:100%x100%; -1=100%/0%:100%x100%')
-            filter.savePreset(presetParams.concat('shotcut:animOut'), qsTr('Slide Out Right'))
-            filter.set(textFilterUi.rectProperty,   ':-1.0=0%/0%:100%x100%; -1=0%/-100%:100%x100%')
-            filter.savePreset(presetParams.concat('shotcut:animOut'), qsTr('Slide Out Top'))
-            filter.set(textFilterUi.rectProperty,   ':-1.0=0%/0%:100%x100%; -1=0%/100%:100%x100%')
-            filter.savePreset(presetParams.concat('shotcut:animOut'), qsTr('Slide Out Bottom'))
-            filter.animateOut = 0
-            filter.animateIn = filter.duration
-            filter.set(textFilterUi.rectProperty,   '0=0%/0%:100%x100%; -1=-5%/-5%:110%x110%')
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Zoom In'))
-            filter.set(textFilterUi.rectProperty,   '0=-5%/-5%:110%x110%; -1=0%/0%:100%x100%')
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Zoom Out'))
-            filter.set(textFilterUi.rectProperty,   '0=-5%/-5%:110%x110%; -1=-10%/-5%:110%x110%')
-            filter.deletePreset(qsTr('Slow Pan Left'))
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Move Left'))
-            filter.set(textFilterUi.rectProperty,   '0=-5%/-5%:110%x110%; -1=0%/-5%:110%x110%')
-            filter.deletePreset(qsTr('Slow Pan Right'))
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Move Right'))
-            filter.set(textFilterUi.rectProperty,   '0=-5%/-5%:110%x110%; -1=-5%/-10%:110%x110%')
-            filter.deletePreset(qsTr('Slow Pan Up'))
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Move Up'))
-            filter.set(textFilterUi.rectProperty,   '0=-5%/-5%:110%x110%; -1=-5%/0%:110%x110%')
-            filter.deletePreset(qsTr('Slow Pan Down'))
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Move Down'))
-            filter.set(textFilterUi.rectProperty,   '0=0%/0%:100%x100%; -1=-10%/-10%:110%x110%')
-            filter.deletePreset(qsTr('Slow Zoom In, Pan Up Left'))
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Zoom In, Move Up Left'))
-            filter.set(textFilterUi.rectProperty,   '0=0%/0%:100%x100%; -1=0%/0%:110%x110%')
-            filter.deletePreset(qsTr('Slow Zoom In, Pan Down Right'))
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Zoom In, Move Down Right'))
-            filter.set(textFilterUi.rectProperty,   '0=-10%/0%:110%x110%; -1=0%/0%:100%x100%')
-            filter.deletePreset(qsTr('Slow Zoom Out, Pan Up Right'))
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Zoom Out, Move Up Right'))
-            filter.set(textFilterUi.rectProperty,   '0=0%/-10%:110%x110%; -1=0%/0%:100%x100%')
-            filter.deletePreset(qsTr('Slow Zoom Out, Pan Down Left'))
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Zoom Out, Move Down Left'))
-            filter.animateIn = 0
-            filter.resetProperty(textFilterUi.rectProperty)
-
-            // Add default preset.
-            filter.set(textFilterUi.rectProperty, '0%/0%:100%x100%')
-            filter.savePreset(presetParams)
-        } else {
-            filter.set(textFilterUi.middleValue, filter.getRect(textFilterUi.rectProperty, filter.animateIn + 1))
-            if (filter.animateIn > 0)
-                filter.set(textFilterUi.startValue, filter.getRect(textFilterUi.rectProperty, 0))
-            if (filter.animateOut > 0)
-                filter.set(textFilterUi.endValue, filter.getRect(textFilterUi.rectProperty, filter.duration - 1))
-        }
-        filter.blockSignals = false
-        setControls()
-        if (filter.isNew)
-            filter.set(textFilterUi.rectProperty, filter.getRect(textFilterUi.rectProperty))
+    function setControls() {
+        textArea.text = filter.get('argument');
+        textFilterUi.setControls();
     }
 
-    function setControls() {
-        textArea.text = filter.get('argument')
-        textFilterUi.setControls()
+    width: 500
+    height: 380
+    Component.onCompleted: {
+        filter.blockSignals = true;
+        filter.set(textFilterUi.middleValue, Qt.rect(0, 0, profile.width, profile.height));
+        filter.set(textFilterUi.startValue, Qt.rect(0, 0, profile.width, profile.height));
+        filter.set(textFilterUi.endValue, Qt.rect(0, 0, profile.width, profile.height));
+        if (filter.isNew) {
+            var presetParams = preset.parameters.slice();
+            var index = presetParams.indexOf('argument');
+            if (index > -1)
+                presetParams.splice(index, 1);
+
+            if (application.OS === 'Windows')
+                filter.set('family', 'Verdana');
+
+            filter.set('fgcolour', '#ffffffff');
+            filter.set('bgcolour', '#00000000');
+            filter.set('olcolour', '#aa000000');
+            filter.set('outline', 3);
+            filter.set('weight', 10 * Font.Normal);
+            filter.set('style', 'normal');
+            filter.set(textFilterUi.useFontSizeProperty, false);
+            filter.set('size', profile.height);
+            filter.set(textFilterUi.rectProperty, '0%/50%:50%x50%');
+            filter.set(textFilterUi.valignProperty, 'bottom');
+            filter.set(textFilterUi.halignProperty, 'left');
+            filter.savePreset(presetParams, qsTr('Bottom Left'));
+            filter.set(textFilterUi.rectProperty, '50%/50%:50%x50%');
+            filter.set(textFilterUi.valignProperty, 'bottom');
+            filter.set(textFilterUi.halignProperty, 'right');
+            filter.savePreset(presetParams, qsTr('Bottom Right'));
+            filter.set(textFilterUi.rectProperty, '0%/0%:50%x50%');
+            filter.set(textFilterUi.valignProperty, 'top');
+            filter.set(textFilterUi.halignProperty, 'left');
+            filter.savePreset(presetParams, qsTr('Top Left'));
+            filter.set(textFilterUi.rectProperty, '50%/0%:50%x50%');
+            filter.set(textFilterUi.valignProperty, 'top');
+            filter.set(textFilterUi.halignProperty, 'right');
+            filter.savePreset(presetParams, qsTr('Top Right'));
+            filter.set(textFilterUi.rectProperty, '0%/76%:100%x14%');
+            filter.set(textFilterUi.valignProperty, 'bottom');
+            filter.set(textFilterUi.halignProperty, 'center');
+            filter.savePreset(presetParams, qsTr('Lower Third'));
+            // Add some animated presets.
+            filter.animateIn = Math.round(profile.fps);
+            filter.set(textFilterUi.rectProperty, '0=-100%/0%:100%x100%; :1.0=0%/0%:100%x100%');
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slide In From Left'));
+            filter.set(textFilterUi.rectProperty, '0=100%/0%:100%x100%; :1.0=0%/0%:100%x100%');
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slide In From Right'));
+            filter.set(textFilterUi.rectProperty, '0=0%/-100%:100%x100%; :1.0=0%/0%:100%x100%');
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slide In From Top'));
+            filter.set(textFilterUi.rectProperty, '0=0%/100%:100%x100%; :1.0=0%/0%:100%x100%');
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slide In From Bottom'));
+            filter.animateIn = 0;
+            filter.animateOut = Math.round(profile.fps);
+            filter.set(textFilterUi.rectProperty, ':-1.0=0%/0%:100%x100%; -1=-100%/0%:100%x100%');
+            filter.savePreset(presetParams.concat('shotcut:animOut'), qsTr('Slide Out Left'));
+            filter.set(textFilterUi.rectProperty, ':-1.0=0%/0%:100%x100%; -1=100%/0%:100%x100%');
+            filter.savePreset(presetParams.concat('shotcut:animOut'), qsTr('Slide Out Right'));
+            filter.set(textFilterUi.rectProperty, ':-1.0=0%/0%:100%x100%; -1=0%/-100%:100%x100%');
+            filter.savePreset(presetParams.concat('shotcut:animOut'), qsTr('Slide Out Top'));
+            filter.set(textFilterUi.rectProperty, ':-1.0=0%/0%:100%x100%; -1=0%/100%:100%x100%');
+            filter.savePreset(presetParams.concat('shotcut:animOut'), qsTr('Slide Out Bottom'));
+            filter.animateOut = 0;
+            filter.animateIn = filter.duration;
+            filter.set(textFilterUi.rectProperty, '0=0%/0%:100%x100%; -1=-5%/-5%:110%x110%');
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Zoom In'));
+            filter.set(textFilterUi.rectProperty, '0=-5%/-5%:110%x110%; -1=0%/0%:100%x100%');
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Zoom Out'));
+            filter.set(textFilterUi.rectProperty, '0=-5%/-5%:110%x110%; -1=-10%/-5%:110%x110%');
+            filter.deletePreset(qsTr('Slow Pan Left'));
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Move Left'));
+            filter.set(textFilterUi.rectProperty, '0=-5%/-5%:110%x110%; -1=0%/-5%:110%x110%');
+            filter.deletePreset(qsTr('Slow Pan Right'));
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Move Right'));
+            filter.set(textFilterUi.rectProperty, '0=-5%/-5%:110%x110%; -1=-5%/-10%:110%x110%');
+            filter.deletePreset(qsTr('Slow Pan Up'));
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Move Up'));
+            filter.set(textFilterUi.rectProperty, '0=-5%/-5%:110%x110%; -1=-5%/0%:110%x110%');
+            filter.deletePreset(qsTr('Slow Pan Down'));
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Move Down'));
+            filter.set(textFilterUi.rectProperty, '0=0%/0%:100%x100%; -1=-10%/-10%:110%x110%');
+            filter.deletePreset(qsTr('Slow Zoom In, Pan Up Left'));
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Zoom In, Move Up Left'));
+            filter.set(textFilterUi.rectProperty, '0=0%/0%:100%x100%; -1=0%/0%:110%x110%');
+            filter.deletePreset(qsTr('Slow Zoom In, Pan Down Right'));
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Zoom In, Move Down Right'));
+            filter.set(textFilterUi.rectProperty, '0=-10%/0%:110%x110%; -1=0%/0%:100%x100%');
+            filter.deletePreset(qsTr('Slow Zoom Out, Pan Up Right'));
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Zoom Out, Move Up Right'));
+            filter.set(textFilterUi.rectProperty, '0=0%/-10%:110%x110%; -1=0%/0%:100%x100%');
+            filter.deletePreset(qsTr('Slow Zoom Out, Pan Down Left'));
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Zoom Out, Move Down Left'));
+            filter.animateIn = 0;
+            filter.resetProperty(textFilterUi.rectProperty);
+            // Add default preset.
+            filter.set(textFilterUi.rectProperty, '0%/0%:100%x100%');
+            filter.savePreset(presetParams);
+        } else {
+            filter.set(textFilterUi.middleValue, filter.getRect(textFilterUi.rectProperty, filter.animateIn + 1));
+            if (filter.animateIn > 0)
+                filter.set(textFilterUi.startValue, filter.getRect(textFilterUi.rectProperty, 0));
+
+            if (filter.animateOut > 0)
+                filter.set(textFilterUi.endValue, filter.getRect(textFilterUi.rectProperty, filter.duration - 1));
+
+        }
+        filter.blockSignals = false;
+        setControls();
+        if (filter.isNew)
+            filter.set(textFilterUi.rectProperty, filter.getRect(textFilterUi.rectProperty));
+
     }
 
     GridLayout {
         id: textGrid
+
         columns: 2
         anchors.fill: parent
         anchors.margins: 8
@@ -155,21 +152,25 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: textFilterUi.parameterList.concat(['argument'])
             onBeforePresetLoaded: {
-                filter.resetProperty(textFilterUi.rectProperty)
+                filter.resetProperty(textFilterUi.rectProperty);
             }
             onPresetSelected: {
-                setControls()
-                filter.blockSignals = true
-                filter.set(textFilterUi.middleValue, filter.getRect(textFilterUi.rectProperty, filter.animateIn + 1))
+                setControls();
+                filter.blockSignals = true;
+                filter.set(textFilterUi.middleValue, filter.getRect(textFilterUi.rectProperty, filter.animateIn + 1));
                 if (filter.animateIn > 0)
-                    filter.set(textFilterUi.startValue, filter.getRect(textFilterUi.rectProperty, 0))
+                    filter.set(textFilterUi.startValue, filter.getRect(textFilterUi.rectProperty, 0));
+
                 if (filter.animateOut > 0)
-                    filter.set(textFilterUi.endValue, filter.getRect(textFilterUi.rectProperty, filter.duration - 1))
-                filter.blockSignals = false
+                    filter.set(textFilterUi.endValue, filter.getRect(textFilterUi.rectProperty, filter.duration - 1));
+
+                filter.blockSignals = false;
             }
         }
 
@@ -179,57 +180,73 @@ Item {
         }
 
         Item {
-            FontMetrics {
-                id: fontMetrics
-                font: textArea.font
-            }
             Layout.minimumHeight: fontMetrics.height * 6
             Layout.maximumHeight: Layout.minimumHeight
             Layout.minimumWidth: preset.width
             Layout.maximumWidth: preset.width
 
+            FontMetrics {
+                id: fontMetrics
+
+                font: textArea.font
+            }
+
             ScrollView {
                 id: scrollview
+
                 width: preset.width - (ScrollBar.vertical.visible ? 16 : 0)
                 height: parent.height - (ScrollBar.horizontal.visible ? 16 : 0)
                 clip: true
+
                 TextArea {
                     id: textArea
+
+                    property int maxLength: 256
+
                     textFormat: TextEdit.PlainText
                     wrapMode: TextEdit.NoWrap
                     selectByMouse: true
                     persistentSelection: true
                     padding: 0
-                    background: Rectangle {
-                        anchors.fill: parent
-                        color: textArea.palette.base
-                    }
-                    text: '__empty__' // workaround initialization problem
-                    property int maxLength: 256
+                    text: '__empty__'
                     onTextChanged: {
-                        if (text === '__empty__') return
+                        if (text === '__empty__')
+                            return ;
+
                         if (length > maxLength) {
-                            text = text.substring(0, maxLength)
-                            cursorPosition = maxLength
+                            text = text.substring(0, maxLength);
+                            cursorPosition = maxLength;
                         }
                         if (!parseInt(filter.get(textFilterUi.useFontSizeProperty)))
-                            filter.set('size', profile.height / text.split('\n').length)
-                        filter.set('argument', text)
+                            filter.set('size', profile.height / text.split('\n').length);
+
+                        filter.set('argument', text);
                     }
                     Keys.onPressed: {
-                        if (event.key === Qt.Key_V && (event.modifiers & Qt.ShiftModifier) &&
-                            (event.modifiers & Qt.ControlModifier || event.modifiers & Qt.MetaModifier)) {
-                            event.accepted = true
-                            textArea.paste()
+                        if (event.key === Qt.Key_V && (event.modifiers & Qt.ShiftModifier) && (event.modifiers & Qt.ControlModifier || event.modifiers & Qt.MetaModifier)) {
+                            event.accepted = true;
+                            textArea.paste();
                         }
                     }
+
                     MouseArea {
                         acceptedButtons: Qt.RightButton
                         anchors.fill: parent
                         onClicked: contextMenu.popup()
                     }
-                    Shotcut.EditMenu { id: contextMenu }
+
+                    Shotcut.EditMenu {
+                        id: contextMenu
+                    }
+
+                    background: Rectangle {
+                        anchors.fill: parent
+                        color: textArea.palette.base
+                    }
+                    // workaround initialization problem
+
                 }
+
                 ScrollBar.horizontal: ScrollBar {
                     height: 16
                     policy: ScrollBar.AlwaysOn
@@ -239,6 +256,7 @@ Item {
                     anchors.left: scrollview.left
                     anchors.right: scrollview.right
                 }
+
                 ScrollBar.vertical: ScrollBar {
                     width: 16
                     policy: ScrollBar.AlwaysOn
@@ -248,41 +266,54 @@ Item {
                     anchors.left: scrollview.right
                     anchors.bottom: scrollview.bottom
                 }
+
             }
+
         }
 
         Label {
             text: qsTr('Insert field')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Shotcut.Button {
                 text: qsTr('# (Hash sign)')
                 onClicked: textArea.insert(textArea.cursorPosition, '\\#')
             }
+
             Shotcut.Button {
                 text: qsTr('Timecode')
                 onClicked: textArea.insert(textArea.cursorPosition, '#timecode#')
             }
+
             Shotcut.Button {
                 text: qsTr('Frame #', 'Frame number')
                 onClicked: textArea.insert(textArea.cursorPosition, '#frame#')
             }
+
             Shotcut.Button {
                 text: qsTr('File date')
                 onClicked: textArea.insert(textArea.cursorPosition, '#localfiledate#')
             }
+
             Shotcut.Button {
                 text: qsTr('File name')
                 onClicked: textArea.insert(textArea.cursorPosition, '#resource#')
             }
+
         }
 
         Shotcut.TextFilterUi {
             id: textFilterUi
+
             Layout.columnSpan: 2
         }
 
-        Item { Layout.fillHeight: true }
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
+
 }

--- a/src/qml/filters/elastic_scale/meta.qml
+++ b/src/qml/filters/elastic_scale/meta.qml
@@ -24,6 +24,7 @@ Metadata {
     mlt_service: "frei0r.elastic_scale"
     objectName: 'elastic_scale'
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -42,14 +43,14 @@ Metadata {
                 isCurve: true
                 minimum: 0
                 maximum: 1
-             },
+            },
             Parameter {
                 name: qsTr('Linear scale factor')
                 property: '2'
                 isCurve: true
                 minimum: 0
                 maximum: 1
-             },
+            },
             Parameter {
                 name: qsTr('Non-Linear scale factor')
                 property: '3'
@@ -59,4 +60,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/elastic_scale/ui.qml
+++ b/src/qml/filters/elastic_scale/ui.qml
@@ -25,57 +25,54 @@ Shotcut.KeyframableFilter {
     property string linearwidth: '1'
     property string linearscalefactor: '2'
     property string nonlinearscalefactor: '3'
-    
-    property double centerDefault: 0.50
-    property double linearwidthDefault: 0.00
-    property double linearscalefactorDefault: 0.50
-    property double nonlinearscalefactorDefault: 0.50
-     
+    property double centerDefault: 0.5
+    property double linearwidthDefault: 0
+    property double linearscalefactorDefault: 0.5
+    property double nonlinearscalefactorDefault: 0.5
+
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        centerSlider.value = filter.getDouble(center, position) * centerSlider.maximumValue;
+        centerKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(center) > 0;
+        linearwidthSlider.value = filter.getDouble(linearwidth, position) * linearwidthSlider.maximumValue;
+        linwKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(linearwidth) > 0;
+        linearscalefactorSlider.value = filter.getDouble(linearscalefactor, position) * linearscalefactorSlider.maximumValue;
+        lsfKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(linearscalefactor) > 0;
+        nonlinearscalefactorSlider.value = filter.getDouble(nonlinearscalefactor, position) * nonlinearscalefactorSlider.maximumValue;
+        nlsfKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(nonlinearscalefactor) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        centerSlider.enabled = linearwidthSlider.enabled = linearscalefactorSlider.enabled = nonlinearscalefactorSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        setControls();
+        updateFilter(center, centerSlider.value / centerSlider.maximumValue, centerKeyframesButton, null);
+        updateFilter(linearwidth, linearwidthSlider.value / linearwidthSlider.maximumValue, linwKeyframesButton, null);
+        updateFilter(linearscalefactor, linearscalefactorSlider.value / linearscalefactorSlider.maximumValue, lsfKeyframesButton, null);
+        updateFilter(nonlinearscalefactor, nonlinearscalefactorSlider.value / nonlinearscalefactorSlider.maximumValue, nlsfKeyframesButton, null);
+    }
+
     keyframableParameters: [center, linearwidth, linearscalefactor, nonlinearscalefactor]
     startValues: [0.5, 0.5, 0.5, 0.5]
     middleValues: [centerDefault, linearwidthDefault, linearscalefactorDefault, nonlinearscalefactorDefault]
     endValues: [0.5, 0.5, 0.5, 0.5]
-
     width: 350
     height: 100
-
     Component.onCompleted: {
-        filter.set('threads', 0)
+        filter.set('threads', 0);
         if (filter.isNew) {
-            filter.set(center, centerDefault)
-            filter.set(linearwidth, linearwidthDefault)
-            filter.set(linearscalefactor, linearscalefactorDefault)
-            filter.set(nonlinearscalefactor, nonlinearscalefactorDefault)
-            filter.savePreset(preset.parameters)
+            filter.set(center, centerDefault);
+            filter.set(linearwidth, linearwidthDefault);
+            filter.set(linearscalefactor, linearscalefactorDefault);
+            filter.set(nonlinearscalefactor, nonlinearscalefactorDefault);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        centerSlider.value = filter.getDouble(center, position) * centerSlider.maximumValue
-        centerKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(center) > 0
-        linearwidthSlider.value = filter.getDouble(linearwidth, position) * linearwidthSlider.maximumValue
-        linwKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(linearwidth) > 0
-        linearscalefactorSlider.value = filter.getDouble(linearscalefactor, position) * linearscalefactorSlider.maximumValue
-        lsfKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(linearscalefactor) > 0
-        nonlinearscalefactorSlider.value = filter.getDouble(nonlinearscalefactor, position) * nonlinearscalefactorSlider.maximumValue
-        nlsfKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(nonlinearscalefactor) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        centerSlider.enabled = linearwidthSlider.enabled = linearscalefactorSlider.enabled = nonlinearscalefactorSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        setControls()
-        updateFilter(center, centerSlider.value / centerSlider.maximumValue, centerKeyframesButton, null)
-        updateFilter(linearwidth, linearwidthSlider.value / linearwidthSlider.maximumValue, linwKeyframesButton, null)
-        updateFilter(linearscalefactor, linearscalefactorSlider.value / linearscalefactorSlider.maximumValue, lsfKeyframesButton, null)
-        updateFilter(nonlinearscalefactor, nonlinearscalefactorSlider.value / nonlinearscalefactorSlider.maximumValue, nlsfKeyframesButton, null)
+        setControls();
     }
 
     GridLayout {
@@ -87,136 +84,197 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [center, linearwidth, linearscalefactor, nonlinearscalefactor]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
         Label {
             text: qsTr('Center')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Horizontal center position of the linear area.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Horizontal center position of the linear area.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: centerSlider
+
             minimumValue: 0
-            maximumValue: 100.0
+            maximumValue: 100
             stepSize: 0.1
             decimals: 1
             suffix: ' '
             onValueChanged: updateFilter(center, centerSlider.value / centerSlider.maximumValue, centerKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: centerSlider.value = centerDefault * centerSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: centerKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, center, centerSlider.value / centerSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, center, centerSlider.value / centerSlider.maximumValue);
             }
         }
 
         Label {
             text: qsTr('Linear width')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Width of the linear area.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Width of the linear area.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: linearwidthSlider
+
             minimumValue: 0
-            maximumValue: 100.0
+            maximumValue: 100
             stepSize: 0.1
             decimals: 1
             suffix: ' '
             onValueChanged: updateFilter(linearwidth, linearwidthSlider.value / linearwidthSlider.maximumValue, linwKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: linearwidthSlider.value = linearwidthDefault * linearwidthSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: linwKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, linearwidth, linearwidthSlider.value / linearwidthSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, linearwidth, linearwidthSlider.value / linearwidthSlider.maximumValue);
             }
         }
 
         Label {
             text: qsTr('Linear scale factor')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Amount the linear area is scaled.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Amount the linear area is scaled.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: linearscalefactorSlider
+
             minimumValue: 0
-            maximumValue: 100.0
+            maximumValue: 100
             stepSize: 0.1
             decimals: 1
             suffix: ' '
             onValueChanged: updateFilter(linearscalefactor, linearscalefactorSlider.value / linearscalefactorSlider.maximumValue, lsfKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: linearscalefactorSlider.value = linearscalefactorDefault * linearscalefactorSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: lsfKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, linearscalefactor, linearscalefactorSlider.value / linearscalefactorSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, linearscalefactor, linearscalefactorSlider.value / linearscalefactorSlider.maximumValue);
             }
         }
 
         Label {
             text: qsTr('Non-Linear scale factor')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Amount the outer left and outer right areas are scaled non linearly.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Amount the outer left and outer right areas are scaled non linearly.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: nonlinearscalefactorSlider
+
             minimumValue: 0
-            maximumValue: 100.0
+            maximumValue: 100
             stepSize: 0.1
             decimals: 1
             suffix: ' '
             onValueChanged: updateFilter(nonlinearscalefactor, nonlinearscalefactorSlider.value / nonlinearscalefactorSlider.maximumValue, nlsfKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: nonlinearscalefactorSlider.value = nonlinearscalefactorDefault * nonlinearscalefactorSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: nlsfKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, nonlinearscalefactor, nonlinearscalefactorSlider.value / nonlinearscalefactorSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, nonlinearscalefactor, nonlinearscalefactorSlider.value / nonlinearscalefactorSlider.maximumValue);
             }
         }
-        
+
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/fadein_brightness/meta.qml
+++ b/src/qml/filters/fadein_brightness/meta.qml
@@ -10,8 +10,10 @@ Metadata {
     isFavorite: true
     gpuAlt: "movit.opacity"
     allowMultiple: false
+
     keyframes {
         allowTrim: false
         allowAnimateIn: true
     }
+
 }

--- a/src/qml/filters/fadein_brightness/ui.qml
+++ b/src/qml/filters/fadein_brightness/ui.qml
@@ -21,38 +21,41 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
+    property alias duration: timeSpinner.value
+
+    function updateFilter() {
+        var name = (filter.get('alpha') != 1) ? 'alpha' : 'level';
+        filter.resetProperty(name);
+        filter.set(name, 0, 0);
+        filter.set(name, 1, Math.min(duration, filter.duration) - 1);
+    }
+
     width: 100
     height: 50
     objectName: 'fadeIn'
-    property alias duration: timeSpinner.value
-
     Component.onCompleted: {
-        filter.blockSignals = true
+        filter.blockSignals = true;
         if (filter.isNew) {
-            filter.set('alpha', 1)
-            duration = Math.ceil(settings.videoInDuration * profile.fps)
+            filter.set('alpha', 1);
+            duration = Math.ceil(settings.videoInDuration * profile.fps);
         } else if (filter.animateIn === 0) {
             // Convert legacy filter.
-            duration = filter.duration
-            filter.set('in', producer.in )
-            filter.set('out', producer.out )
+            duration = filter.duration;
+            filter.set('in', producer.in);
+            filter.set('out', producer.out);
         } else {
-            duration = filter.animateIn
+            duration = filter.animateIn;
         }
-        alphaCheckbox.checked = filter.get('alpha') != 1
-        filter.blockSignals = false
+        alphaCheckbox.checked = filter.get('alpha') != 1;
+        filter.blockSignals = false;
     }
 
     Connections {
-        target: filter
-        function onAnimateInChanged() { duration = filter.animateIn }
-    }
+        function onAnimateInChanged() {
+            duration = filter.animateIn;
+        }
 
-    function updateFilter() {
-        var name = (filter.get('alpha') != 1)? 'alpha' : 'level'
-        filter.resetProperty(name)
-        filter.set(name, 0, 0)
-        filter.set(name, 1, Math.min(duration, filter.duration) - 1)
+        target: filter
     }
 
     ColumnLayout {
@@ -60,38 +63,48 @@ Item {
         anchors.margins: 8
 
         RowLayout {
-            Label { text: qsTr('Duration') }
+            Label {
+                text: qsTr('Duration')
+            }
+
             Shotcut.TimeSpinner {
                 id: timeSpinner
+
                 minimumValue: 2
                 maximumValue: 5000
                 onValueChanged: {
-                    filter.animateIn = duration
-                    updateFilter()
+                    filter.animateIn = duration;
+                    updateFilter();
                 }
                 onSetDefaultClicked: {
-                    duration = Math.ceil(settings.videoInDuration * profile.fps)
+                    duration = Math.ceil(settings.videoInDuration * profile.fps);
                 }
                 onSaveDefaultClicked: {
-                    settings.videoInDuration = duration / profile.fps
+                    settings.videoInDuration = duration / profile.fps;
                 }
             }
+
         }
+
         CheckBox {
             id: alphaCheckbox
+
             text: qsTr('Adjust opacity instead of fade with black')
             onClicked: {
                 if (checked) {
-                    filter.set('alpha', 0)
-                    filter.set('level', 1)
+                    filter.set('alpha', 0);
+                    filter.set('level', 1);
                 } else {
-                    filter.set('alpha', 1)
+                    filter.set('alpha', 1);
                 }
-                updateFilter()
+                updateFilter();
             }
         }
+
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/fadein_movit/meta.qml
+++ b/src/qml/filters/fadein_movit/meta.qml
@@ -10,8 +10,10 @@ Metadata {
     qml: "ui.qml"
     isFavorite: true
     allowMultiple: false
+
     keyframes {
         allowTrim: false
         allowAnimateIn: true
     }
+
 }

--- a/src/qml/filters/fadein_movit/ui.qml
+++ b/src/qml/filters/fadein_movit/ui.qml
@@ -22,29 +22,32 @@ import Shotcut.Controls 1.0 as Shotcut
 import org.shotcut.qml 1.0
 
 Item {
+    property alias duration: timeSpinner.value
+
     width: 100
     height: 50
     objectName: 'fadeIn'
-    property alias duration: timeSpinner.value
-
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set('alpha', 1)
-            duration = Math.ceil(settings.videoInDuration * profile.fps)
+            filter.set('alpha', 1);
+            duration = Math.ceil(settings.videoInDuration * profile.fps);
         } else if (filter.animateIn === 0) {
             // Convert legacy filter.
-            duration = filter.duration
-            filter.set('in', producer.in )
-            filter.set('out', producer.out )
+            duration = filter.duration;
+            filter.set('in', producer.in);
+            filter.set('out', producer.out);
         } else {
-            duration = filter.animateIn
+            duration = filter.animateIn;
         }
-        alphaCheckbox.checked = filter.get('alpha') != 1
+        alphaCheckbox.checked = filter.get('alpha') != 1;
     }
 
     Connections {
+        function onAnimateInChanged() {
+            duration = filter.animateIn;
+        }
+
         target: filter
-        function onAnimateInChanged() { duration = filter.animateIn }
     }
 
     ColumnLayout {
@@ -52,33 +55,43 @@ Item {
         anchors.margins: 8
 
         RowLayout {
-            Label { text: qsTr('Duration') }
+            Label {
+                text: qsTr('Duration')
+            }
+
             Shotcut.TimeSpinner {
                 id: timeSpinner
+
                 minimumValue: 2
                 maximumValue: 5000
                 onValueChanged: {
-                    filter.animateIn = duration
-                    filter.resetProperty('opacity')
-                    filter.set('opacity', 0, 0, KeyframesModel.SmoothInterpolation)
-                    filter.set('opacity', 1, Math.min(duration, filter.duration) - 1)
+                    filter.animateIn = duration;
+                    filter.resetProperty('opacity');
+                    filter.set('opacity', 0, 0, KeyframesModel.SmoothInterpolation);
+                    filter.set('opacity', 1, Math.min(duration, filter.duration) - 1);
                 }
                 onSetDefaultClicked: {
-                    duration = Math.ceil(settings.videoInDuration * profile.fps)
+                    duration = Math.ceil(settings.videoInDuration * profile.fps);
                 }
                 onSaveDefaultClicked: {
-                    settings.videoInDuration = duration / profile.fps
+                    settings.videoInDuration = duration / profile.fps;
                 }
             }
+
         }
+
         CheckBox {
             id: alphaCheckbox
+
             text: qsTr('Adjust opacity instead of fade with black')
             // When =-1, alpha follows opacity value.
-            onClicked: filter.set('alpha', checked? -1 : 1)
+            onClicked: filter.set('alpha', checked ? -1 : 1)
         }
+
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/fadeout_brightness/meta.qml
+++ b/src/qml/filters/fadeout_brightness/meta.qml
@@ -10,8 +10,10 @@ Metadata {
     isFavorite: true
     gpuAlt: "movit.opacity"
     allowMultiple: false
+
     keyframes {
         allowTrim: false
         allowAnimateOut: true
     }
+
 }

--- a/src/qml/filters/fadeout_brightness/ui.qml
+++ b/src/qml/filters/fadeout_brightness/ui.qml
@@ -21,38 +21,41 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
+    property alias duration: timeSpinner.value
+
+    function updateFilter() {
+        var name = (filter.get('alpha') != 1) ? 'alpha' : 'level';
+        filter.resetProperty(name);
+        filter.set(name, 1, Math.max(filter.duration - duration, 0));
+        filter.set(name, 0, filter.duration - 1);
+    }
+
     width: 100
     height: 50
     objectName: 'fadeOut'
-    property alias duration: timeSpinner.value
-
     Component.onCompleted: {
-        filter.blockSignals = true
+        filter.blockSignals = true;
         if (filter.isNew) {
-            filter.set('alpha', 1)
-            duration = Math.ceil(settings.videoOutDuration * profile.fps)
+            filter.set('alpha', 1);
+            duration = Math.ceil(settings.videoOutDuration * profile.fps);
         } else if (filter.animateOut === 0) {
             // Convert legacy filter.
-            duration = filter.duration
-            filter.set('in', producer.in )
-            filter.set('out', producer.out )
+            duration = filter.duration;
+            filter.set('in', producer.in);
+            filter.set('out', producer.out);
         } else {
-            duration = filter.animateOut
+            duration = filter.animateOut;
         }
-        alphaCheckbox.checked = filter.get('alpha') != 1
-        filter.blockSignals = false
+        alphaCheckbox.checked = filter.get('alpha') != 1;
+        filter.blockSignals = false;
     }
 
     Connections {
-        target: filter
-        function onAnimateOutChanged() { duration = filter.animateOut }
-    }
+        function onAnimateOutChanged() {
+            duration = filter.animateOut;
+        }
 
-    function updateFilter() {
-        var name = (filter.get('alpha') != 1)? 'alpha' : 'level'
-        filter.resetProperty(name)
-        filter.set(name, 1, Math.max(filter.duration - duration, 0))
-        filter.set(name, 0, filter.duration - 1)
+        target: filter
     }
 
     ColumnLayout {
@@ -60,38 +63,48 @@ Item {
         anchors.margins: 8
 
         RowLayout {
-            Label { text: qsTr('Duration') }
+            Label {
+                text: qsTr('Duration')
+            }
+
             Shotcut.TimeSpinner {
                 id: timeSpinner
+
                 minimumValue: 2
                 maximumValue: 5000
                 onValueChanged: {
-                    filter.animateOut = duration
-                    updateFilter()
+                    filter.animateOut = duration;
+                    updateFilter();
                 }
                 onSetDefaultClicked: {
-                    duration = Math.ceil(settings.videoOutDuration * profile.fps)
+                    duration = Math.ceil(settings.videoOutDuration * profile.fps);
                 }
                 onSaveDefaultClicked: {
-                    settings.videoOutDuration = duration / profile.fps
+                    settings.videoOutDuration = duration / profile.fps;
                 }
             }
+
         }
+
         CheckBox {
             id: alphaCheckbox
+
             text: qsTr('Adjust opacity instead of fade with black')
             onClicked: {
                 if (checked) {
-                    filter.set('alpha', 0)
-                    filter.set('level', 1)
+                    filter.set('alpha', 0);
+                    filter.set('level', 1);
                 } else {
-                    filter.set('alpha', 1)
+                    filter.set('alpha', 1);
                 }
-                updateFilter()
+                updateFilter();
             }
         }
+
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/fadeout_movit/meta.qml
+++ b/src/qml/filters/fadeout_movit/meta.qml
@@ -10,8 +10,10 @@ Metadata {
     qml: "ui.qml"
     isFavorite: true
     allowMultiple: false
+
     keyframes {
         allowTrim: false
         allowAnimateOut: true
     }
+
 }

--- a/src/qml/filters/fadeout_movit/ui.qml
+++ b/src/qml/filters/fadeout_movit/ui.qml
@@ -22,34 +22,37 @@ import Shotcut.Controls 1.0 as Shotcut
 import org.shotcut.qml 1.0
 
 Item {
+    property alias duration: timeSpinner.value
+
+    function updateFilter() {
+        var filterDuration = producer.duration;
+        filter.set('opacity', '%1~=1; %2=0'.arg(Math.max(filterDuration - duration, 0)).arg(filterDuration - 1));
+    }
+
     width: 100
     height: 50
     objectName: 'fadeOut'
-    property alias duration: timeSpinner.value
-
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set('alpha', 1)
-            duration = Math.ceil(settings.videoOutDuration * profile.fps)
+            filter.set('alpha', 1);
+            duration = Math.ceil(settings.videoOutDuration * profile.fps);
         } else if (filter.animateOut === 0) {
             // Convert legacy filter.
-            duration = filter.duration
-            filter.set('in', producer.in )
-            filter.set('out', producer.out )
+            duration = filter.duration;
+            filter.set('in', producer.in);
+            filter.set('out', producer.out);
         } else {
-            duration = filter.animateOut
+            duration = filter.animateOut;
         }
-        alphaCheckbox.checked = filter.get('alpha') != 1
+        alphaCheckbox.checked = filter.get('alpha') != 1;
     }
 
     Connections {
-        target: filter
-        function onAnimateOutChanged() { duration = filter.animateOut }
-    }
+        function onAnimateOutChanged() {
+            duration = filter.animateOut;
+        }
 
-    function updateFilter() {
-        var filterDuration = producer.duration
-        filter.set('opacity', '%1~=1; %2=0'.arg(Math.max(filterDuration - duration, 0)).arg(filterDuration - 1))
+        target: filter
     }
 
     ColumnLayout {
@@ -57,31 +60,41 @@ Item {
         anchors.margins: 8
 
         RowLayout {
-            Label { text: qsTr('Duration') }
+            Label {
+                text: qsTr('Duration')
+            }
+
             Shotcut.TimeSpinner {
                 id: timeSpinner
+
                 minimumValue: 2
                 maximumValue: 5000
                 onValueChanged: {
-                    filter.animateOut = duration
-                    updateFilter()
+                    filter.animateOut = duration;
+                    updateFilter();
                 }
                 onSetDefaultClicked: {
-                    duration = Math.ceil(settings.videoOutDuration * profile.fps)
+                    duration = Math.ceil(settings.videoOutDuration * profile.fps);
                 }
                 onSaveDefaultClicked: {
-                    settings.videoOutDuration = duration / profile.fps
+                    settings.videoOutDuration = duration / profile.fps;
                 }
             }
+
         }
+
         CheckBox {
             id: alphaCheckbox
+
             text: qsTr('Adjust opacity instead of fade with black')
             // When =-1, alpha follows opacity value.
-            onClicked: filter.set('alpha', checked? -1 : 1)
+            onClicked: filter.set('alpha', checked ? -1 : 1)
         }
+
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/fisheye/meta.qml
+++ b/src/qml/filters/fisheye/meta.qml
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
 
 import QtQuick 2.0
 import org.shotcut.qml 1.0

--- a/src/qml/filters/fisheye/ui.qml
+++ b/src/qml/filters/fisheye/ui.qml
@@ -17,15 +17,28 @@
 
 import QtQuick 2.12
 import QtQuick.Controls 2.12
+import QtQuick.Controls.Styles 1.1
 import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
-import QtQuick.Controls.Styles 1.1
 
 Item {
-    width: 300
-    height: 240
+    //Action
+    // tries to keep all 4 borders in frame. straighten left/right edge. zoomed center, makes motion look faster
+    //Focused
+    // close match gopro studio, trimmed left/right edges, centre zoom slightly, makes motion look faster
+    //Linear
+    // minimal distortion at frame centre. edges have increased croped to suit
+    //               focal, defish, lens,       scalePreset,    scaleManual,        interpolation,   A/R_preset,      A/R_manual,          crop,  fix stretch,         scaleY,        camera, qsTr(mode), qsTr(result)
+    //append unique camera
+    //match camera
+    //match mode
+    //match camera
+    //match mode
+    //match result
+    //append unique results
+    //append unique modes
+
     id: mainItemLayout
-    SystemPalette { id: activePalette }
 
     //plugin input index values
     property string focalRatioParam: '0'
@@ -38,381 +51,389 @@ Item {
     property string aspectManualParam: '7'
     property string cropParam: '8'
     property string stretchParam: '9'
-    property string scaleYParam: '10'    
-
+    property string scaleYParam: '10'
     //default plugin values
-    property double focalRatioDefault: 0.5  //default was 0.0
-    property bool   deFishDefault: true
-    property double lensTypeDefault: 0.6    //default #3
+    property double focalRatioDefault: 0.5
+    //default was 0.0
+    property bool deFishDefault: true
+    property double lensTypeDefault: 0.6 //default #3
     property double scalePresetDefault: 0.6 //default #3
     property double scaleManualDefault: 0.5
     property double qualityDefault: 0.16
-    property double aspectPresetDefault: 0.0
+    property double aspectPresetDefault: 0
     property double aspectManualDefault: 0.5
     property bool cropDefault: false
     property double stretchDefault: 0.5
     property bool superViewDefault: false
-    property double scaleYDefault: 0.5    
-
+    property double scaleYDefault: 0.5
     //hide user sliders
     property bool scaleShowSlider: false
     property bool aspectShowSlider: false
     property bool cameraShowNew: false
-    property bool pluginShowNew: false    //hide newer dll features?
+    property bool pluginShowNew: false //hide newer dll features?
     property bool stretchShowSlider: false
-    property bool scaleYShowSlider: false  
-
+    property bool scaleYShowSlider: false
     //combobox presets text index
     property int iDX_CAMERA: 11
     property int iDX_WIDE: 12
     property int iDX_RESULT: 13
-
-    property var defaultParameters: [focalRatioParam,deFishParam,lensTypeParam,scaePresetParam,
-                scaleManualParam,qualityParam,aspectPresetParam,aspectManualParam, cropParam, stretchParam, scaleYParam]
-    
+    property var defaultParameters: [focalRatioParam, deFishParam, lensTypeParam, scaePresetParam, scaleManualParam, qualityParam, aspectPresetParam, aspectManualParam, cropParam, stretchParam, scaleYParam]
     property bool blockUpdate: true
-    
+
     //todo: no cropped action versions yet
     //preset data. used for comboboxes.
     function getPresetData(index) {
         switch (index) {
-            //Action
-            // tries to keep all 4 borders in frame. straighten left/right edge. zoomed center, makes motion look faster
-            //
-            //Focused
-            // close match gopro studio, trimmed left/right edges, centre zoom slightly, makes motion look faster
-            //
-            //Linear
-            // minimal distortion at frame centre. edges have increased croped to suit
-
-
+        case 0:
             //HERO3
-            case  0: return [0.736, true, lensValue(4), scalePreset(1), scaleManual(0.000), qualityIndex(2), aspectPreset(1), aspectManual(0.000),  false, dynamicStretch(0.0), scaleY(0.00), 'HERO3 1080', 'Wide', 'Focus']
-
+            return [0.736, true, lensValue(4), scalePreset(1), scaleManual(0), qualityIndex(2), aspectPreset(1), aspectManual(0), false, dynamicStretch(0), scaleY(0), 'HERO3 1080', 'Wide', 'Focus'];
+        case 1:
             //HERO4 1080 (medium)
-            case  1: return [0.634, true, lensValue(1), scalePreset(4), scaleManual(0.011), qualityIndex(2), aspectPreset(5), aspectManual(-0.07), false, dynamicStretch(0.0), scaleY(0.12), 'HERO4 1080', 'Medium', 'Action']
-            case  2: return [0.643, true, lensValue(1), scalePreset(1), scaleManual(0.000), qualityIndex(2), aspectPreset(5), aspectManual(-0.01), false, dynamicStretch(0.0), scaleY(0.00), 'HERO4 1080', 'Medium', 'Focus']
-            case  3: return [0.685, true, lensValue(4), scalePreset(2), scaleManual(0.000), qualityIndex(2), aspectPreset(1), aspectManual(-0.00), false, dynamicStretch(0.0), scaleY(0.00), 'HERO4 1080', 'Medium', 'Linear']
+            return [0.634, true, lensValue(1), scalePreset(4), scaleManual(0.011), qualityIndex(2), aspectPreset(5), aspectManual(-0.07), false, dynamicStretch(0), scaleY(0.12), 'HERO4 1080', 'Medium', 'Action'];
+        case 2:
+            return [0.643, true, lensValue(1), scalePreset(1), scaleManual(0), qualityIndex(2), aspectPreset(5), aspectManual(-0.01), false, dynamicStretch(0), scaleY(0), 'HERO4 1080', 'Medium', 'Focus'];
+        case 3:
+            return [0.685, true, lensValue(4), scalePreset(2), scaleManual(0), qualityIndex(2), aspectPreset(1), aspectManual(-0), false, dynamicStretch(0), scaleY(0), 'HERO4 1080', 'Medium', 'Linear'];
+        case 4:
             //HERO4 1080 (wide)
-            case  4: return [0.700, true, lensValue(1), scalePreset(4), scaleManual(0.019), qualityIndex(2), aspectPreset(5), aspectManual(-0.01), false, dynamicStretch(0.0), scaleY(0.23), 'HERO4 1080', 'Wide', 'Action']
-            case  5: return [0.704, true, lensValue(1), scalePreset(1), scaleManual(0.000), qualityIndex(2), aspectPreset(1), aspectManual(-0.00), false, dynamicStretch(0.0), scaleY(0.00), 'HERO4 1080', 'Wide', 'Focus']
-            case  6: return [0.700, true, lensValue(1), scalePreset(2), scaleManual(0.000), qualityIndex(2), aspectPreset(1), aspectManual(-0.00), false, dynamicStretch(0.0), scaleY(0.00), 'HERO4 1080', 'Wide', 'Linear']
+            return [0.7, true, lensValue(1), scalePreset(4), scaleManual(0.019), qualityIndex(2), aspectPreset(5), aspectManual(-0.01), false, dynamicStretch(0), scaleY(0.23), 'HERO4 1080', 'Wide', 'Action'];
+        case 5:
+            return [0.704, true, lensValue(1), scalePreset(1), scaleManual(0), qualityIndex(2), aspectPreset(1), aspectManual(-0), false, dynamicStretch(0), scaleY(0), 'HERO4 1080', 'Wide', 'Focus'];
+        case 6:
+            return [0.7, true, lensValue(1), scalePreset(2), scaleManual(0), qualityIndex(2), aspectPreset(1), aspectManual(-0), false, dynamicStretch(0), scaleY(0), 'HERO4 1080', 'Wide', 'Linear'];
+        case 7:
             //HERO4 1080 (superview)
-            case  7: return [0.725, true, lensValue(1), scalePreset(4), scaleManual(0.038), qualityIndex(2), aspectPreset(5), aspectManual(-0.23), false, dynamicStretch(-0.14), scaleY(0.15), 'HERO4 1080', 'SuperView', 'Action']
-            case  8: return [0.737, true, lensValue(1), scalePreset(1), scaleManual(0.000), qualityIndex(2), aspectPreset(5), aspectManual(-0.25), false, dynamicStretch(-0.14), scaleY(0.00), 'HERO4 1080', 'SuperView', 'Focus']
-            case  9: return [0.725, true, lensValue(1), scalePreset(2), scaleManual(0.000), qualityIndex(2), aspectPreset(5), aspectManual(-0.25), false, dynamicStretch(-0.14), scaleY(0.00), 'HERO4 1080', 'SuperView', 'Linear']        
+            return [0.725, true, lensValue(1), scalePreset(4), scaleManual(0.038), qualityIndex(2), aspectPreset(5), aspectManual(-0.23), false, dynamicStretch(-0.14), scaleY(0.15), 'HERO4 1080', 'SuperView', 'Action'];
+        case 8:
+            return [0.737, true, lensValue(1), scalePreset(1), scaleManual(0), qualityIndex(2), aspectPreset(5), aspectManual(-0.25), false, dynamicStretch(-0.14), scaleY(0), 'HERO4 1080', 'SuperView', 'Focus'];
+        case 9:
+            return [0.725, true, lensValue(1), scalePreset(2), scaleManual(0), qualityIndex(2), aspectPreset(5), aspectManual(-0.25), false, dynamicStretch(-0.14), scaleY(0), 'HERO4 1080', 'SuperView', 'Linear'];
+        case 10:
             //HERO4 1440
-            case 10: return [0.781, true, lensValue(4), scalePreset(4), scaleManual(0.041), qualityIndex(2), aspectPreset(5), aspectManual(-0.23), false, dynamicStretch(0.0), scaleY(0.18), 'HERO4 1440', 'Wide', 'Action']
-            case 11: return [0.739, true, lensValue(1), scalePreset(1), scaleManual(0.000), qualityIndex(2), aspectPreset(5), aspectManual(-0.21), false, dynamicStretch(0.0), scaleY(0.00), 'HERO4 1440', 'Wide', 'Focus']
-            case 12: return [0.739, true, lensValue(1), scalePreset(2), scaleManual(0.000), qualityIndex(2), aspectPreset(5), aspectManual(-0.21), false, dynamicStretch(0.0), scaleY(0.00), 'HERO4 1440', 'Wide', 'Linear']
+            return [0.781, true, lensValue(4), scalePreset(4), scaleManual(0.041), qualityIndex(2), aspectPreset(5), aspectManual(-0.23), false, dynamicStretch(0), scaleY(0.18), 'HERO4 1440', 'Wide', 'Action'];
+        case 11:
+            return [0.739, true, lensValue(1), scalePreset(1), scaleManual(0), qualityIndex(2), aspectPreset(5), aspectManual(-0.21), false, dynamicStretch(0), scaleY(0), 'HERO4 1440', 'Wide', 'Focus'];
+        case 12:
+            return [0.739, true, lensValue(1), scalePreset(2), scaleManual(0), qualityIndex(2), aspectPreset(5), aspectManual(-0.21), false, dynamicStretch(0), scaleY(0), 'HERO4 1440', 'Wide', 'Linear'];
+        case 13:
             //HERO4 1440 4:3 (videos default saved aspect ratio)
-            case 13: return [0.782, true, lensValue(4), scalePreset(4), scaleManual(0.042), qualityIndex(2), aspectPreset(5), aspectManual(-0.02), false, dynamicStretch(0.0), scaleY(0.18), 'HERO4 1440 4:3', 'Wide', 'Action']
-            case 14: return [0.739, true, lensValue(1), scalePreset(1), scaleManual(0.000), qualityIndex(2), aspectPreset(5), aspectManual(-0.03), false, dynamicStretch(0.0), scaleY(0.00), 'HERO4 1440 4:3', 'Wide', 'Focus']
-            case 15: return [0.736, true, lensValue(1), scalePreset(2), scaleManual(0.000), qualityIndex(2), aspectPreset(5), aspectManual(-0.04), false, dynamicStretch(0.0), scaleY(0.00), 'HERO4 1440 4:3', 'Wide', 'Linear']
- 
+            return [0.782, true, lensValue(4), scalePreset(4), scaleManual(0.042), qualityIndex(2), aspectPreset(5), aspectManual(-0.02), false, dynamicStretch(0), scaleY(0.18), 'HERO4 1440 4:3', 'Wide', 'Action'];
+        case 14:
+            return [0.739, true, lensValue(1), scalePreset(1), scaleManual(0), qualityIndex(2), aspectPreset(5), aspectManual(-0.03), false, dynamicStretch(0), scaleY(0), 'HERO4 1440 4:3', 'Wide', 'Focus'];
+        case 15:
+            return [0.736, true, lensValue(1), scalePreset(2), scaleManual(0), qualityIndex(2), aspectPreset(5), aspectManual(-0.04), false, dynamicStretch(0), scaleY(0), 'HERO4 1440 4:3', 'Wide', 'Linear'];
+        case 16:
             //HERO 5
-            case 16: return [0.730, true, lensValue(4), scalePreset(2), scaleManual(0.000), qualityIndex(2), aspectPreset(1), aspectManual(-0.00), false, dynamicStretch(0.0), scaleY(0.00), 'HERO5 1080', 'Wide', 'Linear']
-            case 17: return [0.696, true, lensValue(4), scalePreset(2), scaleManual(0.000), qualityIndex(2), aspectPreset(1), aspectManual(-0.00), false, dynamicStretch(0.0), scaleY(0.00), 'HERO5 1080', 'SuperView', 'Linear']
-
+            return [0.73, true, lensValue(4), scalePreset(2), scaleManual(0), qualityIndex(2), aspectPreset(1), aspectManual(-0), false, dynamicStretch(0), scaleY(0), 'HERO5 1080', 'Wide', 'Linear'];
+        case 17:
+            return [0.696, true, lensValue(4), scalePreset(2), scaleManual(0), qualityIndex(2), aspectPreset(1), aspectManual(-0), false, dynamicStretch(0), scaleY(0), 'HERO5 1080', 'SuperView', 'Linear'];
+        case 18:
             //4k CLONE
-            case 18: return [0.494, true, lensValue(1), scalePreset(1), scaleManual(0.000), qualityIndex(2), aspectPreset(5), aspectManual(-0.41), false, dynamicStretch(0.0), scaleY(0.00), '4K CLONE 1080p', 'Wide', 'Action']
-            case 19: return [0.643, true, lensValue(1), scalePreset(1), scaleManual(0.000), qualityIndex(2), aspectPreset(5), aspectManual(-0.01), false, dynamicStretch(0.0), scaleY(0.00), '4K CLONE 1080p', 'Wide', 'Focus']
-            case 20: return [0.695, true, lensValue(4), scalePreset(2), scaleManual(0.000), qualityIndex(2), aspectPreset(1), aspectManual(-0.00), false, dynamicStretch(0.0), scaleY(0.00), '4K CLONE 1080p', 'Wide', 'Linear']
-
-            case 21: return [0.442, true, lensValue(1), scalePreset(1), scaleManual(0.000), qualityIndex(2), aspectPreset(5), aspectManual(-0.14), false, dynamicStretch(0.0), scaleY(0.00), '4K CLONE 720p',  'Medium', 'Focus']
-            case 22: return [0.531, true, lensValue(4), scalePreset(2), scaleManual(0.000), qualityIndex(2), aspectPreset(5), aspectManual(-0.21), false, dynamicStretch(0.0), scaleY(0.00), '4K CLONE 720p', 'Medium', 'Linear']
-            //               focal, defish, lens,       scalePreset,    scaleManual,        interpolation,   A/R_preset,      A/R_manual,          crop,  fix stretch,         scaleY,        camera, qsTr(mode), qsTr(result)
+            return [0.494, true, lensValue(1), scalePreset(1), scaleManual(0), qualityIndex(2), aspectPreset(5), aspectManual(-0.41), false, dynamicStretch(0), scaleY(0), '4K CLONE 1080p', 'Wide', 'Action'];
+        case 19:
+            return [0.643, true, lensValue(1), scalePreset(1), scaleManual(0), qualityIndex(2), aspectPreset(5), aspectManual(-0.01), false, dynamicStretch(0), scaleY(0), '4K CLONE 1080p', 'Wide', 'Focus'];
+        case 20:
+            return [0.695, true, lensValue(4), scalePreset(2), scaleManual(0), qualityIndex(2), aspectPreset(1), aspectManual(-0), false, dynamicStretch(0), scaleY(0), '4K CLONE 1080p', 'Wide', 'Linear'];
+        case 21:
+            return [0.442, true, lensValue(1), scalePreset(1), scaleManual(0), qualityIndex(2), aspectPreset(5), aspectManual(-0.14), false, dynamicStretch(0), scaleY(0), '4K CLONE 720p', 'Medium', 'Focus'];
+        case 22:
+            return [0.531, true, lensValue(4), scalePreset(2), scaleManual(0), qualityIndex(2), aspectPreset(5), aspectManual(-0.21), false, dynamicStretch(0), scaleY(0), '4K CLONE 720p', 'Medium', 'Linear'];
         }
-
-        return '' //done
+        return ''; //done
     }
 
     //set UI control values
     function setControlData() {
-        var activeIndex
-
+        var activeIndex;
         // #0 Focal Ratio
-        focalRatioSlider.value = filter.getDouble(focalRatioParam)
-
+        focalRatioSlider.value = filter.getDouble(focalRatioParam);
         // #1 Fish or Defish
         if (filter.get(deFishParam) === '1')
-             fisheyeRemoveButton.checked = true
+            fisheyeRemoveButton.checked = true;
         else
-            fisheyeAddButton.checked = true
-
+            fisheyeAddButton.checked = true;
         // #2 Mapping function (lens type)
-        lensCombo.currentIndex = indexFromFloat(lensTypeParam, lensCombo.count) - 1
-
+        lensCombo.currentIndex = indexFromFloat(lensTypeParam, lensCombo.count) - 1;
         // #3 Scaling method
-        activeIndex = indexFromFloat(scaePresetParam, scaleCombo.count )
-        scaleCombo.currentIndex = activeIndex - 1
-        scaleShowSlider = (activeIndex == scaleCombo.count) //only show custom slider when last option used
-
+        activeIndex = indexFromFloat(scaePresetParam, scaleCombo.count);
+        scaleCombo.currentIndex = activeIndex - 1;
+        scaleShowSlider = (activeIndex == scaleCombo.count); //only show custom slider when last option used
         // #4 Manual Scale
-        scaleManualSlider.value = filter.getDouble(scaleManualParam) - 0.5
-
+        scaleManualSlider.value = filter.getDouble(scaleManualParam) - 0.5;
         // #5 interpolation quality
-        qualityCombo.currentIndex = indexFromFloat(qualityParam, qualityCombo.count) - 1
-
+        qualityCombo.currentIndex = indexFromFloat(qualityParam, qualityCombo.count) - 1;
         // #6 Pixel aspect ratio presets
-        activeIndex = indexFromFloat(aspectPresetParam, aspectCombo.count)
-        aspectCombo.currentIndex = activeIndex - 1
-        aspectShowSlider = (activeIndex == aspectCombo.count) //only show custom slider when last option used
-
+        activeIndex = indexFromFloat(aspectPresetParam, aspectCombo.count);
+        aspectCombo.currentIndex = activeIndex - 1;
+        aspectShowSlider = (activeIndex == aspectCombo.count); //only show custom slider when last option used
         // #7 Manual Pixel Aspect ratio
-        aspectManualSlider.value = filter.getDouble(aspectManualParam) - 0.5
-
+        aspectManualSlider.value = filter.getDouble(aspectManualParam) - 0.5;
         // #8 crop
-        cropCheckBox.checked = (filter.get(cropParam) === '1')
-
+        cropCheckBox.checked = (filter.get(cropParam) === '1');
         // #9 stretch
-        stretchSlider.value = filter.getDouble(stretchParam) - 0.5
-        stretchCheckBox.checked = (stretchSlider.value !== 0.0)
-        stretchShowSlider = stretchCheckBox.checked
-        
+        stretchSlider.value = filter.getDouble(stretchParam) - 0.5;
+        stretchCheckBox.checked = (stretchSlider.value !== 0);
+        stretchShowSlider = stretchCheckBox.checked;
         // #10 scale Y
-        scaleYSlider.value = filter.getDouble(scaleYParam) - 0.5
-        scaleYCheckBox.checked = (scaleYSlider.value !== 0.0)
-        scaleYShowSlider = scaleYCheckBox.checked
-
-        setScollbarHeight()
+        scaleYSlider.value = filter.getDouble(scaleYParam) - 0.5;
+        scaleYCheckBox.checked = (scaleYSlider.value !== 0);
+        scaleYShowSlider = scaleYCheckBox.checked;
+        setScollbarHeight();
     }
 
     //set plugin values
     function setPluginData(idx0, idx1, idx2, idx3, idx4, idx5, idx6, idx7, idx8, idx9, idx10) {
-        filter.set(focalRatioParam, idx0)   // focal ratio
-        filter.set(deFishParam, idx1)       // add/remove fisheye
-        filter.set(lensTypeParam, idx2)     // Lens type
-        filter.set(scaePresetParam, idx3)   // scale Presets
-        filter.set(scaleManualParam, idx4)  // scale manual
-        filter.set(qualityParam, idx5)      // Filter
-        filter.set(aspectPresetParam, idx6) // A/R Presets
-        filter.set(aspectManualParam, idx7) // A/R Manual
-        filter.set(cropParam, idx8)         // crop
-        filter.set(stretchParam, idx9)      // stretch
-        filter.set(scaleYParam, idx10)      // scaleY 
+        filter.set(focalRatioParam, idx0); // focal ratio
+        filter.set(deFishParam, idx1); // add/remove fisheye
+        filter.set(lensTypeParam, idx2); // Lens type
+        filter.set(scaePresetParam, idx3); // scale Presets
+        filter.set(scaleManualParam, idx4); // scale manual
+        filter.set(qualityParam, idx5); // Filter
+        filter.set(aspectPresetParam, idx6); // A/R Presets
+        filter.set(aspectManualParam, idx7); // A/R Manual
+        filter.set(cropParam, idx8); // crop
+        filter.set(stretchParam, idx9); // stretch
+        filter.set(scaleYParam, idx10); // scaleY
     }
 
     //fix scrollbar height when dynamic slider visibility changes
-    function setScollbarHeight(){
-        var h = 240
-        h += stretchShowSlider? 26: 0
-        h += scaleShowSlider? 26: 0
-        h += aspectShowSlider? 26: 0
-        h += cameraShowNew? 26*4: 0
-        h += scaleYShowSlider? 26: 0
-        mainItemLayout.height = h
+    function setScollbarHeight() {
+        var h = 240;
+        h += stretchShowSlider ? 26 : 0;
+        h += scaleShowSlider ? 26 : 0;
+        h += aspectShowSlider ? 26 : 0;
+        h += cameraShowNew ? 26 * 4 : 0;
+        h += scaleYShowSlider ? 26 : 0;
+        mainItemLayout.height = h;
     }
 
     //get text string from presets
     function getPresetName(index, strIdx) {
-        var v_ret = getPresetData(index)
+        var v_ret = getPresetData(index);
         if (v_ret !== '') {
             if (strIdx == iDX_CAMERA)
-                return v_ret[strIdx]
+                return v_ret[strIdx];
             else
-                return qsTr(v_ret[strIdx]) //language on 'mode' and 'results'
+                return qsTr(v_ret[strIdx]); //language on 'mode' and 'results'
         }
-        return v_ret
+        return v_ret;
     }
 
     //fill combobox 'camera'
     function fillCameraCombo() {
-        var a_list = [''] //start blank
-        var v_more = true
-        var v_ret = ''
-        var i = 0
-
+        var a_list = ['']; //start blank
+        var v_more = true;
+        var v_ret = '';
+        var i = 0;
         do {
-            v_ret = getPresetName(i, iDX_CAMERA)
-            if (v_ret !== ''){
+            v_ret = getPresetName(i, iDX_CAMERA);
+            if (v_ret !== '') {
                 if (a_list.indexOf(v_ret) === -1)
-                    a_list.push(v_ret) //append unique camera
+                    a_list.push(v_ret);
+
             } else {
-                v_more = false
+                v_more = false;
             }
-
-            i += 1
-        } while(v_more)
-
-        cameraCombo.model = a_list
-        fillModeCombo()
-
+            i += 1;
+        } while (v_more)
+        cameraCombo.model = a_list;
+        fillModeCombo();
     }
+
     //fill combobox 'camera modes'
     function fillModeCombo() {
-        var a_list = []
-        var v_more = true
-        var v_ret = ''
-        var i = 0
-        var v_cam = cameraCombo.currentText
-        
-        if (v_cam === '') return
+        var a_list = [];
+        var v_more = true;
+        var v_ret = '';
+        var i = 0;
+        var v_cam = cameraCombo.currentText;
+        if (v_cam === '')
+            return ;
 
         do {
-            v_ret = getPresetName(i, iDX_CAMERA)
-            if (v_ret !== '' ){
+            v_ret = getPresetName(i, iDX_CAMERA);
+            if (v_ret !== '') {
                 if (v_ret === v_cam) {
-                    v_ret = getPresetName(i, iDX_WIDE)
-                    if (a_list.indexOf(v_ret) === -1){
-                        a_list.push(v_ret) //append unique modes
-                    }
+                    v_ret = getPresetName(i, iDX_WIDE);
+                    if (a_list.indexOf(v_ret) === -1)
+                        a_list.push(v_ret);
+
                 }
             } else {
-                v_more = false
+                v_more = false;
             }
-            i += 1
-        } while(v_more)
-
-        camModeCombo.model = a_list
-        fillResultsCombo()
+            i += 1;
+        } while (v_more)
+        camModeCombo.model = a_list;
+        fillResultsCombo();
     }
 
     //fill combobox 'results'
-    function fillResultsCombo()  {
-        var a_list = []
-        var v_more = true
-        var v_ret = ''
-        var i = 0
-        var v_cam = cameraCombo.currentText
-        var v_mode = camModeCombo.currentText
-
+    function fillResultsCombo() {
+        var a_list = [];
+        var v_more = true;
+        var v_ret = '';
+        var i = 0;
+        var v_cam = cameraCombo.currentText;
+        var v_mode = camModeCombo.currentText;
         do {
-            v_ret = getPresetName(i, iDX_CAMERA)
-            if (v_ret !== '' ){
-                if (   v_cam === v_ret //match camera
-                    && v_mode === getPresetName(i, iDX_WIDE)) //match mode
-                {
-                    a_list.push(getPresetName(i, iDX_RESULT)) //append unique results
-                }
-            } else {
-                v_more = false
-            }
-            i += 1
-        } while(v_more)
+            v_ret = getPresetName(i, iDX_CAMERA);
+            if (v_ret !== '') {
+                if (v_cam === v_ret && v_mode === getPresetName(i, iDX_WIDE))
+                    a_list.push(getPresetName(i, iDX_RESULT));
 
-        resultCombo.model = a_list
+            } else {
+                v_more = false;
+            }
+            i += 1;
+        } while (v_more)
+        resultCombo.model = a_list;
     }
 
     //update plugin/ui with preset data
-    function sendPresetData(index){
-        var v_ret = getPresetData(index)
-        setPluginData(v_ret[0], v_ret[1], v_ret[2], v_ret[3], v_ret[4], v_ret[5], v_ret[6], v_ret[7], v_ret[8], v_ret[9], v_ret[10])
-        setControlData()
+    function sendPresetData(index) {
+        var v_ret = getPresetData(index);
+        setPluginData(v_ret[0], v_ret[1], v_ret[2], v_ret[3], v_ret[4], v_ret[5], v_ret[6], v_ret[7], v_ret[8], v_ret[9], v_ret[10]);
+        setControlData();
     }
-    //'Apply' button pressed
-    function setCameraData(){
-        var v_more = true
-        var v_cam = cameraCombo.currentText
-        var v_mode = camModeCombo.currentText
-        var v_result = resultCombo.currentText
-        var i = 0
-        var v_ret = ''
 
+    //'Apply' button pressed
+    function setCameraData() {
+        var v_more = true;
+        var v_cam = cameraCombo.currentText;
+        var v_mode = camModeCombo.currentText;
+        var v_result = resultCombo.currentText;
+        var i = 0;
+        var v_ret = '';
         do {
-            v_ret = getPresetName(i, iDX_CAMERA)
-            if (v_ret !== '' ){
-                if (   v_cam === v_ret //match camera
-                    && v_mode === getPresetName(i, iDX_WIDE) //match mode
-                    && v_result === getPresetName(i, iDX_RESULT)) //match result
-                {
-                    sendPresetData(i)
-                    v_more = false
+            v_ret = getPresetName(i, iDX_CAMERA);
+            if (v_ret !== '') {
+                if (v_cam === v_ret && v_mode === getPresetName(i, iDX_WIDE) && v_result === getPresetName(i, iDX_RESULT)) {
+                    sendPresetData(i);
+                    v_more = false;
                 }
             } else {
-                v_more = false
+                v_more = false;
             }
-            i += 1
-        } while(v_more)
+            i += 1;
+        } while (v_more)
     }
 
     //lens presets
-    function lensValue(index) { return floatFromIndex(index, lensCombo.count) }
+    function lensValue(index) {
+        return floatFromIndex(index, lensCombo.count);
+    }
+
     //scale presets
-    function scalePreset(index) { return floatFromIndex(index, scaleCombo.count) }
+    function scalePreset(index) {
+        return floatFromIndex(index, scaleCombo.count);
+    }
+
     //scale manual
-    function scaleManual(fValue) { return fValue + 0.5 }
+    function scaleManual(fValue) {
+        return fValue + 0.5;
+    }
+
     //quality presets
-    function qualityIndex(index) { return floatFromIndex(index, qualityCombo.count) }
+    function qualityIndex(index) {
+        return floatFromIndex(index, qualityCombo.count);
+    }
+
     //aspect ratio presets
-    function aspectPreset(index) { return floatFromIndex(index, aspectCombo.count) }
+    function aspectPreset(index) {
+        return floatFromIndex(index, aspectCombo.count);
+    }
+
     //aspect ratio manual
-    function aspectManual(fValue) { return fValue + 0.5 }    
+    function aspectManual(fValue) {
+        return fValue + 0.5;
+    }
+
     //dynamic stretch
-    function dynamicStretch(fValue) { return fValue + 0.5 }
+    function dynamicStretch(fValue) {
+        return fValue + 0.5;
+    }
+
     //scale Y preset
-    function scaleY(fValue) { return fValue + 0.5 }    
+    function scaleY(fValue) {
+        return fValue + 0.5;
+    }
 
     //calculate a float for plugin. 1-based
     function floatFromIndex(idx, max) {
         if (idx < 1)
-            idx = 1
+            idx = 1;
+
         if (idx > max)
-            idx = max
-        return ((1 / (max-1)) * (idx-1)).toPrecision(6)
+            idx = max;
+
+        return ((1 / (max - 1)) * (idx - 1)).toPrecision(6);
     }
 
     //convert float to int for UI inputs. 1-based
     function indexFromFloat(idx, max) {
-        var v_rng = 1 / max
-        var v_plug = filter.getDouble(idx)
+        var v_rng = 1 / max;
+        var v_plug = filter.getDouble(idx);
         for (var i = 1; i < max; i++) {
-            if (v_plug < (v_rng * i)) {
-                return i
-            }
+            if (v_plug < (v_rng * i))
+                return i;
+
         }
-        return max
+        return max;
     }
 
     //index for reset button. 1-based
-    function setDefaultIndex(value, max){
-        var v_rng = 1 / max
+    function setDefaultIndex(value, max) {
+        var v_rng = 1 / max;
         for (var i = 1; i < max; i++) {
             if (value < (v_rng * i))
-                return i
+                return i;
+
         }
-        return max
+        return max;
     }
 
     //set presets
     function setPresetData() {
-        var v_more = true
-        var v_ret = ''
-        var i = 0
-
+        var v_more = true;
+        var v_ret = '';
+        var i = 0;
         do {
-            v_ret = getPresetData(i)
-            if (v_ret !== '' ){
-                setPluginData(v_ret[0], v_ret[1], v_ret[2], v_ret[3], v_ret[4], v_ret[5], v_ret[6], v_ret[7], v_ret[8], v_ret[9], v_ret[10])
-                filter.savePreset(preset.parameters, qsTr(v_ret[iDX_CAMERA]+ ' ' +qsTr(v_ret[iDX_WIDE]) + ' (' +qsTr(v_ret[iDX_RESULT])+')'))
+            v_ret = getPresetData(i);
+            if (v_ret !== '') {
+                setPluginData(v_ret[0], v_ret[1], v_ret[2], v_ret[3], v_ret[4], v_ret[5], v_ret[6], v_ret[7], v_ret[8], v_ret[9], v_ret[10]);
+                filter.savePreset(preset.parameters, qsTr(v_ret[iDX_CAMERA] + ' ' + qsTr(v_ret[iDX_WIDE]) + ' (' + qsTr(v_ret[iDX_RESULT]) + ')'));
             } else {
-                v_more = false
+                v_more = false;
             }
-            i += 1
-        } while(v_more)
+            i += 1;
+        } while (v_more)
     }
 
+    width: 300
+    height: 240
     Component.onCompleted: {
-        if (filter.getDouble(scaleYParam) > 0.0) 
-            pluginShowNew = true        
-          
-        filter.blockSignals = true
+        if (filter.getDouble(scaleYParam) > 0)
+            pluginShowNew = true;
+
+        filter.blockSignals = true;
         if (filter.isNew) {
-            setPresetData()
-
+            setPresetData();
             // save (default) in preset dropdown
-            setPluginData(focalRatioDefault, deFishDefault, lensTypeDefault, scalePresetDefault, scaleManualDefault,
-                            qualityDefault, aspectPresetDefault, aspectManualDefault, cropDefault, stretchDefault, scaleYDefault)
-            filter.savePreset(defaultParameters)
+            setPluginData(focalRatioDefault, deFishDefault, lensTypeDefault, scalePresetDefault, scaleManualDefault, qualityDefault, aspectPresetDefault, aspectManualDefault, cropDefault, stretchDefault, scaleYDefault);
+            filter.savePreset(defaultParameters);
         }
-        filter.blockSignals = false
+        filter.blockSignals = false;
+        if (cameraShowNew)
+            fillCameraCombo();
 
-        if (cameraShowNew) fillCameraCombo()
-
-        setControlData()
-        blockUpdate = false
+        setControlData();
+        blockUpdate = false;
     }
 
+    SystemPalette {
+        id: activePalette
+    }
 
     GridLayout {
         columns: 3
@@ -424,46 +445,73 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: defaultParameters
             onPresetSelected: setControlData()
         }
-        Row {width: 6} //blank
+        //blank
+
+        Row {
+            width: 6
+        }
 
         // Row 2 defish/fish
         Label {
             text: qsTr('Fisheye')
-            Shotcut.HoverTip { text: qsTr('Add or remove fisheye effect') }
             Layout.alignment: Qt.AlignRight
+
+            Shotcut.HoverTip {
+                text: qsTr('Add or remove fisheye effect')
+            }
+
         }
+
         RowLayout {
-            ButtonGroup { id: fisheyeGroup }
+            ButtonGroup {
+                id: fisheyeGroup
+            }
+
             RadioButton {
                 id: fisheyeRemoveButton
+
                 text: qsTr('Remove')
                 ButtonGroup.group: fisheyeGroup
                 checked: deFishDefault
                 onCheckedChanged: {
-                    if (blockUpdate) return
-                    if (checked) { filter.set(deFishParam, true) }
+                    if (blockUpdate)
+                        return ;
+
+                    if (checked)
+                        filter.set(deFishParam, true);
+
                 }
             }
+
             RadioButton {
                 id: fisheyeAddButton
+
                 text: qsTr('Add')
                 ButtonGroup.group: fisheyeGroup
                 checked: !deFishDefault
                 onCheckedChanged: {
-                    if (blockUpdate) return
-                    if (checked) { filter.set(deFishParam, false) }
+                    if (blockUpdate)
+                        return ;
+
+                    if (checked)
+                        filter.set(deFishParam, false);
+
                 }
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                fisheyeRemoveButton.checked = deFishDefault
-                fisheyeAddButton.checked = !deFishDefault
+                fisheyeRemoveButton.checked = deFishDefault;
+                fisheyeAddButton.checked = !deFishDefault;
             }
         }
 
@@ -471,18 +519,30 @@ Item {
         Label {
             text: qsTr('Focal ratio')
             leftPadding: 10
-            Shotcut.HoverTip { text: qsTr('The amount of lens distortion') }
             Layout.alignment: Qt.AlignRight
+
+            Shotcut.HoverTip {
+                text: qsTr('The amount of lens distortion')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: focalRatioSlider
+
             minimumValue: 0
             maximumValue: 1
             decimals: 3
             suffix: ''
             value: focalRatioDefault
-            onValueChanged: { if (blockUpdate) return; filter.set(focalRatioParam, value) }
+            onValueChanged: {
+                if (blockUpdate)
+                    return ;
+
+                filter.set(focalRatioParam, value);
+            }
         }
+
         Shotcut.UndoButton {
             onClicked: focalRatioSlider.value = focalRatioDefault
         }
@@ -490,78 +550,150 @@ Item {
         // Row 4: Interpolation Quality
         Label {
             text: qsTr('Quality')
-            Shotcut.HoverTip { text: qsTr( 'Resample quality') }
             Layout.alignment: Qt.AlignRight
+
+            Shotcut.HoverTip {
+                text: qsTr('Resample quality')
+            }
+
         }
+
         Shotcut.ComboBox {
             id: qualityCombo
+
             implicitWidth: 150
-            model: ListModel {
-                id: qualityModel
-                ListElement { text: qsTr('Nearest neighbor'); value: 0.0 }
-                ListElement { text: qsTr('Bilinear'); value: 0.166 }
-                ListElement { text: qsTr('Bicubic smooth'); value: 0.333 }
-                ListElement { text: qsTr('Bicubic sharp'); value: 0.500 }
-                ListElement { text: qsTr('Spline 4x4'); value: 0.666 }
-                ListElement { text: qsTr('Spline 6x6'); value: 0.833 }
-                ListElement { text: qsTr('Lanczos 16x16'); value: 1.0 }
-            }
             textRole: 'text'
             onActivated: {
-                filter.set(qualityParam, qualityModel.get(currentIndex).value)
+                filter.set(qualityParam, qualityModel.get(currentIndex).value);
             }
+
+            model: ListModel {
+                id: qualityModel
+
+                ListElement {
+                    text: qsTr('Nearest neighbor')
+                    value: 0
+                }
+
+                ListElement {
+                    text: qsTr('Bilinear')
+                    value: 0.166
+                }
+
+                ListElement {
+                    text: qsTr('Bicubic smooth')
+                    value: 0.333
+                }
+
+                ListElement {
+                    text: qsTr('Bicubic sharp')
+                    value: 0.5
+                }
+
+                ListElement {
+                    text: qsTr('Spline 4x4')
+                    value: 0.666
+                }
+
+                ListElement {
+                    text: qsTr('Spline 6x6')
+                    value: 0.833
+                }
+
+                ListElement {
+                    text: qsTr('Lanczos 16x16')
+                    value: 1
+                }
+
+            }
+
         }
-         Shotcut.UndoButton {
+
+        Shotcut.UndoButton {
             onClicked: {
-                filter.set(qualityParam, qualityDefault)
-                qualityCombo.currentIndex = setDefaultIndex(qualityDefault, qualityCombo.count) - 1
+                filter.set(qualityParam, qualityDefault);
+                qualityCombo.currentIndex = setDefaultIndex(qualityDefault, qualityCombo.count) - 1;
             }
         }
 
         // Row 5: Lens Type
         Label {
             text: qsTr('Lens')
-            Shotcut.HoverTip { text: qsTr('Select a lens distortion pattern that best matches your camera') }
             Layout.alignment: Qt.AlignRight
+
+            Shotcut.HoverTip {
+                text: qsTr('Select a lens distortion pattern that best matches your camera')
+            }
+
         }
+
         RowLayout {
             Shotcut.ComboBox {
                 id: lensCombo
+
                 implicitWidth: 150
-                model: ListModel {
-                    id: lensModel
-                    ListElement { text: qsTr('Equidistant'); value: 0.0 }
-                    ListElement { text: qsTr('Ortographic'); value: 0.333 }
-                    ListElement { text: qsTr('Equiarea'); value: 0.666 }
-                    ListElement { text: qsTr('Stereographic'); value: 1.0 }
-                }
                 textRole: 'text'
                 onActivated: {
-                    filter.set(lensTypeParam, lensModel.get(currentIndex).value)
+                    filter.set(lensTypeParam, lensModel.get(currentIndex).value);
                 }
+
+                model: ListModel {
+                    id: lensModel
+
+                    ListElement {
+                        text: qsTr('Equidistant')
+                        value: 0
+                    }
+
+                    ListElement {
+                        text: qsTr('Ortographic')
+                        value: 0.333
+                    }
+
+                    ListElement {
+                        text: qsTr('Equiarea')
+                        value: 0.666
+                    }
+
+                    ListElement {
+                        text: qsTr('Stereographic')
+                        value: 1
+                    }
+
+                }
+
             }
+
             CheckBox {
+                id: stretchCheckBox
+
                 text: qsTr('Non-Linear scale') //stretch view
                 leftPadding: 6
-                Shotcut.HoverTip { text: qsTr(  'The image will be stretched/squished to fix camera scaling between 4:3 and 16:9\n'+
-                                                'Like used in GoPro\'s superview' ) }
-                id: stretchCheckBox
                 padding: 0
                 visible: pluginShowNew
                 checked: superViewDefault
                 onCheckedChanged: {
-                    if (blockUpdate) return
-                    stretchShowSlider = checked
-                    filter.set(stretchParam, checked? stretchSlider.value+0.5: 0.5)                    
-                    setScollbarHeight()
+                    if (blockUpdate)
+                        return ;
+
+                    stretchShowSlider = checked;
+                    filter.set(stretchParam, checked ? stretchSlider.value + 0.5 : 0.5);
+                    setScollbarHeight();
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('The image will be stretched/squished to fix camera scaling between 4:3 and 16:9\n' + 'Like used in GoPro\'s superview')
+                }
+
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filter.set(lensTypeParam, lensTypeDefault)
-                lensCombo.currentIndex = setDefaultIndex(lensTypeDefault, lensCombo.count) - 1
-                stretchCheckBox.checked = superViewDefault
+                filter.set(lensTypeParam, lensTypeDefault);
+                lensCombo.currentIndex = setDefaultIndex(lensTypeDefault, lensCombo.count) - 1;
+                stretchCheckBox.checked = superViewDefault;
             }
         }
 
@@ -569,266 +701,442 @@ Item {
         Label {
             visible: stretchShowSlider
             text: qsTr('Scale')
-            Shotcut.HoverTip { text: qsTr(  'Use negative values for up-scaled videos\n'+
-                                            'Use positive values for down-scaled videos' ) }
             Layout.alignment: Qt.AlignRight
+
+            Shotcut.HoverTip {
+                text: qsTr('Use negative values for up-scaled videos\n' + 'Use positive values for down-scaled videos')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            visible: stretchShowSlider
             id: stretchSlider
+
+            visible: stretchShowSlider
             minimumValue: -0.5
             maximumValue: 0.5
             decimals: 2
             suffix: ''
             value: 0
-            onValueChanged: { if (blockUpdate) return; filter.set(stretchParam, value+0.5) }
+            onValueChanged: {
+                if (blockUpdate)
+                    return ;
+
+                filter.set(stretchParam, value + 0.5);
+            }
         }
+
         Shotcut.UndoButton {
             visible: stretchShowSlider
             onClicked: stretchSlider.value = stretchDefault - 0.5
         }
 
-
         //line separator #1
-         RowLayout {
+        RowLayout {
             Layout.columnSpan: 3
-            Label { text: qsTr('Scale')}  
-            Rectangle{ Layout.fillWidth: true;height: 1; color: activePalette.text; opacity: 0.3 }
+
+            Label {
+                text: qsTr('Scale')
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                height: 1
+                color: activePalette.text
+                opacity: 0.3
+            }
+
         }
-        
+
         // Row 7: Scale (Preset)
         Label {
             text: qsTr('Preset')
-            Shotcut.HoverTip { text: qsTr( 'Preset scale methods\n'+
-                                           'Lock pixels at specific locations') }
             Layout.alignment: Qt.AlignRight
+
+            Shotcut.HoverTip {
+                text: qsTr('Preset scale methods\n' + 'Lock pixels at specific locations')
+            }
+
         }
+
         RowLayout {
             Shotcut.ComboBox {
                 id: scaleCombo
+
                 implicitWidth: 150
-                model: ListModel {
-                    id: scaleModel
-                    ListElement { text: qsTr('Scale to Fill'); value: 0.0 }
-                    ListElement { text: qsTr('Keep Center Scale'); value: 0.333 }
-                    ListElement { text: qsTr('Scale to Fit'); value: 0.666 }
-                    ListElement { text: qsTr('Manual Scale'); value: 1.0 }
-                }
                 textRole: 'text'
                 onActivated: {
-                    filter.set(scaePresetParam, scaleModel.get(currentIndex).value)
-                    scaleShowSlider = ((currentIndex+1)==scaleCombo.count) //show user input?
-                    setScollbarHeight()
+                    filter.set(scaePresetParam, scaleModel.get(currentIndex).value);
+                    scaleShowSlider = ((currentIndex + 1) == scaleCombo.count); //show user input?
+                    setScollbarHeight();
                 }
+
+                model: ListModel {
+                    id: scaleModel
+
+                    ListElement {
+                        text: qsTr('Scale to Fill')
+                        value: 0
+                    }
+
+                    ListElement {
+                        text: qsTr('Keep Center Scale')
+                        value: 0.333
+                    }
+
+                    ListElement {
+                        text: qsTr('Scale to Fit')
+                        value: 0.666
+                    }
+
+                    ListElement {
+                        text: qsTr('Manual Scale')
+                        value: 1
+                    }
+
+                }
+
             }
+
             CheckBox {
+                id: scaleYCheckBox
+
                 text: qsTr('Y')
                 leftPadding: 6
-                Shotcut.HoverTip { text: qsTr('Scale Y separately\nThis changes video aspect ratio') }
-                id: scaleYCheckBox
-                visible: pluginShowNew                
+                visible: pluginShowNew
                 padding: 0
                 checked: false
                 onCheckedChanged: {
-                    if (blockUpdate) return
-                    filter.set(scaleYParam, checked? scaleYSlider.value+0.5:0.5)
-                    scaleYShowSlider = checked                  
-                    setScollbarHeight()
+                    if (blockUpdate)
+                        return ;
+
+                    filter.set(scaleYParam, checked ? scaleYSlider.value + 0.5 : 0.5);
+                    scaleYShowSlider = checked;
+                    setScollbarHeight();
                 }
-            }            
+
+                Shotcut.HoverTip {
+                    text: qsTr('Scale Y separately\nThis changes video aspect ratio')
+                }
+
+            }
+
             CheckBox {
+                id: cropCheckBox
+
                 text: qsTr('Crop')
                 leftPadding: 6
-                Shotcut.HoverTip { text: qsTr('Remove distorted edges') }                
-                id: cropCheckBox
                 padding: 0
                 checked: cropDefault
                 visible: (pluginShowNew && fisheyeRemoveButton.checked)
-                onCheckedChanged: { if (blockUpdate) return; filter.set(cropParam, checked) }
+                onCheckedChanged: {
+                    if (blockUpdate)
+                        return ;
+
+                    filter.set(cropParam, checked);
+                }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Remove distorted edges')
+                }
+
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filter.set(scaePresetParam, scalePresetDefault)
-                scaleCombo.currentIndex = setDefaultIndex(scalePresetDefault, scaleCombo.count) - 1
-                scaleShowSlider = false
-                cropCheckBox.checked = cropDefault
-                scaleYShowSlider = false
-                scaleYCheckBox.checked = false
-                setScollbarHeight()
+                filter.set(scaePresetParam, scalePresetDefault);
+                scaleCombo.currentIndex = setDefaultIndex(scalePresetDefault, scaleCombo.count) - 1;
+                scaleShowSlider = false;
+                cropCheckBox.checked = cropDefault;
+                scaleYShowSlider = false;
+                scaleYCheckBox.checked = false;
+                setScollbarHeight();
             }
         }
 
         // Row 8: Scale (Manual)
         Label {
             text: qsTr('Manual')
-            Shotcut.HoverTip { text: qsTr('User set zoom/scale\nSides of image are not fixed') }
             Layout.alignment: Qt.AlignRight
             visible: scaleShowSlider
+
+            Shotcut.HoverTip {
+                text: qsTr('User set zoom/scale\nSides of image are not fixed')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: scaleManualSlider
+
             visible: scaleShowSlider
             minimumValue: -0.5
             maximumValue: 0.5
             decimals: 3
             suffix: ''
             value: 0
-            onValueChanged: { if (blockUpdate) return; filter.set(scaleManualParam, value+0.5) }
+            onValueChanged: {
+                if (blockUpdate)
+                    return ;
+
+                filter.set(scaleManualParam, value + 0.5);
+            }
         }
+
         Shotcut.UndoButton {
             visible: scaleShowSlider
             onClicked: scaleManualSlider.value = 0
         }
-       
+
         // Row 9: Scale (Y)
         Label {
             text: qsTr('Y ratio')
-            Shotcut.HoverTip { text: qsTr('Seperate Y scale') }
             Layout.alignment: Qt.AlignRight
-            visible:  scaleYShowSlider
+            visible: scaleYShowSlider
+
+            Shotcut.HoverTip {
+                text: qsTr('Seperate Y scale')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: scaleYSlider
+
             visible: scaleYShowSlider
             minimumValue: -0.49
             maximumValue: 0.5
             value: 0
             decimals: 2
             suffix: ''
-            onValueChanged: { if (blockUpdate) return; filter.set(scaleYParam, value+0.5) }
+            onValueChanged: {
+                if (blockUpdate)
+                    return ;
+
+                filter.set(scaleYParam, value + 0.5);
+            }
         }
+
         Shotcut.UndoButton {
             visible: scaleYShowSlider
             onClicked: scaleYSlider.value = 0
-        }        
+        }
 
         //line separator #2
-         RowLayout {
+        RowLayout {
             Layout.columnSpan: 3
-            Label { text: qsTr('Aspect')}  
-            Rectangle{ Layout.fillWidth: true; height: 1; color: activePalette.text; opacity: 0.3 }
+
+            Label {
+                text: qsTr('Aspect')
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                height: 1
+                color: activePalette.text
+                opacity: 0.3
+            }
+
         }
-        
+
         // Row 10: A/R (Preset)
         Label {
             text: qsTr('Preset')
-            Shotcut.HoverTip { text: qsTr( 'Preset pixel aspect ratio') }
             Layout.alignment: Qt.AlignRight
+
+            Shotcut.HoverTip {
+                text: qsTr('Preset pixel aspect ratio')
+            }
+
         }
+
         RowLayout {
             Shotcut.ComboBox {
                 id: aspectCombo
+
                 implicitWidth: 150
-                model: ListModel {
-                    id: aspectModel
-                    ListElement { text:      'Square Pixel'; value: 0.0 }
-                    ListElement { text:      'PAL DV  1.067'; value: 0.250 }
-                    ListElement { text:      'NTSC DV 0.889'; value: 0.500 }
-                    ListElement { text:      'HDV     1.333'; value: 0.750 }
-                    ListElement { text: qsTr('Manual Aspect'); value: 1.0 }
-                }
                 textRole: 'text'
                 onActivated: {
-                    filter.set(aspectPresetParam, aspectModel.get(currentIndex).value)
-                    aspectShowSlider = ((currentIndex+1) == aspectCombo.count) //show user input?
-                    setScollbarHeight()
+                    filter.set(aspectPresetParam, aspectModel.get(currentIndex).value);
+                    aspectShowSlider = ((currentIndex + 1) == aspectCombo.count); //show user input?
+                    setScollbarHeight();
                 }
+
+                model: ListModel {
+                    id: aspectModel
+
+                    ListElement {
+                        text: 'Square Pixel'
+                        value: 0
+                    }
+
+                    ListElement {
+                        text: 'PAL DV  1.067'
+                        value: 0.25
+                    }
+
+                    ListElement {
+                        text: 'NTSC DV 0.889'
+                        value: 0.5
+                    }
+
+                    ListElement {
+                        text: 'HDV     1.333'
+                        value: 0.75
+                    }
+
+                    ListElement {
+                        text: qsTr('Manual Aspect')
+                        value: 1
+                    }
+
+                }
+
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filter.set(aspectPresetParam, aspectPresetDefault)
-                aspectCombo.currentIndex = setDefaultIndex(aspectPresetDefault, aspectCombo.count) - 1
-                aspectShowSlider = false
-                setScollbarHeight()
+                filter.set(aspectPresetParam, aspectPresetDefault);
+                aspectCombo.currentIndex = setDefaultIndex(aspectPresetDefault, aspectCombo.count) - 1;
+                aspectShowSlider = false;
+                setScollbarHeight();
             }
         }
 
         // Row 11: A/R (Manual)
         Label {
             text: qsTr('Manual')
-            Shotcut.HoverTip { text: qsTr( 'User set pixel aspect ratios\n'+
-                                           'Change top/side distortion bias') }
             Layout.alignment: Qt.AlignRight
             visible: aspectShowSlider
+
+            Shotcut.HoverTip {
+                text: qsTr('User set pixel aspect ratios\n' + 'Change top/side distortion bias')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: aspectManualSlider
+
             minimumValue: -0.5
             maximumValue: 0.5
             decimals: 2
             suffix: ''
             visible: aspectShowSlider
-            value: 0 
-            onValueChanged: { if (blockUpdate) return; filter.set(aspectManualParam, value+0.5) }
+            value: 0
+            onValueChanged: {
+                if (blockUpdate)
+                    return ;
+
+                filter.set(aspectManualParam, value + 0.5);
+            }
         }
+
         Shotcut.UndoButton {
             visible: aspectShowSlider
             onClicked: aspectManualSlider.value = 0
         }
 
         //line separator #3
-         RowLayout {
+        RowLayout {
             visible: cameraShowNew
             Layout.columnSpan: 3
-            Label { text: qsTr('Cameras')}  
-            Rectangle{ Layout.fillWidth: true; height: 1; color: activePalette.text; opacity: 0.3 }
+
+            Label {
+                text: qsTr('Cameras')
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                height: 1
+                color: activePalette.text
+                opacity: 0.3
+            }
+
         }
 
         //row 12 combo cameras
-         Label {
+        Label {
             visible: cameraShowNew
             text: qsTr('Camera')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
+            id: cameraCombo
+
             visible: cameraShowNew
             Layout.columnSpan: 2
-            id: cameraCombo
             implicitWidth: 150
-            model: ListModel { id: tempList1 }
             onActivated: fillModeCombo()
+
+            model: ListModel {
+                id: tempList1
+            }
+
         }
         //row 13 combo camera mode
-         Label {
+
+        Label {
             visible: cameraShowNew
             text: qsTr('Record mode')
             leftPadding: 10
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
+            id: camModeCombo
+
             visible: cameraShowNew
             Layout.columnSpan: 2
-            id: camModeCombo
             implicitWidth: 150
-            model:  ListModel { id: tempList2 }
             onActivated: fillResultsCombo()
+
+            model: ListModel {
+                id: tempList2
+            }
+
         }
         //row 14 combo results
+
         Label {
             visible: cameraShowNew
             text: qsTr('Result')
             Layout.alignment: Qt.AlignRight
         }
+
         Row {
             visible: cameraShowNew
             Layout.columnSpan: 2
+
             Shotcut.ComboBox {
                 id: resultCombo
+
                 implicitWidth: 150
-                model:  ListModel { id: tempList3 }
+
+                model: ListModel {
+                    id: tempList3
+                }
+
             }
+
             Shotcut.Button {
                 Layout.alignment: Qt.AlignRight
                 text: qsTr('Apply')
                 implicitWidth: 80
                 onClicked: setCameraData()
             }
+
         }
 
         Item {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/fspp/ui.qml
+++ b/src/qml/filters/fspp/ui.qml
@@ -27,22 +27,21 @@ Item {
     property int strengthMin: -15
     property int strengthMax: 32
 
-    width: 350
-    height: 100
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            filter.set('av.quality', qualityDefault)
-            filter.set('av.qp', qpDefault)
-            filter.set('av.strength', strengthDefault)
-            filter.savePreset(preset.parameters)
-        }
-        setControls()
+    function setControls() {
+        qpSlider.value = filter.get('av.qp');
+        strengthSlider.value = Math.round((filter.get('av.strength') - strengthMin) / (strengthMax - strengthMin) * 100);
     }
 
-    function setControls() {
-        qpSlider.value = filter.get('av.qp')
-        strengthSlider.value = Math.round((filter.get('av.strength') - strengthMin) / (strengthMax - strengthMin) * 100)
+    width: 350
+    height: 100
+    Component.onCompleted: {
+        if (filter.isNew) {
+            filter.set('av.quality', qualityDefault);
+            filter.set('av.qp', qpDefault);
+            filter.set('av.strength', strengthDefault);
+            filter.savePreset(preset.parameters);
+        }
+        setControls();
     }
 
     GridLayout {
@@ -54,8 +53,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ['av.qp', 'av.strength']
             Layout.columnSpan: 2
             onPresetSelected: setControls()
@@ -65,13 +66,16 @@ Item {
             text: qsTr('Quantization')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: qpSlider
+
             minimumValue: 0
             maximumValue: 64
             stepSize: 1
             onValueChanged: filter.set('av.qp', qpSlider.value)
         }
+
         Shotcut.UndoButton {
             onClicked: qpSlider.value = qpDefault
         }
@@ -80,14 +84,17 @@ Item {
             text: qsTr('Strength')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: strengthSlider
+
             minimumValue: 0
             maximumValue: 100
             stepSize: 1
             suffix: ' %'
-            onValueChanged: filter.set('av.strength', strengthSlider.value/100 * (strengthMax - strengthMin) + strengthMin)
+            onValueChanged: filter.set('av.strength', strengthSlider.value / 100 * (strengthMax - strengthMin) + strengthMin)
         }
+
         Shotcut.UndoButton {
             onClicked: strengthSlider.value = Math.round((strengthDefault - strengthMin) / (strengthMax - strengthMin) * 100)
         }
@@ -95,5 +102,7 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/glitch/meta.qml
+++ b/src/qml/filters/glitch/meta.qml
@@ -23,6 +23,7 @@ Metadata {
     name: qsTr("Glitch")
     mlt_service: "frei0r.glitch0r"
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -41,14 +42,14 @@ Metadata {
                 isCurve: true
                 minimum: 0
                 maximum: 1
-             },   
+            },
             Parameter {
                 name: qsTr('Shift intensity')
                 property: '2'
                 isCurve: true
                 minimum: 0
                 maximum: 1
-             },   
+            },
             Parameter {
                 name: qsTr('Color intensity')
                 property: '3'
@@ -58,4 +59,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/glitch/ui.qml
+++ b/src/qml/filters/glitch/ui.qml
@@ -30,51 +30,48 @@ Shotcut.KeyframableFilter {
     property double shiftIntDefault: 0.5
     property double colorIntDefault: 0.5
 
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        glitchFreqSlider.value = filter.getDouble(glitchFreq, position) * glitchFreqSlider.maximumValue;
+        glitchKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(glitchFreq) > 0;
+        blockHSlider.value = filter.getDouble(blockH, position) * blockHSlider.maximumValue;
+        blockKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(blockH) > 0;
+        shiftIntSlider.value = filter.getDouble(shiftInt, position) * shiftIntSlider.maximumValue;
+        shiftKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(shiftInt) > 0;
+        colorIntSlider.value = filter.getDouble(colorInt, position) * colorIntSlider.maximumValue;
+        colorKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(colorInt) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        glitchFreqSlider.enabled = blockHSlider.enabled = shiftIntSlider.enabled = colorIntSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        setControls();
+        updateFilter(glitchFreq, glitchFreqSlider.value / glitchFreqSlider.maximumValue, glitchKeyframesButton, null);
+        updateFilter(blockH, blockHSlider.value / blockHSlider.maximumValue, blockKeyframesButton, null);
+        updateFilter(shiftInt, shiftIntSlider.value / shiftIntSlider.maximumValue, shiftKeyframesButton, null);
+        updateFilter(colorInt, colorIntSlider.value / colorIntSlider.maximumValue, colorKeyframesButton, null);
+    }
+
     keyframableParameters: [glitchFreq, blockH, shiftInt, colorInt]
     startValues: [0, 0.5, 0.5, 0.5]
     middleValues: [glitchFreqDefault, blockHDefault, shiftIntDefault, colorIntDefault]
     endValues: [0, 0.5, 0.5, 0.5]
-
     width: 350
     height: 150
-
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set(glitchFreq, glitchFreqDefault)
-            filter.set(blockH, blockHDefault)
-            filter.set(shiftInt, shiftIntDefault)
-            filter.set(colorInt, colorIntDefault)
-            filter.savePreset(preset.parameters)
+            filter.set(glitchFreq, glitchFreqDefault);
+            filter.set(blockH, blockHDefault);
+            filter.set(shiftInt, shiftIntDefault);
+            filter.set(colorInt, colorIntDefault);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        glitchFreqSlider.value = filter.getDouble(glitchFreq, position) * glitchFreqSlider.maximumValue
-        glitchKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(glitchFreq) > 0
-        blockHSlider.value = filter.getDouble(blockH, position) * blockHSlider.maximumValue
-        blockKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(blockH) > 0
-        shiftIntSlider.value = filter.getDouble(shiftInt, position) * shiftIntSlider.maximumValue
-        shiftKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(shiftInt) > 0
-        colorIntSlider.value = filter.getDouble(colorInt, position) * colorIntSlider.maximumValue
-        colorKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(colorInt) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        glitchFreqSlider.enabled = blockHSlider.enabled = shiftIntSlider.enabled = colorIntSlider.enabled = enabled
-        
-    }
-
-    function updateSimpleKeyframes() {
-        setControls()
-        updateFilter(glitchFreq, glitchFreqSlider.value / glitchFreqSlider.maximumValue, glitchKeyframesButton, null)
-        updateFilter(blockH, blockHSlider.value / blockHSlider.maximumValue, blockKeyframesButton, null)
-        updateFilter(shiftInt, shiftIntSlider.value / shiftIntSlider.maximumValue, shiftKeyframesButton, null)
-        updateFilter(colorInt, colorIntSlider.value / colorIntSlider.maximumValue, colorKeyframesButton, null)
+        setControls();
     }
 
     GridLayout {
@@ -86,16 +83,18 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [glitchFreq, blockH, shiftInt, colorInt]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes
+                resetSimpleKeyframes;
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -103,8 +102,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Frequency')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: glitchFreqSlider
+
             minimumValue: 0
             maximumValue: 100
             stepSize: 0.1
@@ -112,14 +113,17 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(glitchFreq, glitchFreqSlider.value / glitchFreqSlider.maximumValue, glitchKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: glitchFreqSlider.value = glitchFreqDefault * glitchFreqSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: glitchKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, glitchFreq, glitchFreqSlider.value / glitchFreqSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, glitchFreq, glitchFreqSlider.value / glitchFreqSlider.maximumValue);
             }
         }
 
@@ -127,8 +131,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Block height')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: blockHSlider
+
             minimumValue: 0
             maximumValue: 100
             stepSize: 0.1
@@ -136,14 +142,17 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(blockH, blockHSlider.value / blockHSlider.maximumValue, blockKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: blockHSlider.value = blockHDefault * blockHSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: blockKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, blockH, blockHSlider.value / blockHSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, blockH, blockHSlider.value / blockHSlider.maximumValue);
             }
         }
 
@@ -151,8 +160,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Shift intensity')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: shiftIntSlider
+
             minimumValue: 0
             maximumValue: 100
             stepSize: 0.1
@@ -160,14 +171,17 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(shiftInt, shiftIntSlider.value / shiftIntSlider.maximumValue, shiftKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: shiftIntSlider.value = shiftIntDefault * shiftIntSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: shiftKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, shiftInt, shiftIntSlider.value / shiftIntSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, shiftInt, shiftIntSlider.value / shiftIntSlider.maximumValue);
             }
         }
 
@@ -175,8 +189,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Color intensity')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: colorIntSlider
+
             minimumValue: 0
             maximumValue: 100
             stepSize: 0.1
@@ -184,34 +200,60 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(colorInt, colorIntSlider.value / colorIntSlider.maximumValue, colorKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: colorIntSlider.value = colorIntDefault * colorIntSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: colorKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, colorInt, colorIntSlider.value / colorIntSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, colorInt, colorIntSlider.value / colorIntSlider.maximumValue);
             }
         }
 
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/glow/meta_frei0r.qml
+++ b/src/qml/filters/glow/meta_frei0r.qml
@@ -7,6 +7,7 @@ Metadata {
     mlt_service: "frei0r.glow"
     qml: "ui_frei0r.qml"
     gpuAlt: "movit.glow"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -21,4 +22,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/glow/meta_movit.qml
+++ b/src/qml/filters/glow/meta_movit.qml
@@ -7,6 +7,7 @@ Metadata {
     mlt_service: "movit.glow"
     needsGPU: true
     qml: "ui_movit.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -31,8 +32,9 @@ Metadata {
                 property: 'highlight_cutoff'
                 isCurve: true
                 minimum: 0.1
-                maximum: 1.0
+                maximum: 1
             }
         ]
     }
+
 }

--- a/src/qml/filters/glow/ui_movit.qml
+++ b/src/qml/filters/glow/ui_movit.qml
@@ -21,129 +21,130 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    property var defaultParameters: ['radius','blur_mix','highlight_cutoff']
+    property var defaultParameters: ['radius', 'blur_mix', 'highlight_cutoff']
     property bool blockUpdate: true
-    property var startValues:  [0.0,  0.0, 0.1]
-    property var middleValues: [20.0, 1.0, 0.2]
-    property var endValues:    [0.0,  0.0, 0.1]
-    width: 350
-    height: 125
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set('radius', 20.0)
-            filter.set('blur_mix', 1.0)
-            filter.set('highlight_cutoff', 0.2)
-            filter.savePreset(defaultParameters)
-        } else {
-            initSimpleAnimation()
-        }
-        setControls()
-    }
+    property var startValues: [0, 0, 0.1]
+    property var middleValues: [20, 1, 0.2]
+    property var endValues: [0, 0, 0.1]
 
     function initSimpleAnimation() {
-        middleValues = [filter.getDouble(defaultParameters[0], filter.animateIn),
-                        filter.getDouble(defaultParameters[1], filter.animateIn),
-                        filter.getDouble(defaultParameters[2], filter.animateIn)]
-        if (filter.animateIn > 0) {
-            startValues = [filter.getDouble(defaultParameters[0], 0),
-                           filter.getDouble(defaultParameters[1], 0),
-                           filter.getDouble(defaultParameters[2], 0)]
-        }
-        if (filter.animateOut > 0) {
-            endValues = [filter.getDouble(defaultParameters[0], filter.duration - 1),
-                         filter.getDouble(defaultParameters[1], filter.duration - 1),
-                         filter.getDouble(defaultParameters[2], filter.duration - 1)]
-        }
+        middleValues = [filter.getDouble(defaultParameters[0], filter.animateIn), filter.getDouble(defaultParameters[1], filter.animateIn), filter.getDouble(defaultParameters[2], filter.animateIn)];
+        if (filter.animateIn > 0)
+            startValues = [filter.getDouble(defaultParameters[0], 0), filter.getDouble(defaultParameters[1], 0), filter.getDouble(defaultParameters[2], 0)];
+
+        if (filter.animateOut > 0)
+            endValues = [filter.getDouble(defaultParameters[0], filter.duration - 1), filter.getDouble(defaultParameters[1], filter.duration - 1), filter.getDouble(defaultParameters[2], filter.duration - 1)];
+
     }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        radiusslider.value = filter.getDouble('radius', position)
-        blurslider.value = filter.getDouble('blur_mix', position)
-        cutoffslider.value = filter.getDouble('highlight_cutoff', position)
-        blockUpdate = false
-        radiusslider.enabled = blurslider.enabled = cutoffslider.enabled
-            = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        radiusslider.value = filter.getDouble('radius', position);
+        blurslider.value = filter.getDouble('blur_mix', position);
+        cutoffslider.value = filter.getDouble('highlight_cutoff', position);
+        blockUpdate = false;
+        radiusslider.enabled = blurslider.enabled = cutoffslider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function updateFilter(parameter, value, position, button) {
-        if (blockUpdate) return
-        var index = defaultParameters.indexOf(parameter)
+        if (blockUpdate)
+            return ;
 
+        var index = defaultParameters.indexOf(parameter);
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValues[index] = value
+                startValues[index] = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValues[index] = value
+                endValues[index] = value;
             else
-                middleValues[index] = value
+                middleValues[index] = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(parameter)
-            button.checked = false
+            filter.resetProperty(parameter);
+            button.checked = false;
             if (filter.animateIn > 0) {
-                filter.set(parameter, startValues[index], 0)
-                filter.set(parameter, middleValues[index], filter.animateIn - 1)
+                filter.set(parameter, startValues[index], 0);
+                filter.set(parameter, middleValues[index], filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(parameter, middleValues[index], filter.duration - filter.animateOut)
-                filter.set(parameter, endValues[index], filter.duration - 1)
+                filter.set(parameter, middleValues[index], filter.duration - filter.animateOut);
+                filter.set(parameter, endValues[index], filter.duration - 1);
             }
         } else if (!button.checked) {
-            filter.resetProperty(parameter)
-            filter.set(parameter, middleValues[index])
+            filter.resetProperty(parameter);
+            filter.set(parameter, middleValues[index]);
         } else if (position !== null) {
-            filter.set(parameter, value, position)
+            filter.set(parameter, value, position);
         }
     }
 
     function onKeyframesButtonClicked(checked, parameter, value) {
         if (checked) {
-            blockUpdate = true
-            radiusslider.enabled = blurslider.enabled = cutoffslider.enabled = true
+            blockUpdate = true;
+            radiusslider.enabled = blurslider.enabled = cutoffslider.enabled = true;
             if (filter.animateIn > 0 || filter.animateOut > 0) {
-                filter.resetProperty('radius')
-                filter.resetProperty('blur_mix')
-                filter.resetProperty('highlight_cutoff')
-                filter.animateIn = filter.animateOut = 0
+                filter.resetProperty('radius');
+                filter.resetProperty('blur_mix');
+                filter.resetProperty('highlight_cutoff');
+                filter.animateIn = filter.animateOut = 0;
             } else {
-                filter.clearSimpleAnimation(parameter)
+                filter.clearSimpleAnimation(parameter);
             }
-            blockUpdate = false
-            filter.set(parameter, value, getPosition())
+            blockUpdate = false;
+            filter.set(parameter, value, getPosition());
         } else {
-            filter.resetProperty(parameter)
-            filter.set(parameter, value)
+            filter.resetProperty(parameter);
+            filter.set(parameter, value);
         }
+    }
+
+    function updateSimpleAnimation() {
+        updateFilter('radius', radiusslider.value, getPosition(), radiusKeyframesButton);
+        updateFilter('blur_mix', blurslider.value, getPosition(), blurKeyframesButton);
+        updateFilter('highlight_cutoff', cutoffslider.value, getPosition(), cutoffKeyframesButton);
+    }
+
+    width: 350
+    height: 125
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set('radius', 20);
+            filter.set('blur_mix', 1);
+            filter.set('highlight_cutoff', 0.2);
+            filter.savePreset(defaultParameters);
+        } else {
+            initSimpleAnimation();
+        }
+        setControls();
     }
 
     GridLayout {
         columns: 4
         anchors.fill: parent
         anchors.margins: 8
-        
+
         Label {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             Layout.columnSpan: 3
             parameters: defaultParameters
             onBeforePresetLoaded: {
-                filter.resetProperty('radius')
-                filter.resetProperty('blur_mix')
-                filter.resetProperty('highlight_cutoff')
+                filter.resetProperty('radius');
+                filter.resetProperty('blur_mix');
+                filter.resetProperty('highlight_cutoff');
             }
             onPresetSelected: {
-                setControls()
-                initSimpleAnimation()
+                setControls();
+                initSimpleAnimation();
             }
         }
 
@@ -152,39 +153,49 @@ Item {
             text: qsTr('Radius')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: radiusslider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
             onValueChanged: updateFilter('radius', value, getPosition(), radiusKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: radiusslider.value = 20
         }
+
         Shotcut.KeyframesButton {
             id: radiusKeyframesButton
+
             checked: filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('radius') > 0
             onToggled: onKeyframesButtonClicked(checked, 'radius', radiusslider.value)
         }
 
         // Row 2
-        Label { 
+        Label {
             text: qsTr('Highlight blurriness')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: blurslider
-            minimumValue: 0.0
-            maximumValue: 1.0
+
+            minimumValue: 0
+            maximumValue: 1
             decimals: 2
             onValueChanged: updateFilter('blur_mix', value, getPosition(), blurKeyframesButton)
         }
+
         Shotcut.UndoButton {
-            onClicked: blurslider.value = 1.0
+            onClicked: blurslider.value = 1
         }
+
         Shotcut.KeyframesButton {
             id: blurKeyframesButton
+
             checked: filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('blur_mix') > 0
             onToggled: onKeyframesButtonClicked(checked, 'blur_mix', blurslider.value)
         }
@@ -194,18 +205,23 @@ Item {
             text: qsTr('Highlight cutoff')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: cutoffslider
+
             minimumValue: 0.1
-            maximumValue: 1.0
+            maximumValue: 1
             decimals: 2
             onValueChanged: updateFilter('highlight_cutoff', value, getPosition(), cutoffKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: cutoffslider.value = 0.2
         }
+
         Shotcut.KeyframesButton {
             id: cutoffKeyframesButton
+
             checked: filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('highlight_cutoff') > 0
             onToggled: onKeyframesButtonClicked(checked, 'highlight_cutoff', cutoffslider.value)
         }
@@ -213,26 +229,43 @@ Item {
         Item {
             Layout.fillHeight: true
         }
-    }
 
-    function updateSimpleAnimation() {
-        updateFilter('radius', radiusslider.value, getPosition(), radiusKeyframesButton)
-        updateFilter('blur_mix', blurslider.value, getPosition(), blurKeyframesButton)
-        updateFilter('highlight_cutoff', cutoffslider.value, getPosition(), cutoffKeyframesButton)
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/gpsgraphic/meta.qml
+++ b/src/qml/filters/gpsgraphic/meta.qml
@@ -25,6 +25,7 @@ Metadata {
     qml: 'ui.qml'
     vui: 'vui.qml'
     allowMultiple: true
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -37,4 +38,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/gpsgraphic/ui.qml
+++ b/src/qml/filters/gpsgraphic/ui.qml
@@ -15,232 +15,38 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import QtQml.Models 2.12
 import QtQuick 2.12
 import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
-
 import QtQuick.Dialogs 1.2
+import QtQuick.Layouts 1.12
 import QtQuick.Window 2.1
 import Shotcut.Controls 1.0 as Shotcut
 import org.shotcut.qml 1.0 as Shotcut
-import QtQml.Models 2.12
 
 Item {
+    //keep in UI order for sanity!
+
     id: gpsGraphRoot
-    width: 350
-    height: 850
 
     property string rectProperty: "rect"
     property rect filterRect: filter.getRect(rectProperty)
-    property var allParameters: [
-        'time_offset', 'smoothing_value', 'speed_multiplier',
-        'graph_data_source', 'graph_type', 'trim_start_p', 'trim_end_p', 'crop_mode_h', 'crop_left_p', 'crop_right_p', 'crop_mode_v', 'crop_bot_p', 'crop_top_p',
-        'color_style', 'color.1', 'color.2', 'color.3', 'color.4', 'color.5', 'color.6', 'color.7', 'color.8', 'color.9', 'color.10',
-        'show_now_dot', 'now_dot_color', 'show_now_text', 'angle', 'thickness', rectProperty, 'show_grid', 'legend_unit', 'draw_individual_dots',
-        'bg_img_path', 'bg_scale_w'
-    ]
+    property var allParameters: ['time_offset', 'smoothing_value', 'speed_multiplier', 'graph_data_source', 'graph_type', 'trim_start_p', 'trim_end_p', 'crop_mode_h', 'crop_left_p', 'crop_right_p', 'crop_mode_v', 'crop_bot_p', 'crop_top_p', 'color_style', 'color.1', 'color.2', 'color.3', 'color.4', 'color.5', 'color.6', 'color.7', 'color.8', 'color.9', 'color.10', 'show_now_dot', 'now_dot_color', 'show_now_text', 'angle', 'thickness', rectProperty, 'show_grid', 'legend_unit', 'draw_individual_dots', 'bg_img_path', 'bg_scale_w']
     property var default_colors: ["#00aaff", "#00e000", "#ffff00", "#ff8c00", "#ff0000"]
     property string color_white: "#ffffff"
     property string default_now_dot: "#00ffffff"
     property string default_rect: '10%/10%:30%x30%'
     property int js_tz_offset: 0
-
     property bool _disableUpdate: true
     property url settingsOpenPath: 'file:///' + settings.openPath
 
-    Shotcut.File { id: gpsFile }
-    Shotcut.File { id: bgFile }
     signal fileOpened(string path)
-    onFileOpened: settings.openPath = path
-
-    Component.onCompleted: {
-        filter.blockSignals = true
-
-        var resource = filter.get('resource')
-        gpsFile.url = resource
-        if (filter.isNew) {
-            var usedParams
-            var _ = undefined //skip params faster
-
-            //main preset
-            usedParams = set_graph_data_params(0,0,  0,100,  0, 0, 100,  0, 0, 100)
-            usedParams.push( set_graph_style_params(1, 1, 0, 0, 5,  default_rect, 0, _, 0) )
-            usedParams.push( set_graph_colors(default_now_dot, default_colors[0], color_white) )
-            filter.savePreset(usedParams, "2D map: full map progress line")
-
-            usedParams = set_graph_data_params(0,1, _,_, 0, 90, 100,  0, 90, 100)
-            filter.savePreset(usedParams, "2D map: follow @90%")
-
-            usedParams = set_graph_data_params(0,1, _,_, 0, 95, 100,  0, 95, 100)
-            filter.savePreset(usedParams, "2D map: follow @95%")
-
-            usedParams = set_graph_data_params(0,1, _,_, 0, 98, 100,  0, 98, 100)
-            filter.savePreset(usedParams, "2D map: follow @98%")
-
-            //1d graphs: speed, altitude, hr
-            usedParams = set_graph_data_params(1,0, _,_, 0, 0, 100,  0, 0, 100)
-            usedParams.push( set_graph_style_params(1,  1, 1,  0, _, _,  1, 'm', 0) )
-            usedParams.push( set_graph_background_params( '!' ) )
-            filter.savePreset(usedParams, "1D graph: Altitude")
-
-            usedParams = set_graph_data_params(1,1, _,_, 0, 90, 100,  0, 0, 100)
-            usedParams.push( set_graph_style_params(1,  1, 1,  0, _, _,  0, 'm', 0) )
-            usedParams.push( set_graph_background_params( '!' ) )
-            filter.savePreset(usedParams, "1D graph: Altitude, follow @90%")
-
-            usedParams = set_graph_data_params(2,0, _,_, 0, 0, 100,  0, 0, 100)
-            usedParams.push( set_graph_style_params(8,  1, 1,  0, _, _,  1, 'bpm', 0) )
-            usedParams.push( set_graph_background_params( '!' ) )
-            filter.savePreset(usedParams, "1D graph: HR")
-
-            usedParams = set_graph_data_params(2,1, _,_, 0, 90, 100,  0, 0, 100)
-            usedParams.push( set_graph_style_params(8,  1, 1,  0, _, _,  0, 'bpm', 0) )
-            usedParams.push( set_graph_background_params( '!' ) )
-            filter.savePreset(usedParams, "1D graph: HR, follow @90%")
-
-            usedParams = set_graph_data_params(3,0, _,_, 0, 0, 100,  0, 0, 100)
-            usedParams.push( set_graph_style_params(1,  1, 1,  0, _, _,  1, 'km/h', 0) )
-            usedParams.push( set_graph_background_params( '!' ) )
-            filter.savePreset(usedParams, "1D graph: Speed")
-
-            usedParams = set_graph_data_params(3,1, _,_, 0, 90, 100,  0, 0, 100)
-            usedParams.push( set_graph_style_params(1,  1, 1,  0, _, _,  0, 'km/h', 0) )
-            usedParams.push( set_graph_background_params( '!' ) )
-            filter.savePreset(usedParams, "1D graph: Speed, follow @90%")
-
-
-            usedParams = set_graph_data_params(0,1, _,_, 0, 99, 100,  0, 99, 100)
-            usedParams.push( set_graph_style_params(1, 1, 0, 0, 8, _, _, _, 1) )
-            filter.savePreset(usedParams, "Map style: show GPS points as dots @99%")
-
-            usedParams = set_graph_style_params(2, 1, 0, 0, 5,  default_rect, 0, _, 0)
-            usedParams.push( set_graph_colors(_, default_colors[0], '#00ffffff') )
-            filter.savePreset(usedParams, "Map style: hide future path")
-
-            usedParams = set_graph_style_params(2, 1, 0, 0, 5,  default_rect, 0, _, 0)
-            usedParams.push( set_graph_colors(_, default_colors[0], '#40ffffff') )
-            filter.savePreset(usedParams, "Map style: 25% opacity thin future path")
-
-            usedParams = set_graph_data_params(3,0,  0,100,  0, 0, 100,  0, 100, 100)
-            usedParams.push( set_graph_style_params(1, 1, 0, 0, 5,  '10%/10%:80%x10%', 0, _, 0) )
-            usedParams.push( set_graph_colors(default_now_dot, default_colors[0], color_white) )
-            usedParams.push( set_graph_background_params("!") )
-            filter.savePreset(usedParams, "Simple line progressbar")
-
-            //speedometer example
-            usedParams = set_graph_data_params(3,2,  _,_,  0,0,100,  1,0,30)
-            usedParams.push( set_graph_style_params(1,  1,1,  0, _, _,  1, 'km/h', _) )
-            usedParams.push( set_graph_background_params("!") )
-            filter.savePreset(usedParams, "Speedometer: 0-30 km/h")
-
-            usedParams = set_graph_data_params(3,2,  _,_,  0,0,100,  1,0,60)
-            usedParams.push( set_graph_style_params(1,  1,1,  0, _, _,  1, 'mi/h', _) )
-            usedParams.push( set_graph_background_params("!") )
-            filter.savePreset(usedParams, "Speedometer: 0-60 mi/h")
-
-            usedParams = set_graph_data_params(3,2,  _,_,  0,0,100,  0,0,100)
-            usedParams.push( set_graph_style_params(1,  1,1,  0, _, _,  0, 'km/h', _) )
-            usedParams.push( set_graph_background_params("!") )
-            filter.savePreset(usedParams, "Speedometer: min-max km/h")
-
-            //basic text only presets
-            usedParams = set_graph_data_params(0,0,  0,100,  0, 0, 0,  0, 0, 0)
-            usedParams.push( set_graph_style_params(_, 0, 1, 0, 5,  default_rect, 0, " ", 0) )
-            filter.savePreset(usedParams, "Text only: GPS coordinates")
-            usedParams = set_graph_data_params(1,0,  0,100,  0, 0, 0,  0, 0, 0)
-            usedParams.push( set_graph_style_params(_, 0, 1, 0, 5,  default_rect, 0, 'm', 0) )
-            filter.savePreset(usedParams, "Text only: Altitude")
-            usedParams = set_graph_data_params(2,0,  0,100,  0, 0, 0,  0, 0, 0)
-            usedParams.push( set_graph_style_params(_, 0, 1, 0, 5,  default_rect, 0, 'bpm', 0) )
-            filter.savePreset(usedParams, "Text only: Heart rate")
-            usedParams = set_graph_data_params(3,0,  0,100,  0, 0, 0,  0, 0, 0)
-            usedParams.push( set_graph_style_params(_, 0, 1, 0, 5,  default_rect, 0, 'km/h', 0) )
-            filter.savePreset(usedParams, "Text only: Speed")
-
-            usedParams = set_graph_data_params(0,2,  _,_,  0, 0, 100,  0, 0, 100)
-            usedParams.push( set_graph_style_params(0, 0, 1, 0, 5,  default_rect, 0, '%', 0) )
-            usedParams.push( set_graph_colors(_, "#00000000", "#00000000") )
-            filter.savePreset(usedParams, "Text only: Percentage of trimmed track")
-
-            //color presets:
-            usedParams = set_graph_style_params(8)
-            usedParams.push ( set_graph_colors(_, default_colors[0], default_colors[1], default_colors[2], default_colors[3], default_colors[4]) )
-            filter.savePreset(usedParams, "Map colors: gradient of heart rate")
-            usedParams = set_graph_style_params(9)
-            usedParams.push ( set_graph_colors(_, default_colors[0], default_colors[1], default_colors[2], default_colors[3], default_colors[4]) )
-            filter.savePreset(usedParams, "Map colors: gradient of speed")
-            usedParams = set_graph_colors(_, default_colors[0], default_colors[1], default_colors[2], default_colors[3], default_colors[4])
-            filter.savePreset(usedParams, "Colors: default (5)")
-            usedParams = set_graph_colors(_, default_colors[4], default_colors[3], default_colors[2], default_colors[1], default_colors[0])
-            filter.savePreset(usedParams, "Colors: inversed default (5)")
-
-            usedParams = reset_all_params()
-            filter.savePreset(usedParams)
-        }
-
-        //get current timezone
-        //TODO: not sure why this doesn't include daylight saving if active, remove completely?
-        var today = new Date()
-        js_tz_offset = today.getTimezoneOffset()*60
-        filter.blockSignals = false
-
-        setControls()
-    }
-
-
-    //gps funcs
-    FileDialog {
-        id: fileDialog
-        title: "Select GPS file"
-        folder: settingsOpenPath
-        modality: application.dialogModality
-        selectMultiple: false
-        selectFolder: false
-        nameFilters: ['Supported files (*.gpx *.tcx)', 'GPS Exchange Format (*.gpx)', 'Training Center XML (*.tcx)']
-        onAccepted: {
-            gpsFile.url = fileDialog.fileUrl
-            gpsGraphRoot.fileOpened(gpsFile.path)
-            fileLabel.text = gpsFile.fileName
-            fileLabel.color = activePalette.text
-            fileLabelTip.text = gpsFile.filePath
-            filter.set('resource', gpsFile.url)
-            filter.set('gps_start_text', '')
-            gpsFinishParseTimer.restart()
-        }
-    }
-
-    //timer to update UI after gps file is processed; max: 10x250ms
-    Timer {
-        id: gpsFinishParseTimer
-        interval: 250
-        repeat: true
-        triggeredOnStart: false
-        property int calls: 0
-        onTriggered: {
-            if (filter.get('gps_start_text') == '') {
-                calls += 1;
-                if (calls > 10) {
-                    gpsFinishParseTimer.stop();
-                    calls = 0;
-                    setControls();
-                }
-            }
-            else {
-                gpsFinishParseTimer.stop();
-                calls = 0;
-                setControls();
-            }
-        }
-    }
 
     //this function combines the text values from sign combobox * days/hours/mins/sec TextFields into an int
     function recompute_time_offset() {
-        var offset_sec = parseInt(Number(offset_days.text), 10)*24*60*60 +
-                         parseInt(Number(offset_hours.text), 10)*60*60 +
-                         parseInt(Number(offset_mins.text), 10)*60 +
-                         parseInt(Number(offset_secs.text), 10);
+        var offset_sec = parseInt(Number(offset_days.text), 10) * 24 * 60 * 60 + parseInt(Number(offset_hours.text), 10) * 60 * 60 + parseInt(Number(offset_mins.text), 10) * 60 + parseInt(Number(offset_secs.text), 10);
         offset_sec *= parseInt(filter.get('majoroffset_sign'), 10);
-        filter.set('time_offset', Number(offset_sec).toFixed(0))
+        filter.set('time_offset', Number(offset_sec).toFixed(0));
     }
 
     //transforms a wheel-up/down event into the correct offset direction
@@ -248,103 +54,96 @@ Item {
         var offset = Number(filter.get("time_offset"));
         if (offset < 0)
             val *= -1;
-        if (offset === 0 && val < 0) return; //fix unnatural behaviour when subtracting at offset 0
-        set_sec_offset_to_textfields( offset + val );
+
+        if (offset === 0 && val < 0)
+            return ;
+
+        //fix unnatural behaviour when subtracting at offset 0
+        set_sec_offset_to_textfields(offset + val);
     }
 
     //splits (and fills) seconds into days/hours/mins/secs textfields
     function set_sec_offset_to_textfields(secs) {
         if (secs === '')
-            return;
+            return ;
 
         if (secs < 0) {
-            combo_majoroffset_sign.currentIndex = 1
-            filter.set('majoroffset_sign', -1)
+            combo_majoroffset_sign.currentIndex = 1;
+            filter.set('majoroffset_sign', -1);
+        } else {
+            combo_majoroffset_sign.currentIndex = 0;
+            filter.set('majoroffset_sign', 1);
         }
-        else {
-            combo_majoroffset_sign.currentIndex = 0
-            filter.set('majoroffset_sign', 1)
-        }
-
-        offset_days.text = parseInt( Math.abs(secs)/(24*60*60) , 10 )
-        offset_hours.text = parseInt( Math.abs(secs)/(60*60)%24 , 10 )
-        offset_mins.text = parseInt( Math.abs(secs)/60%60 , 10 )
-        offset_secs.text = parseInt( Math.abs(secs)%60 , 10 )
-
+        offset_days.text = parseInt(Math.abs(secs) / (24 * 60 * 60), 10);
+        offset_hours.text = parseInt(Math.abs(secs) / (60 * 60) % 24, 10);
+        offset_mins.text = parseInt(Math.abs(secs) / 60 % 60, 10);
+        offset_secs.text = parseInt(Math.abs(secs) % 60, 10);
         //toFixed(0) avoids scientific notation!
-        filter.set('time_offset', Number(secs).toFixed(0))
+        filter.set('time_offset', Number(secs).toFixed(0));
     }
 
     //graph rect
     function setFilter() {
-        _disableUpdate = true
-        var x = rectX.value
-        var y = rectY.value
-        var w = rectW.value
-        var h = rectH.value
-        if (x !== filterRect.x ||
-            y !== filterRect.y ||
-            w !== filterRect.width ||
-            h !== filterRect.height) {
-            filterRect.x = x
-            filterRect.y = y
-            filterRect.width = w
-            filterRect.height = h
-            filter.set(rectProperty, filterRect)
+        _disableUpdate = true;
+        var x = rectX.value;
+        var y = rectY.value;
+        var w = rectW.value;
+        var h = rectH.value;
+        if (x !== filterRect.x || y !== filterRect.y || w !== filterRect.width || h !== filterRect.height) {
+            filterRect.x = x;
+            filterRect.y = y;
+            filterRect.width = w;
+            filterRect.height = h;
+            filter.set(rectProperty, filterRect);
         }
-        _disableUpdate = false
+        _disableUpdate = false;
     }
 
     function setControls() {
-        _disableUpdate = true
-
-        //keep in UI order for sanity!
-
+        _disableUpdate = true;
         //gps sync data
         if (gpsFile.exists()) {
-            fileLabel.text = gpsFile.fileName
-            fileLabelTip.text = gpsFile.filePath + "\nGPS start time: " + filter.get('gps_start_text') + "\nVideo start time: " + filter.get('video_start_text')
+            fileLabel.text = gpsFile.fileName;
+            fileLabelTip.text = gpsFile.filePath + "\nGPS start time: " + filter.get('gps_start_text') + "\nVideo start time: " + filter.get('video_start_text');
         } else {
-            fileLabel.text = qsTr("No File Loaded.")
-            fileLabel.color = 'red'
-            fileLabelTip.text = qsTr('No GPS file loaded.\nClick "Open" to load a file.')
+            fileLabel.text = qsTr("No File Loaded.");
+            fileLabel.color = 'red';
+            fileLabelTip.text = qsTr('No GPS file loaded.\nClick "Open" to load a file.');
         }
         set_sec_offset_to_textfields(filter.get('time_offset'));
         combo_smoothing.currentIndex = combo_smoothing.get_smooth_index_from_val(filter.get('smoothing_value'));
         speed_multiplier.value = filter.get('speed_multiplier');
-
         //graph data
-        combo_data_source.currentIndex = filter.get("graph_data_source")
-        combo_graph_type.currentIndex = filter.get("graph_type")
-        spin_start.value = crop_start_end_slider.first.value = filter.getDouble('trim_start_p')
-        spin_end.value = crop_start_end_slider.second.value = filter.getDouble('trim_end_p')
-        combo_cropmode_h.currentIndex = filter.get("crop_mode_h")
-        combo_cropmode_v.currentIndex = filter.get("crop_mode_v")
-        spin_bot.value = crop_top_bot_slider.first.value = filter.getDouble('crop_bot_p')
-        spin_top.value = crop_top_bot_slider.second.value = filter.getDouble('crop_top_p')
-        spin_left.value = crop_left_right_slider.first.value = filter.getDouble('crop_left_p')
-        spin_right.value = crop_left_right_slider.second.value = filter.getDouble('crop_right_p')
-
+        combo_data_source.currentIndex = filter.get("graph_data_source");
+        combo_graph_type.currentIndex = filter.get("graph_type");
+        spin_start.value = crop_start_end_slider.first.value = filter.getDouble('trim_start_p');
+        spin_end.value = crop_start_end_slider.second.value = filter.getDouble('trim_end_p');
+        combo_cropmode_h.currentIndex = filter.get("crop_mode_h");
+        combo_cropmode_v.currentIndex = filter.get("crop_mode_v");
+        spin_bot.value = crop_top_bot_slider.first.value = filter.getDouble('crop_bot_p');
+        spin_top.value = crop_top_bot_slider.second.value = filter.getDouble('crop_top_p');
+        spin_left.value = crop_left_right_slider.first.value = filter.getDouble('crop_left_p');
+        spin_right.value = crop_left_right_slider.second.value = filter.getDouble('crop_right_p');
         //graph design
-        combo_color_style.currentIndex = filter.get("color_style")
+        combo_color_style.currentIndex = filter.get("color_style");
         //todo: fix gradient number of colors after project reopen
-        colGradient.colors = filter.getGradient('color') //.splice(0, combo_color_style.get_combo_gradient_nr_colors())
-        checkbox_now_dot.checked = (filter.get("show_now_dot") == 1)
-        checkbox_now_text.checked = (filter.get("show_now_text") == 1)
-        now_dot_color.value = filter.get('now_dot_color')
-        graph_rotation.value = filter.get("angle")
-        thicknessSlider.value = filter.getDouble('thickness')
-        checkbox_grid.checked = (filter.get("show_grid") == 1)
-        legend_unit.text = filter.get("legend_unit")
-        rectX.value = filterRect.x
-        rectY.value = filterRect.y
-        rectW.value = filterRect.width
-        rectH.value = filterRect.height
+        colGradient.colors = filter.getGradient('color');
+        //.splice(0, combo_color_style.get_combo_gradient_nr_colors())
+        checkbox_now_dot.checked = (filter.get("show_now_dot") == 1);
+        checkbox_now_text.checked = (filter.get("show_now_text") == 1);
+        now_dot_color.value = filter.get('now_dot_color');
+        graph_rotation.value = filter.get("angle");
+        thicknessSlider.value = filter.getDouble('thickness');
+        checkbox_grid.checked = (filter.get("show_grid") == 1);
+        legend_unit.text = filter.get("legend_unit");
+        rectX.value = filterRect.x;
+        rectY.value = filterRect.y;
+        rectW.value = filterRect.width;
+        rectH.value = filterRect.height;
         //advanced options
-        bg_img_path.text = filter.get("bg_img_path")
-        slider_scaleW.value = filter.getDouble('bg_scale_w')
-
-        _disableUpdate = false
+        bg_img_path.text = filter.get("bg_img_path");
+        slider_scaleW.value = filter.getDouble('bg_scale_w');
+        _disableUpdate = false;
     }
 
     function reset_legend_unit() {
@@ -358,8 +157,321 @@ Item {
             legend_unit.text = "";
     }
 
+    //just filter.set(param, val) but returns the param name so I don't have to manually compose a used_params for presets
+    function filterset_getparams(param, val) {
+        filter.set(param, val);
+        return param;
+    }
+
+    function reset_all_params() {
+        var used_params = [];
+        used_params.push(set_gps_file_params(0, 5, 1));
+        used_params.push(set_graph_data_params(0, 0, 0, 100, 0, 0, 100, 0, 0, 100));
+        used_params.push(set_graph_style_params(1, 1, 0, 0, 5, default_rect, 0, '', 0));
+        used_params.push(set_graph_colors(default_now_dot, default_colors[0], color_white, default_colors[2], default_colors[3], default_colors[4], default_colors[5]));
+        used_params.push(set_graph_background_params("!", 1, 1));
+        return used_params;
+    }
+
+    function set_gps_file_params(offset, smooth, speed) {
+        var used_params = [];
+        if (offset !== undefined)
+            used_params.push(filterset_getparams('time_offset', offset));
+
+        if (smooth !== undefined)
+            used_params.push(filterset_getparams('smoothing_value', smooth));
+
+        if (speed !== undefined)
+            used_params.push(filterset_getparams('speed_multiplier', speed));
+
+        return used_params;
+    }
+
+    function set_graph_data_params(src, type, startp, endp, modeh, leftp, rightp, modev, botp, topp) {
+        var used_params = [];
+        if (src !== undefined)
+            used_params.push(filterset_getparams('graph_data_source', src));
+
+        if (type !== undefined)
+            used_params.push(filterset_getparams('graph_type', type));
+
+        if (startp !== undefined)
+            used_params.push(filterset_getparams('trim_start_p', startp));
+
+        if (endp !== undefined)
+            used_params.push(filterset_getparams('trim_end_p', endp));
+
+        if (modeh !== undefined)
+            used_params.push(filterset_getparams('crop_mode_h', modeh));
+
+        if (leftp !== undefined)
+            used_params.push(filterset_getparams('crop_left_p', leftp));
+
+        if (rightp !== undefined)
+            used_params.push(filterset_getparams('crop_right_p', rightp));
+
+        if (modev !== undefined)
+            used_params.push(filterset_getparams('crop_mode_v', modev));
+
+        if (botp !== undefined)
+            used_params.push(filterset_getparams('crop_bot_p', botp));
+
+        if (topp !== undefined)
+            used_params.push(filterset_getparams('crop_top_p', topp));
+
+        return used_params;
+    }
+
+    function set_graph_style_params(style, nowdot, nowtext, angle, thick, rect, grid, legendunit, drawdots) {
+        var used_params = [];
+        if (style !== undefined)
+            used_params.push(filterset_getparams('color_style', style));
+
+        if (nowdot !== undefined)
+            used_params.push(filterset_getparams('show_now_dot', nowdot));
+
+        if (nowtext !== undefined)
+            used_params.push(filterset_getparams('show_now_text', nowtext));
+
+        if (angle !== undefined)
+            used_params.push(filterset_getparams('angle', angle));
+
+        if (thick !== undefined)
+            used_params.push(filterset_getparams('thickness', thick));
+
+        //can't figure out how to properly set rect from preset to update the VUI
+        //if (rect !== undefined) used_params.push(filterset_getparams(rectProperty, rect))
+        if (grid !== undefined)
+            used_params.push(filterset_getparams('show_grid', grid));
+
+        if (legendunit !== undefined)
+            used_params.push(filterset_getparams('legend_unit', legendunit));
+
+        if (drawdots !== undefined)
+            used_params.push(filterset_getparams('draw_individual_dots', drawdots));
+
+        return used_params;
+    }
+
+    function set_graph_colors(cdot, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10) {
+        var used_params = [];
+        if (cdot !== undefined)
+            used_params.push(filterset_getparams('now_dot_color', cdot));
+
+        if (c1 !== undefined)
+            used_params.push(filterset_getparams('color.1', c1));
+
+        if (c2 !== undefined)
+            used_params.push(filterset_getparams('color.2', c2));
+
+        if (c3 !== undefined)
+            used_params.push(filterset_getparams('color.3', c3));
+
+        if (c4 !== undefined)
+            used_params.push(filterset_getparams('color.4', c4));
+
+        if (c5 !== undefined)
+            used_params.push(filterset_getparams('color.5', c5));
+
+        if (c6 !== undefined)
+            used_params.push(filterset_getparams('color.6', c6));
+
+        if (c7 !== undefined)
+            used_params.push(filterset_getparams('color.7', c7));
+
+        if (c8 !== undefined)
+            used_params.push(filterset_getparams('color.8', c8));
+
+        if (c9 !== undefined)
+            used_params.push(filterset_getparams('color.9', c9));
+
+        if (c10 !== undefined)
+            used_params.push(filterset_getparams('color.10', c10));
+
+        return used_params;
+    }
+
+    function set_graph_background_params(bgpath, scalew, opacity) {
+        var used_params = [];
+        if (bgpath !== undefined)
+            used_params.push(filterset_getparams('bg_img_path', bgpath));
+
+        if (scalew !== undefined)
+            used_params.push(filterset_getparams('bg_scale_w', scalew));
+
+        return used_params;
+    }
+
+    width: 350
+    height: 850
+    onFileOpened: settings.openPath = path
+    Component.onCompleted: {
+        filter.blockSignals = true;
+        var resource = filter.get('resource');
+        gpsFile.url = resource;
+        if (filter.isNew) {
+            var usedParams;
+            var _ = undefined; //skip params faster
+            //main preset
+            usedParams = set_graph_data_params(0, 0, 0, 100, 0, 0, 100, 0, 0, 100);
+            usedParams.push(set_graph_style_params(1, 1, 0, 0, 5, default_rect, 0, _, 0));
+            usedParams.push(set_graph_colors(default_now_dot, default_colors[0], color_white));
+            filter.savePreset(usedParams, "2D map: full map progress line");
+            usedParams = set_graph_data_params(0, 1, _, _, 0, 90, 100, 0, 90, 100);
+            filter.savePreset(usedParams, "2D map: follow @90%");
+            usedParams = set_graph_data_params(0, 1, _, _, 0, 95, 100, 0, 95, 100);
+            filter.savePreset(usedParams, "2D map: follow @95%");
+            usedParams = set_graph_data_params(0, 1, _, _, 0, 98, 100, 0, 98, 100);
+            filter.savePreset(usedParams, "2D map: follow @98%");
+            //1d graphs: speed, altitude, hr
+            usedParams = set_graph_data_params(1, 0, _, _, 0, 0, 100, 0, 0, 100);
+            usedParams.push(set_graph_style_params(1, 1, 1, 0, _, _, 1, 'm', 0));
+            usedParams.push(set_graph_background_params('!'));
+            filter.savePreset(usedParams, "1D graph: Altitude");
+            usedParams = set_graph_data_params(1, 1, _, _, 0, 90, 100, 0, 0, 100);
+            usedParams.push(set_graph_style_params(1, 1, 1, 0, _, _, 0, 'm', 0));
+            usedParams.push(set_graph_background_params('!'));
+            filter.savePreset(usedParams, "1D graph: Altitude, follow @90%");
+            usedParams = set_graph_data_params(2, 0, _, _, 0, 0, 100, 0, 0, 100);
+            usedParams.push(set_graph_style_params(8, 1, 1, 0, _, _, 1, 'bpm', 0));
+            usedParams.push(set_graph_background_params('!'));
+            filter.savePreset(usedParams, "1D graph: HR");
+            usedParams = set_graph_data_params(2, 1, _, _, 0, 90, 100, 0, 0, 100);
+            usedParams.push(set_graph_style_params(8, 1, 1, 0, _, _, 0, 'bpm', 0));
+            usedParams.push(set_graph_background_params('!'));
+            filter.savePreset(usedParams, "1D graph: HR, follow @90%");
+            usedParams = set_graph_data_params(3, 0, _, _, 0, 0, 100, 0, 0, 100);
+            usedParams.push(set_graph_style_params(1, 1, 1, 0, _, _, 1, 'km/h', 0));
+            usedParams.push(set_graph_background_params('!'));
+            filter.savePreset(usedParams, "1D graph: Speed");
+            usedParams = set_graph_data_params(3, 1, _, _, 0, 90, 100, 0, 0, 100);
+            usedParams.push(set_graph_style_params(1, 1, 1, 0, _, _, 0, 'km/h', 0));
+            usedParams.push(set_graph_background_params('!'));
+            filter.savePreset(usedParams, "1D graph: Speed, follow @90%");
+            usedParams = set_graph_data_params(0, 1, _, _, 0, 99, 100, 0, 99, 100);
+            usedParams.push(set_graph_style_params(1, 1, 0, 0, 8, _, _, _, 1));
+            filter.savePreset(usedParams, "Map style: show GPS points as dots @99%");
+            usedParams = set_graph_style_params(2, 1, 0, 0, 5, default_rect, 0, _, 0);
+            usedParams.push(set_graph_colors(_, default_colors[0], '#00ffffff'));
+            filter.savePreset(usedParams, "Map style: hide future path");
+            usedParams = set_graph_style_params(2, 1, 0, 0, 5, default_rect, 0, _, 0);
+            usedParams.push(set_graph_colors(_, default_colors[0], '#40ffffff'));
+            filter.savePreset(usedParams, "Map style: 25% opacity thin future path");
+            usedParams = set_graph_data_params(3, 0, 0, 100, 0, 0, 100, 0, 100, 100);
+            usedParams.push(set_graph_style_params(1, 1, 0, 0, 5, '10%/10%:80%x10%', 0, _, 0));
+            usedParams.push(set_graph_colors(default_now_dot, default_colors[0], color_white));
+            usedParams.push(set_graph_background_params("!"));
+            filter.savePreset(usedParams, "Simple line progressbar");
+            //speedometer example
+            usedParams = set_graph_data_params(3, 2, _, _, 0, 0, 100, 1, 0, 30);
+            usedParams.push(set_graph_style_params(1, 1, 1, 0, _, _, 1, 'km/h', _));
+            usedParams.push(set_graph_background_params("!"));
+            filter.savePreset(usedParams, "Speedometer: 0-30 km/h");
+            usedParams = set_graph_data_params(3, 2, _, _, 0, 0, 100, 1, 0, 60);
+            usedParams.push(set_graph_style_params(1, 1, 1, 0, _, _, 1, 'mi/h', _));
+            usedParams.push(set_graph_background_params("!"));
+            filter.savePreset(usedParams, "Speedometer: 0-60 mi/h");
+            usedParams = set_graph_data_params(3, 2, _, _, 0, 0, 100, 0, 0, 100);
+            usedParams.push(set_graph_style_params(1, 1, 1, 0, _, _, 0, 'km/h', _));
+            usedParams.push(set_graph_background_params("!"));
+            filter.savePreset(usedParams, "Speedometer: min-max km/h");
+            //basic text only presets
+            usedParams = set_graph_data_params(0, 0, 0, 100, 0, 0, 0, 0, 0, 0);
+            usedParams.push(set_graph_style_params(_, 0, 1, 0, 5, default_rect, 0, " ", 0));
+            filter.savePreset(usedParams, "Text only: GPS coordinates");
+            usedParams = set_graph_data_params(1, 0, 0, 100, 0, 0, 0, 0, 0, 0);
+            usedParams.push(set_graph_style_params(_, 0, 1, 0, 5, default_rect, 0, 'm', 0));
+            filter.savePreset(usedParams, "Text only: Altitude");
+            usedParams = set_graph_data_params(2, 0, 0, 100, 0, 0, 0, 0, 0, 0);
+            usedParams.push(set_graph_style_params(_, 0, 1, 0, 5, default_rect, 0, 'bpm', 0));
+            filter.savePreset(usedParams, "Text only: Heart rate");
+            usedParams = set_graph_data_params(3, 0, 0, 100, 0, 0, 0, 0, 0, 0);
+            usedParams.push(set_graph_style_params(_, 0, 1, 0, 5, default_rect, 0, 'km/h', 0));
+            filter.savePreset(usedParams, "Text only: Speed");
+            usedParams = set_graph_data_params(0, 2, _, _, 0, 0, 100, 0, 0, 100);
+            usedParams.push(set_graph_style_params(0, 0, 1, 0, 5, default_rect, 0, '%', 0));
+            usedParams.push(set_graph_colors(_, "#00000000", "#00000000"));
+            filter.savePreset(usedParams, "Text only: Percentage of trimmed track");
+            //color presets:
+            usedParams = set_graph_style_params(8);
+            usedParams.push(set_graph_colors(_, default_colors[0], default_colors[1], default_colors[2], default_colors[3], default_colors[4]));
+            filter.savePreset(usedParams, "Map colors: gradient of heart rate");
+            usedParams = set_graph_style_params(9);
+            usedParams.push(set_graph_colors(_, default_colors[0], default_colors[1], default_colors[2], default_colors[3], default_colors[4]));
+            filter.savePreset(usedParams, "Map colors: gradient of speed");
+            usedParams = set_graph_colors(_, default_colors[0], default_colors[1], default_colors[2], default_colors[3], default_colors[4]);
+            filter.savePreset(usedParams, "Colors: default (5)");
+            usedParams = set_graph_colors(_, default_colors[4], default_colors[3], default_colors[2], default_colors[1], default_colors[0]);
+            filter.savePreset(usedParams, "Colors: inversed default (5)");
+            usedParams = reset_all_params();
+            filter.savePreset(usedParams);
+        }
+        //get current timezone
+        //TODO: not sure why this doesn't include daylight saving if active, remove completely?
+        var today = new Date();
+        js_tz_offset = today.getTimezoneOffset() * 60;
+        filter.blockSignals = false;
+        setControls();
+    }
+
+    Shotcut.File {
+        id: gpsFile
+    }
+
+    Shotcut.File {
+        id: bgFile
+    }
+
+    //gps funcs
+    FileDialog {
+        id: fileDialog
+
+        title: "Select GPS file"
+        folder: settingsOpenPath
+        modality: application.dialogModality
+        selectMultiple: false
+        selectFolder: false
+        nameFilters: ['Supported files (*.gpx *.tcx)', 'GPS Exchange Format (*.gpx)', 'Training Center XML (*.tcx)']
+        onAccepted: {
+            gpsFile.url = fileDialog.fileUrl;
+            gpsGraphRoot.fileOpened(gpsFile.path);
+            fileLabel.text = gpsFile.fileName;
+            fileLabel.color = activePalette.text;
+            fileLabelTip.text = gpsFile.filePath;
+            filter.set('resource', gpsFile.url);
+            filter.set('gps_start_text', '');
+            gpsFinishParseTimer.restart();
+        }
+    }
+
+    //timer to update UI after gps file is processed; max: 10x250ms
+    Timer {
+        id: gpsFinishParseTimer
+
+        property int calls: 0
+
+        interval: 250
+        repeat: true
+        triggeredOnStart: false
+        onTriggered: {
+            if (filter.get('gps_start_text') == '') {
+                calls += 1;
+                if (calls > 10) {
+                    gpsFinishParseTimer.stop();
+                    calls = 0;
+                    setControls();
+                }
+            } else {
+                gpsFinishParseTimer.stop();
+                calls = 0;
+                setControls();
+            }
+        }
+    }
+
     FileDialog {
         id: selectBgImage
+
         title: "Select background image"
         folder: settingsOpenPath
         modality: application.dialogModality
@@ -367,32 +479,39 @@ Item {
         selectFolder: false
         nameFilters: ['Image files (*.jpg *.jpeg *.png)', 'JPG (*.jpg *.jpeg)', 'PNG (*.png)', 'All files (*)']
         onAccepted: {
-            bgFile.url = selectBgImage.fileUrl
-            bg_img_path.text = bgFile.filePath
-            gpsGraphRoot.fileOpened(bgFile.path)
-            filter.set("bg_img_path", bgFile.filePath)
+            bgFile.url = selectBgImage.fileUrl;
+            bg_img_path.text = bgFile.filePath;
+            gpsGraphRoot.fileOpened(bgFile.path);
+            filter.set("bg_img_path", bgFile.filePath);
         }
     }
 
-
     GridLayout {
         id: mainGrid
+
         columns: 2
         anchors.fill: parent
         anchors.margins: 8
 
         Shotcut.Button {
             id: openButton
+
             text: qsTr('Open file')
             Layout.alignment: Qt.AlignRight
             onClicked: {
-                fileDialog.open()
+                fileDialog.open();
             }
         }
+
         Label {
             id: fileLabel
+
             Layout.fillWidth: true
-            Shotcut.HoverTip { id: fileLabelTip }
+
+            Shotcut.HoverTip {
+                id: fileLabelTip
+            }
+
         }
 
         Label {
@@ -400,18 +519,19 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
-            Layout.topMargin: 10
             id: preset
+
+            Layout.topMargin: 10
             parameters: allParameters
             onBeforePresetLoaded: {
-                filter.resetProperty("legend_unit")
+                filter.resetProperty("legend_unit");
             }
-
             onPresetSelected: {
-                filterRect = filter.getRect(rectProperty)
-                setControls()
-                reset_legend_unit()
+                filterRect = filter.getRect(rectProperty);
+                setControls();
+                reset_legend_unit();
             }
         }
 
@@ -423,210 +543,387 @@ Item {
 
         Label {
             id: gps_sync_major
+
             text: qsTr('GPS offset')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('This is added to video time to sync with gps time.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('This is added to video time to sync with gps time.')
+            }
+
         }
+
         RowLayout {
             Shotcut.ComboBox {
                 id: combo_majoroffset_sign
+
                 implicitWidth: 39
-                model: ListModel {
-                    id: sign_val
-                    ListElement { text: '+'; value: 1}
-                    ListElement { text: '-'; value: -1}
-                }
                 currentIndex: 0
                 textRole: 'text'
-                Shotcut.HoverTip { text: qsTr('+ : Adds time to video (use if GPS is ahead).\n - : Subtracts time from video (use if video is ahead).') }
                 onActivated: {
-                    if (_disableUpdate) return
-                    filter.set('majoroffset_sign', sign_val.get(currentIndex).value)
-                    recompute_time_offset()
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set('majoroffset_sign', sign_val.get(currentIndex).value);
+                    recompute_time_offset();
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('+ : Adds time to video (use if GPS is ahead).\n - : Subtracts time from video (use if video is ahead).')
+                }
+
+                model: ListModel {
+                    id: sign_val
+
+                    ListElement {
+                        text: '+'
+                        value: 1
+                    }
+
+                    ListElement {
+                        text: '-'
+                        value: -1
+                    }
+
+                }
+
             }
+
             TextField {
                 id: offset_days
+
                 text: '0'
                 horizontalAlignment: TextInput.AlignRight
-                validator: IntValidator {bottom: 0; top: 36600;}
                 implicitWidth: 60
+                onFocusChanged: {
+                    if (focus)
+                        selectAll();
+
+                }
+                onTextChanged: {
+                    if (!acceptableInput)
+                        offset_days.undo();
+
+                }
+                onEditingFinished: recompute_time_offset()
+
                 MouseArea {
                     anchors.fill: parent
-                    onWheel: wheel_offset( wheel.angleDelta.y>0 ? 86400 : -86400 )
+                    onWheel: wheel_offset(wheel.angleDelta.y > 0 ? 86400 : -86400)
                     onClicked: offset_days.forceActiveFocus()
                 }
-                onFocusChanged: if (focus) selectAll()
-                onTextChanged:
-                {
-                    if(!acceptableInput)
-                        offset_days.undo()
+
+                Shotcut.HoverTip {
+                    text: qsTr('Number of days to add/subtract to video time to sync them.\nTip: you can use mousewheel to change values.')
                 }
-                onEditingFinished: recompute_time_offset()
-                Shotcut.HoverTip { text: qsTr('Number of days to add/subtract to video time to sync them.\nTip: you can use mousewheel to change values.') }
+
+                validator: IntValidator {
+                    bottom: 0
+                    top: 36600
+                }
+
             }
+
             Label {
                 text: ':'
                 Layout.alignment: Qt.AlignRight
             }
+
             TextField {
                 id: offset_hours
+
                 text: '0'
                 horizontalAlignment: TextInput.AlignRight
-                validator: IntValidator {bottom: 0; top: 23;}
                 implicitWidth: 30
+                onFocusChanged: {
+                    if (focus)
+                        selectAll();
+
+                }
+                onTextChanged: {
+                    if (!acceptableInput)
+                        offset_hours.undo();
+
+                }
+                onEditingFinished: recompute_time_offset()
+
                 MouseArea {
                     anchors.fill: parent
-                    onWheel: wheel_offset( wheel.angleDelta.y>0 ? 3600 : -3600 )
-                    onClicked: { offset_hours.forceActiveFocus() }
+                    onWheel: wheel_offset(wheel.angleDelta.y > 0 ? 3600 : -3600)
+                    onClicked: {
+                        offset_hours.forceActiveFocus();
+                    }
                 }
-                onFocusChanged: if (focus) selectAll()
-                onTextChanged:
-                {
-                    if(!acceptableInput)
-                        offset_hours.undo()
+
+                Shotcut.HoverTip {
+                    text: qsTr('Number of hours to add/subtract to video time to sync them.\nTip: you can use mousewheel to change values.')
                 }
-                onEditingFinished: recompute_time_offset();
-                Shotcut.HoverTip { text: qsTr('Number of hours to add/subtract to video time to sync them.\nTip: you can use mousewheel to change values.') }
+
+                validator: IntValidator {
+                    bottom: 0
+                    top: 23
+                }
+
             }
+
             Label {
                 text: ':'
                 Layout.alignment: Qt.AlignRight
             }
+
             TextField {
                 id: offset_mins
+
                 text: '0'
                 horizontalAlignment: TextInput.AlignRight
-                validator: IntValidator {bottom: 0; top: 59;}
                 implicitWidth: 30
-                MouseArea {
-                    anchors.fill: parent
-                    onWheel: wheel_offset( wheel.angleDelta.y>0 ? 60 : -60 )
-                    onClicked: { offset_mins.forceActiveFocus() }
+                onFocusChanged: {
+                    if (focus)
+                        selectAll();
+
                 }
-                onFocusChanged: if (focus) selectAll()
-                onTextChanged:
-                {
-                    if(!acceptableInput)
-                        offset_mins.undo()
+                onTextChanged: {
+                    if (!acceptableInput)
+                        offset_mins.undo();
+
                 }
                 onEditingFinished: recompute_time_offset()
-                Shotcut.HoverTip { text: qsTr('Number of minutes to add/subtract to video time to sync them.\nTip: you can use mousewheel to change values.') }
+
+                MouseArea {
+                    anchors.fill: parent
+                    onWheel: wheel_offset(wheel.angleDelta.y > 0 ? 60 : -60)
+                    onClicked: {
+                        offset_mins.forceActiveFocus();
+                    }
+                }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Number of minutes to add/subtract to video time to sync them.\nTip: you can use mousewheel to change values.')
+                }
+
+                validator: IntValidator {
+                    bottom: 0
+                    top: 59
+                }
+
             }
+
             Label {
                 text: ':'
                 Layout.alignment: Qt.AlignRight
             }
+
             TextField {
                 id: offset_secs
+
                 text: '0'
                 horizontalAlignment: TextInput.AlignRight
-                validator: IntValidator {bottom: 0; top: 59;}
                 implicitWidth: 30
-                MouseArea {
-                    anchors.fill: parent
-                    onWheel: wheel_offset( wheel.angleDelta.y>0 ? 1 : -1 )
-                    onClicked: { offset_secs.forceActiveFocus() }
+                onFocusChanged: {
+                    if (focus)
+                        selectAll();
+
                 }
-                onFocusChanged: if (focus) selectAll()
-                onTextChanged:
-                {
-                    if(!acceptableInput)
-                        offset_secs.undo()
+                onTextChanged: {
+                    if (!acceptableInput)
+                        offset_secs.undo();
+
                 }
                 onEditingFinished: recompute_time_offset()
-                Shotcut.HoverTip { text: qsTr('Number of seconds to add/subtract to video time to sync them.\nTip: you can use mousewheel to change values.') }
+
+                MouseArea {
+                    anchors.fill: parent
+                    onWheel: wheel_offset(wheel.angleDelta.y > 0 ? 1 : -1)
+                    onClicked: {
+                        offset_secs.forceActiveFocus();
+                    }
+                }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Number of seconds to add/subtract to video time to sync them.\nTip: you can use mousewheel to change values.')
+                }
+
+                validator: IntValidator {
+                    bottom: 0
+                    top: 59
+                }
+
             }
 
             //buttons:
             Shotcut.Button {
                 icon.name: 'media-skip-backward'
-                Shotcut.HoverTip { text: qsTr('Sync start of GPS to start of video file.\nTip: use this if you started GPS and video recording at the same time.') }
                 implicitWidth: 20
                 implicitHeight: 20
-                onClicked: { set_sec_offset_to_textfields(filter.get('auto_gps_offset_start')) }
+                onClicked: {
+                    set_sec_offset_to_textfields(filter.get('auto_gps_offset_start'));
+                }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Sync start of GPS to start of video file.\nTip: use this if you started GPS and video recording at the same time.')
+                }
+
             }
+
             Shotcut.Button {
                 icon.name: 'document-open-recent'
-                Shotcut.HoverTip { text: qsTr('Remove timezone (%1 seconds) time from video file (convert to UTC).\nTip: use this if your video camera doesn\'t have timezone settings as it will set local time as UTC.'.arg(js_tz_offset) ) }
                 implicitWidth: 20
                 implicitHeight: 20
-                onClicked: { set_sec_offset_to_textfields( parseInt(Number(filter.get('time_offset'))) + parseInt(Number(js_tz_offset)) ) }
+                onClicked: {
+                    set_sec_offset_to_textfields(parseInt(Number(filter.get('time_offset'))) + parseInt(Number(js_tz_offset)));
+                }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Remove timezone (%1 seconds) time from video file (convert to UTC).\nTip: use this if your video camera doesn\'t have timezone settings as it will set local time as UTC.'.arg(js_tz_offset))
+                }
+
             }
+
             Shotcut.Button {
                 icon.name: 'format-indent-less'
-                Shotcut.HoverTip { text: qsTr('Fix video start time: if file time is actually end time, press this button to subtract file length (%1 seconds) from GPS offset.'.arg(parseInt(producer.length / profile.fps)) ) }
                 implicitWidth: 20
                 implicitHeight: 20
-                onClicked: { set_sec_offset_to_textfields( parseInt(Number(filter.get('time_offset')) - producer.length / profile.fps) ); }
+                onClicked: {
+                    set_sec_offset_to_textfields(parseInt(Number(filter.get('time_offset')) - producer.length / profile.fps));
+                }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Fix video start time: if file time is actually end time, press this button to subtract file length (%1 seconds) from GPS offset.'.arg(parseInt(producer.length / profile.fps)))
+                }
+
             }
+
             Shotcut.Button {
                 icon.name: 'media-playback-pause'
-                Shotcut.HoverTip { text: qsTr('Sync start of GPS to current video time.\nTip: use this if you recorded the moment of the first GPS fix.') }
                 implicitWidth: 20
                 implicitHeight: 20
-                onClicked: { set_sec_offset_to_textfields(filter.get('auto_gps_offset_now')) }
+                onClicked: {
+                    set_sec_offset_to_textfields(filter.get('auto_gps_offset_now'));
+                }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Sync start of GPS to current video time.\nTip: use this if you recorded the moment of the first GPS fix.')
+                }
+
             }
+
             Shotcut.UndoButton {
-                onClicked: set_sec_offset_to_textfields( 0 )
+                onClicked: set_sec_offset_to_textfields(0)
             }
+
         }
 
         Label {
             text: qsTr('GPS smoothing')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Average nearby GPS points to smooth out errors.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Average nearby GPS points to smooth out errors.')
+            }
+
         }
+
         RowLayout {
             Shotcut.ComboBox {
                 id: combo_smoothing
-                implicitWidth: 300
-                model: ListModel {
-                    id: smooth_val_list
-                    ListElement { text: '1 point (no smoothing)'; value: 1}
-                    ListElement { text: '3 points'; value: 3}
-                    ListElement { text: '5 points'; value: 5}
-                    ListElement { text: '7 points'; value: 7}
-                    ListElement { text: '11 points'; value: 11}
-                    ListElement { text: '15 points'; value: 15}
-                    ListElement { text: '31 points'; value: 31}
-                    ListElement { text: '63 points'; value: 63}
-                    ListElement { text: '127 points'; value: 127}
+
+                function get_smooth_index_from_val(val) {
+                    for (var i = 0; i < smooth_val_list.count; i++) {
+                        if (smooth_val_list.get(i).value == val)
+                            return i;
+
+                    }
+                    console.log("get_smooth_index_from_val: no match for smooth val= " + val);
+                    return 2; //default
                 }
+
+                implicitWidth: 300
                 textRole: 'text'
                 currentIndex: 2
                 onActivated: {
-                    if (_disableUpdate) return
-                    filter.set('smoothing_value', smooth_val_list.get(currentIndex).value)
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set('smoothing_value', smooth_val_list.get(currentIndex).value);
                 }
-                function get_smooth_index_from_val(val) {
-                    for (var i=0; i<smooth_val_list.count; i++) {
-                        if (smooth_val_list.get(i).value == val)
-                            return i
+
+                model: ListModel {
+                    id: smooth_val_list
+
+                    ListElement {
+                        text: '1 point (no smoothing)'
+                        value: 1
                     }
-                    console.log("get_smooth_index_from_val: no match for smooth val= "+val)
-                    return 2 //default
+
+                    ListElement {
+                        text: '3 points'
+                        value: 3
+                    }
+
+                    ListElement {
+                        text: '5 points'
+                        value: 5
+                    }
+
+                    ListElement {
+                        text: '7 points'
+                        value: 7
+                    }
+
+                    ListElement {
+                        text: '11 points'
+                        value: 11
+                    }
+
+                    ListElement {
+                        text: '15 points'
+                        value: 15
+                    }
+
+                    ListElement {
+                        text: '31 points'
+                        value: 31
+                    }
+
+                    ListElement {
+                        text: '63 points'
+                        value: 63
+                    }
+
+                    ListElement {
+                        text: '127 points'
+                        value: 127
+                    }
+
                 }
+
             }
+
             Shotcut.UndoButton {
                 onClicked: {
-                    combo_smoothing.currentIndex = 2
-                    filter.set('smoothing_value', 5)
+                    combo_smoothing.currentIndex = 2;
+                    filter.set('smoothing_value', 5);
                 }
             }
+
         }
 
         Label {
             text: qsTr('Video speed')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('If the current video is sped up (timelapse) or slowed down use this field to set the speed.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('If the current video is sped up (timelapse) or slowed down use this field to set the speed.')
+            }
+
         }
+
         RowLayout {
             Shotcut.DoubleSpinBox {
                 id: speed_multiplier
+
                 value: 1
                 horizontalAlignment: Qt.AlignRight
-                Shotcut.HoverTip { text: qsTr('Fractional times are also allowed (0.25 = 4x slow motion, 5 = 5x timelapse).') }
                 Layout.minimumWidth: 80
                 from: 0
                 to: 10000
@@ -634,18 +931,26 @@ Item {
                 stepSize: 1
                 suffix: 'x'
                 onValueChanged: {
-                    if (_disableUpdate) return;
+                    if (_disableUpdate)
+                        return ;
+
                     filter.set('speed_multiplier', speed_multiplier.value);
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Fractional times are also allowed (0.25 = 4x slow motion, 5 = 5x timelapse).')
+                }
+
             }
+
             Shotcut.UndoButton {
                 onClicked: {
-                    filter.set('speed_multiplier', 1)
+                    filter.set('speed_multiplier', 1);
                     speed_multiplier.value = 1;
                 }
             }
-        }
 
+        }
 
         Label {
             topPadding: 10
@@ -656,63 +961,82 @@ Item {
         Label {
             text: qsTr('Data source')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Choose which data type is used for graph drawing.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Choose which data type is used for graph drawing.')
+            }
+
         }
+
         RowLayout {
             Shotcut.ComboBox {
-                implicitWidth: 300
                 id: combo_data_source
-                model:
-                    [   qsTr('Location (2D map)'),
-                        qsTr('Altitude'),
-                        qsTr('Heart rate'),
-                        qsTr('Speed'),
-                    ]
+
+                implicitWidth: 300
+                model: [qsTr('Location (2D map)'), qsTr('Altitude'), qsTr('Heart rate'), qsTr('Speed')]
                 onActivated: {
-                    if (_disableUpdate) return
-                    filter.set('graph_data_source', currentIndex)
-                    reset_legend_unit()
-                    setControls()
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set('graph_data_source', currentIndex);
+                    reset_legend_unit();
+                    setControls();
                 }
             }
+
         }
 
         Label {
             text: qsTr('Graph type')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Graph types can add advanced interactions.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Graph types can add advanced interactions.')
+            }
+
         }
+
         RowLayout {
             Shotcut.ComboBox {
-                implicitWidth: 300
                 id: combo_graph_type
-                Shotcut.HoverTip { text: qsTr('Standard = just a static map.\nFollow dot = centers on the current location.\nSpeedometer = draws a simple speedometer.') }
-                model:
-                    [   qsTr('Standard'),
-                        qsTr('Follow dot (cropped)'),
-                        qsTr('Speedometer')
-                    ]
+
+                implicitWidth: 300
+                model: [qsTr('Standard'), qsTr('Follow dot (cropped)'), qsTr('Speedometer')]
                 onActivated: {
-                    if (_disableUpdate) return
-                    filter.set('graph_type', currentIndex)
-                    setControls()
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set('graph_type', currentIndex);
+                    setControls();
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Standard = just a static map.\nFollow dot = centers on the current location.\nSpeedometer = draws a simple speedometer.')
+                }
+
             }
+
         }
 
         Label {
             text: qsTr('Trim time')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Hides part of the graph at beginning or end.\nThis does not recompute min/max for any field.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Hides part of the graph at beginning or end.\nThis does not recompute min/max for any field.')
+            }
+
         }
+
         GridLayout {
             columns: 2
+
             RowLayout {
                 Shotcut.DoubleSpinBox {
                     id: spin_start
+
                     value: 0
                     horizontalAlignment: Qt.AlignRight
-                    Shotcut.HoverTip { text: qsTr('Hides part of the beginning of the graph.') }
                     Layout.minimumWidth: 80
                     from: 0
                     to: 100
@@ -720,33 +1044,47 @@ Item {
                     stepSize: 1 / Math.pow(10, decimals)
                     suffix: '%'
                     onValueChanged: {
-                        if (_disableUpdate) return
-                        filter.set("trim_start_p", value)
-                        setControls()
+                        if (_disableUpdate)
+                            return ;
+
+                        filter.set("trim_start_p", value);
+                        setControls();
                     }
+
+                    Shotcut.HoverTip {
+                        text: qsTr('Hides part of the beginning of the graph.')
+                    }
+
                 }
+
                 RangeSlider {
                     id: crop_start_end_slider
+
                     from: 0
                     to: 100
                     first.value: 0
                     second.value: 100
                     first.onMoved: {
-                        if (_disableUpdate) return
-                        filter.set("trim_start_p", first.value)
-                        setControls()
+                        if (_disableUpdate)
+                            return ;
+
+                        filter.set("trim_start_p", first.value);
+                        setControls();
                     }
                     second.onMoved: {
-                        if (_disableUpdate) return
-                        filter.set("trim_end_p", second.value)
-                        setControls()
+                        if (_disableUpdate)
+                            return ;
+
+                        filter.set("trim_end_p", second.value);
+                        setControls();
                     }
                 }
+
                 Shotcut.DoubleSpinBox {
                     id: spin_end
+
                     value: 100
                     horizontalAlignment: Qt.AlignRight
-                    Shotcut.HoverTip { text: qsTr('Hides part of the end of the graph.') }
                     Layout.minimumWidth: 80
                     from: 0
                     to: 100
@@ -754,183 +1092,271 @@ Item {
                     stepSize: 1 / Math.pow(10, decimals)
                     suffix: '%'
                     onValueChanged: {
-                        if (_disableUpdate) return
-                        filter.set("trim_end_p", value)
-                        setControls()
+                        if (_disableUpdate)
+                            return ;
+
+                        filter.set("trim_end_p", value);
+                        setControls();
                     }
+
+                    Shotcut.HoverTip {
+                        text: qsTr('Hides part of the end of the graph.')
+                    }
+
                 }
+
             }
+
             Shotcut.UndoButton {
                 onClicked: {
-                    if (_disableUpdate) return
-                    filter.set("trim_start_p", 0)
-                    filter.set("trim_end_p", 100)
-                    setControls()
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set("trim_start_p", 0);
+                    filter.set("trim_end_p", 100);
+                    setControls();
                 }
             }
+
         }
 
         Label {
             text: qsTr('Crop horizontal')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Zooms in on the graph on the horizontal axis (longitude if map, time if simple graph).\nThe number is either a percentage or a numeric value interpreted as the legend type.\nThis field is not applicable for Speedometer type.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Zooms in on the graph on the horizontal axis (longitude if map, time if simple graph).\nThe number is either a percentage or a numeric value interpreted as the legend type.\nThis field is not applicable for Speedometer type.')
+            }
+
         }
+
         RowLayout {
             Shotcut.DoubleSpinBox {
                 id: spin_left
+
                 horizontalAlignment: Qt.AlignRight
-                Shotcut.HoverTip { text: qsTr('Crops the graph from the left side.') }
                 Layout.minimumWidth: 80
                 from: -999999
                 to: 999999
                 decimals: 1
                 stepSize: 1 / Math.pow(10, decimals)
                 onValueChanged: {
-                    if (_disableUpdate) return
-                    filter.set("crop_left_p", value)
-                    setControls()
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set("crop_left_p", value);
+                    setControls();
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Crops the graph from the left side.')
+                }
+
             }
+
             RangeSlider {
                 id: crop_left_right_slider
+
                 from: -10
                 to: 110
                 first.value: 0
                 second.value: 100
                 first.onMoved: {
-                    if (_disableUpdate) return
-                    filter.set("crop_left_p", first.value)
-                    setControls()
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set("crop_left_p", first.value);
+                    setControls();
                 }
                 second.onMoved: {
-                    if (_disableUpdate) return
-                    filter.set("crop_right_p", second.value)
-                    setControls()
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set("crop_right_p", second.value);
+                    setControls();
                 }
             }
+
             Shotcut.DoubleSpinBox {
                 id: spin_right
+
                 value: 100
                 horizontalAlignment: Qt.AlignRight
-                Shotcut.HoverTip { text: qsTr('Crops the graph from the right side. This value is ignored if mode is Follow dot.') }
                 Layout.minimumWidth: 80
                 from: -999999
                 to: 999999
                 decimals: 1
                 stepSize: 1 / Math.pow(10, decimals)
                 onValueChanged: {
-                    if (_disableUpdate) return
-                    filter.set("crop_right_p", value)
-                    setControls()
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set("crop_right_p", value);
+                    setControls();
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Crops the graph from the right side. This value is ignored if mode is Follow dot.')
+                }
+
             }
+
             Shotcut.ComboBox {
                 id: combo_cropmode_h
-                Shotcut.HoverTip { text: qsTr('The crop values are interpreted as a percentage of total or as an absolute value (in legend unit).') }
+
                 implicitWidth: 40
-                model:
-                    [   qsTr('%'),
-                        qsTr('value')
-                    ]
+                model: [qsTr('%'), qsTr('value')]
                 currentIndex: 0
                 onActivated: {
-                    if (_disableUpdate) return
-                    filter.set('crop_mode_h', currentIndex)
-                    setControls()
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set('crop_mode_h', currentIndex);
+                    setControls();
                 }
-                Shotcut.HoverTip { text: qsTr('Input for horizontal crops can be a percentage or an absolute value.') }
+
+                Shotcut.HoverTip {
+                    text: qsTr('The crop values are interpreted as a percentage of total or as an absolute value (in legend unit).')
+                }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Input for horizontal crops can be a percentage or an absolute value.')
+                }
+
             }
+
             Shotcut.UndoButton {
                 onClicked: {
-                    if (_disableUpdate) return
-                    filter.set("crop_left_p", 0)
-                    filter.set("crop_right_p", 100)
-                    filter.set('crop_mode_h', 0)
-                    setControls()
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set("crop_left_p", 0);
+                    filter.set("crop_right_p", 100);
+                    filter.set('crop_mode_h', 0);
+                    setControls();
                 }
             }
+
         }
 
         Label {
             text: qsTr('Crop vertical')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Zooms in on the graph on the vertical axis (latitude if map, value if simple graph).\nThe number is either a percentage or a numeric value interpreted as the legend type.\nThis field affects min/max values on the Speedometer type.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Zooms in on the graph on the vertical axis (latitude if map, value if simple graph).\nThe number is either a percentage or a numeric value interpreted as the legend type.\nThis field affects min/max values on the Speedometer type.')
+            }
+
         }
+
         RowLayout {
             Shotcut.DoubleSpinBox {
                 id: spin_bot
+
                 value: 0
                 horizontalAlignment: Qt.AlignRight
-                Shotcut.HoverTip { text: qsTr('Crops the graph from the bottom side.') }
                 Layout.minimumWidth: 80
                 from: -999999
                 to: 999999
                 decimals: 1
                 stepSize: 1 / Math.pow(10, decimals)
                 onValueChanged: {
-                    if (_disableUpdate) return
-                    filter.set("crop_bot_p", value)
-                    setControls()
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set("crop_bot_p", value);
+                    setControls();
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Crops the graph from the bottom side.')
+                }
+
             }
+
             RangeSlider {
                 id: crop_top_bot_slider
+
                 from: -10
                 to: 110
                 first.value: 0
                 second.value: 100
                 first.onMoved: {
-                    if (_disableUpdate) return
-                    filter.set("crop_bot_p", first.value)
-                    setControls()
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set("crop_bot_p", first.value);
+                    setControls();
                 }
                 second.onMoved: {
-                    if (_disableUpdate) return
-                    filter.set("crop_top_p", second.value)
-                    setControls()
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set("crop_top_p", second.value);
+                    setControls();
                 }
             }
+
             Shotcut.DoubleSpinBox {
                 id: spin_top
+
                 value: 100
                 horizontalAlignment: Qt.AlignRight
-                Shotcut.HoverTip { text: qsTr('Crops the graph from the top side. This value is ignored if mode is Follow dot.') }
                 Layout.minimumWidth: 80
                 from: -999999
                 to: 999999
                 decimals: 1
                 stepSize: 1 / Math.pow(10, decimals)
                 onValueChanged: {
-                    if (_disableUpdate) return
-                    filter.set("crop_top_p", value)
-                    setControls()
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set("crop_top_p", value);
+                    setControls();
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Crops the graph from the top side. This value is ignored if mode is Follow dot.')
+                }
+
             }
+
             Shotcut.ComboBox {
                 id: combo_cropmode_v
-                Shotcut.HoverTip { text: qsTr('The crop values are interpreted as a percentage of total or as an absolute value (in legend unit).') }
+
                 implicitWidth: 40
-                model:
-                    [   qsTr('%'),
-                        qsTr('value')
-                    ]
+                model: [qsTr('%'), qsTr('value')]
                 currentIndex: 0
                 onActivated: {
-                    if (_disableUpdate) return
-                    filter.set('crop_mode_v', currentIndex)
-                    setControls()
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set('crop_mode_v', currentIndex);
+                    setControls();
                 }
-                Shotcut.HoverTip { text: qsTr('Input for vertical crops can be a percentage or an absolute value.') }
+
+                Shotcut.HoverTip {
+                    text: qsTr('The crop values are interpreted as a percentage of total or as an absolute value (in legend unit).')
+                }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Input for vertical crops can be a percentage or an absolute value.')
+                }
+
             }
+
             Shotcut.UndoButton {
                 onClicked: {
-                    if (_disableUpdate) return
-                    filter.set("crop_bot_p", 0)
-                    filter.set("crop_top_p", 100)
-                    filter.set('crop_mode_v', 0)
-                    setControls()
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set("crop_bot_p", 0);
+                    filter.set("crop_top_p", 100);
+                    filter.set('crop_mode_v', 0);
+                    setControls();
                 }
             }
+
         }
 
         Label {
@@ -942,310 +1368,425 @@ Item {
         Label {
             text: qsTr('Color style')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Choose how you want to color the graph line.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Choose how you want to color the graph line.')
+            }
+
         }
+
         RowLayout {
             Shotcut.ComboBox {
-                implicitWidth: 300
+                //0
+                //4
+                //6
+
                 id: combo_color_style
-                model:
-                    [
-                        qsTr('One color'),              //0
-                        qsTr('Two colors'),
-                        qsTr('Solid past, thin future'),
-                        qsTr('Solid future, thin past'),
-                        qsTr('Vertical gradient'),      //4
-                        qsTr('Horizontal gradient'),
-                        qsTr('Color by duration'),      //6
-                        qsTr('Color by altitude'),
-                        qsTr('Color by heart rate'),
-                        qsTr('Color by speed')
-                    ]
-                currentIndex: 1
-                onActivated: {
-                    if (_disableUpdate) return
-                    filter.set('color_style', currentIndex)
-                    colGradient.set_defcolors_in_gradient_control()
-                    setControls()
-                }
+
                 function get_combo_gradient_nr_colors() {
                     if (combo_color_style.currentIndex === 0)
-                        return 1
-                    else if (combo_color_style.currentIndex <=3)
-                        return 2
+                        return 1;
+                    else if (combo_color_style.currentIndex <= 3)
+                        return 2;
                     else
-                        return filter.getGradient('color').length
+                        return filter.getGradient('color').length;
+                }
+
+                implicitWidth: 300
+                model: [qsTr('One color'), qsTr('Two colors'), qsTr('Solid past, thin future'), qsTr('Solid future, thin past'), qsTr('Vertical gradient'), qsTr('Horizontal gradient'), qsTr('Color by duration'), qsTr('Color by altitude'), qsTr('Color by heart rate'), qsTr('Color by speed')]
+                currentIndex: 1
+                onActivated: {
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set('color_style', currentIndex);
+                    colGradient.set_defcolors_in_gradient_control();
+                    setControls();
                 }
             }
+
         }
 
         Label {
             text: qsTr('Color')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Color by Altitude/HR only work if there are recorded values in the gps file.\nFor speedometer type, only first 2 colors are used.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Color by Altitude/HR only work if there are recorded values in the gps file.\nFor speedometer type, only first 2 colors are used.')
+            }
+
         }
+
         RowLayout {
             Shotcut.GradientControl {
                 id: colGradient
-                onGradientChanged: {
-                    if (_disableUpdate) return
-                    filter.setGradient('color', colors)
+
+                function set_defcolors_in_gradient_control() {
+                    filter.setGradient('color', []);
+                    if (combo_color_style.currentIndex === 0) {
+                        colGradient.colors = default_colors.slice(0, 1);
+                    } else if (combo_color_style.currentIndex <= 3) {
+                        colGradient.colors = default_colors.slice(0, 2);
+                        colGradient.colors[1] = color_white;
+                    } else {
+                        colGradient.colors = default_colors.slice(0, 5);
+                    }
+                    filter.setGradient('color', colGradient.colors);
                 }
+
+                onGradientChanged: {
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.setGradient('color', colors);
+                }
+
                 Shotcut.UndoButton {
                     onClicked: {
-                        if (_disableUpdate) return
-                        colGradient.set_defcolors_in_gradient_control()
-                        setControls()
-                    }
-                }
-                function set_defcolors_in_gradient_control() {
-                    filter.setGradient('color', [])
-                    if (combo_color_style.currentIndex === 0) {
-                        colGradient.colors = default_colors.slice(0, 1)
-                    }
-                    else if (combo_color_style.currentIndex <=3) {
-                        colGradient.colors = default_colors.slice(0, 2)
-                        colGradient.colors[1] = color_white
-                    }
-                    else {
-                        colGradient.colors = default_colors.slice(0, 5)
-                    }
-                    filter.setGradient('color', colGradient.colors)
-                }
-            }
-        }
+                        if (_disableUpdate)
+                            return ;
 
+                        colGradient.set_defcolors_in_gradient_control();
+                        setControls();
+                    }
+                }
+
+            }
+
+        }
 
         Label {
             text: qsTr('Now dot')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Draw a dot showing current position on the graph.\nFor speedometer type, this is the needle.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Draw a dot showing current position on the graph.\nFor speedometer type, this is the needle.')
+            }
+
         }
+
         RowLayout {
             CheckBox {
                 id: checkbox_now_dot
+
                 checked: true
                 leftPadding: 0
                 onClicked: filter.set('show_now_dot', checked ? 1 : 0)
             }
+
             Label {
                 text: qsTr('Color')
                 Layout.alignment: Qt.AlignRight
-                Shotcut.HoverTip { text: qsTr('Set the color of the inside of the now_dot (or needle).') }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Set the color of the inside of the now_dot (or needle).')
+                }
+
             }
+
             Shotcut.ColorPicker {
                 id: now_dot_color
+
                 eyedropper: true
                 alpha: true
                 onValueChanged: {
-                    if (_disableUpdate) return
-                    filter.set('now_dot_color', value)
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set('now_dot_color', value);
                 }
             }
+
             Shotcut.UndoButton {
                 onClicked: {
-                    now_dot_color.value = default_now_dot
-                    filter.set('now_dot_color', default_now_dot)
+                    now_dot_color.value = default_now_dot;
+                    filter.set('now_dot_color', default_now_dot);
                 }
             }
+
             Label {
                 text: qsTr('Now text')
                 leftPadding: 5
                 Layout.alignment: Qt.AlignRight
-                Shotcut.HoverTip { text: qsTr('Draw a large white text showing the current value.\nThe legend unit (if present) will be appended at the end.') }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Draw a large white text showing the current value.\nThe legend unit (if present) will be appended at the end.')
+                }
+
             }
+
             CheckBox {
                 id: checkbox_now_text
+
                 leftPadding: 0
                 checked: true
                 onClicked: filter.set('show_now_text', checked ? 1 : 0)
             }
+
         }
 
         Label {
             text: qsTr('Rotation')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Rotate the entire graph. Speedometer also rotates internal text.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Rotate the entire graph. Speedometer also rotates internal text.')
+            }
+
         }
+
         RowLayout {
             Shotcut.SliderSpinner {
                 id: graph_rotation
+
                 minimumValue: -360
                 maximumValue: 360
                 decimals: 1
                 suffix: qsTr(' °', 'degrees')
                 onValueChanged: {
-                    if (_disableUpdate) return
-                    filter.set('angle', graph_rotation.value)
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set('angle', graph_rotation.value);
                 }
             }
+
             Shotcut.UndoButton {
                 onClicked: {
-                    if (_disableUpdate) return
-                    graph_rotation.value = 0
-                    filter.set('angle', 0)
+                    if (_disableUpdate)
+                        return ;
+
+                    graph_rotation.value = 0;
+                    filter.set('angle', 0);
                 }
             }
+
         }
 
         Label {
             text: qsTr('Thickness')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Set the thickness of the graph line. Does not affect speedometer.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Set the thickness of the graph line. Does not affect speedometer.')
+            }
+
         }
+
         RowLayout {
             Shotcut.SliderSpinner {
                 id: thicknessSlider
+
                 minimumValue: 1
                 maximumValue: 10
                 decimals: 0
                 suffix: ' px'
                 onValueChanged: {
-                    if (_disableUpdate) return
-                    filter.set("thickness", value)
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set("thickness", value);
                 }
             }
+
             Shotcut.UndoButton {
                 onClicked: {
-                    if (_disableUpdate) return
-                    thicknessSlider.value = 5
-                    filter.set("thickness", 5)
+                    if (_disableUpdate)
+                        return ;
+
+                    thicknessSlider.value = 5;
+                    filter.set("thickness", 5);
                 }
             }
+
         }
 
         Label {
             text: qsTr('Draw legend')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Draw 5 horizontal white lines with individual values for graph readability. 2D map also draws vertical (longitude) lines.\nFor speedometer this draws text for divisions.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Draw 5 horizontal white lines with individual values for graph readability. 2D map also draws vertical (longitude) lines.\nFor speedometer this draws text for divisions.')
+            }
+
         }
+
         RowLayout {
             CheckBox {
                 id: checkbox_grid
+
                 leftPadding: 0
                 onClicked: filter.set('show_grid', checked ? 1 : 0)
             }
+
             Label {
                 text: qsTr('Unit')
                 Layout.alignment: Qt.AlignRight
-                Shotcut.HoverTip { text: qsTr('This will be used in legend text if active and in absolute value math.') }
+
+                Shotcut.HoverTip {
+                    text: qsTr('This will be used in legend text if active and in absolute value math.')
+                }
+
             }
+
             TextField {
                 id: legend_unit
+
                 horizontalAlignment: TextInput.AlignRight
                 implicitWidth: 80
-                Shotcut.HoverTip { text: qsTr('Defaults are km/h (speed) and meters (altitude).\n Available options: km/h, mi/h, nm/h (kn), m/s, ft/s.') }
-                onEditingFinished: filter.set('legend_unit', legend_unit.text);
+                onEditingFinished: filter.set('legend_unit', legend_unit.text)
+
+                Shotcut.HoverTip {
+                    text: qsTr('Defaults are km/h (speed) and meters (altitude).\n Available options: km/h, mi/h, nm/h (kn), m/s, ft/s.')
+                }
+
             }
+
             Shotcut.UndoButton {
                 onClicked: {
-                    if (_disableUpdate) return
+                    if (_disableUpdate)
+                        return ;
+
                     reset_legend_unit();
                     filter.set('legend_unit', legend_unit.text);
                 }
             }
-        }
 
+        }
 
         Label {
             text: qsTr('Position')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Shotcut.DoubleSpinBox {
                 id: rectX
+
                 value: filterRect.x
                 Layout.minimumWidth: 80
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
+                from: -1e+09
+                to: 1e+09
                 onValueModified: {
-                    if (_disableUpdate) return
-                    setFilter()
+                    if (_disableUpdate)
+                        return ;
+
+                    setFilter();
                 }
             }
-            Label { text: ','; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: ','
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectY
+
                 value: filterRect.y
                 Layout.minimumWidth: 80
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
+                from: -1e+09
+                to: 1e+09
                 onValueModified: {
-                    if (_disableUpdate) return
-                    setFilter()
+                    if (_disableUpdate)
+                        return ;
+
+                    setFilter();
                 }
             }
+
             Shotcut.UndoButton {
                 onClicked: {
-                    rectX.value = profile.width * 0.10
-                    rectY.value = profile.height * 0.10
-                    setFilter()
+                    rectX.value = profile.width * 0.1;
+                    rectY.value = profile.height * 0.1;
+                    setFilter();
                 }
             }
+
         }
 
         Label {
             text: qsTr('Size')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Shotcut.DoubleSpinBox {
                 id: rectW
+
                 value: filterRect.width
                 Layout.minimumWidth: 80
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
+                from: -1e+09
+                to: 1e+09
                 onValueModified: {
-                    if (_disableUpdate) return
-                    setFilter()
+                    if (_disableUpdate)
+                        return ;
+
+                    setFilter();
                 }
             }
-            Label { text: 'x'; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: 'x'
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectH
+
                 value: filterRect.height
                 Layout.minimumWidth: 80
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
+                from: -1e+09
+                to: 1e+09
                 onValueModified: {
-                    if (_disableUpdate) return
-                    setFilter()
+                    if (_disableUpdate)
+                        return ;
+
+                    setFilter();
                 }
             }
+
             Shotcut.UndoButton {
-                Shotcut.HoverTip { text: qsTr('Sets the height to the correct map aspect ratio or 1:1.') }
                 onClicked: {
                     //for map, try to compute height from width using map_aspect_ratio and the crop values
                     if (combo_data_source.currentIndex === 0) {
-                        var width_p = (spin_right.value - spin_left.value)/100.0;
-                        var height_p = (spin_top.value - spin_bot.value)/100.0;
-                        rectH.value = 1.0 * ((rectW.value * height_p) / filter.getDouble('map_original_aspect_ratio')) / width_p;
-                    }
-                    else {
+                        var width_p = (spin_right.value - spin_left.value) / 100;
+                        var height_p = (spin_top.value - spin_bot.value) / 100;
+                        rectH.value = 1 * ((rectW.value * height_p) / filter.getDouble('map_original_aspect_ratio')) / width_p;
+                    } else {
                         rectH.value = rectW.value;
                     }
                     //if it's outside viewport just make it inside, ignore map or crops
                     if (rectW.value + rectX.value > profile.width)
-                        rectW.value = profile.width - rectX.value
+                        rectW.value = profile.width - rectX.value;
+
                     if (rectH.value + rectY.value > profile.height)
-                        rectH.value = profile.height - rectY.value
+                        rectH.value = profile.height - rectY.value;
+
                     setFilter();
                 }
-            }
-        }
 
+                Shotcut.HoverTip {
+                    text: qsTr('Sets the height to the correct map aspect ratio or 1:1.')
+                }
+
+            }
+
+        }
 
         Label {
             topPadding: 10
@@ -1256,72 +1797,101 @@ Item {
         Label {
             text: qsTr('Image path')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Choose an image to overlay behind the graph. Tip: you can use an actual map image to make the GPS track more interesting.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Choose an image to overlay behind the graph. Tip: you can use an actual map image to make the GPS track more interesting.')
+            }
+
         }
+
         RowLayout {
             TextField {
                 id: bg_img_path
+
                 Layout.alignment: Qt.AlignLeft
                 implicitWidth: 300
                 selectByMouse: true
                 onEditingFinished: {
                     if (bg_img_path.text[0] !== '!')
-                        filter.set('bg_img_path', text)
+                        filter.set('bg_img_path', text);
+
                 }
             }
+
             Button {
                 icon.name: 'dialog-information'
-                Shotcut.HoverTip { text: qsTr('Get the center coordinate of GPS map. This does not change with trim or crop.\nTIP:OpenStreetMap website can save the current standard map centered on searched location (but only at screen resolution).\nGoogle Earth for desktop can center on a coordinate and save a 4K image of it. Disable the Terrain layer for best results.') }
                 implicitWidth: 20
                 implicitHeight: 20
                 onClicked: bg_img_path.text = "! " + qsTr("GPS file center is: ") + filter.get("map_coords_hint")
+
+                Shotcut.HoverTip {
+                    text: qsTr('Get the center coordinate of GPS map. This does not change with trim or crop.\nTIP:OpenStreetMap website can save the current standard map centered on searched location (but only at screen resolution).\nGoogle Earth for desktop can center on a coordinate and save a 4K image of it. Disable the Terrain layer for best results.')
+                }
+
             }
+
             Button {
                 icon.name: 'document-open'
-                Shotcut.HoverTip { text: qsTr('Browse for an image file to be assigned as graph background.') }
                 implicitWidth: 20
                 implicitHeight: 20
                 onClicked: selectBgImage.open()
+
+                Shotcut.HoverTip {
+                    text: qsTr('Browse for an image file to be assigned as graph background.')
+                }
+
             }
+
             Shotcut.UndoButton {
                 onClicked: {
                     bg_img_path.text = "";
-                    filter.set("bg_img_path", "")
+                    filter.set("bg_img_path", "");
                 }
             }
+
         }
 
         Label {
             text: qsTr('Scale')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Increase or decrease the size of the background image.\nValues smaller than 1 will zoom into image.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Increase or decrease the size of the background image.\nValues smaller than 1 will zoom into image.')
+            }
+
         }
+
         RowLayout {
             Shotcut.SliderSpinner {
                 id: slider_scaleW
+
                 minimumValue: 0
                 maximumValue: 2
                 decimals: 3
                 stepSize: 1 / Math.pow(10, decimals)
                 onValueChanged: {
-                    if (_disableUpdate) return
-                    filter.set('bg_scale_w', value)
+                    if (_disableUpdate)
+                        return ;
+
+                    filter.set('bg_scale_w', value);
                 }
             }
+
             Shotcut.UndoButton {
                 onClicked: {
-                    slider_scaleW.value = 1
-                    filter.set('bg_scale_w', 1)
+                    slider_scaleW.value = 1;
+                    filter.set('bg_scale_w', 1);
                 }
             }
-        }
 
+        }
 
         Rectangle {
             Layout.columnSpan: parent.columns
             Layout.fillWidth: true
             Layout.minimumHeight: 12
             color: 'transparent'
+
             Rectangle {
                 anchors.verticalCenter: parent.verticalCenter
                 width: parent.width
@@ -1329,124 +1899,72 @@ Item {
                 radius: 2
                 color: activePalette.text
             }
+
         }
+
         Label {
             text: qsTr('Video start time:')
             leftPadding: 10
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Detected date-time for the video file.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Detected date-time for the video file.')
+            }
+
         }
+
         Label {
             id: video_start
+
             text: filter.get('video_start_text')
             Layout.alignment: Qt.AlignLeft
-            Shotcut.HoverTip { text: "This time will be used for synchronization." }
+
+            Shotcut.HoverTip {
+                text: "This time will be used for synchronization."
+            }
+
         }
 
         Label {
             id: start_location_datetime
+
             text: qsTr('GPS start time:')
             leftPadding: 10
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Detected date-time for the GPS file.') }
-        } Label {
+
+            Shotcut.HoverTip {
+                text: qsTr('Detected date-time for the GPS file.')
+            }
+
+        }
+
+        Label {
             id: gps_start
+
             text: filter.get('gps_start_text')
             Layout.alignment: Qt.AlignLeft
-            Shotcut.HoverTip { text: qsTr('This time will be used for synchronization.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('This time will be used for synchronization.')
+            }
+
         }
 
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
         target: filter
         onChanged: {
-            var newValue = filter.getRect(rectProperty)
+            var newValue = filter.getRect(rectProperty);
             if (filterRect !== newValue) {
-                filterRect = newValue
-                setControls()
+                filterRect = newValue;
+                setControls();
             }
         }
     }
 
-    //just filter.set(param, val) but returns the param name so I don't have to manually compose a used_params for presets
-    function filterset_getparams (param, val)
-    {
-        filter.set(param, val)
-        return param
-    }
-    function reset_all_params()
-    {
-        var used_params = []
-        used_params.push(set_gps_file_params(0, 5, 1))
-        used_params.push(set_graph_data_params(0, 0,  0, 100,  0, 0, 100,  0, 0, 100,))
-        used_params.push(set_graph_style_params(1, 1, 0, 0, 5, default_rect, 0, '', 0))
-        used_params.push(set_graph_colors(default_now_dot, default_colors[0], color_white, default_colors[2], default_colors[3], default_colors[4], default_colors[5]))
-        used_params.push(set_graph_background_params("!", 1, 1))
-        return used_params
-    }
-    function set_gps_file_params(offset, smooth, speed)
-    {
-        var used_params = []
-        if (offset !== undefined) used_params.push(filterset_getparams('time_offset', offset))
-        if (smooth !== undefined) used_params.push(filterset_getparams('smoothing_value', smooth))
-        if (speed !== undefined) used_params.push(filterset_getparams('speed_multiplier', speed))
-        return used_params
-    }
-    function set_graph_data_params(src, type, startp, endp, modeh, leftp, rightp, modev, botp, topp)
-    {
-        var used_params = []
-        if (src !== undefined) used_params.push(filterset_getparams('graph_data_source', src))
-        if (type !== undefined) used_params.push(filterset_getparams('graph_type', type))
-        if (startp !== undefined) used_params.push(filterset_getparams('trim_start_p', startp))
-        if (endp !== undefined) used_params.push(filterset_getparams('trim_end_p', endp))
-        if (modeh !== undefined) used_params.push(filterset_getparams('crop_mode_h', modeh))
-        if (leftp !== undefined) used_params.push(filterset_getparams('crop_left_p', leftp))
-        if (rightp !== undefined) used_params.push(filterset_getparams('crop_right_p', rightp))
-        if (modev !== undefined) used_params.push(filterset_getparams('crop_mode_v', modev))
-        if (botp !== undefined) used_params.push(filterset_getparams('crop_bot_p', botp))
-        if (topp !== undefined) used_params.push(filterset_getparams('crop_top_p', topp))
-        return used_params
-    }
-    function set_graph_style_params(style, nowdot, nowtext, angle, thick, rect, grid, legendunit, drawdots)
-    {
-        var used_params = []
-        if (style !== undefined) used_params.push(filterset_getparams('color_style', style))
-        if (nowdot !== undefined) used_params.push(filterset_getparams('show_now_dot', nowdot))
-        if (nowtext !== undefined) used_params.push(filterset_getparams('show_now_text', nowtext))
-        if (angle !== undefined) used_params.push(filterset_getparams('angle', angle))
-        if (thick !== undefined) used_params.push(filterset_getparams('thickness', thick))
-        //can't figure out how to properly set rect from preset to update the VUI
-        //if (rect !== undefined) used_params.push(filterset_getparams(rectProperty, rect))
-        if (grid !== undefined) used_params.push(filterset_getparams('show_grid', grid))
-        if (legendunit !== undefined) used_params.push(filterset_getparams('legend_unit', legendunit))
-        if (drawdots !== undefined) used_params.push(filterset_getparams('draw_individual_dots', drawdots))
-        return used_params
-    }
-    function set_graph_colors(cdot, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
-    {
-        var used_params = []
-        if (cdot !== undefined) used_params.push(filterset_getparams('now_dot_color', cdot))
-        if (c1 !== undefined) used_params.push(filterset_getparams('color.1', c1))
-        if (c2 !== undefined) used_params.push(filterset_getparams('color.2', c2))
-        if (c3 !== undefined) used_params.push(filterset_getparams('color.3', c3))
-        if (c4 !== undefined) used_params.push(filterset_getparams('color.4', c4))
-        if (c5 !== undefined) used_params.push(filterset_getparams('color.5', c5))
-        if (c6 !== undefined) used_params.push(filterset_getparams('color.6', c6))
-        if (c7 !== undefined) used_params.push(filterset_getparams('color.7', c7))
-        if (c8 !== undefined) used_params.push(filterset_getparams('color.8', c8))
-        if (c9 !== undefined) used_params.push(filterset_getparams('color.9', c9))
-        if (c10 !== undefined) used_params.push(filterset_getparams('color.10', c10))
-        return used_params
-    }
-    function set_graph_background_params(bgpath, scalew, opacity)
-    {
-        var used_params = []
-        if (bgpath !== undefined) used_params.push(filterset_getparams('bg_img_path', bgpath))
-        if (scalew !== undefined) used_params.push(filterset_getparams('bg_scale_w', scalew))
-        return used_params
-    }
 }

--- a/src/qml/filters/gpsgraphic/vui.qml
+++ b/src/qml/filters/gpsgraphic/vui.qml
@@ -20,12 +20,12 @@ import Shotcut.Controls 1.0 as Shotcut
 
 Shotcut.VuiBase {
     property string rectProperty: "rect"
-    property real zoom: (video.zoom > 0)? video.zoom : 1.0
+    property real zoom: (video.zoom > 0) ? video.zoom : 1
     property rect filterRect: filter.getRect(rectProperty)
 
     Component.onCompleted: {
-        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag'))
-        rectangle.setHandles(filter.getRect(rectProperty))
+        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag'));
+        rectangle.setHandles(filter.getRect(rectProperty));
     }
 
     Flickable {
@@ -39,6 +39,7 @@ Shotcut.VuiBase {
 
         Item {
             id: videoItem
+
             x: video.rect.x
             y: video.rect.y
             width: video.rect.width
@@ -47,32 +48,36 @@ Shotcut.VuiBase {
 
             Shotcut.RectangleControl {
                 id: rectangle
+
                 widthScale: video.rect.width / profile.width
                 heightScale: video.rect.height / profile.height
                 handleSize: Math.max(Math.round(8 / zoom), 4)
                 borderSize: Math.max(Math.round(1.33 / zoom), 1)
                 onWidthScaleChanged: setHandles(filter.getRect(rectProperty))
                 onHeightScaleChanged: setHandles(filter.getRect(rectProperty))
-                onRectChanged:  {
-                    filterRect.x = Math.round(rect.x / rectangle.widthScale)
-                    filterRect.y = Math.round(rect.y / rectangle.heightScale)
-                    filterRect.width = Math.round(rect.width / rectangle.widthScale)
-                    filterRect.height = Math.round(rect.height / rectangle.heightScale)
-                    filter.set(rectProperty, filterRect)
+                onRectChanged: {
+                    filterRect.x = Math.round(rect.x / rectangle.widthScale);
+                    filterRect.y = Math.round(rect.y / rectangle.heightScale);
+                    filterRect.width = Math.round(rect.width / rectangle.widthScale);
+                    filterRect.height = Math.round(rect.height / rectangle.heightScale);
+                    filter.set(rectProperty, filterRect);
                 }
             }
+
         }
+
     }
 
     Connections {
         target: filter
         onChanged: {
-            var newRect = filter.getRect(rectProperty)
+            var newRect = filter.getRect(rectProperty);
             if (filterRect !== newRect) {
-                filterRect = newRect
-                rectangle.setHandles(filterRect)
+                filterRect = newRect;
+                rectangle.setHandles(filterRect);
             }
-            videoItem.enabled = filter.get('disable') !== '1'
+            videoItem.enabled = filter.get('disable') !== '1';
         }
     }
+
 }

--- a/src/qml/filters/gpstext/meta.qml
+++ b/src/qml/filters/gpstext/meta.qml
@@ -24,6 +24,7 @@ Metadata {
     mlt_service: 'gpstext'
     qml: 'ui.qml'
     vui: 'vui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -36,4 +37,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/gpstext/ui.qml
+++ b/src/qml/filters/gpstext/ui.qml
@@ -15,121 +15,181 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import QtQml.Models 2.12
 import QtQuick 2.12
 import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
 import QtQuick.Dialogs 1.2
+import QtQuick.Layouts 1.12
 import QtQuick.Window 2.1
 import Shotcut.Controls 1.0 as Shotcut
 import org.shotcut.qml 1.0 as Shotcut
-import QtQml.Models 2.12
 
 Item {
     id: gpsTextRoot
+
+    property url settingsOpenPath: 'file:///' + settings.openPath
+    property int js_tz_offset: 0
+
+    signal fileOpened(string path)
+
+    function setControls() {
+        textArea.text = filter.get('argument');
+        textFilterUi.setControls();
+        if (gpsFile.exists()) {
+            fileLabel.text = gpsFile.fileName;
+            fileLabelTip.text = gpsFile.filePath + "\nGPS start time: " + filter.get('gps_start_text') + "\nVideo start time: " + filter.get('video_start_text');
+        } else {
+            fileLabel.text = qsTr("No File Loaded.");
+            fileLabel.color = 'red';
+            fileLabelTip.text = qsTr('No GPS file loaded.\nClick "Open" to load a file.');
+        }
+        set_sec_offset_to_textfields(filter.get('time_offset'));
+        combo_smoothing.currentIndex = combo_smoothing.get_smooth_index_from_val(filter.get('smoothing_value'));
+        speed_multiplier.value = filter.get('speed_multiplier');
+        updates_per_second.text = filter.get('updates_per_second');
+        gps_processing_start.text = filter.get('gps_processing_start_time');
+    }
+
+    //this function combines the text values from sign combobox * days/hours/mins/sec TextFields into an int
+    function recompute_time_offset() {
+        var offset_sec = parseInt(Number(offset_days.text), 10) * 24 * 60 * 60 + parseInt(Number(offset_hours.text), 10) * 60 * 60 + parseInt(Number(offset_mins.text), 10) * 60 + parseInt(Number(offset_secs.text), 10);
+        offset_sec *= parseInt(filter.get('majoroffset_sign'), 10);
+        filter.set('time_offset', Number(offset_sec).toFixed(0));
+    }
+
+    //transforms a wheel-up/down event into the correct offset direction
+    function wheel_offset(val) {
+        var offset = Number(filter.get("time_offset"));
+        if (offset < 0)
+            val *= -1;
+
+        if (offset == 0 && val < 0)
+            return ;
+
+        //fix unnatural behaviour when subtracting at offset 0
+        set_sec_offset_to_textfields(offset + val);
+    }
+
+    //splits (and fills) seconds into days/hours/mins/secs textfields
+    function set_sec_offset_to_textfields(secs) {
+        if (secs === '')
+            return ;
+
+        if (secs < 0) {
+            combo_majoroffset_sign.currentIndex = 1;
+            filter.set('majoroffset_sign', -1);
+        } else {
+            combo_majoroffset_sign.currentIndex = 0;
+            filter.set('majoroffset_sign', 1);
+        }
+        offset_days.text = parseInt(Math.abs(secs) / (24 * 60 * 60), 10);
+        offset_hours.text = parseInt(Math.abs(secs) / (60 * 60) % 24, 10);
+        offset_mins.text = parseInt(Math.abs(secs) / 60 % 60, 10);
+        offset_secs.text = parseInt(Math.abs(secs) % 60, 10);
+        //toFixed(0) avoids scientific notation!
+        filter.set('time_offset', Number(secs).toFixed(0));
+    }
+
     width: 300
     height: 800
-    
-    property url settingsOpenPath: 'file:///' + settings.openPath
-    Shotcut.File { id: gpsFile }
-    property int js_tz_offset: 0
-    
-    signal fileOpened(string path)
     onFileOpened: settings.openPath = path
-    
     Component.onCompleted: {
-        var resource = filter.get('resource')
+        var resource = filter.get('resource');
         if (!resource)
-            resource = filter.get('gps.file')
-        gpsFile.url = resource
-   
-        filter.blockSignals = true
+            resource = filter.get('gps.file');
 
-        filter.set(textFilterUi.middleValue, Qt.rect(0, 0, profile.width, profile.height))
-        filter.set(textFilterUi.startValue, Qt.rect(0, 0, profile.width, profile.height))
-        filter.set(textFilterUi.endValue, Qt.rect(0, 0, profile.width, profile.height))
+        gpsFile.url = resource;
+        filter.blockSignals = true;
+        filter.set(textFilterUi.middleValue, Qt.rect(0, 0, profile.width, profile.height));
+        filter.set(textFilterUi.startValue, Qt.rect(0, 0, profile.width, profile.height));
+        filter.set(textFilterUi.endValue, Qt.rect(0, 0, profile.width, profile.height));
         if (filter.isNew) {
-            var presetParams = preset.parameters.slice()
-            var index = presetParams.indexOf('argument')
+            var presetParams = preset.parameters.slice();
+            var index = presetParams.indexOf('argument');
             if (index > -1)
-                presetParams.splice(index, 1)
+                presetParams.splice(index, 1);
 
             if (application.OS === 'Windows')
-                filter.set('family', 'Verdana')
-            filter.set('fgcolour', '#ffffffff')
-            filter.set('bgcolour', '#00000000')
-            filter.set('olcolour', '#aa000000')
-            filter.set('outline', 3)
-            filter.set('weight', 10 * Font.Normal)
-            filter.set('style', 'normal')
-            filter.set(textFilterUi.useFontSizeProperty, false)
-            filter.set('size', profile.height)
-            
-            // Add default preset.
-            filter.set(textFilterUi.valignProperty, 'bottom')
-            filter.set(textFilterUi.halignProperty, 'left')
-            filter.set(textFilterUi.rectProperty, '10%/10%:80%x80%')
-            filter.savePreset(presetParams)
-            
-            filter.set(textFilterUi.rectProperty, filter.getRect(textFilterUi.rectProperty))
-        } else {
-            filter.set(textFilterUi.middleValue, filter.getRect(textFilterUi.rectProperty, filter.animateIn + 1))
-            if (filter.animateIn > 0)
-                filter.set(textFilterUi.startValue, filter.getRect(textFilterUi.rectProperty, 0))
-            if (filter.animateOut > 0)
-                filter.set(textFilterUi.endValue, filter.getRect(textFilterUi.rectProperty, filter.duration - 1))
-        }
+                filter.set('family', 'Verdana');
 
+            filter.set('fgcolour', '#ffffffff');
+            filter.set('bgcolour', '#00000000');
+            filter.set('olcolour', '#aa000000');
+            filter.set('outline', 3);
+            filter.set('weight', 10 * Font.Normal);
+            filter.set('style', 'normal');
+            filter.set(textFilterUi.useFontSizeProperty, false);
+            filter.set('size', profile.height);
+            // Add default preset.
+            filter.set(textFilterUi.valignProperty, 'bottom');
+            filter.set(textFilterUi.halignProperty, 'left');
+            filter.set(textFilterUi.rectProperty, '10%/10%:80%x80%');
+            filter.savePreset(presetParams);
+            filter.set(textFilterUi.rectProperty, filter.getRect(textFilterUi.rectProperty));
+        } else {
+            filter.set(textFilterUi.middleValue, filter.getRect(textFilterUi.rectProperty, filter.animateIn + 1));
+            if (filter.animateIn > 0)
+                filter.set(textFilterUi.startValue, filter.getRect(textFilterUi.rectProperty, 0));
+
+            if (filter.animateOut > 0)
+                filter.set(textFilterUi.endValue, filter.getRect(textFilterUi.rectProperty, filter.duration - 1));
+
+        }
         //gps properties
         if (filter.isNew) {
             filter.set('time_offset', 0);
             filter.set('majoroffset_sign', 1);
             filter.set('smoothing_value', 5);
             filter.set('videofile_timezone_seconds', 0);
-            filter.set('speed_multiplier', 1)
+            filter.set('speed_multiplier', 1);
             filter.set('updates_per_second', 1);
             filter.set('gps_processing_start_time', 'yyyy-MM-dd hh:mm:ss');
-        }
-        else {
+        } else {
             if (filter.get('gps_processing_start_time') == 'yyyy-MM-dd hh:mm:ss' && filter.get('gps_start_text') != '')
                 filter.set('gps_processing_start_time', filter.get('gps_start_text'));
+
         }
-
-        filter.blockSignals = false
-
+        filter.blockSignals = false;
         //get current timezone
-        var date = new Date()
-        js_tz_offset = date.getTimezoneOffset()*60
-
+        var date = new Date();
+        js_tz_offset = date.getTimezoneOffset() * 60;
         setControls();
+    }
+
+    Shotcut.File {
+        id: gpsFile
     }
 
     FileDialog {
         id: fileDialog
+
         modality: application.dialogModality
         selectMultiple: false
         selectFolder: false
         folder: settingsOpenPath
         nameFilters: ['Supported files (*.gpx *.tcx)', 'GPS Exchange Format (*.gpx)', 'Training Center XML (*.tcx)']
         onAccepted: {
-            gpsFile.url = fileDialog.fileUrl
-            gpsTextRoot.fileOpened(gpsFile.path)
-            fileLabel.text = gpsFile.fileName
-            fileLabel.color = activePalette.text
-            fileLabelTip.text = gpsFile.filePath
-            filter.set('resource', gpsFile.url)
-            filter.set('gps_start_text', '')
+            gpsFile.url = fileDialog.fileUrl;
+            gpsTextRoot.fileOpened(gpsFile.path);
+            fileLabel.text = gpsFile.fileName;
+            fileLabel.color = activePalette.text;
+            fileLabelTip.text = gpsFile.filePath;
+            filter.set('resource', gpsFile.url);
+            filter.set('gps_start_text', '');
             filter.set('gps_processing_start_time', 'yyyy-MM-dd hh:mm:ss');
-            gpsFinishParseTimer.restart()
+            gpsFinishParseTimer.restart();
         }
     }
-    
+
     //timer to update UI after gps file is processed; max: 10x250ms
     Timer {
         id: gpsFinishParseTimer
+
+        property int calls: 0
+
         interval: 250
         repeat: true
         triggeredOnStart: false
-        property int calls: 0
         onTriggered: {
             if (filter.get('gps_start_text') == '') {
                 calls += 1;
@@ -139,8 +199,7 @@ Item {
                     filter.set('gps_processing_start_time', 'yyyy-MM-dd hh:mm:ss');
                     setControls();
                 }
-            }
-            else {
+            } else {
                 gpsFinishParseTimer.stop();
                 calls = 0;
                 filter.set('gps_processing_start_time', filter.get('gps_start_text'));
@@ -149,71 +208,9 @@ Item {
         }
     }
 
-    function setControls() {
-        textArea.text = filter.get('argument');
-        textFilterUi.setControls();
-
-        if (gpsFile.exists()) {
-            fileLabel.text = gpsFile.fileName
-            fileLabelTip.text = gpsFile.filePath + "\nGPS start time: " + filter.get('gps_start_text') + "\nVideo start time: " + filter.get('video_start_text')
-        } else {
-            fileLabel.text = qsTr("No File Loaded.")
-            fileLabel.color = 'red'
-            fileLabelTip.text = qsTr('No GPS file loaded.\nClick "Open" to load a file.')
-        }
-        set_sec_offset_to_textfields(filter.get('time_offset'));
-        combo_smoothing.currentIndex = combo_smoothing.get_smooth_index_from_val(filter.get('smoothing_value'));
-
-        speed_multiplier.value = filter.get('speed_multiplier');
-        updates_per_second.text = filter.get('updates_per_second');
-        gps_processing_start.text = filter.get('gps_processing_start_time');
-    }
-    
-    //this function combines the text values from sign combobox * days/hours/mins/sec TextFields into an int
-    function recompute_time_offset() {
-        var offset_sec = parseInt(Number(offset_days.text), 10)*24*60*60 + 
-                         parseInt(Number(offset_hours.text), 10)*60*60 +
-                         parseInt(Number(offset_mins.text), 10)*60 +
-                         parseInt(Number(offset_secs.text), 10);
-        offset_sec *= parseInt(filter.get('majoroffset_sign'), 10);
-        filter.set('time_offset', Number(offset_sec).toFixed(0))
-    }
-    
-    //transforms a wheel-up/down event into the correct offset direction
-    function wheel_offset(val) {
-        var offset = Number(filter.get("time_offset"));
-        if (offset < 0)
-            val *= -1;
-        if (offset == 0 && val<0) return; //fix unnatural behaviour when subtracting at offset 0
-        set_sec_offset_to_textfields( offset + val );
-    }
-
-    //splits (and fills) seconds into days/hours/mins/secs textfields
-    function set_sec_offset_to_textfields(secs) {
-        if (secs === '')
-            return;
-            
-        if (secs < 0) {
-            combo_majoroffset_sign.currentIndex = 1
-            filter.set('majoroffset_sign', -1)
-        }
-        else {
-            combo_majoroffset_sign.currentIndex = 0
-            filter.set('majoroffset_sign', 1)
-        }
-
-        offset_days.text = parseInt( Math.abs(secs)/(24*60*60) , 10 )
-        offset_hours.text = parseInt( Math.abs(secs)/(60*60)%24 , 10 )
-        offset_mins.text = parseInt( Math.abs(secs)/60%60 , 10 )
-        offset_secs.text = parseInt( Math.abs(secs)%60 , 10 )
-        
-        //toFixed(0) avoids scientific notation!
-        filter.set('time_offset', Number(secs).toFixed(0))
-    }
-
-    
     GridLayout {
         id: mainGrid
+
         columns: 2
         anchors.fill: parent
         anchors.margins: 8
@@ -221,268 +218,468 @@ Item {
 
         Shotcut.Button {
             id: openButton
+
             text: qsTr('Open file')
             Layout.alignment: Qt.AlignRight
             onClicked: {
-                fileDialog.selectExisting = true
-                fileDialog.title = qsTr( "Open GPS File" )
-                fileDialog.open()
+                fileDialog.selectExisting = true;
+                fileDialog.title = qsTr("Open GPS File");
+                fileDialog.open();
             }
         }
+
         Label {
             id: fileLabel
+
             Layout.fillWidth: true
-            Shotcut.HoverTip { id: fileLabelTip }
+
+            Shotcut.HoverTip {
+                id: fileLabelTip
+            }
+
         }
-        
 
         Label {
             topPadding: 10
             text: qsTr('<b>GPS options</b>')
             Layout.columnSpan: 2
         }
-        
+
         Label {
             id: gps_sync_major
+
             text: qsTr('GPS offset')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('This is added to video time to sync with gps time.') }
-        } 
+
+            Shotcut.HoverTip {
+                text: qsTr('This is added to video time to sync with gps time.')
+            }
+
+        }
+
         RowLayout {
             Shotcut.ComboBox {
                 id: combo_majoroffset_sign
+
                 implicitWidth: 39
-                model: ListModel {
-                    id: sign_val
-                    ListElement { text: '+'; value: 1}
-                    ListElement { text: '-'; value: -1}
-                }
                 currentIndex: 0
                 textRole: 'text'
-                Shotcut.HoverTip { text: qsTr('+ : Adds time to video (use if GPS is ahead).\n - : Subtracts time from video (use if video is ahead).') }
                 onActivated: {
-                    filter.set('majoroffset_sign', sign_val.get(currentIndex).value)
-                    recompute_time_offset()
+                    filter.set('majoroffset_sign', sign_val.get(currentIndex).value);
+                    recompute_time_offset();
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('+ : Adds time to video (use if GPS is ahead).\n - : Subtracts time from video (use if video is ahead).')
+                }
+
+                model: ListModel {
+                    id: sign_val
+
+                    ListElement {
+                        text: '+'
+                        value: 1
+                    }
+
+                    ListElement {
+                        text: '-'
+                        value: -1
+                    }
+
+                }
+
             }
+
             TextField {
                 id: offset_days
+
                 text: '0'
                 horizontalAlignment: TextInput.AlignRight
-                validator: IntValidator {bottom: 0; top: 36600;}
                 implicitWidth: 60
+                onFocusChanged: {
+                    if (focus)
+                        selectAll();
+
+                }
+                onTextChanged: {
+                    if (!acceptableInput)
+                        offset_days.undo();
+
+                }
+                onEditingFinished: recompute_time_offset()
+
                 MouseArea {
                     anchors.fill: parent
-                    onWheel: wheel_offset( wheel.angleDelta.y>0 ? 86400 : -86400 )
+                    onWheel: wheel_offset(wheel.angleDelta.y > 0 ? 86400 : -86400)
                     onClicked: offset_days.forceActiveFocus()
                 }
-                onFocusChanged: if (focus) selectAll()
-                onTextChanged:
-                {
-                    if(!acceptableInput)
-                        offset_days.undo()
+
+                Shotcut.HoverTip {
+                    text: qsTr('Number of days to add/subtract to video time to sync them.\nTip: you can use mousewheel to change values.')
                 }
-                onEditingFinished: recompute_time_offset()
-                Shotcut.HoverTip { text: qsTr('Number of days to add/subtract to video time to sync them.\nTip: you can use mousewheel to change values.') }
+
+                validator: IntValidator {
+                    bottom: 0
+                    top: 36600
+                }
+
             }
+
             Label {
                 text: ':'
                 Layout.alignment: Qt.AlignRight
             }
+
             TextField {
                 id: offset_hours
+
                 text: '0'
                 horizontalAlignment: TextInput.AlignRight
-                validator: IntValidator {bottom: 0; top: 23;}
                 implicitWidth: 30
+                onFocusChanged: {
+                    if (focus)
+                        selectAll();
+
+                }
+                onTextChanged: {
+                    if (!acceptableInput)
+                        offset_hours.undo();
+
+                }
+                onEditingFinished: recompute_time_offset()
+
                 MouseArea {
                     anchors.fill: parent
-                    onWheel: wheel_offset( wheel.angleDelta.y>0 ? 3600 : -3600 )
-                    onClicked: { offset_hours.forceActiveFocus() }
+                    onWheel: wheel_offset(wheel.angleDelta.y > 0 ? 3600 : -3600)
+                    onClicked: {
+                        offset_hours.forceActiveFocus();
+                    }
                 }
-                onFocusChanged: if (focus) selectAll()
-                onTextChanged:
-                {
-                    if(!acceptableInput)
-                        offset_hours.undo()
+
+                Shotcut.HoverTip {
+                    text: qsTr('Number of hours to add/subtract to video time to sync them.\nTip: you can use mousewheel to change values.')
                 }
-                onEditingFinished: recompute_time_offset();
-                Shotcut.HoverTip { text: qsTr('Number of hours to add/subtract to video time to sync them.\nTip: you can use mousewheel to change values.') }
+
+                validator: IntValidator {
+                    bottom: 0
+                    top: 23
+                }
+
             }
+
             Label {
                 text: ':'
                 Layout.alignment: Qt.AlignRight
             }
+
             TextField {
                 id: offset_mins
+
                 text: '0'
                 horizontalAlignment: TextInput.AlignRight
-                validator: IntValidator {bottom: 0; top: 59;}
                 implicitWidth: 30
-                MouseArea {
-                    anchors.fill: parent
-                    onWheel: wheel_offset( wheel.angleDelta.y>0 ? 60 : -60 )
-                    onClicked: { offset_mins.forceActiveFocus() }
+                onFocusChanged: {
+                    if (focus)
+                        selectAll();
+
                 }
-                onFocusChanged: if (focus) selectAll()
-                onTextChanged:
-                {
-                    if(!acceptableInput)
-                        offset_mins.undo()
+                onTextChanged: {
+                    if (!acceptableInput)
+                        offset_mins.undo();
+
                 }
                 onEditingFinished: recompute_time_offset()
-                Shotcut.HoverTip { text: qsTr('Number of minutes to add/subtract to video time to sync them.\nTip: you can use mousewheel to change values.') }
+
+                MouseArea {
+                    anchors.fill: parent
+                    onWheel: wheel_offset(wheel.angleDelta.y > 0 ? 60 : -60)
+                    onClicked: {
+                        offset_mins.forceActiveFocus();
+                    }
+                }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Number of minutes to add/subtract to video time to sync them.\nTip: you can use mousewheel to change values.')
+                }
+
+                validator: IntValidator {
+                    bottom: 0
+                    top: 59
+                }
+
             }
+
             Label {
                 text: ':'
                 Layout.alignment: Qt.AlignRight
             }
+
             TextField {
                 id: offset_secs
+
                 text: '0'
                 horizontalAlignment: TextInput.AlignRight
-                validator: IntValidator {bottom: 0; top: 59;}
                 implicitWidth: 30
-                MouseArea {
-                    anchors.fill: parent
-                    onWheel: wheel_offset( wheel.angleDelta.y>0 ? 1 : -1 )
-                    onClicked: { offset_secs.forceActiveFocus() }
+                onFocusChanged: {
+                    if (focus)
+                        selectAll();
+
                 }
-                onFocusChanged: if (focus) selectAll()
-                onTextChanged:
-                {
-                    if(!acceptableInput)
-                        offset_secs.undo()
+                onTextChanged: {
+                    if (!acceptableInput)
+                        offset_secs.undo();
+
                 }
                 onEditingFinished: recompute_time_offset()
-                Shotcut.HoverTip { text: qsTr('Number of seconds to add/subtract to video time to sync them.\nTip: you can use mousewheel to change values.') }
+
+                MouseArea {
+                    anchors.fill: parent
+                    onWheel: wheel_offset(wheel.angleDelta.y > 0 ? 1 : -1)
+                    onClicked: {
+                        offset_secs.forceActiveFocus();
+                    }
+                }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Number of seconds to add/subtract to video time to sync them.\nTip: you can use mousewheel to change values.')
+                }
+
+                validator: IntValidator {
+                    bottom: 0
+                    top: 59
+                }
+
             }
 
             //buttons:
             Shotcut.Button {
                 icon.name: 'media-skip-backward'
-                Shotcut.HoverTip { text: qsTr('Sync start of GPS to start of video file.\nTip: use this if you started GPS and video recording at the same time.') }
                 implicitWidth: 20
                 implicitHeight: 20
-                onClicked: { set_sec_offset_to_textfields(filter.get('auto_gps_offset_start')) }
+                onClicked: {
+                    set_sec_offset_to_textfields(filter.get('auto_gps_offset_start'));
+                }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Sync start of GPS to start of video file.\nTip: use this if you started GPS and video recording at the same time.')
+                }
+
             }
+
             Shotcut.Button {
                 icon.name: 'document-open-recent'
-                Shotcut.HoverTip { text: qsTr('Remove timezone (%1 seconds) time from video file (convert to UTC).\nTip: use this if your video camera doesn\'t have timezone settings as it will set local time as UTC.'.arg(js_tz_offset) ) }
                 implicitWidth: 20
                 implicitHeight: 20
-                onClicked: { set_sec_offset_to_textfields( parseInt(Number(filter.get('time_offset'))) + parseInt(Number(js_tz_offset)) ) }
+                onClicked: {
+                    set_sec_offset_to_textfields(parseInt(Number(filter.get('time_offset'))) + parseInt(Number(js_tz_offset)));
+                }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Remove timezone (%1 seconds) time from video file (convert to UTC).\nTip: use this if your video camera doesn\'t have timezone settings as it will set local time as UTC.'.arg(js_tz_offset))
+                }
+
             }
+
             Shotcut.Button {
                 icon.name: 'format-indent-less'
-                Shotcut.HoverTip { text: qsTr('Fix video start time: if file time is actually end time, press this button to subtract file length (%1 seconds) from GPS offset.'.arg(parseInt(producer.length / profile.fps)) ) }
                 implicitWidth: 20
                 implicitHeight: 20
-                onClicked: { set_sec_offset_to_textfields( parseInt(Number(filter.get('time_offset')) - producer.length / profile.fps) ); }
+                onClicked: {
+                    set_sec_offset_to_textfields(parseInt(Number(filter.get('time_offset')) - producer.length / profile.fps));
+                }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Fix video start time: if file time is actually end time, press this button to subtract file length (%1 seconds) from GPS offset.'.arg(parseInt(producer.length / profile.fps)))
+                }
+
             }
+
             Shotcut.Button {
                 icon.name: 'media-playback-pause'
-                Shotcut.HoverTip { text: qsTr('Sync start of GPS to current video time.\nTip: use this if you recorded the moment of the first GPS fix.') }
                 implicitWidth: 20
                 implicitHeight: 20
-                onClicked: { set_sec_offset_to_textfields(filter.get('auto_gps_offset_now')) }
+                onClicked: {
+                    set_sec_offset_to_textfields(filter.get('auto_gps_offset_now'));
+                }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Sync start of GPS to current video time.\nTip: use this if you recorded the moment of the first GPS fix.')
+                }
+
             }
+
             Shotcut.UndoButton {
-                onClicked: set_sec_offset_to_textfields( 0 )
+                onClicked: set_sec_offset_to_textfields(0)
             }
+
         }
-        
+
         Label {
             text: qsTr('GPS smoothing')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Average nearby GPS points to smooth out errors.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Average nearby GPS points to smooth out errors.')
+            }
+
         }
+
         RowLayout {
             Shotcut.ComboBox {
                 id: combo_smoothing
-                implicitWidth: 300
-                model: ListModel {
-                    id: smooth_val_list
-                    ListElement { text: '0 (raw data)'; value: 0}
-                    ListElement { text: '1 (interpolate and process data)'; value: 1}
-                    ListElement { text: '3 points'; value: 3}
-                    ListElement { text: '5 points'; value: 5}
-                    ListElement { text: '7 points'; value: 7}
-                    ListElement { text: '11 points'; value: 11}
-                    ListElement { text: '15 points'; value: 15}
-                    ListElement { text: '31 points'; value: 31}
-                    ListElement { text: '63 points'; value: 63}
-                    ListElement { text: '127 points'; value: 127}
+
+                function get_smooth_index_from_val(val) {
+                    for (var i = 0; i < smooth_val_list.count; i++) {
+                        if (smooth_val_list.get(i).value == val)
+                            return i;
+
+                    }
+                    console.log("get_smooth_index_from_val: no match for smooth val= " + val);
+                    return 3; //default
                 }
+
+                implicitWidth: 300
                 textRole: 'text'
                 currentIndex: 3
                 onActivated: {
-                    filter.set('smoothing_value', smooth_val_list.get(currentIndex).value)
+                    filter.set('smoothing_value', smooth_val_list.get(currentIndex).value);
                 }
-                function get_smooth_index_from_val(val) {
-                    for (var i=0; i<smooth_val_list.count; i++) {
-                        if (smooth_val_list.get(i).value == val)
-                            return i
+
+                model: ListModel {
+                    id: smooth_val_list
+
+                    ListElement {
+                        text: '0 (raw data)'
+                        value: 0
                     }
-                    console.log("get_smooth_index_from_val: no match for smooth val= "+val)
-                    return 3 //default
+
+                    ListElement {
+                        text: '1 (interpolate and process data)'
+                        value: 1
+                    }
+
+                    ListElement {
+                        text: '3 points'
+                        value: 3
+                    }
+
+                    ListElement {
+                        text: '5 points'
+                        value: 5
+                    }
+
+                    ListElement {
+                        text: '7 points'
+                        value: 7
+                    }
+
+                    ListElement {
+                        text: '11 points'
+                        value: 11
+                    }
+
+                    ListElement {
+                        text: '15 points'
+                        value: 15
+                    }
+
+                    ListElement {
+                        text: '31 points'
+                        value: 31
+                    }
+
+                    ListElement {
+                        text: '63 points'
+                        value: 63
+                    }
+
+                    ListElement {
+                        text: '127 points'
+                        value: 127
+                    }
+
                 }
+
             }
+
             Shotcut.UndoButton {
                 onClicked: {
-                    combo_smoothing.currentIndex = 3
-                    filter.set('smoothing_value', 5)
+                    combo_smoothing.currentIndex = 3;
+                    filter.set('smoothing_value', 5);
                 }
             }
+
         }
 
         Label {
             text: qsTr('Processing start')
             leftPadding: 10
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Distances are calculated since the start of the gps file, use this field to reset them (GPS time).') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Distances are calculated since the start of the gps file, use this field to reset them (GPS time).')
+            }
+
         }
+
         RowLayout {
             TextField {
                 id: gps_processing_start
+
                 text: 'yyyy-MM-dd hh:mm:ss'
                 horizontalAlignment: TextInput.AlignRight
                 //TODO: regex to validate date yyyy-MM-dd hh:mm:ss
                 implicitWidth: 128
-                Shotcut.HoverTip { text: qsTr('Insert date and time formatted exactly as: YYYY-MM-DD HH:MM:SS (GPS time).') }
-                onEditingFinished: filter.set('gps_processing_start_time', gps_processing_start.text);
+                onEditingFinished: filter.set('gps_processing_start_time', gps_processing_start.text)
+
+                Shotcut.HoverTip {
+                    text: qsTr('Insert date and time formatted exactly as: YYYY-MM-DD HH:MM:SS (GPS time).')
+                }
+
             }
+
             Shotcut.Button {
                 icon.source: 'qrc:///icons/dark/32x32/media-playback-pause'
-                Shotcut.HoverTip { text: qsTr('Set start of GPS processing to current video time.') }
                 implicitWidth: 20
                 implicitHeight: 20
                 onClicked: {
-                    var gps_time_now = filter.get('auto_gps_processing_start_now')
-                    gps_processing_start.text = gps_time_now
+                    var gps_time_now = filter.get('auto_gps_processing_start_now');
+                    gps_processing_start.text = gps_time_now;
                     filter.set('gps_processing_start_time', gps_time_now);
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Set start of GPS processing to current video time.')
+                }
+
             }
+
             Shotcut.UndoButton {
                 onClicked: {
                     gps_processing_start.text = filter.get('gps_start_text');
                     filter.set('gps_processing_start_time', filter.get('gps_start_text'));
                 }
             }
+
         }
 
         Label {
             text: qsTr('Video speed')
             leftPadding: 10
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('If the current video is sped up (timelapse) or slowed down use this field to set the speed.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('If the current video is sped up (timelapse) or slowed down use this field to set the speed.')
+            }
+
         }
+
         RowLayout {
             Shotcut.DoubleSpinBox {
                 id: speed_multiplier
+
                 value: 1
                 horizontalAlignment: Qt.AlignRight
-                Shotcut.HoverTip { text: qsTr('Fractional times are also allowed (0.25 = 4x slow motion, 5 = 5x timelapse).') }
                 Layout.minimumWidth: 80
                 from: 0
                 to: 1000
@@ -492,15 +689,21 @@ Item {
                 onValueChanged: {
                     filter.set('speed_multiplier', value);
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Fractional times are also allowed (0.25 = 4x slow motion, 5 = 5x timelapse).')
+                }
+
             }
+
             Shotcut.UndoButton {
                 onClicked: {
-                    filter.set('speed_multiplier', 1)
+                    filter.set('speed_multiplier', 1);
                     speed_multiplier.value = 1;
                 }
             }
-        }
 
+        }
 
         Label {
             topPadding: 10
@@ -508,71 +711,88 @@ Item {
             Layout.columnSpan: 2
         }
 
-        
         Label {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: textFilterUi.parameterList.concat(['argument'])
             onBeforePresetLoaded: {
-                filter.resetProperty(textFilterUi.rectProperty)
+                filter.resetProperty(textFilterUi.rectProperty);
             }
             onPresetSelected: {
-                setControls()
-                filter.blockSignals = true
-                filter.set(textFilterUi.middleValue, filter.getRect(textFilterUi.rectProperty, filter.animateIn + 1))
+                setControls();
+                filter.blockSignals = true;
+                filter.set(textFilterUi.middleValue, filter.getRect(textFilterUi.rectProperty, filter.animateIn + 1));
                 if (filter.animateIn > 0)
-                    filter.set(textFilterUi.startValue, filter.getRect(textFilterUi.rectProperty, 0))
+                    filter.set(textFilterUi.startValue, filter.getRect(textFilterUi.rectProperty, 0));
+
                 if (filter.animateOut > 0)
-                    filter.set(textFilterUi.endValue, filter.getRect(textFilterUi.rectProperty, filter.duration - 1))
-                filter.blockSignals = false
+                    filter.set(textFilterUi.endValue, filter.getRect(textFilterUi.rectProperty, filter.duration - 1));
+
+                filter.blockSignals = false;
             }
         }
-        
+
         Label {
             text: qsTr('Text')
             Layout.alignment: Qt.AlignRight | Qt.AlignTop
         }
+
         Item {
-            FontMetrics {
-                id: fontMetrics
-                font: textArea.font
-            }
             Layout.minimumHeight: fontMetrics.height * 6
             Layout.maximumHeight: Layout.minimumHeight
             Layout.minimumWidth: preset.width
             Layout.maximumWidth: preset.width
 
+            FontMetrics {
+                id: fontMetrics
+
+                font: textArea.font
+            }
+
             ScrollView {
                 id: scrollview
+
                 width: preset.width - (ScrollBar.vertical.visible ? 16 : 0)
                 height: parent.height - (ScrollBar.horizontal.visible ? 16 : 0)
                 clip: true
+
                 TextArea {
                     id: textArea
+
+                    property int maxLength: 1024
+
                     textFormat: TextEdit.PlainText
                     wrapMode: TextEdit.NoWrap
                     selectByMouse: true
                     padding: 0
+                    text: '__empty__'
+                    onTextChanged: {
+                        if (text === '__empty__')
+                            return ;
+
+                        if (length > maxLength) {
+                            text = text.substring(0, maxLength);
+                            cursorPosition = maxLength;
+                        }
+                        if (!parseInt(filter.get(textFilterUi.useFontSizeProperty), 10))
+                            filter.set('size', profile.height / text.split('\n').length);
+
+                        filter.set('argument', text);
+                    }
+
                     background: Rectangle {
                         anchors.fill: parent
                         color: textArea.palette.base
                     }
-                    text: '__empty__' // workaround initialization problem
-                    property int maxLength: 1024
-                    onTextChanged: {
-                        if (text === '__empty__') return
-                        if (length > maxLength) {
-                            text = text.substring(0, maxLength)
-                            cursorPosition = maxLength
-                        }
-                        if (!parseInt(filter.get(textFilterUi.useFontSizeProperty), 10))
-                            filter.set('size', profile.height / text.split('\n').length)
-                        filter.set('argument', text)
-                    }
+                    // workaround initialization problem
+
                 }
+
                 ScrollBar.horizontal: ScrollBar {
                     height: 16
                     policy: ScrollBar.AlwaysOn
@@ -582,6 +802,7 @@ Item {
                     anchors.left: scrollview.left
                     anchors.right: scrollview.right
                 }
+
                 ScrollBar.vertical: ScrollBar {
                     width: 16
                     policy: ScrollBar.AlwaysOn
@@ -591,96 +812,119 @@ Item {
                     anchors.left: scrollview.right
                     anchors.bottom: scrollview.bottom
                 }
+
             }
+
         }
 
         Label {
             text: qsTr('Insert GPS field')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Layout.bottomMargin: 5
+
             Shotcut.ComboBox {
-                Shotcut.HoverTip { text: qsTr('Extra arguments can be added inside keywords:\nDistance units: m [km|ft|mi].\nSpeed units: km/h [mi/h|m/s|ft/s].\nTime default: %Y-%m-%d %H:%M:%S, extra offset can be added as +/-seconds (+3600).\nExtra keyword: RAW (prints only values from file).') }
+                //0
+                //1
+                //2
+                //3
+                //4
+                //5
+                //6
+                //7
+                //8
+                //9
+                //10
+                //11
+                //12
+                //13
+                //14
+
                 implicitWidth: 300
-                model: 
-                    [   qsTr('GPS latitude'),                   //0
-                        qsTr('GPS longitude'),                  //1
-                        qsTr('Elevation (m)'),                  //2
-                        qsTr('Speed (km/h)'),                   //3
-                        qsTr('Distance (m)'),                   //4
-                        qsTr('GPS date-time'),                  //5
-                        qsTr('Video file date-time'),           //6
-                        qsTr('Heart-rate (bpm)'),               //7
-                        qsTr('Bearing (degrees)'),              //8
-                        qsTr('Bearing (compass)'),              //9
-                        qsTr('Elevation gain (m)'),             //10
-                        qsTr('Elevation loss (m)'),             //11
-                        qsTr('Distance uphill (m)'),            //12
-                        qsTr('Distance downhill (m)'),          //13
-                        qsTr('Distance flat (m)')               //14
-                    ]   
-                        
+                model: [qsTr('GPS latitude'), qsTr('GPS longitude'), qsTr('Elevation (m)'), qsTr('Speed (km/h)'), qsTr('Distance (m)'), qsTr('GPS date-time'), qsTr('Video file date-time'), qsTr('Heart-rate (bpm)'), qsTr('Bearing (degrees)'), qsTr('Bearing (compass)'), qsTr('Elevation gain (m)'), qsTr('Elevation loss (m)'), qsTr('Distance uphill (m)'), qsTr('Distance downhill (m)'), qsTr('Distance flat (m)')]
                 onActivated: {
                     switch (currentIndex) {
-                        case 0:
-                            onClicked: textArea.insert(textArea.cursorPosition, '#gps_lat#')
-                            break
-                        case 1:
-                            onClicked: textArea.insert(textArea.cursorPosition, '#gps_lon#')
-                            break
-                        case 2:
-                            onClicked: textArea.insert(textArea.cursorPosition, '#gps_elev m#')
-                            break
-                        case 3:
-                            onClicked: textArea.insert(textArea.cursorPosition, '#gps_speed kmh#')
-                            break
-                        case 4:
-                            onClicked: textArea.insert(textArea.cursorPosition, '#gps_dist m#')
-                            break;
-                        case 5:
-                            onClicked: textArea.insert(textArea.cursorPosition, '#gps_datetime_now#')
-                            break;
-                        case 6:
-                            onClicked: textArea.insert(textArea.cursorPosition, '#file_datetime_now#')
-                            break;
-                        case 7:
-                            onClicked: textArea.insert(textArea.cursorPosition, '#gps_hr#')
-                            break;
-                        case 8:
-                            onClicked: textArea.insert(textArea.cursorPosition, '#gps_bearing#')
-                            break;
-                        case 9:
-                            onClicked: textArea.insert(textArea.cursorPosition, '#gps_compass#')
-                            break;
-                        case 10:
-                            onClicked: textArea.insert(textArea.cursorPosition, '#gps_vdist_up#')
-                            break;
-                        case 11:
-                            onClicked: textArea.insert(textArea.cursorPosition, '#gps_vdist_down#')
-                            break;
-                        case 12:
-                            onClicked: textArea.insert(textArea.cursorPosition, '#gps_dist_uphill#')
-                            break;
-                        case 13:
-                            onClicked: textArea.insert(textArea.cursorPosition, '#gps_dist_downhill#')
-                            break;
-                        case 14:
-                            onClicked: textArea.insert(textArea.cursorPosition, '#gps_dist_flat#')
-                            break;
-                        default:
-                            console.log('gps_combobox: current index not supported: ' + currentIndex)
+                    case 0:
+                        onClicked:
+                        textArea.insert(textArea.cursorPosition, '#gps_lat#');
+                        break;
+                    case 1:
+                        onClicked:
+                        textArea.insert(textArea.cursorPosition, '#gps_lon#');
+                        break;
+                    case 2:
+                        onClicked:
+                        textArea.insert(textArea.cursorPosition, '#gps_elev m#');
+                        break;
+                    case 3:
+                        onClicked:
+                        textArea.insert(textArea.cursorPosition, '#gps_speed kmh#');
+                        break;
+                    case 4:
+                        onClicked:
+                        textArea.insert(textArea.cursorPosition, '#gps_dist m#');
+                        break;
+                    case 5:
+                        onClicked:
+                        textArea.insert(textArea.cursorPosition, '#gps_datetime_now#');
+                        break;
+                    case 6:
+                        onClicked:
+                        textArea.insert(textArea.cursorPosition, '#file_datetime_now#');
+                        break;
+                    case 7:
+                        onClicked:
+                        textArea.insert(textArea.cursorPosition, '#gps_hr#');
+                        break;
+                    case 8:
+                        onClicked:
+                        textArea.insert(textArea.cursorPosition, '#gps_bearing#');
+                        break;
+                    case 9:
+                        onClicked:
+                        textArea.insert(textArea.cursorPosition, '#gps_compass#');
+                        break;
+                    case 10:
+                        onClicked:
+                        textArea.insert(textArea.cursorPosition, '#gps_vdist_up#');
+                        break;
+                    case 11:
+                        onClicked:
+                        textArea.insert(textArea.cursorPosition, '#gps_vdist_down#');
+                        break;
+                    case 12:
+                        onClicked:
+                        textArea.insert(textArea.cursorPosition, '#gps_dist_uphill#');
+                        break;
+                    case 13:
+                        onClicked:
+                        textArea.insert(textArea.cursorPosition, '#gps_dist_downhill#');
+                        break;
+                    case 14:
+                        onClicked:
+                        textArea.insert(textArea.cursorPosition, '#gps_dist_flat#');
+                        break;
+                    default:
+                        console.log('gps_combobox: current index not supported: ' + currentIndex);
                     }
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Extra arguments can be added inside keywords:\nDistance units: m [km|ft|mi].\nSpeed units: km/h [mi/h|m/s|ft/s].\nTime default: %Y-%m-%d %H:%M:%S, extra offset can be added as +/-seconds (+3600).\nExtra keyword: RAW (prints only values from file).')
+                }
+
             }
+
         }
 
         Shotcut.TextFilterUi {
             id: textFilterUi
+
             Layout.leftMargin: 10
             Layout.columnSpan: 2
         }
-
 
         Label {
             topPadding: 10
@@ -692,26 +936,49 @@ Item {
             text: qsTr('Update speed')
             leftPadding: 10
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Set how many text updates to show per second.\nSet to 0 to only print real points (no interpolation).') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Set how many text updates to show per second.\nSet to 0 to only print real points (no interpolation).')
+            }
+
         }
+
         RowLayout {
             TextField {
                 id: updates_per_second
+
                 text: '1'
-                validator: DoubleValidator {bottom: 0; top: 1000;}
                 horizontalAlignment: TextInput.AlignRight
                 implicitWidth: 25
-                onFocusChanged: if (focus) selectAll()
-                Shotcut.HoverTip { text: qsTr('Fractional times are also allowed (0.25 = update every 4 seconds, 5 = 5 updates per second).') }
-                onEditingFinished: filter.set('updates_per_second', updates_per_second.text);
+                onFocusChanged: {
+                    if (focus)
+                        selectAll();
+
+                }
+                onEditingFinished: filter.set('updates_per_second', updates_per_second.text)
+
+                Shotcut.HoverTip {
+                    text: qsTr('Fractional times are also allowed (0.25 = update every 4 seconds, 5 = 5 updates per second).')
+                }
+
+                validator: DoubleValidator {
+                    bottom: 0
+                    top: 1000
+                }
+
             }
-            Label { text: qsTr(' per second') }
+
+            Label {
+                text: qsTr(' per second')
+            }
+
             Shotcut.UndoButton {
                 onClicked: {
-                    filter.set('updates_per_second', 1)
+                    filter.set('updates_per_second', 1);
                     updates_per_second.text = '1';
                 }
             }
+
         }
 
         Rectangle {
@@ -719,6 +986,7 @@ Item {
             Layout.fillWidth: true
             Layout.minimumHeight: 12
             color: 'transparent'
+
             Rectangle {
                 anchors.verticalCenter: parent.verticalCenter
                 width: parent.width
@@ -726,33 +994,61 @@ Item {
                 radius: 2
                 color: activePalette.text
             }
+
         }
+
         Label {
             text: qsTr('Video start time:')
             leftPadding: 10
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Detected date-time for the video file.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Detected date-time for the video file.')
+            }
+
         }
+
         Label {
             id: video_start
+
             text: filter.get('video_start_text')
             Layout.alignment: Qt.AlignLeft
-            Shotcut.HoverTip { text: "This time will be used for synchronization." }
+
+            Shotcut.HoverTip {
+                text: "This time will be used for synchronization."
+            }
+
         }
 
         Label {
             id: start_location_datetime
+
             text: qsTr('GPS start time:')
             leftPadding: 10
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Detected date-time for the GPS file.') }
-        } Label {
-            id: gps_start
-            text: filter.get('gps_start_text')
-            Layout.alignment: Qt.AlignLeft
-            Shotcut.HoverTip { text: qsTr('This time will be used for synchronization.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Detected date-time for the GPS file.')
+            }
+
         }
 
-        Item { Layout.fillHeight: true }
+        Label {
+            id: gps_start
+
+            text: filter.get('gps_start_text')
+            Layout.alignment: Qt.AlignLeft
+
+            Shotcut.HoverTip {
+                text: qsTr('This time will be used for synchronization.')
+            }
+
+        }
+
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
+
 }

--- a/src/qml/filters/gradient/meta.qml
+++ b/src/qml/filters/gradient/meta.qml
@@ -8,9 +8,11 @@ Metadata {
     mlt_service: 'frei0r.cairogradient'
     qml: 'ui.qml'
     vui: 'vui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
         simpleProperties: ['shotcut:rect']
     }
+
 }

--- a/src/qml/filters/gradient/ui.qml
+++ b/src/qml/filters/gradient/ui.qml
@@ -36,160 +36,163 @@ Item {
     property rect filterRect
     property string startValue: '_shotcut:startValue'
     property string middleValue: '_shotcut:middleValue'
-    property string endValue:  '_shotcut:endValue'
+    property string endValue: '_shotcut:endValue'
     property bool _disableUpdate: true
 
-    width: 350
-    height: 180
-
-    Component.onCompleted: {
-        filter.blockSignals = true
-        filter.set(middleValue, Qt.rect(profile.width / 2, 0, profile.width * 0.01, profile.height))
-        filter.set(startValue, filter.getRect(middleValue))
-        filter.set(endValue, filter.getRect(middleValue))
-        if (filter.isNew) {
-            filter.set(patternProperty, 'gradient_linear')
-            filter.set(startColorProperty, '#000000')
-            filter.set(startOpacityProperty, 1.0)
-            filter.set(endColorProperty, '#ffffff')
-            filter.set(endOpacityProperty, 1.0)
-            filter.set(offsetProperty, 0)
-            filter.set(blendProperty, 'normal')
-
-            filter.set(rectProperty, '0%/50%:100%x1%')
-            filter.set(startXProperty, 0)
-            filter.set(startYProperty, 0.5)
-            filter.set(endXProperty, 1.0)
-            filter.set(endYProperty, 0.5)
-            filter.savePreset(preset.parameters, qsTr('Horizontal'))
-
-            filter.set(rectProperty, '50%/0%:1%x100%')
-            filter.set(startXProperty, 0.5)
-            filter.set(startYProperty, 0)
-            filter.set(endXProperty, 0.5)
-            filter.set(endYProperty, 1.0)
-            // Add default preset.
-            filter.savePreset(preset.parameters)
-        } else {
-            filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1))
-            if (filter.animateIn > 0)
-                filter.set(startValue, filter.getRect(rectProperty, 0))
-            if (filter.animateOut > 0)
-                filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1))
-        }
-        filter.blockSignals = false
-        setControls()
-        setKeyframedControls()
-        if (filter.isNew)
-            filter.set(rectProperty, filter.getRect(rectProperty))
-    }
-
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function resetFilterRect() {
-        filter.resetProperty(rectProperty)
-        filter.resetProperty(startXProperty)
-        filter.resetProperty(startYProperty)
-        filter.resetProperty(endXProperty)
-        filter.resetProperty(endYProperty)
+        filter.resetProperty(rectProperty);
+        filter.resetProperty(startXProperty);
+        filter.resetProperty(startYProperty);
+        filter.resetProperty(endXProperty);
+        filter.resetProperty(endYProperty);
     }
 
     function updateFilterRect(rect, position) {
         if (position === null)
-            position = -1
-        filter.set(rectProperty, rect, position)
+            position = -1;
+
+        filter.set(rectProperty, rect, position);
         if (filter.get(patternProperty) === 'gradient_linear') {
-            filter.set(startXProperty, rect.x / profile.width, position)
-            filter.set(startYProperty, rect.y / profile.height, position)
-            filter.set(endXProperty, (rect.x + rect.width) / profile.width, position)
-            filter.set(endYProperty, (rect.y + rect.height) / profile.height, position)
+            filter.set(startXProperty, rect.x / profile.width, position);
+            filter.set(startYProperty, rect.y / profile.height, position);
+            filter.set(endXProperty, (rect.x + rect.width) / profile.width, position);
+            filter.set(endYProperty, (rect.y + rect.height) / profile.height, position);
         } else {
-            filter.set(startXProperty, (rect.x + rect.width / 2) / profile.width, position)
-            filter.set(startYProperty, (rect.y + rect.height / 2) / profile.height, position)
-            filter.set(endXProperty, (rect.x + rect.width) / profile.width, position)
-            filter.set(endYProperty, (rect.y + rect.height) / profile.height, position)
+            filter.set(startXProperty, (rect.x + rect.width / 2) / profile.width, position);
+            filter.set(startYProperty, (rect.y + rect.height / 2) / profile.height, position);
+            filter.set(endXProperty, (rect.x + rect.width) / profile.width, position);
+            filter.set(endYProperty, (rect.y + rect.height) / profile.height, position);
         }
     }
 
     function setFilter(position) {
         if (position !== null) {
-            filter.blockSignals = true
-            if (position <= 0 && filter.animateIn > 0) {
-                filter.set(startValue, filterRect)
-            } else if (position >= filter.duration - 1 && filter.animateOut > 0) {
-                filter.set(endValue, filterRect)
-            } else {
-                filter.set(middleValue, filterRect)
-            }
-            filter.blockSignals = false
+            filter.blockSignals = true;
+            if (position <= 0 && filter.animateIn > 0)
+                filter.set(startValue, filterRect);
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                filter.set(endValue, filterRect);
+            else
+                filter.set(middleValue, filterRect);
+            filter.blockSignals = false;
         }
-
-        resetFilterRect()
+        resetFilterRect();
         if (filter.animateIn > 0 || filter.animateOut > 0) {
             if (filter.animateIn > 0) {
-                updateFilterRect(filter.getRect(startValue), 0)
-                updateFilterRect(filter.getRect(middleValue), filter.animateIn - 1)
+                updateFilterRect(filter.getRect(startValue), 0);
+                updateFilterRect(filter.getRect(middleValue), filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                updateFilterRect(filter.getRect(middleValue), filter.duration - filter.animateOut)
-                updateFilterRect(filter.getRect(endValue), filter.duration - 1)
+                updateFilterRect(filter.getRect(middleValue), filter.duration - filter.animateOut);
+                updateFilterRect(filter.getRect(endValue), filter.duration - 1);
             }
         } else {
-            updateFilterRect(filter.getRect(middleValue))
+            updateFilterRect(filter.getRect(middleValue));
         }
     }
 
     function setControls() {
-        _disableUpdate = true
+        _disableUpdate = true;
         if (filter.get(patternProperty) === 'gradient_linear')
-            linearRadioButton.checked = true
+            linearRadioButton.checked = true;
         else
-            radialRadioButton.checked = true
-        offsetSlider.value = filter.getDouble(offsetProperty) * 100
-        var colors = []
-        var alpha = Math.round(filter.getDouble(endOpacityProperty) * 255).toString(16)
+            radialRadioButton.checked = true;
+        offsetSlider.value = filter.getDouble(offsetProperty) * 100;
+        var colors = [];
+        var alpha = Math.round(filter.getDouble(endOpacityProperty) * 255).toString(16);
         if (alpha.length < 2)
-            alpha = '0' + alpha
-        colors[0] = filter.get(endColorProperty)
-        colors[0] = colors[0].substring(colors[0].length - 6)
-        colors[0] = '#' + alpha + colors[0]
-        alpha = Math.round(filter.getDouble(startOpacityProperty) * 255).toString(16)
+            alpha = '0' + alpha;
+
+        colors[0] = filter.get(endColorProperty);
+        colors[0] = colors[0].substring(colors[0].length - 6);
+        colors[0] = '#' + alpha + colors[0];
+        alpha = Math.round(filter.getDouble(startOpacityProperty) * 255).toString(16);
         if (alpha.length < 2)
-            alpha = '0' + alpha
-        colors[1] = filter.get(startColorProperty)
-        colors[1] = colors[1].substring(colors[1].length - 6)
-        colors[1] = '#' + alpha + colors[1]
-        gradient.colors = colors
-        var value = filter.get(blendProperty)
+            alpha = '0' + alpha;
+
+        colors[1] = filter.get(startColorProperty);
+        colors[1] = colors[1].substring(colors[1].length - 6);
+        colors[1] = '#' + alpha + colors[1];
+        gradient.colors = colors;
+        var value = filter.get(blendProperty);
         for (var i = 0; i < comboItems.count; i++) {
             if (value === comboItems.get(i).value) {
-                blendCombo.currentIndex = i
-                break
+                blendCombo.currentIndex = i;
+                break;
             }
         }
-        _disableUpdate = false
+        _disableUpdate = false;
     }
 
     function setKeyframedControls() {
-        var position = getPosition()
-        var newValue = filter.getRect(rectProperty, position)
+        var position = getPosition();
+        var newValue = filter.getRect(rectProperty, position);
         if (filterRect !== newValue) {
-            filterRect = newValue
-            rectX.value = filterRect.x.toFixed()
-            rectY.value = filterRect.y.toFixed()
-            rectW.value = filterRect.width.toFixed()
-            rectH.value = filterRect.height.toFixed()
+            filterRect = newValue;
+            rectX.value = filterRect.x.toFixed();
+            rectY.value = filterRect.y.toFixed();
+            rectW.value = filterRect.width.toFixed();
+            rectH.value = filterRect.height.toFixed();
         }
-        var enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
-        rectX.enabled = enabled
-        rectY.enabled = enabled
-        rectW.enabled = enabled
-        rectH.enabled = enabled
+        var enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
+        rectX.enabled = enabled;
+        rectY.enabled = enabled;
+        rectW.enabled = enabled;
+        rectH.enabled = enabled;
     }
 
-    ButtonGroup { id: patternGroup }
+    width: 350
+    height: 180
+    Component.onCompleted: {
+        filter.blockSignals = true;
+        filter.set(middleValue, Qt.rect(profile.width / 2, 0, profile.width * 0.01, profile.height));
+        filter.set(startValue, filter.getRect(middleValue));
+        filter.set(endValue, filter.getRect(middleValue));
+        if (filter.isNew) {
+            filter.set(patternProperty, 'gradient_linear');
+            filter.set(startColorProperty, '#000000');
+            filter.set(startOpacityProperty, 1);
+            filter.set(endColorProperty, '#ffffff');
+            filter.set(endOpacityProperty, 1);
+            filter.set(offsetProperty, 0);
+            filter.set(blendProperty, 'normal');
+            filter.set(rectProperty, '0%/50%:100%x1%');
+            filter.set(startXProperty, 0);
+            filter.set(startYProperty, 0.5);
+            filter.set(endXProperty, 1);
+            filter.set(endYProperty, 0.5);
+            filter.savePreset(preset.parameters, qsTr('Horizontal'));
+            filter.set(rectProperty, '50%/0%:1%x100%');
+            filter.set(startXProperty, 0.5);
+            filter.set(startYProperty, 0);
+            filter.set(endXProperty, 0.5);
+            filter.set(endYProperty, 1);
+            // Add default preset.
+            filter.savePreset(preset.parameters);
+        } else {
+            filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1));
+            if (filter.animateIn > 0)
+                filter.set(startValue, filter.getRect(rectProperty, 0));
+
+            if (filter.animateOut > 0)
+                filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1));
+
+        }
+        filter.blockSignals = false;
+        setControls();
+        setKeyframedControls();
+        if (filter.isNew)
+            filter.set(rectProperty, filter.getRect(rectProperty));
+
+    }
+
+    ButtonGroup {
+        id: patternGroup
+    }
 
     GridLayout {
         columns: 3
@@ -200,23 +203,27 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [patternProperty, rectProperty, startColorProperty, startOpacityProperty, endColorProperty, endOpacityProperty, blendProperty]
             Layout.columnSpan: 2
             onBeforePresetLoaded: {
-                filter.resetProperty(rectProperty)
+                filter.resetProperty(rectProperty);
             }
             onPresetSelected: {
-                setControls()
-                setKeyframedControls()
-                filter.blockSignals = true
-                filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1))
+                setControls();
+                setKeyframedControls();
+                filter.blockSignals = true;
+                filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1));
                 if (filter.animateIn > 0)
-                    filter.set(startValue, filter.getRect(rectProperty, 0))
+                    filter.set(startValue, filter.getRect(rectProperty, 0));
+
                 if (filter.animateOut > 0)
-                    filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1))
-                filter.blockSignals = false
+                    filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1));
+
+                filter.blockSignals = false;
             }
         }
 
@@ -224,30 +231,36 @@ Item {
             text: qsTr('Type')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             RadioButton {
                 id: linearRadioButton
+
                 text: qsTr('Linear')
                 ButtonGroup.group: patternGroup
                 onClicked: {
-                    filter.set(patternProperty, 'gradient_linear')
-                    setFilter(null)
+                    filter.set(patternProperty, 'gradient_linear');
+                    setFilter(null);
                 }
             }
+
             RadioButton {
                 id: radialRadioButton
+
                 text: qsTr('Radial')
                 ButtonGroup.group: patternGroup
                 onClicked: {
-                    filter.set(patternProperty, 'gradient_radial')
-                    setFilter(null)
+                    filter.set(patternProperty, 'gradient_radial');
+                    setFilter(null);
                 }
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                linearRadioButton.checked = true
-                filter.set(patternProperty, 'gradient_linear')
+                linearRadioButton.checked = true;
+                filter.set(patternProperty, 'gradient_linear');
             }
         }
 
@@ -255,14 +268,17 @@ Item {
             text: qsTr('Offset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: offsetSlider
+
             minimumValue: 0
             maximumValue: 99.9
             decimals: 1
             suffix: ' %'
             onValueChanged: filter.set(offsetProperty, value / 100)
         }
+
         Shotcut.UndoButton {
             onClicked: offsetSlider.value = 0
         }
@@ -271,31 +287,37 @@ Item {
             text: qsTr('Colors')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.GradientControl {
             id: gradient
-            spinnerVisible: false
+
             function cssColor(color) {
-                if (color.length > 7) {
-                    return '#' + color.substring(color.length - 6)
-                }
-                return color
+                if (color.length > 7)
+                    return '#' + color.substring(color.length - 6);
+
+                return color;
             }
+
+            spinnerVisible: false
             onGradientChanged: {
-                 if (_disableUpdate) return
-                 var color = Qt.darker(colors[0], 1.0)
-                 filter.set(endOpacityProperty, color.a)
-                 filter.set(endColorProperty, cssColor(colors[0]))
-                 if (colors.length > 0) {
-                     color = Qt.darker(colors[1], 1.0)
-                     filter.set(startOpacityProperty, color.a)
-                     filter.set(startColorProperty, cssColor(colors[1]))
-                 }
+                if (_disableUpdate)
+                    return ;
+
+                var color = Qt.darker(colors[0], 1);
+                filter.set(endOpacityProperty, color.a);
+                filter.set(endColorProperty, cssColor(colors[0]));
+                if (colors.length > 0) {
+                    color = Qt.darker(colors[1], 1);
+                    filter.set(startOpacityProperty, color.a);
+                    filter.set(startColorProperty, cssColor(colors[1]));
+                }
             }
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                gradient.colors = ['#ff000000', '#ffffffff']
-                gradient.gradientChanged()
+                gradient.colors = ['#ff000000', '#ffffffff'];
+                gradient.gradientChanged();
             }
         }
 
@@ -305,40 +327,55 @@ Item {
             font.bold: true
             font.italic: true
         }
+
         RowLayout {
             Shotcut.DoubleSpinBox {
                 id: rectX
+
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.x !== value) {
-                    filterRect.x = value
-                    setFilter(getPosition())
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.x !== value) {
+                        filterRect.x = value;
+                        setFilter(getPosition());
+                    }
                 }
             }
-            Label { text: ','; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCente }
+
+            Label {
+                text: ','
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCente
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectY
+
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.y !== value) {
-                    filterRect.y = value
-                    setFilter(getPosition())
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.y !== value) {
+                        filterRect.y = value;
+                        setFilter(getPosition());
+                    }
                 }
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filterRect.x = rectX.value = profile.width / 2
-                filterRect.y = rectY.value = 0
-                setFilter(getPosition())
+                filterRect.x = rectX.value = profile.width / 2;
+                filterRect.y = rectY.value = 0;
+                setFilter(getPosition());
             }
         }
 
@@ -348,93 +385,210 @@ Item {
             font.bold: true
             font.italic: true
         }
+
         RowLayout {
             Shotcut.DoubleSpinBox {
                 id: rectW
+
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.width !== value) {
-                    filterRect.width = value
-                    setFilter(getPosition())
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.width !== value) {
+                        filterRect.width = value;
+                        setFilter(getPosition());
+                    }
                 }
             }
-            Label { text: 'x'; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCente }
+
+            Label {
+                text: 'x'
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCente
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectH
+
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.height !== value) {
-                    filterRect.height = value
-                    setFilter(getPosition())
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.height !== value) {
+                        filterRect.height = value;
+                        setFilter(getPosition());
+                    }
                 }
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filterRect.width = rectW.value = profile.width * 0.01
-                filterRect.height = rectH.value = profile.height
-                setFilter(getPosition())
+                filterRect.width = rectW.value = profile.width * 0.01;
+                filterRect.height = rectH.value = profile.height;
+                setFilter(getPosition());
             }
         }
 
-        Label { text: qsTr('Blend mode') }
+        Label {
+            text: qsTr('Blend mode')
+        }
+
         Shotcut.ComboBox {
             id: blendCombo
-            model: ListModel {
-                id: comboItems
-                ListElement { text: qsTr('Over'); value: 'normal' }
-                ListElement { text: qsTr('None'); value: '' }
-                ListElement { text: qsTr('Add'); value: 'add' }
-                ListElement { text: qsTr('Saturate'); value: 'saturate' }
-                ListElement { text: qsTr('Multiply'); value: 'multiply' }
-                ListElement { text: qsTr('Screen'); value: 'screen' }
-                ListElement { text: qsTr('Overlay'); value: 'overlay' }
-                ListElement { text: qsTr('Darken'); value: 'darken' }
-                ListElement { text: qsTr('Dodge'); value: 'colordodge' }
-                ListElement { text: qsTr('Burn'); value: 'colorburn' }
-                ListElement { text: qsTr('Hard Light'); value: 'hardlight' }
-                ListElement { text: qsTr('Soft Light'); value: 'softlight' }
-                ListElement { text: qsTr('Difference'); value: 'difference' }
-                ListElement { text: qsTr('Exclusion'); value: 'exclusion' }
-                ListElement { text: qsTr('HSL Hue'); value: 'hslhue' }
-                ListElement { text: qsTr('HSL Saturation'); value: 'hslsaturatation' }
-                ListElement { text: qsTr('HSL Color'); value: 'hslcolor' }
-                ListElement { text: qsTr('HSL Luminosity'); value: 'hslluminocity' }
-            }
+
             textRole: 'text'
             onActivated: {
-                filter.set(blendProperty, comboItems.get(currentIndex).value)
+                filter.set(blendProperty, comboItems.get(currentIndex).value);
             }
+
+            model: ListModel {
+                id: comboItems
+
+                ListElement {
+                    text: qsTr('Over')
+                    value: 'normal'
+                }
+
+                ListElement {
+                    text: qsTr('None')
+                    value: ''
+                }
+
+                ListElement {
+                    text: qsTr('Add')
+                    value: 'add'
+                }
+
+                ListElement {
+                    text: qsTr('Saturate')
+                    value: 'saturate'
+                }
+
+                ListElement {
+                    text: qsTr('Multiply')
+                    value: 'multiply'
+                }
+
+                ListElement {
+                    text: qsTr('Screen')
+                    value: 'screen'
+                }
+
+                ListElement {
+                    text: qsTr('Overlay')
+                    value: 'overlay'
+                }
+
+                ListElement {
+                    text: qsTr('Darken')
+                    value: 'darken'
+                }
+
+                ListElement {
+                    text: qsTr('Dodge')
+                    value: 'colordodge'
+                }
+
+                ListElement {
+                    text: qsTr('Burn')
+                    value: 'colorburn'
+                }
+
+                ListElement {
+                    text: qsTr('Hard Light')
+                    value: 'hardlight'
+                }
+
+                ListElement {
+                    text: qsTr('Soft Light')
+                    value: 'softlight'
+                }
+
+                ListElement {
+                    text: qsTr('Difference')
+                    value: 'difference'
+                }
+
+                ListElement {
+                    text: qsTr('Exclusion')
+                    value: 'exclusion'
+                }
+
+                ListElement {
+                    text: qsTr('HSL Hue')
+                    value: 'hslhue'
+                }
+
+                ListElement {
+                    text: qsTr('HSL Saturation')
+                    value: 'hslsaturatation'
+                }
+
+                ListElement {
+                    text: qsTr('HSL Color')
+                    value: 'hslcolor'
+                }
+
+                ListElement {
+                    text: qsTr('HSL Luminosity')
+                    value: 'hslluminocity'
+                }
+
+            }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filter.set(blendProperty, comboItems.get(0).value)
-                blendCombo.currentIndex = 0
+                filter.set(blendProperty, comboItems.get(0).value);
+                blendCombo.currentIndex = 0;
             }
         }
 
-        Item { Layout.fillHeight: true }
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
 
     Connections {
+        function onChanged() {
+            setKeyframedControls();
+        }
+
+        function onInChanged() {
+            setFilter(null);
+        }
+
+        function onOutChanged() {
+            setFilter(null);
+        }
+
+        function onAnimateInChanged() {
+            setFilter(null);
+        }
+
+        function onAnimateOutChanged() {
+            setFilter(null);
+        }
+
         target: filter
-        function onChanged() { setKeyframedControls() }
-        function onInChanged() { setFilter(null) }
-        function onOutChanged() { setFilter(null) }
-        function onAnimateInChanged() { setFilter(null) }
-        function onAnimateOutChanged() { setFilter(null) }
     }
 
     Connections {
+        function onPositionChanged() {
+            setKeyframedControls();
+        }
+
         target: producer
-        function onPositionChanged() { setKeyframedControls() }
     }
+
 }

--- a/src/qml/filters/gradient/vui.qml
+++ b/src/qml/filters/gradient/vui.qml
@@ -25,91 +25,92 @@ Shotcut.VuiBase {
     property string startYProperty: '6'
     property string endXProperty: '7'
     property string endYProperty: '8'
-    property real zoom: (video.zoom > 0)? video.zoom : 1.0
+    property real zoom: (video.zoom > 0) ? video.zoom : 1
     property rect filterRect: Qt.rect(-1, -1, -1, -1)
     property bool blockUpdate: false
     property string startValue: '_shotcut:startValue'
     property string middleValue: '_shotcut:middleValue'
-    property string endValue:  '_shotcut:endValue'
-
-    Component.onCompleted: {
-        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag'))
-        setRectangleControl()
-    }
+    property string endValue: '_shotcut:endValue'
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setRectangleControl() {
-        if (blockUpdate) return
-        var position = getPosition()
-        var newValue = filter.getRect(rectProperty, position)
+        if (blockUpdate)
+            return ;
+
+        var position = getPosition();
+        var newValue = filter.getRect(rectProperty, position);
         if (filterRect !== newValue) {
-            filterRect = newValue
-            rectangle.setHandles(filterRect)
+            filterRect = newValue;
+            rectangle.setHandles(filterRect);
         }
-        rectangle.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        rectangle.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function resetFilterRect() {
-        filter.resetProperty(rectProperty)
-        filter.resetProperty(startXProperty)
-        filter.resetProperty(startYProperty)
-        filter.resetProperty(endXProperty)
-        filter.resetProperty(endYProperty)
+        filter.resetProperty(rectProperty);
+        filter.resetProperty(startXProperty);
+        filter.resetProperty(startYProperty);
+        filter.resetProperty(endXProperty);
+        filter.resetProperty(endYProperty);
     }
 
     function updateFilterRect(rect, position) {
         if (position === null)
-            position = -1
-        filter.set(rectProperty, rect, position)
+            position = -1;
+
+        filter.set(rectProperty, rect, position);
         if (filter.get(patternProperty) === 'gradient_linear') {
-            filter.set(startXProperty, rect.x / profile.width, position)
-            filter.set(startYProperty, rect.y / profile.height, position)
-            filter.set(endXProperty, (rect.x + rect.width) / profile.width, position)
-            filter.set(endYProperty, (rect.y + rect.height) / profile.height, position)
+            filter.set(startXProperty, rect.x / profile.width, position);
+            filter.set(startYProperty, rect.y / profile.height, position);
+            filter.set(endXProperty, (rect.x + rect.width) / profile.width, position);
+            filter.set(endYProperty, (rect.y + rect.height) / profile.height, position);
         } else {
-            filter.set(startXProperty, (rect.x + rect.width / 2) / profile.width, position)
-            filter.set(startYProperty, (rect.y + rect.height / 2) / profile.height, position)
-            filter.set(endXProperty, (rect.x + rect.width) / profile.width, position)
-            filter.set(endYProperty, (rect.y + rect.height) / profile.height, position)
+            filter.set(startXProperty, (rect.x + rect.width / 2) / profile.width, position);
+            filter.set(startYProperty, (rect.y + rect.height / 2) / profile.height, position);
+            filter.set(endXProperty, (rect.x + rect.width) / profile.width, position);
+            filter.set(endYProperty, (rect.y + rect.height) / profile.height, position);
         }
     }
 
     function setFilter(position) {
-        blockUpdate = true
-        var rect = rectangle.rectangle
-        filterRect.x = Math.round(rect.x / rectangle.widthScale)
-        filterRect.y = Math.round(rect.y / rectangle.heightScale)
-        filterRect.width = Math.round(rect.width / rectangle.widthScale)
-        filterRect.height = Math.round(rect.height / rectangle.heightScale)
-
+        blockUpdate = true;
+        var rect = rectangle.rectangle;
+        filterRect.x = Math.round(rect.x / rectangle.widthScale);
+        filterRect.y = Math.round(rect.y / rectangle.heightScale);
+        filterRect.width = Math.round(rect.width / rectangle.widthScale);
+        filterRect.height = Math.round(rect.height / rectangle.heightScale);
         if (position !== null) {
-            filter.blockSignals = true
+            filter.blockSignals = true;
             if (position <= 0 && filter.animateIn > 0)
-                filter.set(startValue, filterRect)
+                filter.set(startValue, filterRect);
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                filter.set(endValue, filterRect)
+                filter.set(endValue, filterRect);
             else
-                filter.set(middleValue, filterRect)
-            filter.blockSignals = false
+                filter.set(middleValue, filterRect);
+            filter.blockSignals = false;
         }
-
-        resetFilterRect()
+        resetFilterRect();
         if (filter.animateIn > 0 || filter.animateOut > 0) {
             if (filter.animateIn > 0) {
-                updateFilterRect(filter.getRect(startValue), 0)
-                updateFilterRect(filter.getRect(middleValue), filter.animateIn - 1)
+                updateFilterRect(filter.getRect(startValue), 0);
+                updateFilterRect(filter.getRect(middleValue), filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                updateFilterRect(filter.getRect(middleValue), filter.duration - filter.animateOut)
-                updateFilterRect(filter.getRect(endValue), filter.duration - 1)
+                updateFilterRect(filter.getRect(middleValue), filter.duration - filter.animateOut);
+                updateFilterRect(filter.getRect(endValue), filter.duration - 1);
             }
         } else {
-            updateFilterRect(filter.getRect(middleValue))
+            updateFilterRect(filter.getRect(middleValue));
         }
-        blockUpdate = false
+        blockUpdate = false;
+    }
+
+    Component.onCompleted: {
+        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag'));
+        setRectangleControl();
     }
 
     Flickable {
@@ -123,6 +124,7 @@ Shotcut.VuiBase {
 
         Item {
             id: videoItem
+
             x: video.rect.x
             y: video.rect.y
             width: video.rect.width
@@ -131,6 +133,7 @@ Shotcut.VuiBase {
 
             Shotcut.RectangleControl {
                 id: rectangle
+
                 widthScale: video.rect.width / profile.width
                 heightScale: video.rect.height / profile.height
                 handleSize: Math.max(Math.round(8 / zoom), 4)
@@ -139,19 +142,26 @@ Shotcut.VuiBase {
                 onHeightScaleChanged: setHandles(filterRect)
                 onRectChanged: setFilter(getPosition())
             }
+
         }
+
     }
 
     Connections {
-        target: filter
         function onChanged() {
-            setRectangleControl()
-            videoItem.enabled = filter.get('disable') !== '1'
+            setRectangleControl();
+            videoItem.enabled = filter.get('disable') !== '1';
         }
+
+        target: filter
     }
 
     Connections {
+        function onPositionChanged() {
+            setRectangleControl();
+        }
+
         target: producer
-        function onPositionChanged() { setRectangleControl() }
     }
+
 }

--- a/src/qml/filters/grain/ui.qml
+++ b/src/qml/filters/grain/ui.qml
@@ -22,22 +22,22 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
+    function setControls() {
+        noiseSlider.value = filter.get('noise');
+        brightnessSlider.value = filter.get('brightness');
+    }
+
     width: 350
     height: 100
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set('noise', 40)
-            filter.set('contrast', 100)
-            filter.set('brightness', 83)
-            filter.savePreset(preset.parameters)
+            filter.set('noise', 40);
+            filter.set('contrast', 100);
+            filter.set('brightness', 83);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        noiseSlider.value = filter.get('noise')
-        brightnessSlider.value = filter.get('brightness')
+        setControls();
     }
 
     GridLayout {
@@ -49,8 +49,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ['noise', 'brightness']
             Layout.columnSpan: 2
             onPresetSelected: setControls()
@@ -60,14 +62,17 @@ Item {
             text: qsTr('Noise')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: noiseSlider
+
             minimumValue: 1
             maximumValue: 200
             suffix: ' %'
             value: filter.get('noise')
             onValueChanged: filter.set('noise', value)
         }
+
         Shotcut.UndoButton {
             onClicked: noiseSlider.value = 40
         }
@@ -76,20 +81,24 @@ Item {
             text: qsTr('Brightness')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: brightnessSlider
+
             minimumValue: 0
             maximumValue: 400
             value: filter.get('brightness')
             onValueChanged: filter.set('brightness', value)
         }
+
         Shotcut.UndoButton {
             onClicked: brightnessSlider.value = 83
-
         }
 
         Item {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/grid/meta.qml
+++ b/src/qml/filters/grid/meta.qml
@@ -6,6 +6,7 @@ Metadata {
     name: qsTr("Grid")
     mlt_service: "frei0r.cairoimagegrid"
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -27,4 +28,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/grid/ui.qml
+++ b/src/qml/filters/grid/ui.qml
@@ -21,8 +21,6 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 200
-    height: 50
     property bool blockUpdate: true
     property double startWidthValue: 0
     property double middleWidthValue: 0.1
@@ -31,104 +29,106 @@ Item {
     property double middleHeightValue: 0.1
     property double endHeightValue: 0
 
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set('0', 0.1)
-            filter.set('1', 0.1)
-            filter.savePreset(preset.parameters)
-        } else {
-            middleWidthValue = filter.getDouble('0', filter.animateIn)
-            middleHeightValue = filter.getDouble('1', filter.animateIn)
-            if (filter.animateIn > 0) {
-                startWidthValue = filter.getDouble('0', 0)
-                startHeightValue = filter.getDouble('1', 0)
-            }
-            if (filter.animateOut > 0) {
-                endWidthValue = filter.getDouble('0', filter.duration - 1)
-                endHeightValue = filter.getDouble('1', filter.duration - 1)
-            }
-        }
-        setControls()
-    }
-
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        wslider.value = filter.getDouble('0', position) * 100
-        hslider.value = filter.getDouble('1', position) * 100
-        widthKeyframesButton.checked = filter.keyframeCount('0') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-        heightKeyframesButton.checked = filter.keyframeCount('1') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-        blockUpdate = false
-        wslider.enabled = hslider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        wslider.value = filter.getDouble('0', position) * 100;
+        hslider.value = filter.getDouble('1', position) * 100;
+        widthKeyframesButton.checked = filter.keyframeCount('0') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+        heightKeyframesButton.checked = filter.keyframeCount('1') > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+        blockUpdate = false;
+        wslider.enabled = hslider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function updateFilterWidth(position) {
-        if (blockUpdate) return
-        var value = wslider.value / 100
+        if (blockUpdate)
+            return ;
 
+        var value = wslider.value / 100;
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startWidthValue = value
+                startWidthValue = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endWidthValue = value
+                endWidthValue = value;
             else
-                middleWidthValue = value
+                middleWidthValue = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty('0')
-            widthKeyframesButton.checked = false
+            filter.resetProperty('0');
+            widthKeyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set('0', startWidthValue, 0)
-                filter.set('0', middleWidthValue, filter.animateIn - 1)
+                filter.set('0', startWidthValue, 0);
+                filter.set('0', middleWidthValue, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set('0', middleWidthValue, filter.duration - filter.animateOut)
-                filter.set('0', endWidthValue, filter.duration - 1)
+                filter.set('0', middleWidthValue, filter.duration - filter.animateOut);
+                filter.set('0', endWidthValue, filter.duration - 1);
             }
         } else if (!widthKeyframesButton.checked) {
-            filter.resetProperty('0')
-            filter.set('0', middleWidthValue)
+            filter.resetProperty('0');
+            filter.set('0', middleWidthValue);
         } else if (position !== null) {
-            filter.set('0', value, position)
+            filter.set('0', value, position);
         }
     }
 
     function updateFilterHeight(position) {
-        if (blockUpdate) return
-        var value = hslider.value / 100
+        if (blockUpdate)
+            return ;
 
+        var value = hslider.value / 100;
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startHeightValue = value
+                startHeightValue = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endHeightValue = value
+                endHeightValue = value;
             else
-                middleHeightValue = value
+                middleHeightValue = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty('1')
-            heightKeyframesButton.checked = false
+            filter.resetProperty('1');
+            heightKeyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set('1', startHeightValue, 0)
-                filter.set('1', middleHeightValue, filter.animateIn - 1)
+                filter.set('1', startHeightValue, 0);
+                filter.set('1', middleHeightValue, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set('1', middleHeightValue, filter.duration - filter.animateOut)
-                filter.set('1', endHeightValue, filter.duration - 1)
+                filter.set('1', middleHeightValue, filter.duration - filter.animateOut);
+                filter.set('1', endHeightValue, filter.duration - 1);
             }
         } else if (!heightKeyframesButton.checked) {
-            filter.resetProperty('1')
-            filter.set('1', middleHeightValue)
+            filter.resetProperty('1');
+            filter.set('1', middleHeightValue);
         } else if (position !== null) {
-            filter.set('1', value, position)
+            filter.set('1', value, position);
         }
+    }
+
+    width: 200
+    height: 50
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set('0', 0.1);
+            filter.set('1', 0.1);
+            filter.savePreset(preset.parameters);
+        } else {
+            middleWidthValue = filter.getDouble('0', filter.animateIn);
+            middleHeightValue = filter.getDouble('1', filter.animateIn);
+            if (filter.animateIn > 0) {
+                startWidthValue = filter.getDouble('0', 0);
+                startHeightValue = filter.getDouble('1', 0);
+            }
+            if (filter.animateOut > 0) {
+                endWidthValue = filter.getDouble('0', filter.duration - 1);
+                endHeightValue = filter.getDouble('1', filter.duration - 1);
+            }
+        }
+        setControls();
     }
 
     GridLayout {
@@ -140,59 +140,67 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: parent.columns - 1
             parameters: ['0', '1']
             onBeforePresetLoaded: {
-                filter.resetProperty('0')
-                filter.resetProperty('1')
+                filter.resetProperty('0');
+                filter.resetProperty('1');
             }
             onPresetSelected: {
-                setControls()
-                middleWidthValue = filter.getDouble('0', filter.animateIn)
-                middleHeightValue = filter.getDouble('1', filter.animateIn)
+                setControls();
+                middleWidthValue = filter.getDouble('0', filter.animateIn);
+                middleHeightValue = filter.getDouble('1', filter.animateIn);
                 if (filter.animateIn > 0) {
-                    startWidthValue = filter.getDouble('0', 0)
-                    startHeightValue = filter.getDouble('1', 0)
+                    startWidthValue = filter.getDouble('0', 0);
+                    startHeightValue = filter.getDouble('1', 0);
                 }
                 if (filter.animateOut > 0) {
-                    endWidthValue = filter.getDouble('0', filter.duration - 1)
-                    endHeightValue = filter.getDouble('1', filter.duration - 1)
+                    endWidthValue = filter.getDouble('0', filter.duration - 1);
+                    endHeightValue = filter.getDouble('1', filter.duration - 1);
                 }
             }
         }
+
         Label {
             text: qsTr('Rows')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: wslider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilterWidth(getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: wslider.value = 10
         }
+
         Shotcut.KeyframesButton {
             id: widthKeyframesButton
+
             onToggled: {
                 if (checked) {
-                    blockUpdate = true
+                    blockUpdate = true;
                     if (filter.animateIn > 0 || filter.animateOut > 0) {
-                        filter.resetProperty('1')
-                        filter.set('1', middleHeightValue)
-                        hslider.enabled = true
+                        filter.resetProperty('1');
+                        filter.set('1', middleHeightValue);
+                        hslider.enabled = true;
                     }
-                    filter.clearSimpleAnimation('0')
-                    blockUpdate = false
-                    filter.set('0', wslider.value / 100, getPosition())
+                    filter.clearSimpleAnimation('0');
+                    blockUpdate = false;
+                    filter.set('0', wslider.value / 100, getPosition());
                 } else {
-                    filter.resetProperty('0')
-                    filter.set('0', wslider.value / 100)
+                    filter.resetProperty('0');
+                    filter.set('0', wslider.value / 100);
                 }
             }
         }
@@ -201,33 +209,38 @@ Item {
             text: qsTr('Columns')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: hslider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilterHeight(getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: hslider.value = 10
         }
+
         Shotcut.KeyframesButton {
             id: heightKeyframesButton
+
             onToggled: {
                 if (checked) {
-                    blockUpdate = true
+                    blockUpdate = true;
                     if (filter.animateIn > 0 || filter.animateOut > 0) {
-                        filter.resetProperty('0')
-                        filter.set('0', middleWidthValue)
-                        wslider.enabled = true
+                        filter.resetProperty('0');
+                        filter.set('0', middleWidthValue);
+                        wslider.enabled = true;
                     }
-                    filter.clearSimpleAnimation('1')
-                    blockUpdate = false
-                    filter.set('1', hslider.value / 100, getPosition())
+                    filter.clearSimpleAnimation('1');
+                    blockUpdate = false;
+                    filter.set('1', hslider.value / 100, getPosition());
                 } else {
-                    filter.resetProperty('1')
-                    filter.set('1', hslider.value / 100)
+                    filter.resetProperty('1');
+                    filter.set('1', hslider.value / 100);
                 }
             }
         }
@@ -235,31 +248,60 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            setControls();
+            updateFilterWidth(null);
+            updateFilterHeight(null);
+        }
+
+        function onOutChanged() {
+            setControls();
+            updateFilterWidth(null);
+            updateFilterHeight(null);
+        }
+
+        function onAnimateInChanged() {
+            setControls();
+            updateFilterWidth(null);
+            updateFilterHeight(null);
+        }
+
+        function onAnimateOutChanged() {
+            setControls();
+            updateFilterWidth(null);
+            updateFilterHeight(null);
+        }
+
+        function onPropertyChanged() {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { setControls(); updateFilterWidth(null); updateFilterHeight(null) }
-        function onOutChanged() { setControls(); updateFilterWidth(null); updateFilterHeight(null) }
-        function onAnimateInChanged() { setControls(); updateFilterWidth(null); updateFilterHeight(null) }
-        function onAnimateOutChanged() { setControls(); updateFilterWidth(null); updateFilterHeight(null) }
-        function onPropertyChanged() { setControls() }
     }
 
     Connections {
-        target: producer
         function onPositionChanged() {
             if (filter.animateIn > 0 || filter.animateOut > 0) {
-                setControls()
+                setControls();
             } else {
-                blockUpdate = true
-                wslider.value = filter.getDouble('0', getPosition()) * 100
-                hslider.value = filter.getDouble('1', getPosition()) * 100
-                blockUpdate = false
-                wslider.enabled = true
-                hslider.enabled = true
+                blockUpdate = true;
+                wslider.value = filter.getDouble('0', getPosition()) * 100;
+                hslider.value = filter.getDouble('1', getPosition()) * 100;
+                blockUpdate = false;
+                wslider.enabled = true;
+                hslider.enabled = true;
             }
         }
+
+        target: producer
     }
+
 }

--- a/src/qml/filters/halftone/meta.qml
+++ b/src/qml/filters/halftone/meta.qml
@@ -7,6 +7,7 @@ Metadata {
     objectName: 'halftone'
     mlt_service: "frei0r.colorhalftone"
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -25,14 +26,14 @@ Metadata {
                 isCurve: true
                 minimum: 0
                 maximum: 1
-             },
+            },
             Parameter {
                 name: qsTr('Magenta')
                 property: '2'
                 isCurve: true
                 minimum: 0
                 maximum: 1
-             },
+            },
             Parameter {
                 name: qsTr('Yellow')
                 property: '3'
@@ -42,4 +43,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/halftone/ui.qml
+++ b/src/qml/filters/halftone/ui.qml
@@ -25,56 +25,53 @@ Shotcut.KeyframableFilter {
     property string cyanangle: '1'
     property string magentaangle: '2'
     property string yellowangle: '3'
-    
-    property double dotradiusDefault: 0.40
-    property double cyanangleDefault: 0.30
+    property double dotradiusDefault: 0.4
+    property double cyanangleDefault: 0.3
     property double magentaangleDefault: 0.45
     property double yellowangleDefault: 0.25
-     
+
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        dotradiusSlider.value = filter.getDouble(dotradius, position) * dotradiusSlider.maximumValue;
+        dotKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(dotradius) > 0;
+        cyanangleSlider.value = filter.getDouble(cyanangle, position) * cyanangleSlider.maximumValue;
+        cyanKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(cyanangle) > 0;
+        magentaangleSlider.value = filter.getDouble(magentaangle, position) * magentaangleSlider.maximumValue;
+        magentaKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(magentaangle) > 0;
+        yellowangleSlider.value = filter.getDouble(yellowangle, position) * yellowangleSlider.maximumValue;
+        yellowKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(yellowangle) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        dotradiusSlider.enabled = cyanangleSlider.enabled = magentaangleSlider.enabled = yellowangleSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        setControls();
+        updateFilter(dotradius, dotradiusSlider.value / dotradiusSlider.maximumValue, dotKeyframesButton, null);
+        updateFilter(cyanangle, cyanangleSlider.value / cyanangleSlider.maximumValue, cyanKeyframesButton, null);
+        updateFilter(magentaangle, magentaangleSlider.value / magentaangleSlider.maximumValue, magentaKeyframesButton, null);
+        updateFilter(yellowangle, yellowangleSlider.value / yellowangleSlider.maximumValue, yellowKeyframesButton, null);
+    }
+
     keyframableParameters: [dotradius, cyanangle, magentaangle, yellowangle]
     startValues: [0.5, 0.5, 0.5, 0.5]
     middleValues: [dotradiusDefault, cyanangleDefault, magentaangleDefault, yellowangleDefault]
     endValues: [0.5, 0.5, 0.5, 0.5]
-
     width: 350
     height: 175
-
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set(dotradius, dotradiusDefault)
-            filter.set(cyanangle, cyanangleDefault)
-            filter.set(magentaangle, magentaangleDefault)
-            filter.set(yellowangle, yellowangleDefault)
-            filter.savePreset(preset.parameters)
+            filter.set(dotradius, dotradiusDefault);
+            filter.set(cyanangle, cyanangleDefault);
+            filter.set(magentaangle, magentaangleDefault);
+            filter.set(yellowangle, yellowangleDefault);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        dotradiusSlider.value = filter.getDouble(dotradius, position) * dotradiusSlider.maximumValue
-        dotKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(dotradius) > 0
-        cyanangleSlider.value = filter.getDouble(cyanangle, position) * cyanangleSlider.maximumValue
-        cyanKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(cyanangle) > 0
-        magentaangleSlider.value = filter.getDouble(magentaangle, position) * magentaangleSlider.maximumValue
-        magentaKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(magentaangle) > 0
-        yellowangleSlider.value = filter.getDouble(yellowangle, position) * yellowangleSlider.maximumValue
-        yellowKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(yellowangle) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        dotradiusSlider.enabled = cyanangleSlider.enabled = magentaangleSlider.enabled = yellowangleSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        setControls()
-        updateFilter(dotradius, dotradiusSlider.value / dotradiusSlider.maximumValue, dotKeyframesButton, null)
-        updateFilter(cyanangle, cyanangleSlider.value / cyanangleSlider.maximumValue, cyanKeyframesButton, null)
-        updateFilter(magentaangle, magentaangleSlider.value / magentaangleSlider.maximumValue, magentaKeyframesButton, null)
-        updateFilter(yellowangle, yellowangleSlider.value / yellowangleSlider.maximumValue, yellowKeyframesButton, null)
+        setControls();
     }
 
     GridLayout {
@@ -86,19 +83,21 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [dotradius, cyanangle, magentaangle, yellowangle]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                filter.resetProperty(dotradius)
-                filter.resetProperty(cyanangle)
-                filter.resetProperty(magentaangle)
-                filter.resetProperty(yellowangle)
+                filter.resetProperty(dotradius);
+                filter.resetProperty(cyanangle);
+                filter.resetProperty(magentaangle);
+                filter.resetProperty(yellowangle);
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -106,23 +105,28 @@ Shotcut.KeyframableFilter {
             text: qsTr('Radius')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: dotradiusSlider
+
             minimumValue: 0
-            maximumValue: 100.0
+            maximumValue: 100
             stepSize: 0.1
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter(dotradius, dotradiusSlider.value / dotradiusSlider.maximumValue, dotKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: dotradiusSlider.value = dotradiusDefault * dotradiusSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: dotKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, dotradius, dotradiusSlider.value / dotradiusSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, dotradius, dotradiusSlider.value / dotradiusSlider.maximumValue);
             }
         }
 
@@ -130,23 +134,28 @@ Shotcut.KeyframableFilter {
             text: qsTr('Cyan')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: cyanangleSlider
+
             minimumValue: 0
-            maximumValue: 100.0
+            maximumValue: 100
             stepSize: 0.1
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter(cyanangle, cyanangleSlider.value / cyanangleSlider.maximumValue, cyanKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: cyanangleSlider.value = cyanangleDefault * cyanangleSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: cyanKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, cyanangle, cyanangleSlider.value / cyanangleSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, cyanangle, cyanangleSlider.value / cyanangleSlider.maximumValue);
             }
         }
 
@@ -154,23 +163,28 @@ Shotcut.KeyframableFilter {
             text: qsTr('Magenta')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: magentaangleSlider
+
             minimumValue: 0
-            maximumValue: 100.0
+            maximumValue: 100
             stepSize: 0.1
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter(magentaangle, magentaangleSlider.value / magentaangleSlider.maximumValue, magentaKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: magentaangleSlider.value = magentaangleDefault * magentaangleSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: magentaKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, magentaangle, magentaangleSlider.value / magentaangleSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, magentaangle, magentaangleSlider.value / magentaangleSlider.maximumValue);
             }
         }
 
@@ -178,43 +192,71 @@ Shotcut.KeyframableFilter {
             text: qsTr('Yellow')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: yellowangleSlider
+
             minimumValue: 0
-            maximumValue: 100.0
+            maximumValue: 100
             stepSize: 0.1
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter(yellowangle, yellowangleSlider.value / yellowangleSlider.maximumValue, yellowKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: yellowangleSlider.value = yellowangleDefault * yellowangleSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: yellowKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, yellowangle, yellowangleSlider.value / yellowangleSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, yellowangle, yellowangleSlider.value / yellowangleSlider.maximumValue);
             }
         }
-        
+
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/hqdn3d/meta.qml
+++ b/src/qml/filters/hqdn3d/meta.qml
@@ -23,6 +23,7 @@ Metadata {
     name: qsTr("Reduce Noise: HQDN3D")
     mlt_service: "frei0r.hqdn3d"
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -44,4 +45,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/hqdn3d/ui.qml
+++ b/src/qml/filters/hqdn3d/ui.qml
@@ -26,42 +26,40 @@ Shotcut.KeyframableFilter {
     property double spatialDefault: 0.04
     property double temporalDefault: 0.06
 
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        spatialSlider.value = filter.getDouble(spatial, position) * spatialSlider.maximumValue;
+        spatialKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(spatial) > 0;
+        temporalSlider.value = filter.getDouble(temporal, position) * temporalSlider.maximumValue;
+        temporalKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(temporal) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        spatialSlider.enabled = temporalSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        setControls();
+        updateFilter(spatial, spatialSlider.value / spatialSlider.maximumValue, spatialKeyframesButton, null);
+        updateFilter(temporal, temporalSlider.value / temporalSlider.maximumValue, temporalKeyframesButton, null);
+    }
+
     keyframableParameters: [spatial, temporal]
     startValues: [0.5, 0.5]
     middleValues: [spatialDefault, temporalDefault]
     endValues: [0.5, 0.5]
-
     width: 350
     height: 100
-
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set(spatial, spatialDefault)
-            filter.set(temporal, temporalDefault)
-            filter.savePreset(preset.parameters)
+            filter.set(spatial, spatialDefault);
+            filter.set(temporal, temporalDefault);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        spatialSlider.value = filter.getDouble(spatial, position) * spatialSlider.maximumValue
-        spatialKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(spatial) > 0
-        temporalSlider.value = filter.getDouble(temporal, position) * temporalSlider.maximumValue
-        temporalKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(temporal) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        spatialSlider.enabled = temporalSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        setControls()
-        updateFilter(spatial, spatialSlider.value / spatialSlider.maximumValue, spatialKeyframesButton, null)
-        updateFilter(temporal, temporalSlider.value / temporalSlider.maximumValue, temporalKeyframesButton, null)
+        setControls();
     }
 
     GridLayout {
@@ -73,16 +71,18 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [spatial, temporal]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -90,23 +90,28 @@ Shotcut.KeyframableFilter {
             text: qsTr('Spatial')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: spatialSlider
-            minimumValue: 0.0
+
+            minimumValue: 0
             maximumValue: 100
             stepSize: 0.1
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter(spatial, spatialSlider.value / spatialSlider.maximumValue, spatialKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: spatialSlider.value = spatialDefault * spatialSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: spatialKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, spatial, spatialSlider.value / spatialSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, spatial, spatialSlider.value / spatialSlider.maximumValue);
             }
         }
 
@@ -114,43 +119,71 @@ Shotcut.KeyframableFilter {
             text: qsTr('Temporal')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: temporalSlider
-            minimumValue: 0.0
+
+            minimumValue: 0
             maximumValue: 100
             stepSize: 0.1
             decimals: 1
             suffix: ' %'
             onValueChanged: updateFilter(temporal, temporalSlider.value / temporalSlider.maximumValue, temporalKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: temporalSlider.value = temporalDefault * temporalSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: temporalKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, temporal, temporalSlider.value / temporalSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, temporal, temporalSlider.value / temporalSlider.maximumValue);
             }
         }
 
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/hue_lightness_saturation/meta.qml
+++ b/src/qml/filters/hue_lightness_saturation/meta.qml
@@ -23,6 +23,7 @@ Metadata {
     name: qsTr("Hue/Lightness/Saturation")
     mlt_service: 'avfilter.hue'
     qml: 'ui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -51,4 +52,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/hue_lightness_saturation/ui.qml
+++ b/src/qml/filters/hue_lightness_saturation/ui.qml
@@ -25,48 +25,46 @@ Shotcut.KeyframableFilter {
     property double lightnessDefault: 0
     property double saturationDefault: 1
 
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        hueDegreeSlider.value = filter.getDouble('av.h', position);
+        hueKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('av.h') > 0;
+        lightnessSlider.value = filter.getDouble('av.b', position) * 100 / 10 + 100;
+        lightnessKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('av.b') > 0;
+        saturationSlider.value = filter.getDouble('av.s', position) * 100;
+        saturationKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('av.s') > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        hueDegreeSlider.enabled = enabled;
+        lightnessSlider.enabled = enabled;
+        saturationSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        setControls();
+        updateFilter('av.h', hueDegreeSlider.value, hueKeyframesButton, null);
+        updateFilter('av.b', (lightnessSlider.value - 100) * 10 / 100, lightnessKeyframesButton, null);
+        updateFilter('av.s', saturationSlider.value / 100, saturationKeyframesButton, null);
+    }
 
     keyframableParameters: ['av.h', 'av.b', 'av.s']
     startValues: [hueDegreeDefault, lightnessDefault, saturationDefault]
     middleValues: [hueDegreeDefault, lightnessDefault, saturationDefault]
     endValues: [hueDegreeDefault, lightnessDefault, saturationDefault]
-
     width: 200
     height: 125
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set('av.h', hueDegreeDefault)
-            filter.set('av.b', lightnessDefault)
-            filter.set('av.s', saturationDefault)
-            filter.savePreset(keyframableParameters)
+            filter.set('av.h', hueDegreeDefault);
+            filter.set('av.b', lightnessDefault);
+            filter.set('av.s', saturationDefault);
+            filter.savePreset(keyframableParameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        hueDegreeSlider.value = filter.getDouble('av.h', position)
-        hueKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('av.h') > 0
-        lightnessSlider.value = filter.getDouble('av.b', position) * 100 / 10 + 100
-        lightnessKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('av.b') > 0
-        saturationSlider.value = filter.getDouble('av.s', position) * 100
-        saturationKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('av.s') > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        hueDegreeSlider.enabled = enabled
-        lightnessSlider.enabled = enabled
-        saturationSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        setControls()
-        updateFilter('av.h', hueDegreeSlider.value, hueKeyframesButton, null)
-        updateFilter('av.b', (lightnessSlider.value - 100) * 10 / 100, lightnessKeyframesButton, null)
-        updateFilter('av.s', saturationSlider.value / 100, saturationKeyframesButton, null)
+        setControls();
     }
 
     GridLayout {
@@ -78,14 +76,16 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: presetItem
+
             Layout.columnSpan: 3
             parameters: keyframableParameters
             onBeforePresetLoaded: resetSimpleKeyframes()
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -93,21 +93,26 @@ Shotcut.KeyframableFilter {
             text: qsTr('Hue')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: hueDegreeSlider
+
             minimumValue: -360
             maximumValue: 360
             suffix: qsTr(' °', 'degrees')
             onValueChanged: updateFilter('av.h', value, hueKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: hueDegreeSlider.value = 0
         }
+
         Shotcut.KeyframesButton {
             id: hueKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, 'av.h', hueDegreeSlider.value)
+                enableControls(true);
+                toggleKeyframes(checked, 'av.h', hueDegreeSlider.value);
             }
         }
 
@@ -115,21 +120,26 @@ Shotcut.KeyframableFilter {
             text: qsTr('Lightness')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: lightnessSlider
+
             minimumValue: 0
             maximumValue: 200
             suffix: ' %'
             onValueChanged: updateFilter('av.b', (value - 100) * 10 / 100, lightnessKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: lightnessSlider.value = 100
         }
+
         Shotcut.KeyframesButton {
             id: lightnessKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, 'av.b', (lightnessSlider.value - 100) * 10 / 100)
+                enableControls(true);
+                toggleKeyframes(checked, 'av.b', (lightnessSlider.value - 100) * 10 / 100);
             }
         }
 
@@ -137,39 +147,69 @@ Shotcut.KeyframableFilter {
             text: qsTr('Saturation')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: saturationSlider
+
             minimumValue: 0
             maximumValue: 500
             suffix: ' %'
-            onValueChanged: updateFilter('av.s', value / 100.0, saturationKeyframesButton, getPosition())
+            onValueChanged: updateFilter('av.s', value / 100, saturationKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: saturationSlider.value = 100
         }
+
         Shotcut.KeyframesButton {
             id: saturationKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, 'av.s', saturationSlider.value / 100)
+                enableControls(true);
+                toggleKeyframes(checked, 'av.s', saturationSlider.value / 100);
             }
         }
 
-        Item { Layout.fillHeight: true }
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/keyspillm0pup/ui.qml
+++ b/src/qml/filters/keyspillm0pup/ui.qml
@@ -47,47 +47,45 @@ Item {
     property bool showMaskDefault: false
     property string maskAlphaParam: '12'
     property bool maskAlphaDefault: false
-    property var defaultParameters: [keyColorParam, targetColorParam, maskTypeParam,
-        toleranceParam, slopeParam, hueGateParam, saturationParam, operation1Param,
-        amount1Param, operation2Param, amount2Param]
+    property var defaultParameters: [keyColorParam, targetColorParam, maskTypeParam, toleranceParam, slopeParam, hueGateParam, saturationParam, operation1Param, amount1Param, operation2Param, amount2Param]
+
+    function setControls() {
+        keyColorPicker.value = filter.get(keyColorParam);
+        targetColorPicker.value = filter.get(targetColorParam);
+        maskTypeCombo.currentIndex = filter.get(maskTypeParam);
+        toleranceSlider.value = filter.getDouble(toleranceParam) * 100;
+        slopeSlider.value = filter.getDouble(slopeParam) * 100;
+        hueGateSlider.value = filter.getDouble(hueGateParam) * 100;
+        saturationSlider.value = filter.getDouble(saturationParam) * 100;
+        operation1Combo.currentIndex = filter.get(operation1Param);
+        amount1Slider.value = filter.getDouble(amount1Param) * 100;
+        operation2Combo.currentIndex = filter.get(operation2Param);
+        amount2Slider.value = filter.getDouble(amount2Param) * 100;
+        showMaskCheckbox.checked = parseInt(filter.get(showMaskParam));
+        maskAlphaCheckbox.checked = parseInt(filter.get(maskAlphaParam));
+    }
 
     width: 200
     height: 380
     Component.onCompleted: {
-        filter.set('threads', 0)
+        filter.set('threads', 0);
         if (filter.isNew) {
-            filter.set(keyColorParam, keyColorDefault)
-            filter.set(targetColorParam, targetColorDefault)
-            filter.set(maskTypeParam, maskTypeDefault)
-            filter.set(toleranceParam, toleranceDefault)
-            filter.set(slopeParam, slopeDefault)
-            filter.set(hueGateParam, hueGateDefault)
-            filter.set(saturationParam, saturationDefault)
-            filter.set(operation1Param, operation1Default)
-            filter.set(amount1Param, amount1Default)
-            filter.set(operation2Param, operation2Default)
-            filter.set(amount2Param, amount2Default)
-            filter.set(showMaskParam, showMaskDefault)
-            filter.set(maskAlphaParam, maskAlphaDefault)
-            filter.savePreset(defaultParameters)
+            filter.set(keyColorParam, keyColorDefault);
+            filter.set(targetColorParam, targetColorDefault);
+            filter.set(maskTypeParam, maskTypeDefault);
+            filter.set(toleranceParam, toleranceDefault);
+            filter.set(slopeParam, slopeDefault);
+            filter.set(hueGateParam, hueGateDefault);
+            filter.set(saturationParam, saturationDefault);
+            filter.set(operation1Param, operation1Default);
+            filter.set(amount1Param, amount1Default);
+            filter.set(operation2Param, operation2Default);
+            filter.set(amount2Param, amount2Default);
+            filter.set(showMaskParam, showMaskDefault);
+            filter.set(maskAlphaParam, maskAlphaDefault);
+            filter.savePreset(defaultParameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        keyColorPicker.value = filter.get(keyColorParam)
-        targetColorPicker.value = filter.get(targetColorParam)
-        maskTypeCombo.currentIndex = filter.get(maskTypeParam)
-        toleranceSlider.value = filter.getDouble(toleranceParam) * 100
-        slopeSlider.value = filter.getDouble(slopeParam) * 100
-        hueGateSlider.value = filter.getDouble(hueGateParam) * 100
-        saturationSlider.value = filter.getDouble(saturationParam) * 100
-        operation1Combo.currentIndex = filter.get(operation1Param)
-        amount1Slider.value = filter.getDouble(amount1Param) * 100
-        operation2Combo.currentIndex = filter.get(operation2Param)
-        amount2Slider.value = filter.getDouble(amount2Param) * 100
-        showMaskCheckbox.checked = parseInt(filter.get(showMaskParam))
-        maskAlphaCheckbox.checked = parseInt(filter.get(maskAlphaParam))
+        setControls();
     }
 
     GridLayout {
@@ -99,8 +97,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: presetItem
+
             Layout.columnSpan: 2
             parameters: defaultParameters
             onPresetSelected: setControls()
@@ -110,13 +110,16 @@ Item {
             text: qsTr('Key color')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ColorPicker {
             id: keyColorPicker
+
             property bool isReady: false
+
             Component.onCompleted: isReady = true
             onValueChanged: {
                 if (isReady) {
-                    filter.set(keyColorParam, value)
+                    filter.set(keyColorParam, value);
                     filter.set("disable", 0);
                 }
             }
@@ -125,6 +128,7 @@ Item {
             }
             onPickCancelled: filter.set('disable', 0)
         }
+
         Shotcut.UndoButton {
             onClicked: keyColorPicker.value = keyColorDefault
         }
@@ -133,13 +137,16 @@ Item {
             text: qsTr('Target color')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ColorPicker {
             id: targetColorPicker
+
             property bool isReady: false
+
             Component.onCompleted: isReady = true
             onValueChanged: {
                 if (isReady) {
-                    filter.set(targetColorParam, value)
+                    filter.set(targetColorParam, value);
                     filter.set("disable", 0);
                 }
             }
@@ -148,6 +155,7 @@ Item {
             }
             onPickCancelled: filter.set('disable', 0)
         }
+
         Shotcut.UndoButton {
             onClicked: targetColorPicker.value = targetColorDefault
         }
@@ -156,16 +164,19 @@ Item {
             text: qsTr('Mask type')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: maskTypeCombo
+
             implicitWidth: 180
             model: [qsTr('Color Distance'), qsTr('Transparency'), qsTr('Edge Inwards'), qsTr('Edge Outwards')]
             onActivated: filter.set(maskTypeParam, currentIndex)
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filter.set(maskTypeParam, maskTypeDefault)
-                maskTypeCombo.currentIndex = maskTypeDefault
+                filter.set(maskTypeParam, maskTypeDefault);
+                maskTypeCombo.currentIndex = maskTypeDefault;
             }
         }
 
@@ -173,8 +184,10 @@ Item {
             text: qsTr('Tolerance')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: toleranceSlider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -182,6 +195,7 @@ Item {
             value: filter.getDouble(toleranceParam) * 100
             onValueChanged: filter.set(toleranceParam, value / 100)
         }
+
         Shotcut.UndoButton {
             onClicked: toleranceSlider.value = toleranceDefault * 100
         }
@@ -190,8 +204,10 @@ Item {
             text: qsTr('Slope')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slopeSlider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -199,6 +215,7 @@ Item {
             value: filter.getDouble(slopeParam) * 100
             onValueChanged: filter.set(slopeParam, value / 100)
         }
+
         Shotcut.UndoButton {
             onClicked: slopeSlider.value = slopeDefault * 100
         }
@@ -207,8 +224,10 @@ Item {
             text: qsTr('Hue gate')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: hueGateSlider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -216,6 +235,7 @@ Item {
             value: filter.getDouble(hueGateParam) * 100
             onValueChanged: filter.set(hueGateParam, value / 100)
         }
+
         Shotcut.UndoButton {
             onClicked: hueGateSlider.value = hueGateDefault * 100
         }
@@ -224,8 +244,10 @@ Item {
             text: qsTr('Saturation threshold')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: saturationSlider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -233,6 +255,7 @@ Item {
             value: filter.getDouble(saturationParam) * 100
             onValueChanged: filter.set(saturationParam, value / 100)
         }
+
         Shotcut.UndoButton {
             onClicked: saturationSlider.value = saturationDefault * 100
         }
@@ -241,16 +264,19 @@ Item {
             text: qsTr('Operation 1')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: operation1Combo
+
             implicitWidth: 180
             model: [qsTr('None'), qsTr('De-Key'), qsTr('Desaturate'), qsTr('Adjust Luma')]
             onActivated: filter.set(operation1Param, currentIndex)
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filter.set(operation1Param, operation1Default)
-                operation1Combo.currentIndex = operation1Default
+                filter.set(operation1Param, operation1Default);
+                operation1Combo.currentIndex = operation1Default;
             }
         }
 
@@ -258,8 +284,10 @@ Item {
             text: qsTr('Amount 1')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: amount1Slider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -267,6 +295,7 @@ Item {
             value: filter.getDouble(amount1Param) * 100
             onValueChanged: filter.set(amount1Param, value / 100)
         }
+
         Shotcut.UndoButton {
             onClicked: amount1Slider.value = amount1Default * 100
         }
@@ -275,16 +304,19 @@ Item {
             text: qsTr('Operation 2')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: operation2Combo
+
             implicitWidth: 180
             model: [qsTr('None'), qsTr('De-Key'), qsTr('Desaturate'), qsTr('Adjust Luma')]
             onActivated: filter.set(operation2Param, currentIndex)
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filter.set(operation2Param, operation2Default)
-                operation2Combo.currentIndex = operation2Default
+                filter.set(operation2Param, operation2Default);
+                operation2Combo.currentIndex = operation2Default;
             }
         }
 
@@ -292,8 +324,10 @@ Item {
             text: qsTr('Amount 2')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: amount2Slider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -301,30 +335,43 @@ Item {
             value: filter.getDouble(amount2Param) * 100
             onValueChanged: filter.set(amount2Param, value / 100)
         }
+
         Shotcut.UndoButton {
             onClicked: amount2Slider.value = amount2Default * 100
         }
 
-        Label {}
+        Label {
+        }
+
         CheckBox {
             id: showMaskCheckbox
+
             text: qsTr('Show mask')
             onCheckedChanged: filter.set(showMaskParam, checked)
         }
+
         Shotcut.UndoButton {
             onClicked: showMaskCheckbox.checked = showMaskDefault
         }
 
-        Label {}
+        Label {
+        }
+
         CheckBox {
             id: maskAlphaCheckbox
+
             text: qsTr('Send mask to alpha channel')
             onCheckedChanged: filter.set(maskAlphaParam, checked)
         }
+
         Shotcut.UndoButton {
             onClicked: maskAlphaCheckbox.checked = maskAlphaDefault
         }
 
-        Item { Layout.fillHeight: true }
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
+
 }

--- a/src/qml/filters/lenscorrection/meta.qml
+++ b/src/qml/filters/lenscorrection/meta.qml
@@ -23,6 +23,7 @@ Metadata {
     name: qsTr("Lens Correction")
     mlt_service: 'frei0r.lenscorrection'
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -41,14 +42,14 @@ Metadata {
                 isCurve: true
                 minimum: 0
                 maximum: 1
-             },
+            },
             Parameter {
                 name: qsTr('Correction at Center')
                 property: '2'
                 isCurve: true
                 minimum: 0
                 maximum: 1
-             },
+            },
             Parameter {
                 name: qsTr('Correction at Edges')
                 property: '3'
@@ -58,4 +59,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/lenscorrection/ui.qml
+++ b/src/qml/filters/lenscorrection/ui.qml
@@ -25,56 +25,53 @@ Shotcut.KeyframableFilter {
     property string ycenter: '1'
     property string correctionnearcenter: '2'
     property string correctionnearedges: '3'
-    
-    property double xcenterDefault: 0.500
-    property double ycenterDefault: 0.500
-    property double correctionnearcenterDefault: 0.500
-    property double correctionnearedgesDefault: 0.500
-     
+    property double xcenterDefault: 0.5
+    property double ycenterDefault: 0.5
+    property double correctionnearcenterDefault: 0.5
+    property double correctionnearedgesDefault: 0.5
+
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        xcenterSlider.value = filter.getDouble(xcenter, position) * xcenterSlider.maximumValue;
+        xcenterKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(xcenter) > 0;
+        ycenterSlider.value = filter.getDouble(ycenter, position) * ycenterSlider.maximumValue;
+        ycenterKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(ycenter) > 0;
+        correctionnearcenterSlider.value = filter.getDouble(correctionnearcenter, position) * correctionnearcenterSlider.maximumValue;
+        cncenKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(correctionnearcenter) > 0;
+        correctionnearedgesSlider.value = filter.getDouble(correctionnearedges, position) * correctionnearedgesSlider.maximumValue;
+        cnedgeKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(correctionnearedges) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        xcenterSlider.enabled = ycenterSlider.enabled = correctionnearcenterSlider.enabled = correctionnearedgesSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        setControls();
+        updateFilter(xcenter, xcenterSlider.value / xcenterSlider.maximumValue, xcenKeyframesButton, null);
+        updateFilter(ycenter, ycenterSlider.value / ycenterSlider.maximumValue, ycentKeyframesButton, null);
+        updateFilter(correctionnearcenter, correctionnearcenterSlider.value / correctionnearcenterSlider.maximumValue, cncenKeyframesButton, null);
+        updateFilter(correctionnearedges, correctionnearedgesSlider.value / correctionnearedgesSlider.maximumValue, cnedgeKeyframesButton, null);
+    }
+
     keyframableParameters: [xcenter, ycenter, correctionnearcenter, correctionnearedges]
     startValues: [0.5, 0.5, 0.5, 0.5]
     middleValues: [xcenterDefault, ycenterDefault, correctionnearcenterDefault, correctionnearedgesDefault]
     endValues: [0.5, 0.5, 0.5, 0.5]
-
     width: 300
     height: 150
-
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set(xcenter, xcenterDefault)
-            filter.set(ycenter, ycenterDefault)
-            filter.set(correctionnearcenter, correctionnearcenterDefault)
-            filter.set(correctionnearedges, correctionnearedgesDefault)
-            filter.savePreset(preset.parameters)
+            filter.set(xcenter, xcenterDefault);
+            filter.set(ycenter, ycenterDefault);
+            filter.set(correctionnearcenter, correctionnearcenterDefault);
+            filter.set(correctionnearedges, correctionnearedgesDefault);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        xcenterSlider.value = filter.getDouble(xcenter, position) * xcenterSlider.maximumValue
-        xcenterKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(xcenter) > 0
-        ycenterSlider.value = filter.getDouble(ycenter, position) * ycenterSlider.maximumValue
-        ycenterKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(ycenter) > 0
-        correctionnearcenterSlider.value = filter.getDouble(correctionnearcenter, position) * correctionnearcenterSlider.maximumValue
-        cncenKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(correctionnearcenter) > 0
-        correctionnearedgesSlider.value = filter.getDouble(correctionnearedges, position) * correctionnearedgesSlider.maximumValue
-        cnedgeKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(correctionnearedges) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        xcenterSlider.enabled = ycenterSlider.enabled = correctionnearcenterSlider.enabled = correctionnearedgesSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        setControls()
-        updateFilter(xcenter, xcenterSlider.value / xcenterSlider.maximumValue, xcenKeyframesButton, null)
-        updateFilter(ycenter, ycenterSlider.value / ycenterSlider.maximumValue, ycentKeyframesButton, null)
-        updateFilter(correctionnearcenter, correctionnearcenterSlider.value / correctionnearcenterSlider.maximumValue, cncenKeyframesButton, null)
-        updateFilter(correctionnearedges, correctionnearedgesSlider.value / correctionnearedgesSlider.maximumValue, cnedgeKeyframesButton, null)
+        setControls();
     }
 
     GridLayout {
@@ -86,16 +83,18 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [xcenter, ycenter, correctionnearcenter, correctionnearedges]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -103,8 +102,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('X Center')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: xcenterSlider
+
             minimumValue: 0
             maximumValue: 100
             stepSize: 0.1
@@ -112,14 +113,17 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(xcenter, xcenterSlider.value / xcenterSlider.maximumValue, xcenterKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: xcenterSlider.value = xcenterDefault * xcenterSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: xcenterKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, xcenter, xcenterSlider.value / xcenterSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, xcenter, xcenterSlider.value / xcenterSlider.maximumValue);
             }
         }
 
@@ -127,8 +131,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Y Center')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: ycenterSlider
+
             minimumValue: 0
             maximumValue: 100
             stepSize: 0.1
@@ -136,14 +142,17 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(ycenter, ycenterSlider.value / ycenterSlider.maximumValue, ycenterKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: ycenterSlider.value = ycenterDefault * ycenterSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: ycenterKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, ycenter, ycenterSlider.value / ycenterSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, ycenter, ycenterSlider.value / ycenterSlider.maximumValue);
             }
         }
 
@@ -151,8 +160,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Correction at Center')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: correctionnearcenterSlider
+
             minimumValue: 0
             maximumValue: 100
             stepSize: 0.1
@@ -160,14 +171,17 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(correctionnearcenter, correctionnearcenterSlider.value / correctionnearcenterSlider.maximumValue, cncenKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: correctionnearcenterSlider.value = correctionnearcenterDefault * correctionnearcenterSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: cncenKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, correctionnearcenter, correctionnearcenterSlider.value / correctionnearcenterSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, correctionnearcenter, correctionnearcenterSlider.value / correctionnearcenterSlider.maximumValue);
             }
         }
 
@@ -175,8 +189,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Correction at Edges')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: correctionnearedgesSlider
+
             minimumValue: 0
             maximumValue: 100
             stepSize: 0.1
@@ -184,34 +200,60 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(correctionnearedges, correctionnearedgesSlider.value / correctionnearedgesSlider.maximumValue, cnedgeKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: correctionnearedgesSlider.value = correctionnearedgesDefault * correctionnearedgesSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: cnedgeKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, correctionnearedges, correctionnearedgesSlider.value / correctionnearedgesSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, correctionnearedges, correctionnearedgesSlider.value / correctionnearedgesSlider.maximumValue);
             }
         }
-        
+
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/levels/meta.qml
+++ b/src/qml/filters/levels/meta.qml
@@ -6,6 +6,7 @@ Metadata {
     name: qsTr('Levels', 'Levels video filter')
     mlt_service: 'frei0r.levels'
     qml: 'ui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -34,4 +35,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/levels/ui.qml
+++ b/src/qml/filters/levels/ui.qml
@@ -21,8 +21,6 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 350
-    height: 225
     property string channelParam: '0'
     property string inputBlackParam: '1'
     property string inputWhiteParam: '2'
@@ -32,121 +30,123 @@ Item {
     property string showHistogramParam: '6'
     property string histogramPositionParam: '7'
     property bool blockUpdate: true
-    property var startValues:  [0, 1, 0.25] // inputBlackParam, inputWhiteParam, gammaParam
+    property var startValues: [0, 1, 0.25] // inputBlackParam, inputWhiteParam, gammaParam
     property var middleValues: [0, 1, 0.25]
-    property var endValues:    [0, 1, 0.25]
-
-    Component.onCompleted: {
-        filter.set('threads', filter.getDouble(showHistogramParam) === 1)
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set(channelParam, 3/10)
-            filter.set(inputBlackParam, 0)
-            filter.set(inputWhiteParam, 1)
-            filter.set(gammaParam, 0.25)
-            filter.set(outputBlackParam, 0)
-            filter.set(outputWhiteParam, 1)
-            filter.savePreset(preset.parameters)
-            filter.set(showHistogramParam, 0)
-            filter.set(histogramPositionParam, 3 / 10)
-        } else {
-            initSimpleAnimation()
-        }
-        setControls()
-    }
+    property var endValues: [0, 1, 0.25]
 
     function initSimpleAnimation() {
-        middleValues = [filter.getDouble(inputBlackParam, filter.animateIn),
-                        filter.getDouble(inputWhiteParam, filter.animateIn),
-                        filter.getDouble(gammaParam, filter.animateIn)]
-        if (filter.animateIn > 0) {
-            startValues = [filter.getDouble(inputBlackParam, 0),
-                           filter.getDouble(inputWhiteParam, 0),
-                           filter.getDouble(gammaParam, 0)]
-        }
-        if (filter.animateOut > 0) {
-            endValues = [filter.getDouble(inputBlackParam, filter.duration - 1),
-                         filter.getDouble(inputWhiteParam, filter.duration - 1),
-                         filter.getDouble(gammaParam, filter.duration - 1)]
-        }
+        middleValues = [filter.getDouble(inputBlackParam, filter.animateIn), filter.getDouble(inputWhiteParam, filter.animateIn), filter.getDouble(gammaParam, filter.animateIn)];
+        if (filter.animateIn > 0)
+            startValues = [filter.getDouble(inputBlackParam, 0), filter.getDouble(inputWhiteParam, 0), filter.getDouble(gammaParam, 0)];
+
+        if (filter.animateOut > 0)
+            endValues = [filter.getDouble(inputBlackParam, filter.duration - 1), filter.getDouble(inputWhiteParam, filter.duration - 1), filter.getDouble(gammaParam, filter.duration - 1)];
+
     }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setKeyframedControls() {
-        var position = getPosition()
-        blockUpdate = true
-        inputBlackSlider.value = filter.getDouble(inputBlackParam, position) * inputBlackSlider.maximumValue
-        inputBlackKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(inputBlackParam) > 0
-        inputWhiteSlider.value = filter.getDouble(inputWhiteParam, position) * inputWhiteSlider.maximumValue
-        inputWhiteKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(inputWhiteParam) > 0
-        gammaSlider.value = filter.getDouble(gammaParam, position) * gammaSlider.maximumValue
-        gammaKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(gammaParam) > 0
-        blockUpdate = false
-        inputBlackSlider.enabled = inputWhiteSlider.enabled = gammaSlider.enabled
-            = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        inputBlackSlider.value = filter.getDouble(inputBlackParam, position) * inputBlackSlider.maximumValue;
+        inputBlackKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(inputBlackParam) > 0;
+        inputWhiteSlider.value = filter.getDouble(inputWhiteParam, position) * inputWhiteSlider.maximumValue;
+        inputWhiteKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(inputWhiteParam) > 0;
+        gammaSlider.value = filter.getDouble(gammaParam, position) * gammaSlider.maximumValue;
+        gammaKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(gammaParam) > 0;
+        blockUpdate = false;
+        inputBlackSlider.enabled = inputWhiteSlider.enabled = gammaSlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function setControls() {
-        setKeyframedControls()
-        channelCombo.currentIndex = Math.round(filter.getDouble(channelParam) * 10)
-        histogramCombo.currentIndex = (filter.getDouble(showHistogramParam) === 1) ? Math.round(filter.getDouble(histogramPositionParam) * 10) : 4
-        outputBlackSlider.value = filter.getDouble(outputBlackParam) * outputBlackSlider.maximumValue
-        outputWhiteSlider.value = filter.getDouble(outputWhiteParam) * outputWhiteSlider.maximumValue
+        setKeyframedControls();
+        channelCombo.currentIndex = Math.round(filter.getDouble(channelParam) * 10);
+        histogramCombo.currentIndex = (filter.getDouble(showHistogramParam) === 1) ? Math.round(filter.getDouble(histogramPositionParam) * 10) : 4;
+        outputBlackSlider.value = filter.getDouble(outputBlackParam) * outputBlackSlider.maximumValue;
+        outputWhiteSlider.value = filter.getDouble(outputWhiteParam) * outputWhiteSlider.maximumValue;
     }
 
     function updateFilter(parameter, value, position, button) {
-        if (blockUpdate) return
-        var index = preset.parameters.indexOf(parameter) - 1
+        if (blockUpdate)
+            return ;
 
+        var index = preset.parameters.indexOf(parameter) - 1;
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValues[index] = value
+                startValues[index] = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValues[index] = value
+                endValues[index] = value;
             else
-                middleValues[index] = value
+                middleValues[index] = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(parameter)
-            button.checked = false
+            filter.resetProperty(parameter);
+            button.checked = false;
             if (filter.animateIn > 0) {
-                filter.set(parameter, startValues[index], 0)
-                filter.set(parameter, middleValues[index], filter.animateIn - 1)
+                filter.set(parameter, startValues[index], 0);
+                filter.set(parameter, middleValues[index], filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(parameter, middleValues[index], filter.duration - filter.animateOut)
-                filter.set(parameter, endValues[index], filter.duration - 1)
+                filter.set(parameter, middleValues[index], filter.duration - filter.animateOut);
+                filter.set(parameter, endValues[index], filter.duration - 1);
             }
         } else if (!button.checked) {
-            filter.resetProperty(parameter)
-            filter.set(parameter, middleValues[index])
+            filter.resetProperty(parameter);
+            filter.set(parameter, middleValues[index]);
         } else if (position !== null) {
-            filter.set(parameter, value, position)
+            filter.set(parameter, value, position);
         }
     }
 
     function onKeyframesButtonClicked(checked, parameter, value) {
         if (checked) {
-            blockUpdate = true
-            inputBlackSlider.enabled = inputWhiteSlider.enabled = gammaSlider.enabled = true
+            blockUpdate = true;
+            inputBlackSlider.enabled = inputWhiteSlider.enabled = gammaSlider.enabled = true;
             if (filter.animateIn > 0 || filter.animateOut > 0) {
-                filter.resetProperty(inputBlackParam)
-                filter.resetProperty(inputWhiteParam)
-                filter.resetProperty(gammaParam)
-                filter.animateIn = filter.animateOut = 0
+                filter.resetProperty(inputBlackParam);
+                filter.resetProperty(inputWhiteParam);
+                filter.resetProperty(gammaParam);
+                filter.animateIn = filter.animateOut = 0;
             } else {
-                filter.clearSimpleAnimation(parameter)
+                filter.clearSimpleAnimation(parameter);
             }
-            blockUpdate = false
-            filter.set(parameter, value, getPosition())
+            blockUpdate = false;
+            filter.set(parameter, value, getPosition());
         } else {
-            filter.resetProperty(parameter)
-            filter.set(parameter, value)
+            filter.resetProperty(parameter);
+            filter.set(parameter, value);
         }
+    }
+
+    function updateSimpleAnimation() {
+        setKeyframedControls();
+        updateFilter(inputBlackParam, inputBlackSlider.value / inputBlackSlider.maximumValue, null, inputBlackKeyframesButton);
+        updateFilter(inputWhiteParam, inputWhiteSlider.value / inputWhiteSlider.maximumValue, null, inputWhiteKeyframesButton);
+        updateFilter(gammaParam, gammaSlider.value / gammaSlider.maximumValue, null, gammaKeyframesButton);
+    }
+
+    width: 350
+    height: 225
+    Component.onCompleted: {
+        filter.set('threads', filter.getDouble(showHistogramParam) === 1);
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set(channelParam, 3 / 10);
+            filter.set(inputBlackParam, 0);
+            filter.set(inputWhiteParam, 1);
+            filter.set(gammaParam, 0.25);
+            filter.set(outputBlackParam, 0);
+            filter.set(outputWhiteParam, 1);
+            filter.savePreset(preset.parameters);
+            filter.set(showHistogramParam, 0);
+            filter.set(histogramPositionParam, 3 / 10);
+        } else {
+            initSimpleAnimation();
+        }
+        setControls();
     }
 
     GridLayout {
@@ -158,18 +158,20 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: parent.columns - 1
             parameters: [channelParam, inputBlackParam, inputWhiteParam, gammaParam, outputBlackParam, outputWhiteParam]
             onBeforePresetLoaded: {
-                filter.resetProperty(inputBlackParam)
-                filter.resetProperty(inputWhiteParam)
-                filter.resetProperty(gammaParam)
+                filter.resetProperty(inputBlackParam);
+                filter.resetProperty(inputWhiteParam);
+                filter.resetProperty(gammaParam);
             }
             onPresetSelected: {
-                setControls()
-                initSimpleAnimation()
+                setControls();
+                initSimpleAnimation();
             }
         }
 
@@ -177,58 +179,76 @@ Item {
             text: qsTr('Channel')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: channelCombo
+
             model: [qsTr('Red'), qsTr('Green'), qsTr('Blue'), qsTr('Value')]
             onActivated: filter.set(channelParam, currentIndex / 10)
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filter.set(channelParam, 3 / 10)
-                channelCombo.currentIndex = 3
+                filter.set(channelParam, 3 / 10);
+                channelCombo.currentIndex = 3;
             }
         }
-        Item { width: 1 }
+
+        Item {
+            width: 1
+        }
 
         Label {
             text: qsTr('Histogram')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: histogramCombo
+
             model: [qsTr('Top Left'), qsTr('Top Right'), qsTr('Bottom Left'), qsTr('Bottom Right'), qsTr('None')]
             onActivated: {
-                filter.set(showHistogramParam, currentIndex < 4)
-                filter.set('threads', filter.getDouble(showHistogramParam) === 1)
+                filter.set(showHistogramParam, currentIndex < 4);
+                filter.set('threads', filter.getDouble(showHistogramParam) === 1);
                 if (currentIndex < 4)
-                    filter.set(histogramPositionParam, currentIndex / 10)
+                    filter.set(histogramPositionParam, currentIndex / 10);
+
             }
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filter.set(showHistogramParam, 0)
-                filter.set('threads', 0)
-                histogramCombo.currentIndex = 4
+                filter.set(showHistogramParam, 0);
+                filter.set('threads', 0);
+                histogramCombo.currentIndex = 4;
             }
         }
-        Item { width: 1 }
+
+        Item {
+            width: 1
+        }
 
         Label {
             text: qsTr('Input Black')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: inputBlackSlider
+
             minimumValue: 0
             maximumValue: 255
             decimals: 1
             onValueChanged: updateFilter(inputBlackParam, value / maximumValue, getPosition(), inputBlackKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: inputBlackSlider.value = 0
         }
+
         Shotcut.KeyframesButton {
             id: inputBlackKeyframesButton
+
             onToggled: onKeyframesButtonClicked(checked, inputBlackParam, inputBlackSlider.value / inputBlackSlider.maximumValue)
         }
 
@@ -236,18 +256,23 @@ Item {
             text: qsTr('Input White')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: inputWhiteSlider
+
             minimumValue: 0
             maximumValue: 255
             decimals: 1
             onValueChanged: updateFilter(inputWhiteParam, value / maximumValue, getPosition(), inputWhiteKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: inputWhiteSlider.value = 255
         }
+
         Shotcut.KeyframesButton {
             id: inputWhiteKeyframesButton
+
             onToggled: onKeyframesButtonClicked(checked, inputWhiteParam, inputWhiteSlider.value / inputWhiteSlider.maximumValue)
         }
 
@@ -255,18 +280,23 @@ Item {
             text: qsTr('Gamma')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: gammaSlider
+
             minimumValue: 0.01
-            maximumValue: 4.0
+            maximumValue: 4
             decimals: 2
             onValueChanged: updateFilter(gammaParam, value / maximumValue, getPosition(), gammaKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: gammaSlider.value = 1
         }
+
         Shotcut.KeyframesButton {
             id: gammaKeyframesButton
+
             onToggled: onKeyframesButtonClicked(checked, gammaParam, gammaSlider.value / gammaSlider.maximumValue)
         }
 
@@ -274,56 +304,84 @@ Item {
             text: qsTr('Output Black')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: outputBlackSlider
+
             minimumValue: 0
             maximumValue: 255
             onValueChanged: filter.set(outputBlackParam, value / maximumValue)
         }
+
         Shotcut.UndoButton {
             onClicked: outputBlackSlider.value = 0
         }
-        Item { width: 1 }
+
+        Item {
+            width: 1
+        }
 
         Label {
             text: qsTr('Output White')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: outputWhiteSlider
+
             minimumValue: 0
             maximumValue: 255
             onValueChanged: filter.set(outputWhiteParam, value / maximumValue)
         }
+
         Shotcut.UndoButton {
             onClicked: outputWhiteSlider.value = 255
         }
-        Item { width: 1 }
+
+        Item {
+            width: 1
+        }
 
         Item {
             Layout.fillHeight: true
         }
-    }
 
-    function updateSimpleAnimation() {
-        setKeyframedControls()
-        updateFilter(inputBlackParam, inputBlackSlider.value / inputBlackSlider.maximumValue, null, inputBlackKeyframesButton)
-        updateFilter(inputWhiteParam, inputWhiteSlider.value / inputWhiteSlider.maximumValue, null, inputWhiteKeyframesButton)
-        updateFilter(gammaParam, gammaSlider.value / gammaSlider.maximumValue, null, gammaKeyframesButton)
     }
 
     Connections {
+        function onChanged() {
+            setKeyframedControls();
+        }
+
+        function onInChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onOutChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onPropertyChanged() {
+            setKeyframedControls();
+        }
+
         target: filter
-        function onChanged() { setKeyframedControls() }
-        function onInChanged() { updateSimpleAnimation() }
-        function onOutChanged() { updateSimpleAnimation() }
-        function onAnimateInChanged() { updateSimpleAnimation() }
-        function onAnimateOutChanged() { updateSimpleAnimation() }
-        function onPropertyChanged() { setKeyframedControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setKeyframedControls();
+        }
+
         target: producer
-        function onPositionChanged() { setKeyframedControls() }
     }
+
 }

--- a/src/qml/filters/lightshow/ui_lightshow.qml
+++ b/src/qml/filters/lightshow/ui_lightshow.qml
@@ -27,52 +27,48 @@ Item {
     property int _minFreqDelta: 100
     property bool _disableUpdate: true
 
-    width: 350
-    height: 225
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            filter.set(rectProperty, '0/50%:50%x50%')
-            filter.set('color.1', '#ffffffff')
-            filter.set('color.2', '#00000000')
-            filter.set('osc', '5')
-            filter.set('frequency_low', '20')
-            filter.set('frequency_high', '20000')
-            filter.set('threshold', '-60')
-            filter.savePreset(defaultParameters)
-        }
-        setControls()
-    }
-
     function setFilter() {
-        var x = rectX.value
-        var y = rectY.value
-        var w = rectW.value
-        var h = rectH.value
-        if (x !== filterRect.x ||
-            y !== filterRect.y ||
-            w !== filterRect.width ||
-            h !== filterRect.height) {
-            filterRect.x = x
-            filterRect.y = y
-            filterRect.width = w
-            filterRect.height = h
-            filter.set(rectProperty, filterRect)
+        var x = rectX.value;
+        var y = rectY.value;
+        var w = rectW.value;
+        var h = rectH.value;
+        if (x !== filterRect.x || y !== filterRect.y || w !== filterRect.width || h !== filterRect.height) {
+            filterRect.x = x;
+            filterRect.y = y;
+            filterRect.width = w;
+            filterRect.height = h;
+            filter.set(rectProperty, filterRect);
         }
     }
 
     function setControls() {
-        _disableUpdate = true
-        fgGradient.colors = filter.getGradient('color')
-        oscSlider.value = filter.getDouble('osc')
-        freqLowSlider.value = filter.getDouble('frequency_low')
-        freqHighSlider.value = filter.getDouble('frequency_high')
-        thresholdSlider.value = filter.getDouble('threshold')
-        rectX.value = filterRect.x
-        rectY.value = filterRect.y
-        rectW.value = filterRect.width
-        rectH.value = filterRect.height
-        _disableUpdate = false
+        _disableUpdate = true;
+        fgGradient.colors = filter.getGradient('color');
+        oscSlider.value = filter.getDouble('osc');
+        freqLowSlider.value = filter.getDouble('frequency_low');
+        freqHighSlider.value = filter.getDouble('frequency_high');
+        thresholdSlider.value = filter.getDouble('threshold');
+        rectX.value = filterRect.x;
+        rectY.value = filterRect.y;
+        rectW.value = filterRect.width;
+        rectH.value = filterRect.height;
+        _disableUpdate = false;
+    }
+
+    width: 350
+    height: 225
+    Component.onCompleted: {
+        if (filter.isNew) {
+            filter.set(rectProperty, '0/50%:50%x50%');
+            filter.set('color.1', '#ffffffff');
+            filter.set('color.2', '#00000000');
+            filter.set('osc', '5');
+            filter.set('frequency_low', '20');
+            filter.set('frequency_high', '20000');
+            filter.set('threshold', '-60');
+            filter.savePreset(defaultParameters);
+        }
+        setControls();
     }
 
     GridLayout {
@@ -84,14 +80,16 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: defaultParameters
             Layout.columnSpan: 4
             onPresetSelected: setControls()
             onBeforePresetLoaded: {
                 // Clear all gradient colors before loading the new values
-                filter.setGradient('color', [])
+                filter.setGradient('color', []);
             }
         }
 
@@ -99,12 +97,16 @@ Item {
             text: qsTr('Waveform Color')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.GradientControl {
-            Layout.columnSpan: 4
             id: fgGradient
+
+            Layout.columnSpan: 4
             onGradientChanged: {
-                 if (_disableUpdate) return
-                 filter.setGradient('color', colors)
+                if (_disableUpdate)
+                    return ;
+
+                filter.setGradient('color', colors);
             }
         }
 
@@ -112,78 +114,107 @@ Item {
             text: qsTr('Position')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Layout.columnSpan: 4
+
             Shotcut.DoubleSpinBox {
                 id: rectX
+
                 value: filterRect.x
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
+                from: -1e+09
+                to: 1e+09
                 onValueModified: setFilter()
             }
-            Label { text: ','; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCente }
+
+            Label {
+                text: ','
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCente
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectY
+
                 value: filterRect.y
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
+                from: -1e+09
+                to: 1e+09
                 onValueModified: setFilter()
             }
+
         }
 
         Label {
             text: qsTr('Size')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Layout.columnSpan: 4
+
             Shotcut.DoubleSpinBox {
                 id: rectW
+
                 value: filterRect.width
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
+                from: -1e+09
+                to: 1e+09
                 onValueModified: setFilter()
             }
-            Label { text: 'x'; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCente }
+
+            Label {
+                text: 'x'
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCente
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectH
+
                 value: filterRect.height
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
+                from: -1e+09
+                to: 1e+09
                 onValueModified: setFilter()
             }
+
         }
 
         Label {
             text: qsTr('Oscillation')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Oscillation can be useful to make the light blink during long periods of sound.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Oscillation can be useful to make the light blink during long periods of sound.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: oscSlider
+
+            Layout.columnSpan: 3
             minimumValue: 0
             maximumValue: 10
             decimals: 0
             suffix: ' Hz'
             onValueChanged: filter.set("osc", value)
         }
+
         Shotcut.UndoButton {
             onClicked: oscSlider.value = 5
         }
@@ -191,22 +222,29 @@ Item {
         Label {
             text: qsTr('Low Frequency')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The low end of the frequency range to be used to influence the light.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The low end of the frequency range to be used to influence the light.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: freqLowSlider
+
+            Layout.columnSpan: 3
             minimumValue: 20
             maximumValue: 20000 - _minFreqDelta
             decimals: 0
             suffix: ' Hz'
             onValueChanged: {
-                filter.set("frequency_low", value)
-                if (!_disableUpdate && (value + _minFreqDelta) > freqHighSlider.value) {
-                    freqHighSlider.value = value + _minFreqDelta
-                }
+                filter.set("frequency_low", value);
+                if (!_disableUpdate && (value + _minFreqDelta) > freqHighSlider.value)
+                    freqHighSlider.value = value + _minFreqDelta;
+
             }
         }
+
         Shotcut.UndoButton {
             onClicked: freqLowSlider.value = 20
         }
@@ -214,22 +252,29 @@ Item {
         Label {
             text: qsTr('High Frequency')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The high end of the frequency range to be used to influence the light.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The high end of the frequency range to be used to influence the light.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: freqHighSlider
+
+            Layout.columnSpan: 3
             minimumValue: 20 + _minFreqDelta
             maximumValue: 20000
             decimals: 0
             suffix: ' Hz'
             onValueChanged: {
-                filter.set("frequency_high", value)
-                if (!_disableUpdate && (value - _minFreqDelta) < freqLowSlider.value) {
-                    freqLowSlider.value = value - _minFreqDelta
-                }
+                filter.set("frequency_high", value);
+                if (!_disableUpdate && (value - _minFreqDelta) < freqLowSlider.value)
+                    freqLowSlider.value = value - _minFreqDelta;
+
             }
         }
+
         Shotcut.UndoButton {
             onClicked: freqHighSlider.value = 20000
         }
@@ -237,32 +282,44 @@ Item {
         Label {
             text: qsTr('Threshold')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The minimum amplitude of sound that must occur within the frequency range to cause the light to change.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The minimum amplitude of sound that must occur within the frequency range to cause the light to change.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: thresholdSlider
+
+            Layout.columnSpan: 3
             minimumValue: -60
             maximumValue: 0
             decimals: 0
             suffix: ' dB'
             onValueChanged: filter.set("threshold", value)
         }
+
         Shotcut.UndoButton {
             onClicked: thresholdSlider.value = -60
         }
-        
-        Item { Layout.fillHeight: true }
+
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
 
     Connections {
-        target: filter
         function onChanged() {
-            var newValue = filter.getRect(rectProperty)
+            var newValue = filter.getRect(rectProperty);
             if (filterRect !== newValue) {
-                filterRect = newValue
-                setControls()
+                filterRect = newValue;
+                setControls();
             }
         }
+
+        target: filter
     }
+
 }

--- a/src/qml/filters/lightshow/vui.qml
+++ b/src/qml/filters/lightshow/vui.qml
@@ -20,12 +20,12 @@ import Shotcut.Controls 1.0 as Shotcut
 
 Shotcut.VuiBase {
     property string rectProperty: "rect"
-    property real zoom: (video.zoom > 0)? video.zoom : 1.0
+    property real zoom: (video.zoom > 0) ? video.zoom : 1
     property rect filterRect: filter ? filter.getRect(rectProperty) : Qt.rect(0, 0, 0, 0)
 
     Component.onCompleted: {
-        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag'))
-        rectangle.setHandles(filter.getRect(rectProperty))
+        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag'));
+        rectangle.setHandles(filter.getRect(rectProperty));
     }
 
     Flickable {
@@ -39,6 +39,7 @@ Shotcut.VuiBase {
 
         Item {
             id: videoItem
+
             x: video.rect.x
             y: video.rect.y
             width: video.rect.width
@@ -47,32 +48,37 @@ Shotcut.VuiBase {
 
             Shotcut.RectangleControl {
                 id: rectangle
+
                 widthScale: video.rect.width / profile.width
                 heightScale: video.rect.height / profile.height
                 handleSize: Math.max(Math.round(8 / zoom), 4)
                 borderSize: Math.max(Math.round(1.33 / zoom), 1)
                 onWidthScaleChanged: setHandles(filter.getRect(rectProperty))
                 onHeightScaleChanged: setHandles(filter.getRect(rectProperty))
-                onRectChanged:  {
-                    filterRect.x = Math.round(rect.x / rectangle.widthScale)
-                    filterRect.y = Math.round(rect.y / rectangle.heightScale)
-                    filterRect.width = Math.round(rect.width / rectangle.widthScale)
-                    filterRect.height = Math.round(rect.height / rectangle.heightScale)
-                    filter.set(rectProperty, filterRect)
+                onRectChanged: {
+                    filterRect.x = Math.round(rect.x / rectangle.widthScale);
+                    filterRect.y = Math.round(rect.y / rectangle.heightScale);
+                    filterRect.width = Math.round(rect.width / rectangle.widthScale);
+                    filterRect.height = Math.round(rect.height / rectangle.heightScale);
+                    filter.set(rectProperty, filterRect);
                 }
             }
+
         }
+
     }
 
     Connections {
-        target: filter
         function onChanged() {
-            var newRect = filter.getRect(rectProperty)
+            var newRect = filter.getRect(rectProperty);
             if (filterRect !== newRect) {
-                filterRect = newRect
-                rectangle.setHandles(filterRect)
+                filterRect = newRect;
+                rectangle.setHandles(filterRect);
             }
-            videoItem.enabled = filter.get('disable') !== '1'
+            videoItem.enabled = filter.get('disable') !== '1';
         }
+
+        target: filter
     }
+
 }

--- a/src/qml/filters/lines/ui.qml
+++ b/src/qml/filters/lines/ui.qml
@@ -22,25 +22,25 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
+    function setControls() {
+        widthSlider.value = filter.get('line_width');
+        amountSlider.value = filter.get('num');
+        darkSlider.value = filter.get('darker');
+        lightSlider.value = filter.get('lighter');
+    }
+
     width: 350
     height: 150
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set('line_width', 2)
-            filter.set('num', 5)
-            filter.set('darker', 40)
-            filter.set('lighter', 40)
-            filter.savePreset(preset.parameters)
-            setControls()
+            filter.set('line_width', 2);
+            filter.set('num', 5);
+            filter.set('darker', 40);
+            filter.set('lighter', 40);
+            filter.savePreset(preset.parameters);
+            setControls();
         }
-    }
-
-    function setControls() {
-        widthSlider.value = filter.get('line_width')
-        amountSlider.value = filter.get('num')
-        darkSlider.value = filter.get('darker')
-        lightSlider.value = filter.get('lighter')
     }
 
     GridLayout {
@@ -52,8 +52,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ['line_width', 'num', 'darker', 'lighter']
             Layout.columnSpan: 2
             onPresetSelected: setControls()
@@ -63,13 +65,16 @@ Item {
             text: qsTr('Width')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: widthSlider
+
             minimumValue: 1
             maximumValue: 100
             value: filter.get('line_width')
             onValueChanged: filter.set('line_width', value)
         }
+
         Shotcut.UndoButton {
             onClicked: widthSlider.value = 2
         }
@@ -78,13 +83,16 @@ Item {
             text: qsTr('Amount')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: amountSlider
+
             minimumValue: 1
             maximumValue: 100
             value: filter.get('num')
             onValueChanged: filter.set('num', value)
-            }
+        }
+
         Shotcut.UndoButton {
             onClicked: amountSlider.value = 5
         }
@@ -93,13 +101,16 @@ Item {
             text: qsTr('Darkness')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: darkSlider
+
             minimumValue: 1
             maximumValue: 100
             value: filter.get('darker')
             onValueChanged: filter.set('darker', value)
         }
+
         Shotcut.UndoButton {
             onClicked: darkSlider.value = 40
         }
@@ -108,19 +119,24 @@ Item {
             text: qsTr('Lightness')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: lightSlider
+
             minimumValue: 0
             maximumValue: 100
             value: filter.get('lighter')
             onValueChanged: filter.set('lighter', value)
         }
+
         Shotcut.UndoButton {
             onClicked: lightSlider.value = 40
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
-  }
+
+}

--- a/src/qml/filters/lut3d/ui.qml
+++ b/src/qml/filters/lut3d/ui.qml
@@ -16,8 +16,8 @@
  */
 
 import QtQuick 2.12
-import QtQuick.Dialogs 1.2
 import QtQuick.Controls 2.12
+import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.12
 import QtQuick.Window 2.1
 import Shotcut.Controls 1.0 as Shotcut
@@ -25,53 +25,60 @@ import org.shotcut.qml 1.0 as Shotcut
 
 Item {
     id: lut3dRoot
-    width: 350
-    height: 100
-    property url settingsOpenPath: 'file:///' + settings.openPath
 
-    SystemPalette { id: activePalette; colorGroup: SystemPalette.Active }
-    Shotcut.File { id: lutFile }
+    property url settingsOpenPath: 'file:///' + settings.openPath
 
     // This signal is used to workaround context properties not available in
     // the FileDialog onAccepted signal handler on Qt 5.5.
     signal fileOpened(string path)
+
+    width: 350
+    height: 100
     onFileOpened: settings.openPath = path
-
     Component.onCompleted: {
-        var resource = filter.get('av.file')
-        lutFile.url = resource
-
+        var resource = filter.get('av.file');
+        lutFile.url = resource;
         if (filter.isNew) {
-            interpolationCombo.currentIndex = 1
-            filter.set('av.interp', interpolationCombo.values[1])
+            interpolationCombo.currentIndex = 1;
+            filter.set('av.interp', interpolationCombo.values[1]);
         } else {
-            interpolationCombo.currentIndex = interpolationCombo.valueToIndex()
+            interpolationCombo.currentIndex = interpolationCombo.valueToIndex();
         }
-
         if (lutFile.exists()) {
-            fileLabel.text = lutFile.fileName
-            fileLabelTip.text = lutFile.filePath
+            fileLabel.text = lutFile.fileName;
+            fileLabelTip.text = lutFile.filePath;
         } else {
-            fileLabel.text = qsTr("No File Loaded")
-            fileLabel.color = 'red'
-            fileLabelTip.text = qsTr('No 3D LUT file loaded.\nClick "Open" to load a file.')
+            fileLabel.text = qsTr("No File Loaded");
+            fileLabel.color = 'red';
+            fileLabelTip.text = qsTr('No 3D LUT file loaded.\nClick "Open" to load a file.');
         }
+    }
+
+    SystemPalette {
+        id: activePalette
+
+        colorGroup: SystemPalette.Active
+    }
+
+    Shotcut.File {
+        id: lutFile
     }
 
     FileDialog {
         id: fileDialog
+
         modality: application.dialogModality
         selectMultiple: false
         selectFolder: false
         folder: settingsOpenPath
         nameFilters: ['3D-LUT Files (*.3dl *.cube *.dat *.m3d)', 'AfterEffects (*.3dl)', 'Iridas (*.cube)', 'DaVinci (*.dat)', 'Pandora (*.m3d)', 'All Files (*)']
         onAccepted: {
-            lutFile.url = fileDialog.fileUrl
-            lut3dRoot.fileOpened(lutFile.path)
-            fileLabel.text = lutFile.fileName
-            fileLabel.color = activePalette.text
-            fileLabelTip.text = lutFile.filePath
-            filter.set('av.file', lutFile.url)
+            lutFile.url = fileDialog.fileUrl;
+            lut3dRoot.fileOpened(lutFile.path);
+            fileLabel.text = lutFile.fileName;
+            fileLabel.color = activePalette.text;
+            fileLabelTip.text = lutFile.filePath;
+            filter.set('av.file', lutFile.url);
         }
     }
 
@@ -82,44 +89,58 @@ Item {
 
         Shotcut.Button {
             id: openButton
+
             text: qsTr('Open...')
             Layout.alignment: Qt.AlignRight
             onClicked: {
-                fileDialog.selectExisting = true
-                fileDialog.title = qsTr( "Open 3D LUT File" )
-                fileDialog.open()
+                fileDialog.selectExisting = true;
+                fileDialog.title = qsTr("Open 3D LUT File");
+                fileDialog.open();
             }
         }
+
         Label {
             id: fileLabel
+
             Layout.columnSpan: 2
             Layout.fillWidth: true
-            Shotcut.HoverTip { id: fileLabelTip }
+
+            Shotcut.HoverTip {
+                id: fileLabelTip
+            }
+
         }
 
         Label {
             text: qsTr('Interpolation')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: interpolationCombo
-            implicitWidth: 180
-            model: [qsTr('Nearest'), qsTr('Trilinear'), qsTr('Tetrahedral')]
+
             property var values: ['nearest', 'trilinear', 'tetrahedral']
-            onActivated: filter.set('av.interp', values[currentIndex])
 
             function valueToIndex() {
-                var w = filter.get('av.interp')
-                for (var i = 0; i < values.length; ++i)
-                    if (values[i] === w) break;
-                if (i === values.length) i = 1;
+                var w = filter.get('av.interp');
+                for (var i = 0; i < values.length; ++i) if (values[i] === w) {
+                    break;
+                }
+                if (i === values.length)
+                    i = 1;
+
                 return i;
             }
+
+            implicitWidth: 180
+            model: [qsTr('Nearest'), qsTr('Trilinear'), qsTr('Tetrahedral')]
+            onActivated: filter.set('av.interp', values[currentIndex])
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                interpolationCombo.currentIndex = 1
-                filter.set('av.interp', interpolationCombo.values[1])
+                interpolationCombo.currentIndex = 1;
+                filter.set('av.interp', interpolationCombo.values[1]);
             }
         }
 
@@ -127,5 +148,7 @@ Item {
             Layout.fillHeight: true
             Layout.columnSpan: 3
         }
+
     }
+
 }

--- a/src/qml/filters/mask/meta.qml
+++ b/src/qml/filters/mask/meta.qml
@@ -7,6 +7,7 @@ Metadata {
     mlt_service: "frei0r.alphaspot"
     isHidden: true
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -42,4 +43,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/mask/ui.qml
+++ b/src/qml/filters/mask/ui.qml
@@ -29,127 +29,123 @@ Item {
     property string paramRotation: '5'
     property string paramSoftness: '6'
     property string paramOperation: '9'
-    property var defaultParameters: [paramHorizontal, paramShape, paramWidth, paramHeight,  paramVertical, paramRotation, paramSoftness, paramOperation]
+    property var defaultParameters: [paramHorizontal, paramShape, paramWidth, paramHeight, paramVertical, paramRotation, paramSoftness, paramOperation]
     property bool blockUpdate: true
     property var startValues: [0.5, 0.5, 0, 0]
     property var middleValues: [0.5, 0.5, 0.1, 0.1]
     property var endValues: [0.5, 0.5, 0, 0]
 
-    width: 350
-    height: 250
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set(paramOperation, 0)
-            filter.set(paramShape, 0)
-            filter.set(paramHorizontal, 0.5)
-            filter.set(paramVertical, 0.5)
-            filter.set(paramWidth, 0.1)
-            filter.set(paramHeight, 0.1)
-            filter.set(paramRotation, 0.5)
-            filter.set(paramSoftness, 0.2)
-            filter.savePreset(defaultParameters)
-        } else {
-            initSimpleAnimation()
-        }
-        setControls()
-    }
-
     function initSimpleAnimation() {
-        middleValues = [filter.getDouble(paramHorizontal, filter.animateIn),
-                        filter.getDouble(paramVertical, filter.animateIn),
-                        filter.getDouble(paramWidth, filter.animateIn),
-                        filter.getDouble(paramHeight, filter.animateIn)]
-        if (filter.animateIn > 0) {
-            startValues = [filter.getDouble(paramHorizontal, 0),
-                           filter.getDouble(paramVertical, 0),
-                           filter.getDouble(paramWidth, 0),
-                           filter.getDouble(paramHeight, 0)]
-        }
-        if (filter.animateOut > 0) {
-            endValues = [filter.getDouble(paramHorizontal, filter.duration - 1),
-                         filter.getDouble(paramVertical, filter.duration - 1),
-                         filter.getDouble(paramWidth, filter.duration - 1),
-                         filter.getDouble(paramHeight, filter.duration - 1)]
-        }
+        middleValues = [filter.getDouble(paramHorizontal, filter.animateIn), filter.getDouble(paramVertical, filter.animateIn), filter.getDouble(paramWidth, filter.animateIn), filter.getDouble(paramHeight, filter.animateIn)];
+        if (filter.animateIn > 0)
+            startValues = [filter.getDouble(paramHorizontal, 0), filter.getDouble(paramVertical, 0), filter.getDouble(paramWidth, 0), filter.getDouble(paramHeight, 0)];
+
+        if (filter.animateOut > 0)
+            endValues = [filter.getDouble(paramHorizontal, filter.duration - 1), filter.getDouble(paramVertical, filter.duration - 1), filter.getDouble(paramWidth, filter.duration - 1), filter.getDouble(paramHeight, filter.duration - 1)];
+
     }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        horizontalSlider.value = filter.getDouble(paramHorizontal, position) * 100
-        horizontalKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramHorizontal) > 0
-        verticalSlider.value   = filter.getDouble(paramVertical, position) * 100
-        verticalKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramVertical) > 0
-        widthSlider.value      = filter.getDouble(paramWidth, position) * 100
-        widthKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramWidth) > 0
-        heightSlider.value     = filter.getDouble(paramHeight, position) * 100
-        heightKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramHeight) > 0
-        blockUpdate = false
-        horizontalSlider.enabled = verticalSlider.enabled = widthSlider.enabled = heightSlider.enabled
-            = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
-        operationCombo.currentIndex = Math.round(filter.getDouble(paramOperation) * 4)
-        shapeCombo.currentIndex = Math.round(filter.getDouble(paramShape) * 3)
-        rotationSlider.value = (filter.getDouble(paramRotation) - 0.5) * 360
-        softnessSlider.value = filter.getDouble(paramSoftness) * 100
+        var position = getPosition();
+        blockUpdate = true;
+        horizontalSlider.value = filter.getDouble(paramHorizontal, position) * 100;
+        horizontalKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramHorizontal) > 0;
+        verticalSlider.value = filter.getDouble(paramVertical, position) * 100;
+        verticalKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramVertical) > 0;
+        widthSlider.value = filter.getDouble(paramWidth, position) * 100;
+        widthKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramWidth) > 0;
+        heightSlider.value = filter.getDouble(paramHeight, position) * 100;
+        heightKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramHeight) > 0;
+        blockUpdate = false;
+        horizontalSlider.enabled = verticalSlider.enabled = widthSlider.enabled = heightSlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
+        operationCombo.currentIndex = Math.round(filter.getDouble(paramOperation) * 4);
+        shapeCombo.currentIndex = Math.round(filter.getDouble(paramShape) * 3);
+        rotationSlider.value = (filter.getDouble(paramRotation) - 0.5) * 360;
+        softnessSlider.value = filter.getDouble(paramSoftness) * 100;
     }
 
     function updateFilter(parameter, value, position, button) {
-        if (blockUpdate) return
-        var index = parseInt(parameter - 1)
+        if (blockUpdate)
+            return ;
 
+        var index = parseInt(parameter - 1);
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValues[index] = value
+                startValues[index] = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValues[index] = value
+                endValues[index] = value;
             else
-                middleValues[index] = value
+                middleValues[index] = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(parameter)
-            button.checked = false
+            filter.resetProperty(parameter);
+            button.checked = false;
             if (filter.animateIn > 0) {
-                filter.set(parameter, startValues[index], 0)
-                filter.set(parameter, middleValues[index], filter.animateIn - 1)
+                filter.set(parameter, startValues[index], 0);
+                filter.set(parameter, middleValues[index], filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(parameter, middleValues[index], filter.duration - filter.animateOut)
-                filter.set(parameter, endValues[index], filter.duration - 1)
+                filter.set(parameter, middleValues[index], filter.duration - filter.animateOut);
+                filter.set(parameter, endValues[index], filter.duration - 1);
             }
         } else if (!button.checked) {
-            filter.resetProperty(parameter)
-            filter.set(parameter, middleValues[index])
+            filter.resetProperty(parameter);
+            filter.set(parameter, middleValues[index]);
         } else if (position !== null) {
-            filter.set(parameter, value, position)
+            filter.set(parameter, value, position);
         }
     }
 
     function onKeyframesButtonClicked(checked, parameter, value) {
         if (checked) {
-            blockUpdate = true
-            horizontalSlider.enabled = verticalSlider.enabled = widthSlider.enabled = heightSlider.enabled = true
+            blockUpdate = true;
+            horizontalSlider.enabled = verticalSlider.enabled = widthSlider.enabled = heightSlider.enabled = true;
             if (filter.animateIn > 0 || filter.animateOut > 0) {
-                filter.resetProperty(paramHorizontal)
-                filter.resetProperty(paramVertical)
-                filter.resetProperty(paramWidth)
-                filter.resetProperty(paramHeight)
-                filter.animateIn = filter.animateOut = 0
+                filter.resetProperty(paramHorizontal);
+                filter.resetProperty(paramVertical);
+                filter.resetProperty(paramWidth);
+                filter.resetProperty(paramHeight);
+                filter.animateIn = filter.animateOut = 0;
             } else {
-                filter.clearSimpleAnimation(parameter)
+                filter.clearSimpleAnimation(parameter);
             }
-            blockUpdate = false
-            filter.set(parameter, value, getPosition())
+            blockUpdate = false;
+            filter.set(parameter, value, getPosition());
         } else {
-            filter.resetProperty(parameter)
-            filter.set(parameter, value)
+            filter.resetProperty(parameter);
+            filter.set(parameter, value);
         }
+    }
+
+    function updatedSimpleAnimation() {
+        updateFilter(paramHorizontal, horizontalSlider.value / 100, null, horizontalKeyframesButton);
+        updateFilter(paramVertical, verticalSlider.value / 100, null, verticalKeyframesButton);
+        updateFilter(paramWidth, widthSlider.value / 100, null, widthKeyframesButton);
+        updateFilter(paramHeight, heightSlider.value / 100, null, heightKeyframesButton);
+    }
+
+    width: 350
+    height: 250
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set(paramOperation, 0);
+            filter.set(paramShape, 0);
+            filter.set(paramHorizontal, 0.5);
+            filter.set(paramVertical, 0.5);
+            filter.set(paramWidth, 0.1);
+            filter.set(paramHeight, 0.1);
+            filter.set(paramRotation, 0.5);
+            filter.set(paramSoftness, 0.2);
+            filter.savePreset(defaultParameters);
+        } else {
+            initSimpleAnimation();
+        }
+        setControls();
     }
 
     GridLayout {
@@ -161,18 +157,19 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             Layout.columnSpan: 3
             parameters: defaultParameters
             onBeforePresetLoaded: {
-                filter.resetProperty(paramHorizontal)
-                filter.resetProperty(paramVertical)
-                filter.resetProperty(paramWidth)
-                filter.resetProperty(paramHeight)
+                filter.resetProperty(paramHorizontal);
+                filter.resetProperty(paramVertical);
+                filter.resetProperty(paramWidth);
+                filter.resetProperty(paramHeight);
             }
             onPresetSelected: {
-                setControls()
-                initSimpleAnimation()
+                setControls();
+                initSimpleAnimation();
             }
         }
 
@@ -180,17 +177,20 @@ Item {
             text: qsTr('Operation')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: operationCombo
+
             implicitWidth: 180
             model: [qsTr('Overwrite'), qsTr('Maximum'), qsTr('Minimum'), qsTr('Add'), qsTr('Subtract')]
             onActivated: filter.set(paramOperation, currentIndex / 4)
         }
+
         Shotcut.UndoButton {
             Layout.columnSpan: 2
             onClicked: {
-                filter.set(paramOperation, 0)
-                operationCombo.currentIndex = 0
+                filter.set(paramOperation, 0);
+                operationCombo.currentIndex = 0;
             }
         }
 
@@ -198,17 +198,20 @@ Item {
             text: qsTr('Shape')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: shapeCombo
+
             implicitWidth: 180
             model: [qsTr('Rectangle'), qsTr('Ellipse'), qsTr('Triangle'), qsTr('Diamond')]
             onActivated: filter.set(paramShape, currentIndex / 3)
         }
+
         Shotcut.UndoButton {
             Layout.columnSpan: 2
             onClicked: {
-                filter.set(paramShape, 0)
-                shapeCombo.currentIndex = 0
+                filter.set(paramShape, 0);
+                shapeCombo.currentIndex = 0;
             }
         }
 
@@ -216,19 +219,24 @@ Item {
             text: qsTr('Horizontal')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: horizontalSlider
+
             minimumValue: -100
             maximumValue: 100
             decimals: 2
             suffix: ' %'
-            onValueChanged: updateFilter(paramHorizontal, value/100, getPosition(), horizontalKeyframesButton)
+            onValueChanged: updateFilter(paramHorizontal, value / 100, getPosition(), horizontalKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: horizontalSlider.value = 50
         }
+
         Shotcut.KeyframesButton {
             id: horizontalKeyframesButton
+
             onToggled: onKeyframesButtonClicked(checked, paramHorizontal, horizontalSlider.value / 100)
         }
 
@@ -236,19 +244,24 @@ Item {
             text: qsTr('Vertical')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: verticalSlider
+
             minimumValue: -100
             maximumValue: 100
             decimals: 2
             suffix: ' %'
-            onValueChanged: updateFilter(paramVertical, value/100, getPosition(), verticalKeyframesButton)
+            onValueChanged: updateFilter(paramVertical, value / 100, getPosition(), verticalKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: verticalSlider.value = 50
         }
+
         Shotcut.KeyframesButton {
             id: verticalKeyframesButton
+
             onToggled: onKeyframesButtonClicked(checked, paramVertical, verticalSlider.value / 100)
         }
 
@@ -256,19 +269,24 @@ Item {
             text: qsTr('Width')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: widthSlider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 2
             suffix: ' %'
-            onValueChanged: updateFilter(paramWidth, value/100, getPosition(), widthKeyframesButton)
+            onValueChanged: updateFilter(paramWidth, value / 100, getPosition(), widthKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: widthSlider.value = 10
         }
+
         Shotcut.KeyframesButton {
             id: widthKeyframesButton
+
             onToggled: onKeyframesButtonClicked(checked, paramWidth, widthSlider.value / 100)
         }
 
@@ -276,19 +294,24 @@ Item {
             text: qsTr('Height')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: heightSlider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 2
             suffix: ' %'
-            onValueChanged: updateFilter(paramHeight, value/100, getPosition(), heightKeyframesButton)
+            onValueChanged: updateFilter(paramHeight, value / 100, getPosition(), heightKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: heightSlider.value = 10
         }
+
         Shotcut.KeyframesButton {
             id: heightKeyframesButton
+
             onToggled: onKeyframesButtonClicked(checked, paramHeight, heightSlider.value / 100)
         }
 
@@ -296,8 +319,10 @@ Item {
             text: qsTr('Rotation')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: rotationSlider
+
             minimumValue: -179.9
             maximumValue: 179.9
             decimals: 1
@@ -305,6 +330,7 @@ Item {
             suffix: qsTr(' deg', 'degrees')
             onValueChanged: filter.set(paramRotation, 0.5 + value / 360)
         }
+
         Shotcut.UndoButton {
             Layout.columnSpan: 2
             onClicked: rotationSlider.value = 0
@@ -314,14 +340,17 @@ Item {
             text: qsTr('Softness')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: softnessSlider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 2
             suffix: ' %'
             onValueChanged: filter.set(paramSoftness, value / 100)
         }
+
         Shotcut.UndoButton {
             Layout.columnSpan: 2
             onClicked: softnessSlider.value = 20
@@ -329,41 +358,55 @@ Item {
 
         Item {
             Layout.columnSpan: 2
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
-    }
 
-    function updatedSimpleAnimation() {
-        updateFilter(paramHorizontal, horizontalSlider.value/100, null, horizontalKeyframesButton)
-        updateFilter(paramVertical,   verticalSlider.value/100,   null, verticalKeyframesButton)
-        updateFilter(paramWidth,      widthSlider.value/100,      null, widthKeyframesButton)
-        updateFilter(paramHeight,     heightSlider.value/100,     null, heightKeyframesButton)
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updatedSimpleAnimation();
+        }
+
+        function onOutChanged() {
+            updatedSimpleAnimation();
+        }
+
+        function onAnimateInChanged() {
+            updatedSimpleAnimation();
+        }
+
+        function onAnimateOutChanged() {
+            updatedSimpleAnimation();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updatedSimpleAnimation() }
-        function onOutChanged() { updatedSimpleAnimation() }
-        function onAnimateInChanged() { updatedSimpleAnimation() }
-        function onAnimateOutChanged() { updatedSimpleAnimation() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
-        target: producer
         function onPositionChanged() {
             if (filter.animateIn > 0 || filter.animateOut > 0) {
-                setControls()
+                setControls();
             } else {
-                blockUpdate = true
-                horizontalSlider.value = filter.getDouble(paramHorizontal, getPosition()) * 100
-                verticalSlider.value   = filter.getDouble(paramVertical,   getPosition()) * 100
-                widthSlider.value      = filter.getDouble(paramWidth,      getPosition()) * 100
-                heightSlider.value     = filter.getDouble(paramHeight,     getPosition()) * 100
-                blockUpdate = false
-                horizontalSlider.enabled = verticalSlider.enabled = widthSlider.enabled = heightSlider.enabled = true
+                blockUpdate = true;
+                horizontalSlider.value = filter.getDouble(paramHorizontal, getPosition()) * 100;
+                verticalSlider.value = filter.getDouble(paramVertical, getPosition()) * 100;
+                widthSlider.value = filter.getDouble(paramWidth, getPosition()) * 100;
+                heightSlider.value = filter.getDouble(paramHeight, getPosition()) * 100;
+                blockUpdate = false;
+                horizontalSlider.enabled = verticalSlider.enabled = widthSlider.enabled = heightSlider.enabled = true;
             }
         }
+
+        target: producer
     }
+
 }

--- a/src/qml/filters/mask_alphaspot/meta.qml
+++ b/src/qml/filters/mask_alphaspot/meta.qml
@@ -7,6 +7,7 @@ Metadata {
     mlt_service: 'mask_start'
     objectName: 'maskSimpleShape'
     qml: 'ui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -49,4 +50,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/mask_alphaspot/ui.qml
+++ b/src/qml/filters/mask_alphaspot/ui.qml
@@ -35,130 +35,122 @@ Item {
     property var middleValues: [0.5, 0.5, 0.1, 0.1, 0, 0.5]
     property var endValues: [0.5, 0.5, 0.1, 0.1, 0, 0.5]
 
-    width: 350
-    height: 300
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set('filter', 'frei0r.alphaspot')
-            filter.set(paramOperation, 0)
-            filter.set(paramShape, 0)
-            filter.set(paramHorizontal, 0.5)
-            filter.set(paramVertical, 0.5)
-            filter.set(paramWidth, 0.1)
-            filter.set(paramHeight, 0.1)
-            filter.set(paramRotation, 0.5)
-            filter.set(paramSoftness, 0.2)
-            filter.savePreset(defaultParameters)
-        } else {
-            initSimpleAnimation()
-        }
-        setControls()
-    }
-
     function initSimpleAnimation() {
-        middleValues = [filter.getDouble(paramHorizontal, filter.animateIn),
-                        filter.getDouble(paramVertical, filter.animateIn),
-                        filter.getDouble(paramWidth, filter.animateIn),
-                        filter.getDouble(paramHeight, filter.animateIn),
-                        0,
-                        filter.getDouble(paramRotation, filter.animateIn)]
-        if (filter.animateIn > 0) {
-            startValues = [filter.getDouble(paramHorizontal, 0),
-                           filter.getDouble(paramVertical, 0),
-                           filter.getDouble(paramWidth, 0),
-                           filter.getDouble(paramHeight, 0),
-                           0,
-                           filter.getDouble(paramRotation, 0)]
-        }
-        if (filter.animateOut > 0) {
-            endValues = [filter.getDouble(paramHorizontal, filter.duration - 1),
-                         filter.getDouble(paramVertical, filter.duration - 1),
-                         filter.getDouble(paramWidth, filter.duration - 1),
-                         filter.getDouble(paramHeight, filter.duration - 1),
-                         0,
-                         filter.getDouble(paramRotation, filter.duration - 1)]
-        }
+        middleValues = [filter.getDouble(paramHorizontal, filter.animateIn), filter.getDouble(paramVertical, filter.animateIn), filter.getDouble(paramWidth, filter.animateIn), filter.getDouble(paramHeight, filter.animateIn), 0, filter.getDouble(paramRotation, filter.animateIn)];
+        if (filter.animateIn > 0)
+            startValues = [filter.getDouble(paramHorizontal, 0), filter.getDouble(paramVertical, 0), filter.getDouble(paramWidth, 0), filter.getDouble(paramHeight, 0), 0, filter.getDouble(paramRotation, 0)];
+
+        if (filter.animateOut > 0)
+            endValues = [filter.getDouble(paramHorizontal, filter.duration - 1), filter.getDouble(paramVertical, filter.duration - 1), filter.getDouble(paramWidth, filter.duration - 1), filter.getDouble(paramHeight, filter.duration - 1), 0, filter.getDouble(paramRotation, filter.duration - 1)];
+
     }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        horizontalSlider.value = filter.getDouble(paramHorizontal, position) * 100
-        horizontalKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramHorizontal) > 0
-        verticalSlider.value   = filter.getDouble(paramVertical, position) * 100
-        verticalKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramVertical) > 0
-        widthSlider.value      = filter.getDouble(paramWidth, position) * 100
-        widthKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramWidth) > 0
-        heightSlider.value     = filter.getDouble(paramHeight, position) * 100
-        heightKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramHeight) > 0
-        rotationSlider.updateFromFilter()
-        rotationKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramRotation) > 0
-        blockUpdate = false
-        horizontalSlider.enabled = verticalSlider.enabled = widthSlider.enabled = heightSlider.enabled = rotationSlider.enabled
-            = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
-        operationCombo.currentIndex = Math.round(filter.getDouble(paramOperation) * 4)
-        shapeCombo.currentIndex = Math.round(filter.getDouble(paramShape) * 3)
-        softnessSlider.value = filter.getDouble(paramSoftness) * 100
+        var position = getPosition();
+        blockUpdate = true;
+        horizontalSlider.value = filter.getDouble(paramHorizontal, position) * 100;
+        horizontalKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramHorizontal) > 0;
+        verticalSlider.value = filter.getDouble(paramVertical, position) * 100;
+        verticalKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramVertical) > 0;
+        widthSlider.value = filter.getDouble(paramWidth, position) * 100;
+        widthKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramWidth) > 0;
+        heightSlider.value = filter.getDouble(paramHeight, position) * 100;
+        heightKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramHeight) > 0;
+        rotationSlider.updateFromFilter();
+        rotationKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramRotation) > 0;
+        blockUpdate = false;
+        horizontalSlider.enabled = verticalSlider.enabled = widthSlider.enabled = heightSlider.enabled = rotationSlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
+        operationCombo.currentIndex = Math.round(filter.getDouble(paramOperation) * 4);
+        shapeCombo.currentIndex = Math.round(filter.getDouble(paramShape) * 3);
+        softnessSlider.value = filter.getDouble(paramSoftness) * 100;
     }
 
     function updateFilter(parameter, value, position, button) {
-        if (blockUpdate) return
-        var index = defaultParameters.indexOf(parameter)
+        if (blockUpdate)
+            return ;
 
+        var index = defaultParameters.indexOf(parameter);
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValues[index] = value
+                startValues[index] = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValues[index] = value
+                endValues[index] = value;
             else
-                middleValues[index] = value
+                middleValues[index] = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(parameter)
-            button.checked = false
+            filter.resetProperty(parameter);
+            button.checked = false;
             if (filter.animateIn > 0) {
-                filter.set(parameter, startValues[index], 0)
-                filter.set(parameter, middleValues[index], filter.animateIn - 1)
+                filter.set(parameter, startValues[index], 0);
+                filter.set(parameter, middleValues[index], filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(parameter, middleValues[index], filter.duration - filter.animateOut)
-                filter.set(parameter, endValues[index], filter.duration - 1)
+                filter.set(parameter, middleValues[index], filter.duration - filter.animateOut);
+                filter.set(parameter, endValues[index], filter.duration - 1);
             }
         } else if (!button.checked) {
-            filter.resetProperty(parameter)
-            filter.set(parameter, middleValues[index])
+            filter.resetProperty(parameter);
+            filter.set(parameter, middleValues[index]);
         } else if (position !== null) {
-            filter.set(parameter, value, position)
+            filter.set(parameter, value, position);
         }
     }
 
     function onKeyframesButtonClicked(checked, parameter, value) {
         if (checked) {
-            blockUpdate = true
-            horizontalSlider.enabled = verticalSlider.enabled = widthSlider.enabled = heightSlider.enabled = true
+            blockUpdate = true;
+            horizontalSlider.enabled = verticalSlider.enabled = widthSlider.enabled = heightSlider.enabled = true;
             if (filter.animateIn > 0 || filter.animateOut > 0) {
-                filter.resetProperty(paramHorizontal)
-                filter.resetProperty(paramVertical)
-                filter.resetProperty(paramWidth)
-                filter.resetProperty(paramHeight)
-                filter.resetProperty(paramRotation)
-                filter.animateIn = filter.animateOut = 0
+                filter.resetProperty(paramHorizontal);
+                filter.resetProperty(paramVertical);
+                filter.resetProperty(paramWidth);
+                filter.resetProperty(paramHeight);
+                filter.resetProperty(paramRotation);
+                filter.animateIn = filter.animateOut = 0;
             } else {
-                filter.clearSimpleAnimation(parameter)
+                filter.clearSimpleAnimation(parameter);
             }
-            blockUpdate = false
-            filter.set(parameter, value, getPosition())
+            blockUpdate = false;
+            filter.set(parameter, value, getPosition());
         } else {
-            filter.resetProperty(parameter)
-            filter.set(parameter, value)
+            filter.resetProperty(parameter);
+            filter.set(parameter, value);
         }
+    }
+
+    function updatedSimpleAnimation() {
+        setControls();
+        updateFilter(paramHorizontal, horizontalSlider.value / 100, null, horizontalKeyframesButton);
+        updateFilter(paramVertical, verticalSlider.value / 100, null, verticalKeyframesButton);
+        updateFilter(paramWidth, widthSlider.value / 100, null, widthKeyframesButton);
+        updateFilter(paramHeight, heightSlider.value / 100, null, heightKeyframesButton);
+        updateFilter(paramRotation, rotationSlider.filterValue(), null, rotationKeyframesButton);
+    }
+
+    width: 350
+    height: 300
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set('filter', 'frei0r.alphaspot');
+            filter.set(paramOperation, 0);
+            filter.set(paramShape, 0);
+            filter.set(paramHorizontal, 0.5);
+            filter.set(paramVertical, 0.5);
+            filter.set(paramWidth, 0.1);
+            filter.set(paramHeight, 0.1);
+            filter.set(paramRotation, 0.5);
+            filter.set(paramSoftness, 0.2);
+            filter.savePreset(defaultParameters);
+        } else {
+            initSimpleAnimation();
+        }
+        setControls();
     }
 
     GridLayout {
@@ -170,19 +162,20 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             Layout.columnSpan: 3
             parameters: defaultParameters
             onBeforePresetLoaded: {
-                filter.resetProperty(paramHorizontal)
-                filter.resetProperty(paramVertical)
-                filter.resetProperty(paramWidth)
-                filter.resetProperty(paramHeight)
-                filter.resetProperty(paramRotation)
+                filter.resetProperty(paramHorizontal);
+                filter.resetProperty(paramVertical);
+                filter.resetProperty(paramWidth);
+                filter.resetProperty(paramHeight);
+                filter.resetProperty(paramRotation);
             }
             onPresetSelected: {
-                setControls()
-                initSimpleAnimation()
+                setControls();
+                initSimpleAnimation();
             }
         }
 
@@ -190,17 +183,20 @@ Item {
             text: qsTr('Operation')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: operationCombo
+
             implicitWidth: 180
             model: [qsTr('Overwrite'), qsTr('Maximum'), qsTr('Minimum'), qsTr('Add'), qsTr('Subtract')]
             onActivated: filter.set(paramOperation, currentIndex / 4)
         }
+
         Shotcut.UndoButton {
             Layout.columnSpan: 2
             onClicked: {
-                filter.set(paramOperation, 0)
-                operationCombo.currentIndex = 0
+                filter.set(paramOperation, 0);
+                operationCombo.currentIndex = 0;
             }
         }
 
@@ -208,17 +204,20 @@ Item {
             text: qsTr('Shape')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: shapeCombo
+
             implicitWidth: 180
             model: [qsTr('Rectangle'), qsTr('Ellipse'), qsTr('Triangle'), qsTr('Diamond')]
             onActivated: filter.set(paramShape, currentIndex / 3)
         }
+
         Shotcut.UndoButton {
             Layout.columnSpan: 2
-            onClicked:  {
-                filter.set(paramShape, 0)
-                shapeCombo.currentIndex = 0
+            onClicked: {
+                filter.set(paramShape, 0);
+                shapeCombo.currentIndex = 0;
             }
         }
 
@@ -226,19 +225,24 @@ Item {
             text: qsTr('Horizontal')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: horizontalSlider
+
             minimumValue: -100
             maximumValue: 100
             decimals: 2
             suffix: ' %'
-            onValueChanged: updateFilter(paramHorizontal, value/100, getPosition(), horizontalKeyframesButton)
+            onValueChanged: updateFilter(paramHorizontal, value / 100, getPosition(), horizontalKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: horizontalSlider.value = 50
         }
+
         Shotcut.KeyframesButton {
             id: horizontalKeyframesButton
+
             onToggled: onKeyframesButtonClicked(checked, paramHorizontal, horizontalSlider.value / 100)
         }
 
@@ -246,19 +250,24 @@ Item {
             text: qsTr('Vertical')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: verticalSlider
+
             minimumValue: -100
             maximumValue: 100
             decimals: 2
             suffix: ' %'
-            onValueChanged: updateFilter(paramVertical, value/100, getPosition(), verticalKeyframesButton)
+            onValueChanged: updateFilter(paramVertical, value / 100, getPosition(), verticalKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: verticalSlider.value = 50
         }
+
         Shotcut.KeyframesButton {
             id: verticalKeyframesButton
+
             onToggled: onKeyframesButtonClicked(checked, paramVertical, verticalSlider.value / 100)
         }
 
@@ -266,19 +275,24 @@ Item {
             text: qsTr('Width')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: widthSlider
+
             minimumValue: 0.0001
             maximumValue: 100
             decimals: 2
             suffix: ' %'
-            onValueChanged: updateFilter(paramWidth, value/100, getPosition(), widthKeyframesButton)
+            onValueChanged: updateFilter(paramWidth, value / 100, getPosition(), widthKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: widthSlider.value = 10
         }
+
         Shotcut.KeyframesButton {
             id: widthKeyframesButton
+
             onToggled: onKeyframesButtonClicked(checked, paramWidth, widthSlider.value / 100)
         }
 
@@ -286,19 +300,24 @@ Item {
             text: qsTr('Height')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: heightSlider
+
             minimumValue: 0.0001
             maximumValue: 100
             decimals: 2
             suffix: ' %'
-            onValueChanged: updateFilter(paramHeight, value/100, getPosition(), heightKeyframesButton)
+            onValueChanged: updateFilter(paramHeight, value / 100, getPosition(), heightKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: heightSlider.value = 10
         }
+
         Shotcut.KeyframesButton {
             id: heightKeyframesButton
+
             onToggled: onKeyframesButtonClicked(checked, paramHeight, heightSlider.value / 100)
         }
 
@@ -306,42 +325,53 @@ Item {
             text: qsTr('Rotation')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: rotationSlider
+
+            function updateFromFilter() {
+                value = (filter.getDouble(paramRotation, getPosition()) - 0.5) * 360;
+            }
+
+            function filterValue() {
+                return 0.5 + value / 360;
+            }
+
             minimumValue: -179.9
             maximumValue: 179.9
             decimals: 1
             spinnerWidth: 110
             suffix: qsTr(' deg', 'degrees')
-            function updateFromFilter() {
-                value = (filter.getDouble(paramRotation, getPosition()) - 0.5) * 360
-            }
-            function filterValue() {
-                return 0.5 + value / 360
-            }
             onValueChanged: updateFilter(paramRotation, filterValue(), getPosition(), rotationKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: rotationSlider.value = 0
         }
+
         Shotcut.KeyframesButton {
             id: rotationKeyframesButton
+
             onToggled: onKeyframesButtonClicked(checked, paramRotation, rotationSlider.filterValue())
         }
 
         Label {
             id: softnessLabel
+
             text: qsTr('Softness')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: softnessSlider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 2
             suffix: ' %'
             onValueChanged: filter.set(paramSoftness, value / 100)
         }
+
         Shotcut.UndoButton {
             Layout.columnSpan: 2
             onClicked: softnessSlider.value = 20
@@ -357,42 +387,54 @@ Item {
         Label {
             Layout.fillHeight: true
         }
-    }
 
-    function updatedSimpleAnimation() {
-        setControls()
-        updateFilter(paramHorizontal, horizontalSlider.value/100, null, horizontalKeyframesButton)
-        updateFilter(paramVertical,   verticalSlider.value/100,   null, verticalKeyframesButton)
-        updateFilter(paramWidth,      widthSlider.value/100,      null, widthKeyframesButton)
-        updateFilter(paramHeight,     heightSlider.value/100,     null, heightKeyframesButton)
-        updateFilter(paramRotation, rotationSlider.filterValue(), null, rotationKeyframesButton)
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updatedSimpleAnimation();
+        }
+
+        function onOutChanged() {
+            updatedSimpleAnimation();
+        }
+
+        function onAnimateInChanged() {
+            updatedSimpleAnimation();
+        }
+
+        function onAnimateOutChanged() {
+            updatedSimpleAnimation();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updatedSimpleAnimation() }
-        function onOutChanged() { updatedSimpleAnimation() }
-        function onAnimateInChanged() { updatedSimpleAnimation() }
-        function onAnimateOutChanged() { updatedSimpleAnimation() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
-        target: producer
         function onPositionChanged() {
             if (filter.animateIn > 0 || filter.animateOut > 0) {
-                setControls()
+                setControls();
             } else {
-                blockUpdate = true
-                horizontalSlider.value = filter.getDouble(paramHorizontal, getPosition()) * 100
-                verticalSlider.value   = filter.getDouble(paramVertical,   getPosition()) * 100
-                widthSlider.value      = filter.getDouble(paramWidth,      getPosition()) * 100
-                heightSlider.value     = filter.getDouble(paramHeight,     getPosition()) * 100
-                rotationSlider.updateFromFilter()
-                blockUpdate = false
-                horizontalSlider.enabled = verticalSlider.enabled = widthSlider.enabled = heightSlider.enabled = true
+                blockUpdate = true;
+                horizontalSlider.value = filter.getDouble(paramHorizontal, getPosition()) * 100;
+                verticalSlider.value = filter.getDouble(paramVertical, getPosition()) * 100;
+                widthSlider.value = filter.getDouble(paramWidth, getPosition()) * 100;
+                heightSlider.value = filter.getDouble(paramHeight, getPosition()) * 100;
+                rotationSlider.updateFromFilter();
+                blockUpdate = false;
+                horizontalSlider.enabled = verticalSlider.enabled = widthSlider.enabled = heightSlider.enabled = true;
             }
         }
+
+        target: producer
     }
+
 }

--- a/src/qml/filters/mask_apply/ui.qml
+++ b/src/qml/filters/mask_apply/ui.qml
@@ -21,6 +21,6 @@ Item {
     width: 10
     height: 10
     Component.onCompleted: {
-        filter.set('transition.threads', 0)
+        filter.set('transition.threads', 0);
     }
 }

--- a/src/qml/filters/mask_chromakey/ui.qml
+++ b/src/qml/filters/mask_chromakey/ui.qml
@@ -26,21 +26,22 @@ Item {
     property string distanceParam: 'filter.1'
     property double distanceDefault: 28.8
     property var defaultParameters: [colorParam, distanceParam]
+
     width: 350
     height: 50
     Component.onCompleted: {
-        presetItem.parameters = defaultParameters
-        filter.set('filter', 'frei0r.bluescreen0r')
-        filter.set('filter.2', 1)
-        filter.set('filter.threads', 0)
+        presetItem.parameters = defaultParameters;
+        filter.set('filter', 'frei0r.bluescreen0r');
+        filter.set('filter.2', 1);
+        filter.set('filter.threads', 0);
         if (filter.isNew) {
             // Set default parameter values
-            filter.set(colorParam, colorDefault)
-            filter.set(distanceParam, distanceDefault / 100)
-            filter.savePreset(defaultParameters)
+            filter.set(colorParam, colorDefault);
+            filter.set(distanceParam, distanceDefault / 100);
+            filter.savePreset(defaultParameters);
         }
-        colorPicker.value = filter.get(colorParam)
-        distanceSlider.value = filter.getDouble(distanceParam) * 100
+        colorPicker.value = filter.get(colorParam);
+        distanceSlider.value = filter.getDouble(distanceParam) * 100;
     }
 
     GridLayout {
@@ -52,12 +53,14 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: presetItem
+
             Layout.columnSpan: 2
             onPresetSelected: {
-                colorPicker.value = filter.get(colorParam)
-                distanceSlider.value = filter.getDouble(distanceParam) * 100
+                colorPicker.value = filter.get(colorParam);
+                distanceSlider.value = filter.getDouble(distanceParam) * 100;
             }
         }
 
@@ -66,15 +69,18 @@ Item {
             text: qsTr('Key color')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ColorPicker {
             id: colorPicker
+
             onValueChanged: {
-                filter.set(colorParam, value)
-                filter.set('disable', 0)
+                filter.set(colorParam, value);
+                filter.set('disable', 0);
             }
             onPickStarted: filter.set('disable', 1)
             onPickCancelled: filter.set('disable', 0)
         }
+
         Shotcut.UndoButton {
             onClicked: colorPicker.value = colorDefault
         }
@@ -84,8 +90,10 @@ Item {
             text: qsTr('Distance')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: distanceSlider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -93,6 +101,7 @@ Item {
             value: filter.getDouble(distanceParam) * 100
             onValueChanged: filter.set(distanceParam, value / 100)
         }
+
         Shotcut.UndoButton {
             onClicked: distanceSlider.value = distanceDefault
         }
@@ -107,5 +116,7 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/mask_glaxnimate/ui.qml
+++ b/src/qml/filters/mask_glaxnimate/ui.qml
@@ -17,82 +17,87 @@
 
 import QtQuick 2.12
 import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
 import QtQuick.Dialogs 1.2
+import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 import org.shotcut.qml 1.0 as Shotcut
 
 Item {
     id: shapeRoot
+
     property url settingsOpenPath: 'file:///' + settings.openPath
-
-    width: 350
-    height: 100
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set('filter', 'shape')
-            filter.set('filter.use_luminance', 0)
-            filter.set('filter.use_mix', 0)
-            filter.set('filter.audio_match', 0)
-        } else {
-            if (filter.get('filter.use_mix').length === 0)
-                filter.set('filter.use_mix', 1)
-            if (filter.get('filter.audio_match').length === 0)
-                filter.set('filter.audio_match', 1)
-        }
-        setControls()
-    }
-
-    function setControls() {
-        shapeFile.url = filter.get('filter.resource')
-    }
 
     // This signal is used to workaround context properties not available in
     // the FileDialog onAccepted signal handler on Qt 5.5.
     signal fileOpened(string path)
+
+    function setControls() {
+        shapeFile.url = filter.get('filter.resource');
+    }
+
+    width: 350
+    height: 100
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set('filter', 'shape');
+            filter.set('filter.use_luminance', 0);
+            filter.set('filter.use_mix', 0);
+            filter.set('filter.audio_match', 0);
+        } else {
+            if (filter.get('filter.use_mix').length === 0)
+                filter.set('filter.use_mix', 1);
+
+            if (filter.get('filter.audio_match').length === 0)
+                filter.set('filter.audio_match', 1);
+
+        }
+        setControls();
+    }
     onFileOpened: {
-        settings.openPath = path
-        fileDialog.folder = 'file:///' + path
+        settings.openPath = path;
+        fileDialog.folder = 'file:///' + path;
     }
 
     Shotcut.File {
         id: shapeFile
+
         onUrlChanged: {
             if (fileName.length > 0) {
-                fileLabel.text = fileName
-                fileLabelTip.text = filePath
+                fileLabel.text = fileName;
+                fileLabelTip.text = filePath;
             }
-            watch()
+            watch();
         }
         onFileChanged: filter.set('filter.producer.refresh', 1)
     }
+
     FileDialog {
         id: fileDialog
+
         modality: application.dialogModality
         selectMultiple: false
         selectFolder: false
         folder: settingsOpenPath
         onAccepted: {
-            shapeFile.url = fileDialog.fileUrl
+            shapeFile.url = fileDialog.fileUrl;
             if (!fileDialog.selectExisting) {
                 // Force file extension to ".rawr"
-                var filename = shapeFile.url
-                var extension = ".rawr"
-                var extIndex = filename.indexOf(extension, filename.length - extension.length)
+                var filename = shapeFile.url;
+                var extension = ".rawr";
+                var extIndex = filename.indexOf(extension, filename.length - extension.length);
                 if (extIndex == -1) {
-                    filename += extension
-                    shapeFile.url = filename
+                    filename += extension;
+                    shapeFile.url = filename;
                 }
-                producer.newGlaxnimateFile(filename)
+                producer.newGlaxnimateFile(filename);
             }
-            filter.set('filter.resource', shapeFile.url)
-            fileLabelTip.text = shapeFile.filePath
-            shapeRoot.fileOpened(shapeFile.path)
-            if (!fileDialog.selectExisting) {
-                producer.launchGlaxnimate(shapeFile.url)
-            }
+            filter.set('filter.resource', shapeFile.url);
+            fileLabelTip.text = shapeFile.filePath;
+            shapeRoot.fileOpened(shapeFile.path);
+            if (!fileDialog.selectExisting)
+                producer.launchGlaxnimate(shapeFile.url);
+
         }
     }
 
@@ -103,53 +108,70 @@ Item {
 
         RowLayout {
             Layout.alignment: Qt.AlignRight
+
             Shotcut.Button {
                 text: qsTr('New...')
                 onClicked: {
-                    var filename = application.getNextProjectFile('rawr')
+                    var filename = application.getNextProjectFile('rawr');
                     if (filename) {
-                        producer.newGlaxnimateFile(filename)
-                        shapeFile.url = filename
-                        filter.set('filter.resource', shapeFile.url)
-                        shapeRoot.fileOpened(shapeFile.path)
-                        producer.launchGlaxnimate(shapeFile.url)
+                        producer.newGlaxnimateFile(filename);
+                        shapeFile.url = filename;
+                        filter.set('filter.resource', shapeFile.url);
+                        shapeRoot.fileOpened(shapeFile.path);
+                        producer.launchGlaxnimate(shapeFile.url);
                     } else {
-                        fileDialog.selectExisting = false
-                        fileDialog.title = qsTr('New Animation File')
-                        fileDialog.open()
+                        fileDialog.selectExisting = false;
+                        fileDialog.title = qsTr('New Animation File');
+                        fileDialog.open();
                     }
                 }
             }
+
             Shotcut.Button {
                 text: qsTr('Open...')
                 onClicked: {
-                    fileDialog.selectExisting = true
-                    fileDialog.title = qsTr('Open Animation File')
-                    fileDialog.open()
+                    fileDialog.selectExisting = true;
+                    fileDialog.title = qsTr('Open Animation File');
+                    fileDialog.open();
                 }
             }
-        }
-        Label {
-            id: fileLabel
-            Layout.columnSpan: parent.columns - 1
-            text: qsTr('Click <b>New...</b> or <b>Open...</b> to use this filter')
-            Shotcut.HoverTip { id: fileLabelTip }
+
         }
 
-        Item { width: 1 }
+        Label {
+            id: fileLabel
+
+            Layout.columnSpan: parent.columns - 1
+            text: qsTr('Click <b>New...</b> or <b>Open...</b> to use this filter')
+
+            Shotcut.HoverTip {
+                id: fileLabelTip
+            }
+
+        }
+
+        Item {
+            width: 1
+        }
+
         RowLayout {
             Shotcut.Button {
                 text: qsTr('Edit...')
                 onClicked: producer.launchGlaxnimate(filter.get('filter.resource'))
             }
+
             Shotcut.Button {
                 text: qsTr('Reload')
                 onClicked: {
-                    filter.set('filter.producer.refresh', 1)
+                    filter.set('filter.producer.refresh', 1);
                 }
             }
+
         }
-        Item { width: 1 }
+
+        Item {
+            width: 1
+        }
 
         Shotcut.TipBox {
             Layout.columnSpan: parent.columns
@@ -161,5 +183,7 @@ Item {
         Label {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/mask_shape/meta.qml
+++ b/src/qml/filters/mask_shape/meta.qml
@@ -7,6 +7,7 @@ Metadata {
     mlt_service: 'mask_start'
     objectName: 'maskFromFile'
     qml: 'ui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -21,4 +22,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/mask_shape/ui.qml
+++ b/src/qml/filters/mask_shape/ui.qml
@@ -17,178 +17,189 @@
 
 import QtQuick 2.12
 import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
 import QtQuick.Dialogs 1.2
+import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 import org.shotcut.qml 1.0 as Shotcut
 
 Item {
     id: shapeRoot
+
     property bool blockUpdate: true
     property double startValue: 50
     property double middleValue: 50
     property double endValue: 50
     property url settingsOpenPath: 'file:///' + settings.openPath
     property int previousResourceComboIndex
-    property string reverseProperty: filter.isAtLeastVersion(3)? 'filter.invert_mask' : 'filter.reverse'
+    property string reverseProperty: filter.isAtLeastVersion(3) ? 'filter.invert_mask' : 'filter.reverse'
 
-    width: 350
-    height: 275
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set('filter', 'shape')
-            filter.set('filter.mix', 50)
-            filter.set('filter.softness', 0)
-            filter.set('filter.invert', 0)
-            filter.set('filter.use_luminance', 1)
-            filter.set('filter.resource', '%luma01.pgm')
-            filter.set('filter.use_mix', 1)
-            filter.set('filter.audio_match', 0)
-            filter.savePreset(preset.parameters)
-        } else {
-            if (filter.get('filter.use_mix').length === 0)
-                filter.set('filter.use_mix', 1)
-            if (filter.get('filter.audio_match').length === 0)
-                filter.set('filter.audio_match', 1)
-            initSimpleAnimation()
-        }
-        setControls()
-    }
+    // This signal is used to workaround context properties not available in
+    // the FileDialog onAccepted signal handler on Qt 5.5.
+    signal fileOpened(string path)
 
     function initSimpleAnimation() {
-        middleValue = filter.getDouble('filter.mix', filter.animateIn)
-        if (filter.animateIn > 0) {
-            startValue = filter.getDouble('filter.mix', 0)
-        }
-        if (filter.animateOut > 0) {
-            endValue = filter.getDouble('filter.mix', filter.duration - 1)
-        }
+        middleValue = filter.getDouble('filter.mix', filter.animateIn);
+        if (filter.animateIn > 0)
+            startValue = filter.getDouble('filter.mix', 0);
+
+        if (filter.animateOut > 0)
+            endValue = filter.getDouble('filter.mix', filter.duration - 1);
+
     }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setKeyframedControls() {
-        var position = getPosition()
-        blockUpdate = true
-        thresholdSlider.value = filter.getDouble('filter.mix', position)
-        thresholdKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('filter.mix') > 0
-        blockUpdate = false
-        thresholdSlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        thresholdSlider.value = filter.getDouble('filter.mix', position);
+        thresholdKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('filter.mix') > 0;
+        blockUpdate = false;
+        thresholdSlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
-    
+
     function setControls() {
-        setKeyframedControls()
-        shapeFile.url = filter.get('filter.resource')
-        if (shapeFile.fileName.substring(0,5) === '%luma') {
+        setKeyframedControls();
+        shapeFile.url = filter.get('filter.resource');
+        if (shapeFile.fileName.substring(0, 5) === '%luma') {
             for (var i = 1; i < resourceCombo.model.count; ++i) {
-                var s = (i < 10) ? '%luma0%1.pgm' : '%luma%1.pgm'
+                var s = (i < 10) ? '%luma0%1.pgm' : '%luma%1.pgm';
                 if (s.arg(i) === shapeFile.fileName) {
-                    resourceCombo.currentIndex = (i === 1)? 0 : i
-                    break
+                    resourceCombo.currentIndex = (i === 1) ? 0 : i;
+                    break;
                 }
             }
-            alphaRadioButton.enabled = false
+            alphaRadioButton.enabled = false;
         } else {
             for (i in application.wipes) {
                 if (shapeFile.filePath === application.wipes[i]) {
                     resourceCombo.currentIndex = i + 23;
-                    break
+                    break;
                 }
             }
-            if (resourceCombo.currentIndex === -1) {
-                resourceCombo.currentIndex = 1
-            }
-            fileLabel.text = shapeFile.fileName
-            fileLabelTip.text = shapeFile.filePath
-            alphaRadioButton.enabled = true
+            if (resourceCombo.currentIndex === -1)
+                resourceCombo.currentIndex = 1;
+
+            fileLabel.text = shapeFile.fileName;
+            fileLabelTip.text = shapeFile.filePath;
+            alphaRadioButton.enabled = true;
         }
-        previousResourceComboIndex = resourceCombo.currentIndex
-        thresholdCheckBox.checked = filter.getDouble('filter.use_mix') === 1
-        invertCheckBox.checked = filter.getDouble('filter.invert') === 1
-        reverseCheckBox.checked = filter.getDouble(reverseProperty) === 1
+        previousResourceComboIndex = resourceCombo.currentIndex;
+        thresholdCheckBox.checked = filter.getDouble('filter.use_mix') === 1;
+        invertCheckBox.checked = filter.getDouble('filter.invert') === 1;
+        reverseCheckBox.checked = filter.getDouble(reverseProperty) === 1;
         if (filter.getDouble('filter.use_luminance') === 1)
-            brightnessRadioButton.checked = true
+            brightnessRadioButton.checked = true;
         else
-            alphaRadioButton.checked = true
-        softnessSlider.value = filter.getDouble('filter.softness') * 100
+            alphaRadioButton.checked = true;
+        softnessSlider.value = filter.getDouble('filter.softness') * 100;
     }
 
     function updateFilter(parameter, value, position, button) {
-        if (blockUpdate) return
+        if (blockUpdate)
+            return ;
 
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValue = value
+                startValue = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValue = value
+                endValue = value;
             else
-                middleValue = value
+                middleValue = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(parameter)
-            button.checked = false
+            filter.resetProperty(parameter);
+            button.checked = false;
             if (filter.animateIn > 0) {
-                filter.set(parameter, startValue, 0)
-                filter.set(parameter, middleValue, filter.animateIn - 1)
+                filter.set(parameter, startValue, 0);
+                filter.set(parameter, middleValue, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(parameter, middleValue, filter.duration - filter.animateOut)
-                filter.set(parameter, endValue, filter.duration - 1)
+                filter.set(parameter, middleValue, filter.duration - filter.animateOut);
+                filter.set(parameter, endValue, filter.duration - 1);
             }
         } else if (!button.checked) {
-            filter.resetProperty(parameter)
-            filter.set(parameter, middleValue)
+            filter.resetProperty(parameter);
+            filter.set(parameter, middleValue);
         } else if (position !== null) {
-            filter.set(parameter, value, position)
+            filter.set(parameter, value, position);
         }
     }
 
     function onKeyframesButtonClicked(checked, parameter, value) {
         if (checked) {
-            blockUpdate = true
-            thresholdSlider.enabled = softnessSlider.enabled = true
+            blockUpdate = true;
+            thresholdSlider.enabled = softnessSlider.enabled = true;
             if (filter.animateIn > 0 || filter.animateOut > 0) {
-                filter.resetProperty('filter.mix')
-                filter.animateIn = filter.animateOut = 0
+                filter.resetProperty('filter.mix');
+                filter.animateIn = filter.animateOut = 0;
             } else {
-                filter.clearSimpleAnimation(parameter)
+                filter.clearSimpleAnimation(parameter);
             }
-            blockUpdate = false
-            filter.set(parameter, value, getPosition())
+            blockUpdate = false;
+            filter.set(parameter, value, getPosition());
         } else {
-            filter.resetProperty(parameter)
-            filter.set(parameter, value)
+            filter.resetProperty(parameter);
+            filter.set(parameter, value);
         }
     }
 
-    // This signal is used to workaround context properties not available in
-    // the FileDialog onAccepted signal handler on Qt 5.5.
-    signal fileOpened(string path)
-    onFileOpened: {
-        settings.openPath = path
-        fileDialog.folder = 'file:///' + path
+    function updatedSimpleAnimation() {
+        setControls();
+        updateFilter('filter.mix', thresholdSlider.value, null, thresholdKeyframesButton);
     }
 
-    Shotcut.File { id: shapeFile }
+    width: 350
+    height: 275
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set('filter', 'shape');
+            filter.set('filter.mix', 50);
+            filter.set('filter.softness', 0);
+            filter.set('filter.invert', 0);
+            filter.set('filter.use_luminance', 1);
+            filter.set('filter.resource', '%luma01.pgm');
+            filter.set('filter.use_mix', 1);
+            filter.set('filter.audio_match', 0);
+            filter.savePreset(preset.parameters);
+        } else {
+            if (filter.get('filter.use_mix').length === 0)
+                filter.set('filter.use_mix', 1);
+
+            if (filter.get('filter.audio_match').length === 0)
+                filter.set('filter.audio_match', 1);
+
+            initSimpleAnimation();
+        }
+        setControls();
+    }
+    onFileOpened: {
+        settings.openPath = path;
+        fileDialog.folder = 'file:///' + path;
+    }
+
+    Shotcut.File {
+        id: shapeFile
+    }
+
     FileDialog {
         id: fileDialog
+
         modality: application.dialogModality
         selectMultiple: false
         selectFolder: false
         folder: settingsOpenPath
         onAccepted: {
-            shapeFile.url = fileDialog.fileUrl
-            filter.set('filter.resource', shapeFile.url)
-            fileLabel.text = shapeFile.fileName
-            fileLabelTip.text = shapeFile.filePath
-            previousResourceComboIndex = resourceCombo.currentIndex
-            alphaRadioButton.enabled = true
-            shapeRoot.fileOpened(shapeFile.path)
+            shapeFile.url = fileDialog.fileUrl;
+            filter.set('filter.resource', shapeFile.url);
+            fileLabel.text = shapeFile.fileName;
+            fileLabelTip.text = shapeFile.filePath;
+            previousResourceComboIndex = resourceCombo.currentIndex;
+            alphaRadioButton.enabled = true;
+            shapeRoot.fileOpened(shapeFile.path);
         }
         onRejected: resourceCombo.currentIndex = previousResourceComboIndex
     }
@@ -202,16 +213,18 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: 3
             parameters: ['filter.mix', 'filter.softness', 'filter.use_luminance', 'filter.invert', 'filter.resource', 'filter.use_mix', reverseProperty]
             onBeforePresetLoaded: {
-                filter.resetProperty('filter.mix')
+                filter.resetProperty('filter.mix');
             }
             onPresetSelected: {
-                setControls()
-                initSimpleAnimation()
+                setControls();
+                initSimpleAnimation();
             }
         }
 
@@ -219,171 +232,325 @@ Item {
             text: qsTr('File')
             Layout.alignment: Qt.AlignRight
         }
-        Shotcut.File { id: wipeFile }
+
+        Shotcut.File {
+            id: wipeFile
+        }
+
         Shotcut.ComboBox {
             id: resourceCombo
-            implicitWidth: 300
-            model: ListModel {
-                id: listModel
-                ListElement { text: qsTr('Bar Horizontal'); value: '%luma01.pgm' }
-                ListElement { text: qsTr('Custom...'); value: '' }
-                ListElement { text: qsTr('Bar Vertical'); value: '%luma02.pgm' }
-                ListElement { text: qsTr('Barn Door Horizontal'); value: '%luma03.pgm' }
-                ListElement { text: qsTr('Barn Door Vertical'); value: '%luma04.pgm' }
-                ListElement { text: qsTr('Barn Door Diagonal SW-NE'); value: '%luma05.pgm' }
-                ListElement { text: qsTr('Barn Door Diagonal NW-SE'); value: '%luma06.pgm' }
-                ListElement { text: qsTr('Diagonal Top Left'); value: '%luma07.pgm' }
-                ListElement { text: qsTr('Diagonal Top Right'); value: '%luma08.pgm' }
-                ListElement { text: qsTr('Matrix Waterfall Horizontal'); value: '%luma09.pgm' }
-                ListElement { text: qsTr('Matrix Waterfall Vertical'); value: '%luma10.pgm' }
-                ListElement { text: qsTr('Matrix Snake Horizontal'); value: '%luma11.pgm' }
-                ListElement { text: qsTr('Matrix Snake Parallel Horizontal'); value: '%luma12.pgm' }
-                ListElement { text: qsTr('Matrix Snake Vertical'); value: '%luma13.pgm' }
-                ListElement { text: qsTr('Matrix Snake Parallel Vertical'); value: '%luma14.pgm' }
-                ListElement { text: qsTr('Barn V Up'); value: '%luma15.pgm' }
-                ListElement { text: qsTr('Iris Circle'); value: '%luma16.pgm' }
-                ListElement { text: qsTr('Double Iris'); value: '%luma17.pgm' }
-                ListElement { text: qsTr('Iris Box'); value: '%luma18.pgm' }
-                ListElement { text: qsTr('Box Bottom Right'); value: '%luma19.pgm' }
-                ListElement { text: qsTr('Box Bottom Left'); value: '%luma20.pgm' }
-                ListElement { text: qsTr('Box Right Center'); value: '%luma21.pgm' }
-                ListElement { text: qsTr('Clock Top'); value: '%luma22.pgm' }
-                Component.onCompleted: {
-                    application.wipes.forEach(function(el) {
-                        wipeFile.url = el
-                        append({text: wipeFile.fileName, value: el})
-                    })
+
+            function updateResource(index) {
+                fileLabel.text = '';
+                fileLabelTip.text = '';
+                if (index === 1) {
+                    fileDialog.selectExisting = true;
+                    fileDialog.title = qsTr('Open Mask File');
+                    fileDialog.open();
+                } else {
+                    var s = resourceCombo.model.get(index).value;
+                    filter.set('filter.resource', s);
+                    previousResourceComboIndex = index;
+                    brightnessRadioButton.checked = true;
+                    filter.set('filter.use_luminance', 1);
+                    alphaRadioButton.enabled = index >= 23;
                 }
             }
+
+            implicitWidth: 300
             textRole: 'text'
             currentIndex: 0
+            onActivated: {
+                // toggling focus works around a weird bug involving sticky
+                // input event focus on the ComboBox
+                enabled = false;
+                updateResource(index);
+                enabled = true;
+            }
+
             Shotcut.HoverTip {
                 text: qsTr('Set a mask from another file\'s brightness or alpha.')
                 visible: !resourceCombo.pressed
             }
-            onActivated: {
-                // toggling focus works around a weird bug involving sticky
-                // input event focus on the ComboBox
-                enabled = false
-                updateResource(index)
-                enabled = true
-            }
-            function updateResource(index) {
-                fileLabel.text = ''
-                fileLabelTip.text = ''
-                if (index === 1) {
-                    fileDialog.selectExisting = true
-                    fileDialog.title = qsTr('Open Mask File')
-                    fileDialog.open()
-                } else {
-                    var s = resourceCombo.model.get(index).value
-                    filter.set('filter.resource', s)
-                    previousResourceComboIndex = index
-                    brightnessRadioButton.checked = true
-                    filter.set('filter.use_luminance', 1)
-                    alphaRadioButton.enabled = index >= 23
+
+            model: ListModel {
+                id: listModel
+
+                Component.onCompleted: {
+                    application.wipes.forEach(function(el) {
+                        wipeFile.url = el;
+                        append({
+                            "text": wipeFile.fileName,
+                            "value": el
+                        });
+                    });
                 }
+
+                ListElement {
+                    text: qsTr('Bar Horizontal')
+                    value: '%luma01.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Custom...')
+                    value: ''
+                }
+
+                ListElement {
+                    text: qsTr('Bar Vertical')
+                    value: '%luma02.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Barn Door Horizontal')
+                    value: '%luma03.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Barn Door Vertical')
+                    value: '%luma04.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Barn Door Diagonal SW-NE')
+                    value: '%luma05.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Barn Door Diagonal NW-SE')
+                    value: '%luma06.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Diagonal Top Left')
+                    value: '%luma07.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Diagonal Top Right')
+                    value: '%luma08.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Matrix Waterfall Horizontal')
+                    value: '%luma09.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Matrix Waterfall Vertical')
+                    value: '%luma10.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Matrix Snake Horizontal')
+                    value: '%luma11.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Matrix Snake Parallel Horizontal')
+                    value: '%luma12.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Matrix Snake Vertical')
+                    value: '%luma13.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Matrix Snake Parallel Vertical')
+                    value: '%luma14.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Barn V Up')
+                    value: '%luma15.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Iris Circle')
+                    value: '%luma16.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Double Iris')
+                    value: '%luma17.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Iris Box')
+                    value: '%luma18.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Box Bottom Right')
+                    value: '%luma19.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Box Bottom Left')
+                    value: '%luma20.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Box Right Center')
+                    value: '%luma21.pgm'
+                }
+
+                ListElement {
+                    text: qsTr('Clock Top')
+                    value: '%luma22.pgm'
+                }
+
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                resourceCombo.currentIndex = 0
-                resourceCombo.updateResource(resourceCombo.currentIndex)
+                resourceCombo.currentIndex = 0;
+                resourceCombo.updateResource(resourceCombo.currentIndex);
             }
         }
-        Item { width: 1 }
 
-        Item { width: 1 }
-        Label {
-            id: fileLabel
-            Layout.columnSpan: 3
-            Shotcut.HoverTip { id: fileLabelTip }
+        Item {
+            width: 1
         }
 
-        Item { width: 1 }
+        Item {
+            width: 1
+        }
+
+        Label {
+            id: fileLabel
+
+            Layout.columnSpan: 3
+
+            Shotcut.HoverTip {
+                id: fileLabelTip
+            }
+
+        }
+
+        Item {
+            width: 1
+        }
+
         RowLayout {
             Layout.columnSpan: 3
+
             CheckBox {
                 id: invertCheckBox
+
                 text: qsTr('Invert')
                 onClicked: filter.set('filter.invert', checked)
             }
+
             Shotcut.UndoButton {
                 onClicked: {
-                    invertCheckBox.checked = false
-                    filter.set('filter.invert', 0)
+                    invertCheckBox.checked = false;
+                    filter.set('filter.invert', 0);
                 }
             }
-            Item { width: 1 }
+
+            Item {
+                width: 1
+            }
+
             CheckBox {
+                // reset the old reverse
+
                 id: reverseCheckBox
+
                 text: qsTr('Reverse')
                 visible: filter.isAtLeastVersion(2)
                 onClicked: {
-                    filter.set(reverseProperty, checked)
-                    if (filter.isAtLeastVersion(3)) {
-                        // reset the old reverse
-                        filter.set('filter.reverse', 0)
-                    }
+                    filter.set(reverseProperty, checked);
+                    if (filter.isAtLeastVersion(3))
+                        filter.set('filter.reverse', 0);
+
                 }
             }
+
             Shotcut.UndoButton {
+                // reset the old reverse
+
                 visible: reverseCheckBox.visible
                 onClicked: {
-                    reverseCheckBox.checked = false
-                    filter.set(reverseProperty, checked)
-                    if (filter.isAtLeastVersion(3)) {
-                        // reset the old reverse
-                        filter.set('filter.reverse', 0)
-                    }
+                    reverseCheckBox.checked = false;
+                    filter.set(reverseProperty, checked);
+                    if (filter.isAtLeastVersion(3))
+                        filter.set('filter.reverse', 0);
+
                 }
             }
-            Item { width: 1 }
+
+            Item {
+                width: 1
+            }
+
         }
 
         Label {
             text: qsTr('Channel')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
-            ButtonGroup { id: channelGroup }
+            ButtonGroup {
+                id: channelGroup
+            }
+
             RadioButton {
                 id: brightnessRadioButton
+
                 text: qsTr('Brightness')
                 ButtonGroup.group: channelGroup
                 onClicked: filter.set('filter.use_luminance', 1)
             }
+
             RadioButton {
                 id: alphaRadioButton
+
                 text: qsTr('Alpha')
                 ButtonGroup.group: channelGroup
                 onClicked: filter.set('filter.use_luminance', 0)
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: brightnessRadioButton.checked = true
         }
-        Item { width: 1 }
+
+        Item {
+            width: 1
+        }
 
         CheckBox {
             id: thresholdCheckBox
+
             text: qsTr('Threshold')
             Layout.alignment: Qt.AlignRight
             onClicked: filter.set('filter.use_mix', checked)
         }
+
         Shotcut.SliderSpinner {
             id: thresholdSlider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 2
             suffix: ' %'
             onValueChanged: updateFilter('filter.mix', value, getPosition(), thresholdKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: thresholdSlider.value = 50
         }
+
         Shotcut.KeyframesButton {
             id: thresholdKeyframesButton
+
             onToggled: onKeyframesButtonClicked(checked, 'filter.mix', thresholdSlider.value)
         }
 
@@ -391,18 +558,24 @@ Item {
             text: qsTr('Softness')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: softnessSlider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 2
             suffix: ' %'
-            onValueChanged: filter.set('filter.softness', value/100)
+            onValueChanged: filter.set('filter.softness', value / 100)
         }
+
         Shotcut.UndoButton {
             onClicked: softnessSlider.value = 0
         }
-        Item { width: 1 }
+
+        Item {
+            width: 1
+        }
 
         Shotcut.TipBox {
             Layout.columnSpan: parent.columns
@@ -414,24 +587,43 @@ Item {
         Label {
             Layout.fillHeight: true
         }
-    }
 
-    function updatedSimpleAnimation() {
-        setControls()
-        updateFilter('filter.mix', thresholdSlider.value, null, thresholdKeyframesButton)
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updatedSimpleAnimation();
+        }
+
+        function onOutChanged() {
+            updatedSimpleAnimation();
+        }
+
+        function onAnimateInChanged() {
+            updatedSimpleAnimation();
+        }
+
+        function onAnimateOutChanged() {
+            updatedSimpleAnimation();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updatedSimpleAnimation() }
-        function onOutChanged() { updatedSimpleAnimation() }
-        function onAnimateInChanged() { updatedSimpleAnimation() }
-        function onAnimateOutChanged() { updatedSimpleAnimation() }
-        function onPropertyChanged(name) { setControls() }
     }
+
     Connections {
+        function onPositionChanged() {
+            setKeyframedControls();
+        }
+
         target: producer
-        function onPositionChanged() { setKeyframedControls() }
     }
+
 }

--- a/src/qml/filters/mirror/ui.qml
+++ b/src/qml/filters/mirror/ui.qml
@@ -18,14 +18,14 @@
 import QtQuick 2.1
 
 Item {
+    // Movit filter
+
     width: 350
     height: 10
-
     Component.onCompleted: {
-        if (filter.get("mlt_service").indexOf("movit.") == 0 ) {
-            // Movit filter
+        if (filter.get("mlt_service").indexOf("movit.") == 0) {
         } else {
-            filter.set('mirror', 'flip')
+            filter.set('mirror', 'flip');
         }
     }
 }

--- a/src/qml/filters/mosaic/meta.qml
+++ b/src/qml/filters/mosaic/meta.qml
@@ -23,6 +23,7 @@ Metadata {
     name: qsTr("Mosaic")
     mlt_service: "frei0r.pixeliz0r"
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -44,4 +45,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/mosaic/ui.qml
+++ b/src/qml/filters/mosaic/ui.qml
@@ -23,46 +23,44 @@ import Shotcut.Controls 1.0 as Shotcut
 Shotcut.KeyframableFilter {
     property string xsize: '0'
     property string ysize: '1'
-    property real maxFilterPercent: 50.0
-    property real maxUserPercent: 20.0
+    property real maxFilterPercent: 50
+    property real maxUserPercent: 20
     property real defaultValue: 2.5 / maxFilterPercent
+
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        xsizeSlider.value = filter.getDouble(xsize, position) * maxFilterPercent;
+        xsizeKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(xsize) > 0;
+        ysizeSlider.value = filter.getDouble(ysize, position) * maxFilterPercent;
+        ysizeKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(ysize) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        xsizeSlider.enabled = ysizeSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        setControls();
+        updateFilter(xsize, xsizeSlider.value / maxFilterPercent, xsizeKeyframesButton, null);
+        updateFilter(ysize, ysizeSlider.value / maxFilterPercent, ysizeKeyframesButton, null);
+    }
 
     keyframableParameters: [xsize, ysize]
     startValues: [0, 0]
     middleValues: [defaultValue, defaultValue]
     endValues: [0, 0]
-
     width: 200
     height: 50
-
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set(xsize, defaultValue)
-            filter.set(ysize, defaultValue)
-            filter.savePreset(preset.parameters)
+            filter.set(xsize, defaultValue);
+            filter.set(ysize, defaultValue);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        xsizeSlider.value = filter.getDouble(xsize, position) * maxFilterPercent
-        xsizeKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(xsize) > 0
-        ysizeSlider.value = filter.getDouble(ysize, position) * maxFilterPercent
-        ysizeKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(ysize) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        xsizeSlider.enabled = ysizeSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        setControls()
-        updateFilter(xsize, xsizeSlider.value / maxFilterPercent, xsizeKeyframesButton, null)
-        updateFilter(ysize, ysizeSlider.value / maxFilterPercent, ysizeKeyframesButton, null)
+        setControls();
     }
 
     GridLayout {
@@ -74,16 +72,18 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [xsize, ysize]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -91,8 +91,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Width')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: xsizeSlider
+
             minimumValue: 0
             maximumValue: 20
             stepSize: 0.1
@@ -100,14 +102,17 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(xsize, xsizeSlider.value / maxFilterPercent, xsizeKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: xsizeSlider.value = defaultValue * maxFilterPercent
         }
+
         Shotcut.KeyframesButton {
             id: xsizeKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, xsize, xsizeSlider.value / maxFilterPercent)
+                enableControls(true);
+                toggleKeyframes(checked, xsize, xsizeSlider.value / maxFilterPercent);
             }
         }
 
@@ -115,8 +120,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Height')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: ysizeSlider
+
             minimumValue: 0
             maximumValue: 20
             stepSize: 0.1
@@ -124,34 +131,60 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(ysize, ysizeSlider.value / maxFilterPercent, ysizeKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: ysizeSlider.value = defaultValue * maxFilterPercent
         }
+
         Shotcut.KeyframesButton {
             id: ysizeKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, ysize, ysizeSlider.value / maxFilterPercent)
+                enableControls(true);
+                toggleKeyframes(checked, ysize, ysizeSlider.value / maxFilterPercent);
             }
         }
 
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/movit_diffusion/ui.qml
+++ b/src/qml/filters/movit_diffusion/ui.qml
@@ -34,8 +34,10 @@ Item {
             text: qsTr('Radius')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: radiusSlider
+
             minimumValue: 0
             maximumValue: 2000
             ratio: 100
@@ -44,6 +46,7 @@ Item {
             value: filter.getDouble('radius') * 100
             onValueChanged: filter.set('radius', value / 100)
         }
+
         Shotcut.UndoButton {
             onClicked: radiusSlider.value = 300
         }
@@ -52,20 +55,25 @@ Item {
             text: qsTr('Blurriness')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: mixSlider
+
             minimumValue: 0
             maximumValue: 100
             suffix: ' %'
             value: filter.getDouble('mix') * 100
             onValueChanged: filter.set('mix', value / 100)
         }
+
         Shotcut.UndoButton {
             onClicked: mixSlider.value = 30
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/nervous/ui.qml
+++ b/src/qml/filters/nervous/ui.qml
@@ -21,17 +21,17 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 350
-    height: 100
     property string amount: 'av.frames'
     property int amountDefault: 2
 
+    width: 350
+    height: 100
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set(amount, amountDefault)
-            filter.savePreset(preset.parameters)
+            filter.set(amount, amountDefault);
+            filter.savePreset(preset.parameters);
         }
-        amountSlider.value = filter.get(amount)
+        amountSlider.value = filter.get(amount);
     }
 
     GridLayout {
@@ -43,8 +43,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [amount]
             Layout.columnSpan: parent.columns - 1
             onPresetSelected: amountSlider.value = filter.get(amount)
@@ -54,8 +56,10 @@ Item {
             text: qsTr('Amount')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: amountSlider
+
             minimumValue: 2
             maximumValue: Math.round(profile.fps)
             stepSize: 1
@@ -63,10 +67,15 @@ Item {
             spinnerWidth: 110
             onValueChanged: filter.set(amount, value)
         }
+
         Shotcut.UndoButton {
             onClicked: amountSlider.value = amountDefault
         }
 
-        Item { Layout.fillHeight: true}
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
+
 }

--- a/src/qml/filters/noise_fast/ui.qml
+++ b/src/qml/filters/noise_fast/ui.qml
@@ -24,20 +24,19 @@ Item {
     property string noise: 'av.all_strength'
     property double noiseDefault: 20
 
-    width: 350
-    height: 100
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            filter.set('av.all_flags', 'a+t')
-            filter.set(noise, noiseDefault)
-            filter.savePreset(preset.parameters)
-        }
-        setControls()
+    function setControls() {
+        noiseSlider.value = filter.getDouble(noise);
     }
 
-    function setControls() {
-        noiseSlider.value = filter.getDouble(noise)
+    width: 350
+    height: 100
+    Component.onCompleted: {
+        if (filter.isNew) {
+            filter.set('av.all_flags', 'a+t');
+            filter.set(noise, noiseDefault);
+            filter.savePreset(preset.parameters);
+        }
+        setControls();
     }
 
     GridLayout {
@@ -49,8 +48,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [noise]
             Layout.columnSpan: 3
             onPresetSelected: setControls()
@@ -60,15 +61,18 @@ Item {
             text: qsTr('Amount')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: noiseSlider
-            minimumValue: 0.0
-            maximumValue: 100.0
+
+            minimumValue: 0
+            maximumValue: 100
             stepSize: 0.1
             decimals: 1
             suffix: ' %'
             onValueChanged: filter.set(noise, noiseSlider.value)
         }
+
         Shotcut.UndoButton {
             onClicked: noiseSlider.value = noiseDefault
         }
@@ -76,5 +80,7 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/noise_keyframes/meta.qml
+++ b/src/qml/filters/noise_keyframes/meta.qml
@@ -24,6 +24,7 @@ Metadata {
     objectName: 'noise_keyframes'
     mlt_service: "frei0r.rgbnoise"
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -38,4 +39,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/nosync/meta.qml
+++ b/src/qml/filters/nosync/meta.qml
@@ -7,6 +7,7 @@ Metadata {
     objectName: 'nosync'
     mlt_service: 'frei0r.nosync0r'
     qml: 'ui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -21,4 +22,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/nosync/ui.qml
+++ b/src/qml/filters/nosync/ui.qml
@@ -24,38 +24,36 @@ Shotcut.KeyframableFilter {
     property string horizontal: '0'
     property double horizontalDefault: 0.2
 
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        horizontalSlider.value = filter.getDouble(horizontal, position) * horizontalSlider.maximumValue;
+        horizontalKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(horizontal) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        horizontalSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        setControls();
+        updateFilter(horizontal, horizontalSlider.value / horizontalSlider.maximumValue, horizontalKeyframesButton, null);
+    }
+
     keyframableParameters: [horizontal]
     startValues: [0]
     middleValues: [horizontalDefault]
     endValues: [0]
-
     width: 350
     height: 100
-
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set(horizontal, horizontalDefault)
-            filter.savePreset(preset.parameters)
+            filter.set(horizontal, horizontalDefault);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        horizontalSlider.value = filter.getDouble(horizontal, position) * horizontalSlider.maximumValue
-        horizontalKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(horizontal) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        horizontalSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        setControls()
-        updateFilter(horizontal, horizontalSlider.value / horizontalSlider.maximumValue, horizontalKeyframesButton, null)
+        setControls();
     }
 
     GridLayout {
@@ -67,16 +65,18 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [horizontal]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                filter.resetProperty(horizontal)
+                filter.resetProperty(horizontal);
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -84,41 +84,71 @@ Shotcut.KeyframableFilter {
             text: qsTr('Offset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: horizontalSlider
-            minimumValue: 0.0
+
+            minimumValue: 0
             maximumValue: 100
             stepSize: 0.01
             decimals: 2
             suffix: ' %'
             onValueChanged: updateFilter(horizontal, horizontalSlider.value / horizontalSlider.maximumValue, horizontalKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: horizontalSlider.value = horizontalDefault * horizontalSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: horizontalKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, horizontal, horizontalSlider.value / horizontalSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, horizontal, horizontalSlider.value / horizontalSlider.maximumValue);
             }
         }
 
-        Item { Layout.fillHeight: true }
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/oldfilm/ui.qml
+++ b/src/qml/filters/oldfilm/ui.qml
@@ -22,33 +22,33 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
+    function setControls() {
+        deltaSlider.value = filter.get('delta');
+        amountSlider.value = filter.get('every');
+        brightDeltaSlider.value = filter.get('brightnessdelta_up');
+        darkDeltaSlider.value = filter.get('brightnessdelta_down');
+        valueSlider.value = filter.get('brightnessdelta_every');
+        highDevelopSlider.value = filter.get('unevendevelop_up');
+        lowDevelopSlider.value = filter.get('unevendevelop_down');
+        durationSlider.value = filter.get('unevendevelop_duration');
+    }
+
     width: 350
     height: 250
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set('delta', 14)
-            filter.set('every', 20)
-            filter.set('brightnessdelta_up', 20)
-            filter.set('brightnessdelta_down', 30)
-            filter.set('brightnessdelta_every', 70)
-            filter.set('unevendevelop_up', 60)
-            filter.set('unevendevelop_down', 20)
-            filter.set('unevendevelop_duration', 70)
-            filter.savePreset(preset.parameters)
+            filter.set('delta', 14);
+            filter.set('every', 20);
+            filter.set('brightnessdelta_up', 20);
+            filter.set('brightnessdelta_down', 30);
+            filter.set('brightnessdelta_every', 70);
+            filter.set('unevendevelop_up', 60);
+            filter.set('unevendevelop_down', 20);
+            filter.set('unevendevelop_duration', 70);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        deltaSlider.value = filter.get('delta')
-        amountSlider.value = filter.get('every')
-        brightDeltaSlider.value = filter.get('brightnessdelta_up')
-        darkDeltaSlider.value = filter.get('brightnessdelta_down')
-        valueSlider.value = filter.get('brightnessdelta_every')
-        highDevelopSlider.value = filter.get('unevendevelop_up')
-        lowDevelopSlider.value = filter.get('unevendevelop_down')
-        durationSlider.value = filter.get('unevendevelop_duration')
+        setControls();
     }
 
     GridLayout {
@@ -60,8 +60,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ['delta', 'every', 'brightnessdelta_up', 'brightnessdelta_down', 'brightnessdelta_every', 'unevendevelop_up', 'unevendevelop_duration']
             Layout.columnSpan: 2
             onPresetSelected: setControls()
@@ -71,13 +73,16 @@ Item {
             text: qsTr('Vertical amount')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: deltaSlider
+
             minimumValue: 0
             maximumValue: 200
             value: filter.get('delta')
             onValueChanged: filter.set('delta', value)
         }
+
         Shotcut.UndoButton {
             onClicked: deltaSlider.value = 14
         }
@@ -86,14 +91,17 @@ Item {
             text: qsTr('Vertical frequency')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: amountSlider
+
             minimumValue: 0
             maximumValue: 100
             suffix: ' %'
             value: filter.get('every')
             onValueChanged: filter.set('every', value)
         }
+
         Shotcut.UndoButton {
             onClicked: amountSlider.value = 20
         }
@@ -102,13 +110,16 @@ Item {
             text: qsTr('Brightness up')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: brightDeltaSlider
+
             minimumValue: 0
             maximumValue: 100
             value: filter.get('brightnessdelta_up')
             onValueChanged: filter.set('brightnessdelta_up', value)
         }
+
         Shotcut.UndoButton {
             onClicked: brightDeltaSlider.value = 20
         }
@@ -117,13 +128,16 @@ Item {
             text: qsTr('Brightness down')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: darkDeltaSlider
+
             minimumValue: 0
             maximumValue: 100
             value: filter.get('brightnessdelta_down')
             onValueChanged: filter.set('brightnessdelta_down', value)
         }
+
         Shotcut.UndoButton {
             onClicked: darkDeltaSlider.value = 30
         }
@@ -132,14 +146,17 @@ Item {
             text: qsTr('Brightness frequency')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: valueSlider
+
             minimumValue: 0
             maximumValue: 100
             suffix: ' %'
             value: filter.get('brightnessdelta_every')
             onValueChanged: filter.set('brightnessdelta_every', value)
         }
+
         Shotcut.UndoButton {
             onClicked: valueSlider.value = 70
         }
@@ -148,13 +165,16 @@ Item {
             text: qsTr('Uneven develop up')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: highDevelopSlider
+
             minimumValue: 0
             maximumValue: 100
             value: filter.get('unevendevelop_up')
             onValueChanged: filter.set('unevendevelop_up', value)
         }
+
         Shotcut.UndoButton {
             onClicked: highDevelopSlider.value = 60
         }
@@ -163,13 +183,16 @@ Item {
             text: qsTr('Uneven develop down')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: lowDevelopSlider
+
             minimumValue: 0
             maximumValue: 100
             value: filter.get('unevendevelop_down')
             onValueChanged: filter.set('unevendevelop_down', value)
         }
+
         Shotcut.UndoButton {
             onClicked: lowDevelopSlider.value = 20
         }
@@ -178,19 +201,24 @@ Item {
             text: qsTr('Uneven develop duration')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: durationSlider
+
             minimumValue: 0
             maximumValue: 1000
             value: filter.get('unevendevelop_duration')
             onValueChanged: filter.set('unevendevelop_duration', value)
         }
+
         Shotcut.UndoButton {
             onClicked: durationSlider.value = 70
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/opacity/meta.qml
+++ b/src/qml/filters/opacity/meta.qml
@@ -8,6 +8,7 @@ Metadata {
     mlt_service: "brightness"
     qml: "ui.qml"
     gpuAlt: "movit.opacity"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -23,4 +24,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/opacity/meta_movit.qml
+++ b/src/qml/filters/opacity/meta_movit.qml
@@ -8,6 +8,7 @@ Metadata {
     mlt_service: "movit.opacity"
     needsGPU: true
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -22,4 +23,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/opacity/ui.qml
+++ b/src/qml/filters/opacity/ui.qml
@@ -21,82 +21,84 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 350
-    height: 50
     property bool blockUpdate: true
-    property double startValue: 1.0
-    property double middleValue: 1.0
-    property double endValue: 1.0
-
-    Component.onCompleted: {
-        filter.set('start', 1)
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set('level', 1)
-            filter.set('alpha', 1.0)
-            filter.set('opacity', filter.getDouble('alpha'))
-            filter.savePreset(preset.parameters)
-        } else {
-            middleValue = filter.getDouble('opacity', filter.animateIn)
-            if (filter.animateIn > 0)
-                startValue = filter.getDouble('opacity', 0)
-            if (filter.animateOut > 0)
-                endValue = filter.getDouble('opacity', filter.duration - 1)
-        }
-        setControls()
-    }
+    property double startValue: 1
+    property double middleValue: 1
+    property double endValue: 1
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        slider.value = filter.getDouble('opacity', position) * 100.0
-        keyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('opacity') > 0
-        blockUpdate = false
-        slider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        slider.value = filter.getDouble('opacity', position) * 100;
+        keyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('opacity') > 0;
+        blockUpdate = false;
+        slider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function updateFilter(position) {
-        if (blockUpdate) return
-        var value = slider.value / 100.0
+        if (blockUpdate)
+            return ;
 
+        var value = slider.value / 100;
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValue = value
+                startValue = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValue = value
+                endValue = value;
             else
-                middleValue = value
+                middleValue = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty('alpha')
-            filter.resetProperty('opacity')
-            keyframesButton.checked = false
+            filter.resetProperty('alpha');
+            filter.resetProperty('opacity');
+            keyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set('alpha', startValue, 0)
-                filter.set('alpha', middleValue, filter.animateIn - 1)
-                filter.set('opacity', startValue, 0)
-                filter.set('opacity', middleValue, filter.animateIn - 1)
+                filter.set('alpha', startValue, 0);
+                filter.set('alpha', middleValue, filter.animateIn - 1);
+                filter.set('opacity', startValue, 0);
+                filter.set('opacity', middleValue, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set('alpha', middleValue, filter.duration - filter.animateOut)
-                filter.set('alpha', endValue, filter.duration - 1)
-                filter.set('opacity', middleValue, filter.duration - filter.animateOut)
-                filter.set('opacity', endValue, filter.duration - 1)
+                filter.set('alpha', middleValue, filter.duration - filter.animateOut);
+                filter.set('alpha', endValue, filter.duration - 1);
+                filter.set('opacity', middleValue, filter.duration - filter.animateOut);
+                filter.set('opacity', endValue, filter.duration - 1);
             }
         } else if (!keyframesButton.checked) {
-            filter.resetProperty('alpha')
-            filter.resetProperty('opacity')
-            filter.set('alpha', middleValue)
-            filter.set('opacity', middleValue)
+            filter.resetProperty('alpha');
+            filter.resetProperty('opacity');
+            filter.set('alpha', middleValue);
+            filter.set('opacity', middleValue);
         } else if (position !== null) {
-            filter.set('alpha', value, position)
-            filter.set('opacity', value, position)
+            filter.set('alpha', value, position);
+            filter.set('opacity', value, position);
         }
+    }
+
+    width: 350
+    height: 50
+    Component.onCompleted: {
+        filter.set('start', 1);
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set('level', 1);
+            filter.set('alpha', 1);
+            filter.set('opacity', filter.getDouble('alpha'));
+            filter.savePreset(preset.parameters);
+        } else {
+            middleValue = filter.getDouble('opacity', filter.animateIn);
+            if (filter.animateIn > 0)
+                startValue = filter.getDouble('opacity', 0);
+
+            if (filter.animateOut > 0)
+                endValue = filter.getDouble('opacity', filter.duration - 1);
+
+        }
+        setControls();
     }
 
     GridLayout {
@@ -108,22 +110,26 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: parent.columns
             parameters: ['opacity', 'alpha']
             onBeforePresetLoaded: {
-                filter.resetProperty(parameters[0])
-                filter.resetProperty(parameters[1])
+                filter.resetProperty(parameters[0]);
+                filter.resetProperty(parameters[1]);
             }
             onPresetSelected: {
-                setControls()
-                keyframesButton.checked = filter.keyframeCount(parameters[0]) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-                middleValue = filter.getDouble(parameters[0], filter.animateIn)
+                setControls();
+                keyframesButton.checked = filter.keyframeCount(parameters[0]) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+                middleValue = filter.getDouble(parameters[0], filter.animateIn);
                 if (filter.animateIn > 0)
-                    startValue = filter.getDouble(parameters[0], 0)
+                    startValue = filter.getDouble(parameters[0], 0);
+
                 if (filter.animateOut > 0)
-                    endValue = filter.getDouble(parameters[0], filter.duration - 1)
+                    endValue = filter.getDouble(parameters[0], filter.duration - 1);
+
             }
         }
 
@@ -131,32 +137,37 @@ Item {
             text: qsTr('Level')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider
+
             minimumValue: 0
             maximumValue: 100
             suffix: ' %'
             onValueChanged: updateFilter(getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: slider.value = 100
         }
+
         Shotcut.KeyframesButton {
             id: keyframesButton
+
             onToggled: {
-                var value = slider.value / 100.0
+                var value = slider.value / 100;
                 if (checked) {
-                    blockUpdate = true
-                    filter.clearSimpleAnimation('alpha')
-                    filter.clearSimpleAnimation('opacity')
-                    blockUpdate = false
-                    filter.set('alpha', value, getPosition())
-                    filter.set('opacity', value, getPosition())
+                    blockUpdate = true;
+                    filter.clearSimpleAnimation('alpha');
+                    filter.clearSimpleAnimation('opacity');
+                    blockUpdate = false;
+                    filter.set('alpha', value, getPosition());
+                    filter.set('opacity', value, getPosition());
                 } else {
-                    filter.resetProperty('alpha')
-                    filter.resetProperty('opacity')
-                    filter.set('alpha', value)
-                    filter.set('opacity', value)
+                    filter.resetProperty('alpha');
+                    filter.resetProperty('opacity');
+                    filter.set('alpha', value);
+                    filter.set('opacity', value);
                 }
             }
         }
@@ -164,29 +175,54 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            setControls();
+            updateFilter(null);
+        }
+
+        function onOutChanged() {
+            setControls();
+            updateFilter(null);
+        }
+
+        function onAnimateInChanged() {
+            setControls();
+            updateFilter(null);
+        }
+
+        function onAnimateOutChanged() {
+            setControls();
+            updateFilter(null);
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { setControls(); updateFilter(null) }
-        function onOutChanged() { setControls(); updateFilter(null) }
-        function onAnimateInChanged() { setControls(); updateFilter(null) }
-        function onAnimateOutChanged() { setControls(); updateFilter(null) }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
-        target: producer
         function onPositionChanged() {
             if (filter.animateIn > 0 || filter.animateOut > 0) {
-                setControls()
+                setControls();
             } else {
-                blockUpdate = true
-                slider.value = filter.getDouble('opacity', getPosition()) * 100.0
-                blockUpdate = false
-                slider.enabled = true
+                blockUpdate = true;
+                slider.value = filter.getDouble('opacity', getPosition()) * 100;
+                blockUpdate = false;
+                slider.enabled = true;
             }
         }
+
+        target: producer
     }
+
 }

--- a/src/qml/filters/pillar_echo/meta.qml
+++ b/src/qml/filters/pillar_echo/meta.qml
@@ -8,6 +8,7 @@ Metadata {
     mlt_service: 'pillar_echo'
     qml: 'ui.qml'
     vui: 'vui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -20,4 +21,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/pillar_echo/ui.qml
+++ b/src/qml/filters/pillar_echo/ui.qml
@@ -25,103 +25,103 @@ Item {
     property rect filterRect
     property string startValue: '_shotcut:startValue'
     property string middleValue: '_shotcut:middleValue'
-    property string endValue:  '_shotcut:endValue'
-
-    width: 350
-    height: 180
-
-    Component.onCompleted: {
-        filter.blockSignals = true
-        var rect = defaultRect()
-        filter.set(middleValue, rect)
-        filter.set(startValue, rect)
-        filter.set(endValue, rect)
-        if (filter.isNew) {
-            // Add default preset.
-            filter.set(rectProperty, '' + rect.x + '/' + rect.y + ':' + rect.width + 'x' + rect.height)
-            filter.set("blur", 4)
-            filter.savePreset(preset.parameters)
-        } else {
-            filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1))
-            if (filter.animateIn > 0)
-                filter.set(startValue, filter.getRect(rectProperty, 0))
-            if (filter.animateOut > 0)
-                filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1))
-        }
-        filter.blockSignals = false
-        setControls()
-        setKeyframedControls()
-        if (filter.isNew)
-            filter.set(rectProperty, filter.getRect(rectProperty))
-    }
+    property string endValue: '_shotcut:endValue'
 
     function defaultRect() {
-        var result
-        if (producer.displayAspectRatio > profile.aspectRatio) {
-            result = Qt.rect(0, 0, profile.width, Math.round(profile.width / producer.displayAspectRatio))
-        } else {
-            result = Qt.rect(0, 0, Math.round(profile.height * producer.displayAspectRatio), profile.height)
-        }
-        result.x = Math.round((profile.width - result.width) / 2)
-        result.y = Math.round((profile.height - result.height) / 2)
-        return result
+        var result;
+        if (producer.displayAspectRatio > profile.aspectRatio)
+            result = Qt.rect(0, 0, profile.width, Math.round(profile.width / producer.displayAspectRatio));
+        else
+            result = Qt.rect(0, 0, Math.round(profile.height * producer.displayAspectRatio), profile.height);
+        result.x = Math.round((profile.width - result.width) / 2);
+        result.y = Math.round((profile.height - result.height) / 2);
+        return result;
     }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setFilter(position) {
         if (position !== null) {
-            filter.blockSignals = true
+            filter.blockSignals = true;
             if (position <= 0 && filter.animateIn > 0)
-                filter.set(startValue, filterRect)
+                filter.set(startValue, filterRect);
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                filter.set(endValue, filterRect)
+                filter.set(endValue, filterRect);
             else
-                filter.set(middleValue, filterRect)
-            filter.blockSignals = false
+                filter.set(middleValue, filterRect);
+            filter.blockSignals = false;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(rectProperty)
-            positionKeyframesButton.checked = false
+            filter.resetProperty(rectProperty);
+            positionKeyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set(rectProperty, filter.getRect(startValue), 0)
-                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1)
+                filter.set(rectProperty, filter.getRect(startValue), 0);
+                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut)
-                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1)
+                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut);
+                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1);
             }
         } else if (!positionKeyframesButton.checked) {
-            filter.resetProperty(rectProperty)
-            filter.set(rectProperty, filter.getRect(middleValue))
+            filter.resetProperty(rectProperty);
+            filter.set(rectProperty, filter.getRect(middleValue));
         } else if (position !== null) {
-            filter.set(rectProperty, filterRect, position)
+            filter.set(rectProperty, filterRect, position);
         }
     }
 
     function setControls() {
-        amountSlider.value = filter.get('blur')
+        amountSlider.value = filter.get('blur');
     }
 
     function setKeyframedControls() {
-        var position = getPosition()
-        var newValue = filter.getRect(rectProperty, position)
+        var position = getPosition();
+        var newValue = filter.getRect(rectProperty, position);
         if (filterRect !== newValue) {
-            filterRect = newValue
-            rectX.value = filterRect.x.toFixed()
-            rectY.value = filterRect.y.toFixed()
-            rectW.value = filterRect.width.toFixed()
-            rectH.value = filterRect.height.toFixed()
+            filterRect = newValue;
+            rectX.value = filterRect.x.toFixed();
+            rectY.value = filterRect.y.toFixed();
+            rectW.value = filterRect.width.toFixed();
+            rectH.value = filterRect.height.toFixed();
         }
-        var enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
-        rectX.enabled = enabled
-        rectY.enabled = enabled
-        rectW.enabled = enabled
-        rectH.enabled = enabled
-        positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
+        var enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
+        rectX.enabled = enabled;
+        rectY.enabled = enabled;
+        rectW.enabled = enabled;
+        rectH.enabled = enabled;
+        positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+    }
+
+    width: 350
+    height: 180
+    Component.onCompleted: {
+        filter.blockSignals = true;
+        var rect = defaultRect();
+        filter.set(middleValue, rect);
+        filter.set(startValue, rect);
+        filter.set(endValue, rect);
+        if (filter.isNew) {
+            // Add default preset.
+            filter.set(rectProperty, '' + rect.x + '/' + rect.y + ':' + rect.width + 'x' + rect.height);
+            filter.set("blur", 4);
+            filter.savePreset(preset.parameters);
+        } else {
+            filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1));
+            if (filter.animateIn > 0)
+                filter.set(startValue, filter.getRect(rectProperty, 0));
+
+            if (filter.animateOut > 0)
+                filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1));
+
+        }
+        filter.blockSignals = false;
+        setControls();
+        setKeyframedControls();
+        if (filter.isNew)
+            filter.set(rectProperty, filter.getRect(rectProperty));
+
     }
 
     GridLayout {
@@ -133,24 +133,28 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [rectProperty]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                filter.resetProperty(rectProperty)
+                filter.resetProperty(rectProperty);
             }
             onPresetSelected: {
-                setControls()
-                setKeyframedControls()
-                positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-                filter.blockSignals = true
-                filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1))
+                setControls();
+                setKeyframedControls();
+                positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+                filter.blockSignals = true;
+                filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1));
                 if (filter.animateIn > 0)
-                    filter.set(startValue, filter.getRect(rectProperty, 0))
+                    filter.set(startValue, filter.getRect(rectProperty, 0));
+
                 if (filter.animateOut > 0)
-                    filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1))
-                filter.blockSignals = false
+                    filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1));
+
+                filter.blockSignals = false;
             }
         }
 
@@ -158,53 +162,70 @@ Item {
             text: qsTr('Position')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Shotcut.DoubleSpinBox {
                 id: rectX
+
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.x !== value) {
-                    filterRect.x = value
-                    setFilter(getPosition())
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.x !== value) {
+                        filterRect.x = value;
+                        setFilter(getPosition());
+                    }
                 }
             }
-            Label { text: ','; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: ','
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectY
+
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.y !== value) {
-                    filterRect.y = value
-                    setFilter(getPosition())
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.y !== value) {
+                        filterRect.y = value;
+                        setFilter(getPosition());
+                    }
                 }
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                var rect = defaultRect()
-                filterRect.x = rectX.value = rect.x
-                filterRect.y = rectY.value = rect.y
-                setFilter(getPosition())
+                var rect = defaultRect();
+                filterRect.x = rectX.value = rect.x;
+                filterRect.y = rectY.value = rect.y;
+                setFilter(getPosition());
             }
         }
+
         Shotcut.KeyframesButton {
             id: positionKeyframesButton
+
             Layout.rowSpan: 2
             onToggled: {
                 if (checked) {
-                    filter.clearSimpleAnimation(rectProperty)
-                    filter.set(rectProperty, filterRect, getPosition())
+                    filter.clearSimpleAnimation(rectProperty);
+                    filter.set(rectProperty, filterRect, getPosition());
                 } else {
-                    filter.resetProperty(rectProperty)
-                    filter.set(rectProperty, filterRect)
+                    filter.resetProperty(rectProperty);
+                    filter.set(rectProperty, filterRect);
                 }
             }
         }
@@ -213,41 +234,56 @@ Item {
             text: qsTr('Size')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Shotcut.DoubleSpinBox {
                 id: rectW
+
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.width !== value) {
-                    filterRect.width = value
-                    setFilter(getPosition())
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.width !== value) {
+                        filterRect.width = value;
+                        setFilter(getPosition());
+                    }
                 }
             }
-            Label { text: 'x'; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: 'x'
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectH
+
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.height !== value) {
-                    filterRect.height = value
-                    setFilter(getPosition())
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.height !== value) {
+                        filterRect.height = value;
+                        setFilter(getPosition());
+                    }
                 }
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                var rect = defaultRect()
-                filterRect.width = rectW.value = rect.width
-                filterRect.height = rectH.value = rect.height
-                setFilter(getPosition())
+                var rect = defaultRect();
+                filterRect.width = rectW.value = rect.width;
+                filterRect.height = rectH.value = rect.height;
+                setFilter(getPosition());
             }
         }
 
@@ -255,35 +291,62 @@ Item {
             text: qsTr('Blur')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: amountSlider
+
             minimumValue: 0
-            maximumValue: 10.0
-            stepSize: .1
+            maximumValue: 10
+            stepSize: 0.1
             decimals: 2
             suffix: ' %'
             onValueChanged: filter.set("blur", value)
         }
+
         Shotcut.UndoButton {
             onClicked: amountSlider.value = 4
         }
-        Item { width: 1 }
 
+        Item {
+            width: 1
+        }
 
-        Item { Layout.fillHeight: true }
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
 
     Connections {
+        function onChanged() {
+            setKeyframedControls;
+        }
+
+        function onInChanged() {
+            setFilter(null);
+        }
+
+        function onOutChanged() {
+            setFilter(null);
+        }
+
+        function onAnimateInChanged() {
+            setFilter(null);
+        }
+
+        function onAnimateOutChanged() {
+            setFilter(null);
+        }
+
         target: filter
-        function onChanged() { setKeyframedControls }
-        function onInChanged() { setFilter(null) }
-        function onOutChanged() { setFilter(null) }
-        function onAnimateInChanged() { setFilter(null) }
-        function onAnimateOutChanged() { setFilter(null) }
     }
 
     Connections {
+        function onPositionChanged() {
+            setKeyframedControls();
+        }
+
         target: producer
-        function onPositionChanged() { setKeyframedControls() }
     }
+
 }

--- a/src/qml/filters/pillar_echo/vui.qml
+++ b/src/qml/filters/pillar_echo/vui.qml
@@ -20,69 +20,69 @@ import Shotcut.Controls 1.0 as Shotcut
 
 Shotcut.VuiBase {
     property string rectProperty: 'rect'
-    property real zoom: (video.zoom > 0)? video.zoom : 1.0
+    property real zoom: (video.zoom > 0) ? video.zoom : 1
     property rect filterRect: Qt.rect(-1, -1, -1, -1)
     property bool blockUpdate: false
     property string startValue: '_shotcut:startValue'
     property string middleValue: '_shotcut:middleValue'
-    property string endValue:  '_shotcut:endValue'
-
-    Component.onCompleted: {
-        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag'))
-        setRectangleControl()
-    }
+    property string endValue: '_shotcut:endValue'
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setRectangleControl() {
-        if (blockUpdate) return
-        var position = getPosition()
-        var newValue = filter.getRect(rectProperty, position)
+        if (blockUpdate)
+            return ;
+
+        var position = getPosition();
+        var newValue = filter.getRect(rectProperty, position);
         if (filterRect !== newValue) {
-            filterRect = newValue
-            rectangle.setHandles(filterRect)
+            filterRect = newValue;
+            rectangle.setHandles(filterRect);
         }
-        rectangle.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        rectangle.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function setFilter(position) {
-        blockUpdate = true
-        var rect = rectangle.rectangle
-        filterRect.x = Math.round(rect.x / rectangle.widthScale)
-        filterRect.y = Math.round(rect.y / rectangle.heightScale)
-        filterRect.width = Math.round(rect.width / rectangle.widthScale)
-        filterRect.height = Math.round(rect.height / rectangle.heightScale)
-
+        blockUpdate = true;
+        var rect = rectangle.rectangle;
+        filterRect.x = Math.round(rect.x / rectangle.widthScale);
+        filterRect.y = Math.round(rect.y / rectangle.heightScale);
+        filterRect.width = Math.round(rect.width / rectangle.widthScale);
+        filterRect.height = Math.round(rect.height / rectangle.heightScale);
         if (position !== null) {
-            filter.blockSignals = true
+            filter.blockSignals = true;
             if (position <= 0 && filter.animateIn > 0)
-                filter.set(startValue, filterRect)
+                filter.set(startValue, filterRect);
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                filter.set(endValue, filterRect)
+                filter.set(endValue, filterRect);
             else
-                filter.set(middleValue, filterRect)
-            filter.blockSignals = false
+                filter.set(middleValue, filterRect);
+            filter.blockSignals = false;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(rectProperty)
+            filter.resetProperty(rectProperty);
             if (filter.animateIn > 0) {
-                filter.set(rectProperty, filter.getRect(startValue), 0)
-                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1)
+                filter.set(rectProperty, filter.getRect(startValue), 0);
+                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut)
-                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1)
+                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut);
+                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1);
             }
         } else if (filter.keyframeCount(rectProperty) <= 0) {
-            filter.resetProperty(rectProperty)
-            filter.set(rectProperty, filter.getRect(middleValue))
+            filter.resetProperty(rectProperty);
+            filter.set(rectProperty, filter.getRect(middleValue));
         } else if (position !== null) {
-            filter.set(rectProperty, filterRect, position)
+            filter.set(rectProperty, filterRect, position);
         }
-        blockUpdate = false
+        blockUpdate = false;
+    }
+
+    Component.onCompleted: {
+        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag'));
+        setRectangleControl();
     }
 
     Flickable {
@@ -96,6 +96,7 @@ Shotcut.VuiBase {
 
         Item {
             id: videoItem
+
             x: video.rect.x
             y: video.rect.y
             width: video.rect.width
@@ -104,6 +105,7 @@ Shotcut.VuiBase {
 
             Shotcut.RectangleControl {
                 id: rectangle
+
                 widthScale: video.rect.width / profile.width
                 heightScale: video.rect.height / profile.height
                 handleSize: Math.max(Math.round(8 / zoom), 4)
@@ -112,19 +114,26 @@ Shotcut.VuiBase {
                 onHeightScaleChanged: setHandles(filterRect)
                 onRectChanged: setFilter(getPosition())
             }
+
         }
+
     }
 
     Connections {
-        target: filter
         function onChanged() {
-            setRectangleControl()
-            videoItem.enabled = filter.get('disable') !== '1'
+            setRectangleControl();
+            videoItem.enabled = filter.get('disable') !== '1';
         }
+
+        target: filter
     }
 
     Connections {
+        function onPositionChanged() {
+            setRectangleControl();
+        }
+
         target: producer
-        function onPositionChanged() { setRectangleControl() }
     }
+
 }

--- a/src/qml/filters/posterize/meta.qml
+++ b/src/qml/filters/posterize/meta.qml
@@ -7,6 +7,7 @@ Metadata {
     objectName: 'posterize'
     mlt_service: "frei0r.posterize"
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -21,4 +22,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/posterize/ui.qml
+++ b/src/qml/filters/posterize/ui.qml
@@ -22,41 +22,39 @@ import Shotcut.Controls 1.0 as Shotcut
 
 Shotcut.KeyframableFilter {
     property string levels: '0'
-    property double levelsDefault: 0.10
-   
+    property double levelsDefault: 0.1
+
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        levelsSlider.value = filter.getDouble(levels, position) * levelsSlider.maximumValue;
+        levelKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(levels) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        levelsSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        setControls();
+        updateFilter(levels, levelsSlider.value / levelsSlider.maximumValue, levelKeyframesButton, null);
+    }
+
     keyframableParameters: [levels]
     startValues: [0.5]
     middleValues: [levelsDefault]
     endValues: [0.5]
-
     width: 350
     height: 100
-
     Component.onCompleted: {
-        filter.set('threads', 0)
+        filter.set('threads', 0);
         if (filter.isNew) {
-            filter.set(levels, levelsDefault)
-            filter.savePreset(preset.parameters)
+            filter.set(levels, levelsDefault);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        levelsSlider.value = filter.getDouble(levels, position) * levelsSlider.maximumValue
-        levelKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(levels) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        levelsSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        setControls()
-        updateFilter(levels, levelsSlider.value / levelsSlider.maximumValue, levelKeyframesButton, null)
+        setControls();
     }
 
     GridLayout {
@@ -68,16 +66,18 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [levels]
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -85,43 +85,71 @@ Shotcut.KeyframableFilter {
             text: qsTr('Levels', 'Posterize filter')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: levelsSlider
+
             minimumValue: 0
-            maximumValue: 100.0
+            maximumValue: 100
             stepSize: 1
             decimals: 0
             suffix: ' %'
             onValueChanged: updateFilter(levels, levelsSlider.value / levelsSlider.maximumValue, levelKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: levelsSlider.value = levelsDefault * levelsSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: levelKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, levels, levelsSlider.value / levelsSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, levels, levelsSlider.value / levelsSlider.maximumValue);
             }
         }
-        
+
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/reflect/ui.qml
+++ b/src/qml/filters/reflect/ui.qml
@@ -15,59 +15,89 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import QtQml.Models 2.12
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
-import QtQml.Models 2.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
     width: 200
     height: 50
-
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set('mirror', 'horizontal')
+            filter.set('mirror', 'horizontal');
         } else {
-            var current = filter.get('mirror')
+            var current = filter.get('mirror');
             for (var i = 0; i < modeModel.count; ++i) {
                 if (modeModel.get(i).value === current) {
-                    modeCombo.currentIndex = i
-                    break
+                    modeCombo.currentIndex = i;
+                    break;
                 }
             }
         }
     }
+
     ColumnLayout {
         anchors.fill: parent
         anchors.margins: 8
 
         RowLayout {
-            Label { text: qsTr('Mode') }
+            Label {
+                text: qsTr('Mode')
+            }
+
             Shotcut.ComboBox {
                 id: modeCombo
+
                 implicitWidth: 200
-                model: ListModel {
-                    id: modeModel
-                    ListElement { text: qsTr('Right'); value: 'horizontal' }
-                    ListElement { text: qsTr('Left'); value: 'horizontal' }
-                    ListElement { text: qsTr('Bottom'); value: 'vertical' }
-                    ListElement { text: qsTr('Top'); value: 'vertical' }
-                }
                 textRole: 'text'
                 onActivated: {
-                    filter.set('mirror', modeModel.get(currentIndex).value)
-                    filter.set('reverse', currentIndex % 2)
+                    filter.set('mirror', modeModel.get(currentIndex).value);
+                    filter.set('reverse', currentIndex % 2);
                 }
+
+                model: ListModel {
+                    id: modeModel
+
+                    ListElement {
+                        text: qsTr('Right')
+                        value: 'horizontal'
+                    }
+
+                    ListElement {
+                        text: qsTr('Left')
+                        value: 'horizontal'
+                    }
+
+                    ListElement {
+                        text: qsTr('Bottom')
+                        value: 'vertical'
+                    }
+
+                    ListElement {
+                        text: qsTr('Top')
+                        value: 'vertical'
+                    }
+
+                }
+
             }
+
             Shotcut.UndoButton {
                 onClicked: {
-                    filter.set('mirror', modeModel.get(0).value)
-                    filter.set('reverse', 0)
-                    modeCombo.currentIndex = 0
+                    filter.set('mirror', modeModel.get(0).value);
+                    filter.set('reverse', 0);
+                    modeCombo.currentIndex = 0;
                 }
             }
+
         }
-        Item { Layout.fillHeight: true }
+
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
+
 }

--- a/src/qml/filters/rgbsplit0r/meta.qml
+++ b/src/qml/filters/rgbsplit0r/meta.qml
@@ -23,6 +23,7 @@ Metadata {
     name: qsTr("RGB Shift")
     mlt_service: "frei0r.rgbsplit0r"
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -44,4 +45,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/rgbsplit0r/ui.qml
+++ b/src/qml/filters/rgbsplit0r/ui.qml
@@ -23,45 +23,43 @@ import Shotcut.Controls 1.0 as Shotcut
 Shotcut.KeyframableFilter {
     property string verSplit: '0'
     property string horSplit: '1'
-    property double  verSplitDefault: 0.4
+    property double verSplitDefault: 0.4
     property double horSplitDefault: 0.4
+
+    function setControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        verSplitSlider.value = filter.getDouble(verSplit, position) * verSplitSlider.maximumValue;
+        verKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(verSplit) > 0;
+        horSplitSlider.value = filter.getDouble(horSplit, position) * horSplitSlider.maximumValue;
+        horKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(horSplit) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        verSplitSlider.enabled = horSplitSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        setControls();
+        updateFilter(verSplit, verSplitSlider.value / verSplitSlider.maximumValue, verKeyframesButton, null);
+        updateFilter(horSplit, horSplitSlider.value / horSplitSlider.maximumValue, horKeyframesButton, null);
+    }
 
     keyframableParameters: [verSplit, horSplit]
     startValues: [0.5, 0.5]
     middleValues: [verSplitDefault, horSplitDefault]
     endValues: [0.5, 0.5]
-
     width: 350
     height: 100
-
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set(verSplit, verSplitDefault)
-            filter.set(horSplit, horSplitDefault)
-            filter.savePreset(preset.parameters)
+            filter.set(verSplit, verSplitDefault);
+            filter.set(horSplit, horSplitDefault);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        verSplitSlider.value = filter.getDouble(verSplit, position) * verSplitSlider.maximumValue
-        verKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(verSplit) > 0
-        horSplitSlider.value = filter.getDouble(horSplit, position) * horSplitSlider.maximumValue
-        horKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(horSplit) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        verSplitSlider.enabled = horSplitSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        setControls()
-        updateFilter(verSplit, verSplitSlider.value / verSplitSlider.maximumValue, verKeyframesButton, null)
-        updateFilter(horSplit, horSplitSlider.value / horSplitSlider.maximumValue, horKeyframesButton, null)
+        setControls();
     }
 
     GridLayout {
@@ -73,14 +71,16 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [verSplit, horSplit]
             Layout.columnSpan: 3
             onBeforePresetLoaded: resetSimpleKeyframes()
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -88,8 +88,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Vertical')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: verSplitSlider
+
             minimumValue: 0
             maximumValue: 100
             stepSize: 0.1
@@ -97,14 +99,17 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(verSplit, value / maximumValue, verKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: verSplitSlider.value = verSplitDefault * verSplitSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: verKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, verSplit, verSplitSlider.value / verSplitSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, verSplit, verSplitSlider.value / verSplitSlider.maximumValue);
             }
         }
 
@@ -112,8 +117,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Horizontal')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: horSplitSlider
+
             minimumValue: 0
             maximumValue: 100
             stepSize: 0.1
@@ -121,34 +128,60 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(horSplit, value / maximumValue, horKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: horSplitSlider.value = horSplitDefault * horSplitSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: horKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, horSplit, horSplitSlider.value / horSplitSlider.maximumValue)
+                enableControls(true);
+                toggleKeyframes(checked, horSplit, horSplitSlider.value / horSplitSlider.maximumValue);
             }
         }
 
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/richtext/meta.qml
+++ b/src/qml/filters/richtext/meta.qml
@@ -10,6 +10,7 @@ Metadata {
     vui: 'vui.qml'
     isFavorite: true
     minimumVersion: '2'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -22,4 +23,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/richtext/ui.qml
+++ b/src/qml/filters/richtext/ui.qml
@@ -25,203 +25,191 @@ Item {
     property rect filterRect
     property string startValue: '_shotcut:startValue'
     property string middleValue: '_shotcut:middleValue'
-    property string endValue:  '_shotcut:endValue'
+    property string endValue: '_shotcut:endValue'
     property string sizeProperty: '_shotcut:size'
     property string specialPresetProperty: 'shotcut:preset'
-    property rect defaultRect: Qt.rect(Math.round(profile.width * 0.1),
-                                       Math.round(profile.height * 0.1),
-                                       Math.round(profile.width * 0.8),
-                                       Math.round(profile.height * 0.8))
-
-    width: 350
-    height: 230
-
-    Component.onCompleted: {
-        filter.blockSignals = true
-        filter.set(middleValue, defaultRect)
-        filter.set(startValue, defaultRect)
-        filter.set(endValue, defaultRect)
-        if (filter.isNew) {
-            var presetParams = [rectProperty]
-            filter.set('html', '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-<html><head><meta name="qrichtext" content="1" /><style type="text/css">
-p, li { white-space: pre-wrap; }
-body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color:#ffffff; }
-</style></head><body></body></html>
-'.arg(application.OS === 'Windows'? 'Verdana' : 'sans-serif'))
-            filter.set('argument', '')
-            filter.set('bgcolour', '#00000000')
-
-            filter.set(rectProperty,   '5%/66.66%:90%x28.34%')
-            filter.savePreset(presetParams, qsTr('Lower Third'))
-            filter.set(rectProperty,   '0%/0%:100%x100%')
-            filter.savePreset(presetParams, qsTr('Full Screen'))
-
-            // Add some animated presets.
-            filter.animateIn = filter.duration
-            filter.set(specialPresetProperty, 'scroll-down')
-            filter.savePreset(['shotcut:animIn', specialPresetProperty], qsTr('Scroll Down'))
-            filter.set(specialPresetProperty, 'scroll-up')
-            filter.savePreset(['shotcut:animIn', specialPresetProperty], qsTr('Scroll Up'))
-            filter.set(specialPresetProperty, 'scroll-right')
-            filter.savePreset(['shotcut:animIn', specialPresetProperty], qsTr('Scroll Right'))
-            filter.set(specialPresetProperty, 'scroll-left')
-            filter.savePreset(['shotcut:animIn', specialPresetProperty], qsTr('Scroll Left'))
-            filter.resetProperty(specialPresetProperty)
-
-            filter.animateIn = Math.round(profile.fps)
-            filter.set(rectProperty,   '0=-100%/0%:100%x100%; :1.0=0%/0%:100%x100%')
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slide In From Left'))
-            filter.set(rectProperty,   '0=100%/0%:100%x100%; :1.0=0%/0%:100%x100%')
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slide In From Right'))
-            filter.set(rectProperty,   '0=0%/-100%:100%x100%; :1.0=0%/0%:100%x100%')
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slide In From Top'))
-            filter.set(rectProperty,   '0=0%/100%:100%x100%; :1.0=0%/0%:100%x100%')
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slide In From Bottom'))
-            filter.animateIn = 0
-            filter.animateOut = Math.round(profile.fps)
-            filter.set(rectProperty,   ':-1.0=0%/0%:100%x100%; -1=-100%/0%:100%x100%')
-            filter.savePreset(presetParams.concat('shotcut:animOut'), qsTr('Slide Out Left'))
-            filter.set(rectProperty,   ':-1.0=0%/0%:100%x100%; -1=100%/0%:100%x100%')
-            filter.savePreset(presetParams.concat('shotcut:animOut'), qsTr('Slide Out Right'))
-            filter.set(rectProperty,   ':-1.0=0%/0%:100%x100%; -1=0%/-100%:100%x100%')
-            filter.savePreset(presetParams.concat('shotcut:animOut'), qsTr('Slide Out Top'))
-            filter.set(rectProperty,   ':-1.0=0%/0%:100%x100%; -1=0%/100%:100%x100%')
-            filter.savePreset(presetParams.concat('shotcut:animOut'), qsTr('Slide Out Bottom'))
-            filter.animateOut = 0
-            filter.animateIn = filter.duration
-            filter.set(rectProperty,   '0=0%/0%:100%x100%; -1=-5%/-5%:110%x110%')
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Zoom In'))
-            filter.set(rectProperty,   '0=-5%/-5%:110%x110%; -1=0%/0%:100%x100%')
-            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Zoom Out'))
-
-            // Add default preset.
-            filter.animateIn = 0
-            filter.resetProperty(rectProperty)
-            filter.set(rectProperty, '10%/10%:80%x80%')
-            filter.savePreset(preset.parameters)
-        } else {
-            filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1))
-            if (filter.animateIn > 0)
-                filter.set(startValue, filter.getRect(rectProperty, 0))
-            if (filter.animateOut > 0)
-                filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1))
-        }
-        filter.blockSignals = false
-        setControls()
-        setKeyframedControls()
-        if (filter.isNew)
-            filter.set(rectProperty, filter.getRect(rectProperty))
-    }
+    property rect defaultRect: Qt.rect(Math.round(profile.width * 0.1), Math.round(profile.height * 0.1), Math.round(profile.width * 0.8), Math.round(profile.height * 0.8))
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function updateFilter(position) {
         if (position !== null) {
-            filter.blockSignals = true
+            filter.blockSignals = true;
             if (position <= 0 && filter.animateIn > 0)
-                filter.set(startValue, filterRect)
+                filter.set(startValue, filterRect);
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                filter.set(endValue, filterRect)
+                filter.set(endValue, filterRect);
             else
-                filter.set(middleValue, filterRect)
-            filter.blockSignals = false
+                filter.set(middleValue, filterRect);
+            filter.blockSignals = false;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(rectProperty)
-            positionKeyframesButton.checked = false
+            filter.resetProperty(rectProperty);
+            positionKeyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set(rectProperty, filter.getRect(startValue), 0)
-                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1)
+                filter.set(rectProperty, filter.getRect(startValue), 0);
+                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut)
-                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1)
+                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut);
+                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1);
             }
         } else if (!positionKeyframesButton.checked) {
-            filter.resetProperty(rectProperty)
-            filter.set(rectProperty, filter.getRect(middleValue))
+            filter.resetProperty(rectProperty);
+            filter.set(rectProperty, filter.getRect(middleValue));
         } else if (position !== null) {
-            filter.set(rectProperty, filterRect, position)
+            filter.set(rectProperty, filterRect, position);
         }
     }
 
     function setControls() {
-        bgColor.value = filter.get('bgcolour')
+        bgColor.value = filter.get('bgcolour');
         switch (filter.get('overflow-y')) {
         case '':
-            automaticOverflowRadioButton.checked = true
+            automaticOverflowRadioButton.checked = true;
             break;
         case '0':
-            hiddenOverflowRadioButton.checked = true
+            hiddenOverflowRadioButton.checked = true;
             break;
         default:
-            visibleOverflowRadioButton.checked = true
+            visibleOverflowRadioButton.checked = true;
         }
     }
 
     function getTextDimensions() {
-        var document = filter.getRect(sizeProperty)
-        if (bgColor.value.substring(0, 3) !== '#00') {
-            document.height = Math.max(document.height, filterRect.height)
-        }
-        return document
+        var document = filter.getRect(sizeProperty);
+        if (bgColor.value.substring(0, 3) !== '#00')
+            document.height = Math.max(document.height, filterRect.height);
+
+        return document;
     }
 
     function setKeyframedControls() {
-        var position = getPosition()
-        var newValue = filter.getRect(rectProperty, position)
+        var position = getPosition();
+        var newValue = filter.getRect(rectProperty, position);
         if (filterRect !== newValue) {
-            filterRect = newValue
-            rectX.value = filterRect.x
-            rectY.value = filterRect.y
-            rectW.value = filterRect.width
-            rectH.value = filterRect.height
+            filterRect = newValue;
+            rectX.value = filterRect.x;
+            rectY.value = filterRect.y;
+            rectW.value = filterRect.width;
+            rectH.value = filterRect.height;
         }
-        var enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
-        rectX.enabled = enabled
-        rectY.enabled = enabled
-        rectW.enabled = enabled
-        rectH.enabled = enabled
-        positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-
-        var document = getTextDimensions()
+        var enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
+        rectX.enabled = enabled;
+        rectY.enabled = enabled;
+        rectW.enabled = enabled;
+        rectH.enabled = enabled;
+        positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+        var document = getTextDimensions();
         if (parseInt(sizeW.text) !== Math.round(document.width) || parseInt(sizeH.text) !== Math.round(document.height)) {
-            sizeW.text = Math.round(document.width)
-            sizeH.text = Math.round(document.height)
-            handleSpecialPreset()
+            sizeW.text = Math.round(document.width);
+            sizeH.text = Math.round(document.height);
+            handleSpecialPreset();
         }
     }
 
     function handleSpecialPreset() {
         if (filter.get(specialPresetProperty)) {
-            var document = getTextDimensions()
-            filter.blockSignals = true
-            filter.resetProperty(rectProperty)
-            filter.animateIn = filter.duration
-            filter.blockSignals = false
-            var s
-            if (filter.get(specialPresetProperty) === 'scroll-down') {
-                s = '0=' + filterRect.x + '/-' + Math.round(document.height) + ':' + filterRect.width + 'x' + filterRect.height +
-                 '; -1=' + filterRect.x + '/' + profile.height + ':' + filterRect.width + 'x' + filterRect.height
-            } else if (filter.get(specialPresetProperty) === 'scroll-up') {
-                s = '0=' + filterRect.x + '/' + profile.height + ':' + filterRect.width + 'x' + filterRect.height +
-                 '; -1=' + filterRect.x + '/-' + Math.round(document.height) + ':' + filterRect.width + 'x' + filterRect.height
-            } else if (filter.get(specialPresetProperty) === 'scroll-right') {
-                s = '0=-' + Math.round(document.width) + '/' + filterRect.y + ':' + filterRect.width + 'x' + filterRect.height +
-                '; -1=' + profile.width + '/' + filterRect.y + ':' + filterRect.width + 'x' + filterRect.height
-            } else if (filter.get(specialPresetProperty) === 'scroll-left') {
-                s = '0=' + profile.width + '/' + filterRect.y + ':' + filterRect.width + 'x' + filterRect.height +
-                '; -1=-' + Math.round(document.width) + '/' + filterRect.y + ':' + filterRect.width + 'x' + filterRect.height
-            }
+            var document = getTextDimensions();
+            filter.blockSignals = true;
+            filter.resetProperty(rectProperty);
+            filter.animateIn = filter.duration;
+            filter.blockSignals = false;
+            var s;
+            if (filter.get(specialPresetProperty) === 'scroll-down')
+                s = '0=' + filterRect.x + '/-' + Math.round(document.height) + ':' + filterRect.width + 'x' + filterRect.height + '; -1=' + filterRect.x + '/' + profile.height + ':' + filterRect.width + 'x' + filterRect.height;
+            else if (filter.get(specialPresetProperty) === 'scroll-up')
+                s = '0=' + filterRect.x + '/' + profile.height + ':' + filterRect.width + 'x' + filterRect.height + '; -1=' + filterRect.x + '/-' + Math.round(document.height) + ':' + filterRect.width + 'x' + filterRect.height;
+            else if (filter.get(specialPresetProperty) === 'scroll-right')
+                s = '0=-' + Math.round(document.width) + '/' + filterRect.y + ':' + filterRect.width + 'x' + filterRect.height + '; -1=' + profile.width + '/' + filterRect.y + ':' + filterRect.width + 'x' + filterRect.height;
+            else if (filter.get(specialPresetProperty) === 'scroll-left')
+                s = '0=' + profile.width + '/' + filterRect.y + ':' + filterRect.width + 'x' + filterRect.height + '; -1=-' + Math.round(document.width) + '/' + filterRect.y + ':' + filterRect.width + 'x' + filterRect.height;
             if (s) {
-                console.log(filter.get(specialPresetProperty) + ': ' + s)
-                filter.set(rectProperty, s)
+                console.log(filter.get(specialPresetProperty) + ': ' + s);
+                filter.set(rectProperty, s);
             }
         }
+    }
+
+    width: 350
+    height: 230
+    Component.onCompleted: {
+        filter.blockSignals = true;
+        filter.set(middleValue, defaultRect);
+        filter.set(startValue, defaultRect);
+        filter.set(endValue, defaultRect);
+        if (filter.isNew) {
+            var presetParams = [rectProperty];
+            filter.set('html', '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
+<html><head><meta name="qrichtext" content="1" /><style type="text/css">
+p, li { white-space: pre-wrap; }
+body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color:#ffffff; }
+</style></head><body></body></html>
+'.arg(application.OS === 'Windows' ? 'Verdana' : 'sans-serif'));
+            filter.set('argument', '');
+            filter.set('bgcolour', '#00000000');
+            filter.set(rectProperty, '5%/66.66%:90%x28.34%');
+            filter.savePreset(presetParams, qsTr('Lower Third'));
+            filter.set(rectProperty, '0%/0%:100%x100%');
+            filter.savePreset(presetParams, qsTr('Full Screen'));
+            // Add some animated presets.
+            filter.animateIn = filter.duration;
+            filter.set(specialPresetProperty, 'scroll-down');
+            filter.savePreset(['shotcut:animIn', specialPresetProperty], qsTr('Scroll Down'));
+            filter.set(specialPresetProperty, 'scroll-up');
+            filter.savePreset(['shotcut:animIn', specialPresetProperty], qsTr('Scroll Up'));
+            filter.set(specialPresetProperty, 'scroll-right');
+            filter.savePreset(['shotcut:animIn', specialPresetProperty], qsTr('Scroll Right'));
+            filter.set(specialPresetProperty, 'scroll-left');
+            filter.savePreset(['shotcut:animIn', specialPresetProperty], qsTr('Scroll Left'));
+            filter.resetProperty(specialPresetProperty);
+            filter.animateIn = Math.round(profile.fps);
+            filter.set(rectProperty, '0=-100%/0%:100%x100%; :1.0=0%/0%:100%x100%');
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slide In From Left'));
+            filter.set(rectProperty, '0=100%/0%:100%x100%; :1.0=0%/0%:100%x100%');
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slide In From Right'));
+            filter.set(rectProperty, '0=0%/-100%:100%x100%; :1.0=0%/0%:100%x100%');
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slide In From Top'));
+            filter.set(rectProperty, '0=0%/100%:100%x100%; :1.0=0%/0%:100%x100%');
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slide In From Bottom'));
+            filter.animateIn = 0;
+            filter.animateOut = Math.round(profile.fps);
+            filter.set(rectProperty, ':-1.0=0%/0%:100%x100%; -1=-100%/0%:100%x100%');
+            filter.savePreset(presetParams.concat('shotcut:animOut'), qsTr('Slide Out Left'));
+            filter.set(rectProperty, ':-1.0=0%/0%:100%x100%; -1=100%/0%:100%x100%');
+            filter.savePreset(presetParams.concat('shotcut:animOut'), qsTr('Slide Out Right'));
+            filter.set(rectProperty, ':-1.0=0%/0%:100%x100%; -1=0%/-100%:100%x100%');
+            filter.savePreset(presetParams.concat('shotcut:animOut'), qsTr('Slide Out Top'));
+            filter.set(rectProperty, ':-1.0=0%/0%:100%x100%; -1=0%/100%:100%x100%');
+            filter.savePreset(presetParams.concat('shotcut:animOut'), qsTr('Slide Out Bottom'));
+            filter.animateOut = 0;
+            filter.animateIn = filter.duration;
+            filter.set(rectProperty, '0=0%/0%:100%x100%; -1=-5%/-5%:110%x110%');
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Zoom In'));
+            filter.set(rectProperty, '0=-5%/-5%:110%x110%; -1=0%/0%:100%x100%');
+            filter.savePreset(presetParams.concat('shotcut:animIn'), qsTr('Slow Zoom Out'));
+            // Add default preset.
+            filter.animateIn = 0;
+            filter.resetProperty(rectProperty);
+            filter.set(rectProperty, '10%/10%:80%x80%');
+            filter.savePreset(preset.parameters);
+        } else {
+            filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1));
+            if (filter.animateIn > 0)
+                filter.set(startValue, filter.getRect(rectProperty, 0));
+
+            if (filter.animateOut > 0)
+                filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1));
+
+        }
+        filter.blockSignals = false;
+        setControls();
+        setKeyframedControls();
+        if (filter.isNew)
+            filter.set(rectProperty, filter.getRect(rectProperty));
+
     }
 
     GridLayout {
@@ -233,26 +221,30 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [rectProperty, 'bgcolour', 'overflow-y']
             Layout.columnSpan: 5
             onBeforePresetLoaded: {
-                filter.resetProperty(rectProperty)
-                filter.resetProperty(specialPresetProperty)
+                filter.resetProperty(rectProperty);
+                filter.resetProperty(specialPresetProperty);
             }
             onPresetSelected: {
-                handleSpecialPreset()
-                setControls()
-                setKeyframedControls()
-                positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-                filter.blockSignals = true
-                filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1))
+                handleSpecialPreset();
+                setControls();
+                setKeyframedControls();
+                positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+                filter.blockSignals = true;
+                filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1));
                 if (filter.animateIn > 0)
-                    filter.set(startValue, filter.getRect(rectProperty, 0))
+                    filter.set(startValue, filter.getRect(rectProperty, 0));
+
                 if (filter.animateOut > 0)
-                    filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1))
-                filter.blockSignals = false
+                    filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1));
+
+                filter.blockSignals = false;
             }
         }
 
@@ -267,59 +259,73 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
             text: qsTr('Position')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Layout.columnSpan: 3
+
             Shotcut.DoubleSpinBox {
                 id: rectX
+
                 horizontalAlignment: Qt.AlignRight
                 Layout.minimumWidth: 100
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
+                from: -1e+09
+                to: 1e+09
                 onValueModified: {
                     if (Math.abs(filterRect.x - value) > 1) {
-                        filterRect.x = value
-                        updateFilter(getPosition())
+                        filterRect.x = value;
+                        updateFilter(getPosition());
                     }
                 }
             }
-            Label { text: ','; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: ','
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectY
+
                 horizontalAlignment: Qt.AlignRight
                 Layout.minimumWidth: 100
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
+                from: -1e+09
+                to: 1e+09
                 onValueModified: {
                     if (Math.abs(filterRect.y - value) > 1) {
-                        filterRect.y = value
-                        updateFilter(getPosition())
+                        filterRect.y = value;
+                        updateFilter(getPosition());
                     }
                 }
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filterRect.x = rectX.value = defaultRect.x
-                filterRect.y = rectY.value = defaultRect.y
-                updateFilter(getPosition())
+                filterRect.x = rectX.value = defaultRect.x;
+                filterRect.y = rectY.value = defaultRect.y;
+                updateFilter(getPosition());
             }
         }
+
         Shotcut.KeyframesButton {
             id: positionKeyframesButton
+
             Layout.rowSpan: 2
             onToggled: {
                 if (checked) {
-                    filter.clearSimpleAnimation(rectProperty)
-                    filter.set(rectProperty, filterRect, getPosition())
+                    filter.clearSimpleAnimation(rectProperty);
+                    filter.set(rectProperty, filterRect, getPosition());
                 } else {
-                    filter.resetProperty(rectProperty)
-                    filter.set(rectProperty, filterRect)
+                    filter.resetProperty(rectProperty);
+                    filter.set(rectProperty, filterRect);
                 }
-                checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
+                checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
             }
         }
 
@@ -327,45 +333,57 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
             text: qsTr('Background size')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Layout.columnSpan: 3
+
             Shotcut.DoubleSpinBox {
                 id: rectW
+
                 horizontalAlignment: Qt.AlignRight
                 Layout.minimumWidth: 100
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
+                from: -1e+09
+                to: 1e+09
                 onValueModified: {
                     if (Math.abs(filterRect.width - value) > 1) {
-                        filterRect.width = value
-                        updateFilter(getPosition())
+                        filterRect.width = value;
+                        updateFilter(getPosition());
                     }
                 }
             }
-            Label { text: 'x'; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: 'x'
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectH
+
                 horizontalAlignment: Qt.AlignRight
                 Layout.minimumWidth: 100
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
+                from: -1e+09
+                to: 1e+09
                 onValueModified: {
                     if (Math.abs(filterRect.height - value) > 1) {
-                        filterRect.height = value
-                        updateFilter(getPosition())
+                        filterRect.height = value;
+                        updateFilter(getPosition());
                     }
                 }
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filterRect.width = rectW.value = defaultRect.width
-                filterRect.height = rectH.value = defaultRect.height
-                updateFilter(getPosition())
+                filterRect.width = rectW.value = defaultRect.width;
+                filterRect.height = rectH.value = defaultRect.height;
+                updateFilter(getPosition());
             }
         }
 
@@ -373,125 +391,205 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
             text: qsTr('Text size')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Layout.columnSpan: 3
+
             TextField {
                 id: sizeW
+
                 horizontalAlignment: Qt.AlignRight
                 readOnly: true
                 opacity: 0.7
                 selectByMouse: true
                 persistentSelection: true
+
                 MouseArea {
                     acceptedButtons: Qt.RightButton
                     anchors.fill: parent
                     onClicked: contextMenu.popup()
                 }
+
                 Menu {
                     id: contextMenu
+
                     width: 150
+
                     MenuItem {
+
                         action: Action {
                             text: qsTr('Copy')
-                            onTriggered: { sizeW.selectAll(); sizeW.copy() }
+                            onTriggered: {
+                                sizeW.selectAll();
+                                sizeW.copy();
+                            }
                         }
+
                     }
+
                 }
+
             }
-            Label { text: 'x'; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: 'x'
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             TextField {
                 id: sizeH
+
                 horizontalAlignment: Qt.AlignRight
                 readOnly: true
                 opacity: 0.7
                 selectByMouse: true
                 persistentSelection: true
+
                 MouseArea {
                     acceptedButtons: Qt.RightButton
                     anchors.fill: parent
                     onClicked: contextMenu2.popup()
                 }
+
                 Menu {
                     id: contextMenu2
+
                     width: 150
+
                     MenuItem {
+
                         action: Action {
                             text: qsTr('Copy')
-                            onTriggered: { sizeH.selectAll(); sizeH.copy() }
+                            onTriggered: {
+                                sizeH.selectAll();
+                                sizeH.copy();
+                            }
                         }
+
                     }
+
                 }
+
             }
+
         }
-        Item { Layout.columnSpan: 2; Layout.fillWidth: true }
+
+        Item {
+            Layout.columnSpan: 2
+            Layout.fillWidth: true
+        }
 
         Label {
             text: qsTr('Background color')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ColorPicker {
             id: bgColor
+
             Layout.columnSpan: 3
             eyedropper: false
             alpha: true
             onValueChanged: filter.set('bgcolour', value)
         }
+
         Shotcut.UndoButton {
             onClicked: bgColor.value = '#00000000'
         }
-        Item { Layout.fillWidth: true }
+
+        Item {
+            Layout.fillWidth: true
+        }
 
         Label {
             text: qsTr('Overflow')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Layout.columnSpan: 3
-            ButtonGroup { id: overflowGroup }
+
+            ButtonGroup {
+                id: overflowGroup
+            }
+
             RadioButton {
                 id: automaticOverflowRadioButton
+
                 text: qsTr('Automatic')
                 ButtonGroup.group: overflowGroup
                 onClicked: {
-                    filter.set('overflow-y', '')
-                    filter.resetProperty('overflow-y')
+                    filter.set('overflow-y', '');
+                    filter.resetProperty('overflow-y');
                 }
             }
+
             RadioButton {
                 id: visibleOverflowRadioButton
+
                 text: qsTr('Visible')
                 ButtonGroup.group: overflowGroup
                 onClicked: filter.set('overflow-y', 1)
             }
+
             RadioButton {
                 id: hiddenOverflowRadioButton
+
                 text: qsTr('Hidden')
                 ButtonGroup.group: overflowGroup
                 onClicked: filter.set('overflow-y', 0)
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filter.resetProperty('overflow-y')
-                automaticOverflowRadioButton.checked = true
+                filter.resetProperty('overflow-y');
+                automaticOverflowRadioButton.checked = true;
             }
         }
-        Item { Layout.fillWidth: true }
 
-        Item { Layout.fillHeight: true }
+        Item {
+            Layout.fillWidth: true
+        }
+
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
 
     Connections {
+        function onChanged() {
+            setKeyframedControls();
+        }
+
+        function onInChanged() {
+            updateFilter(null);
+        }
+
+        function onOutChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateInChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateOutChanged() {
+            updateFilter(null);
+        }
+
         target: filter
-        function onChanged() { setKeyframedControls() }
-        function onInChanged() { updateFilter(null) }
-        function onOutChanged() { updateFilter(null) }
-        function onAnimateInChanged() { updateFilter(null) }
-        function onAnimateOutChanged() { updateFilter(null) }
     }
 
     Connections {
+        function onPositionChanged() {
+            setKeyframedControls();
+        }
+
         target: producer
-        function onPositionChanged() { setKeyframedControls() }
     }
+
 }

--- a/src/qml/filters/richtext/vui.qml
+++ b/src/qml/filters/richtext/vui.qml
@@ -17,112 +17,116 @@
 
 import QtQuick 2.12
 import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.0
 import QtQuick.Dialogs 1.2
+import QtQuick.Layouts 1.0
 import Shotcut.Controls 1.0 as Shotcut
 import org.shotcut.qml 1.0
 
 Shotcut.VuiBase {
     id: vui
+
     property string rectProperty: 'geometry'
     property string halignProperty: 'valign'
     property string valignProperty: 'halign'
     property string useFontSizeProperty: 'shotcut:usePointSize'
-    property real zoom: (video.zoom > 0)? video.zoom : 1.0
+    property real zoom: (video.zoom > 0) ? video.zoom : 1
     property rect filterRect: Qt.rect(-1, -1, -1, -1)
     property bool blockUpdate: false
     property string startValue: '_shotcut:startValue'
     property string middleValue: '_shotcut:middleValue'
-    property string endValue:  '_shotcut:endValue'
+    property string endValue: '_shotcut:endValue'
     property string sizeProperty: '_shotcut:size'
     property bool smallIcons: settings.smallIcons || toolbar.maxWidth >= videoItem.width
     property int smallIconSize: 22
     property url settingsSavePath: 'file:///' + settings.savePath
 
-    Component.onCompleted: {
-        setRectangleControl()
-        filter.set('_hide', 1)
-        background.color = filter.get('bgcolour')
-        setTextAreaHeight()
-        textArea.text = filter.get('html')
-        fontSizeSpinBox.value = document.fontSize
-        toolbar.expanded = filter.get('_shotcut:toolbarCollapsed') !== '1'
-    }
-
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setRectangleControl() {
-        if (blockUpdate) return
-        var position = getPosition()
-        var newValue = filter.getRect(rectProperty, position)
+        if (blockUpdate)
+            return ;
+
+        var position = getPosition();
+        var newValue = filter.getRect(rectProperty, position);
         if (filterRect !== newValue) {
-            filterRect = newValue
-            rectangle.setHandles(filterRect)
+            filterRect = newValue;
+            rectangle.setHandles(filterRect);
         }
-        rectangle.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
-        textArea.visible = !producer.outOfBounds()
+        rectangle.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
+        textArea.visible = !producer.outOfBounds();
     }
 
     function updateFilter(position) {
-        blockUpdate = true
-        var rect = rectangle.rectangle
-        filterRect.x = Math.round(rect.x / rectangle.widthScale)
-        filterRect.y = Math.round(rect.y / rectangle.heightScale)
-        filterRect.width = Math.round(rect.width / rectangle.widthScale)
-        filterRect.height = Math.round(rect.height / rectangle.heightScale)
-
+        blockUpdate = true;
+        var rect = rectangle.rectangle;
+        filterRect.x = Math.round(rect.x / rectangle.widthScale);
+        filterRect.y = Math.round(rect.y / rectangle.heightScale);
+        filterRect.width = Math.round(rect.width / rectangle.widthScale);
+        filterRect.height = Math.round(rect.height / rectangle.heightScale);
         if (position !== null) {
-            filter.blockSignals = true
+            filter.blockSignals = true;
             if (position <= 0 && filter.animateIn > 0)
-                filter.set(startValue, filterRect)
+                filter.set(startValue, filterRect);
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                filter.set(endValue, filterRect)
+                filter.set(endValue, filterRect);
             else
-                filter.set(middleValue, filterRect)
-            filter.blockSignals = false
+                filter.set(middleValue, filterRect);
+            filter.blockSignals = false;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(rectProperty)
+            filter.resetProperty(rectProperty);
             if (filter.animateIn > 0) {
-                filter.set(rectProperty, filter.getRect(startValue), 0)
-                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1)
+                filter.set(rectProperty, filter.getRect(startValue), 0);
+                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut)
-                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1)
+                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut);
+                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1);
             }
         } else if (filter.keyframeCount(rectProperty) <= 0) {
-            filter.resetProperty(rectProperty)
-            filter.set(rectProperty, filter.getRect(middleValue))
+            filter.resetProperty(rectProperty);
+            filter.set(rectProperty, filter.getRect(middleValue));
         } else if (position !== null) {
-            filter.set(rectProperty, filterRect, position)
+            filter.set(rectProperty, filterRect, position);
         }
-        blockUpdate = false
-        filter.set(sizeProperty, Qt.rect(0, 0, document.size.width, document.size.height))
+        blockUpdate = false;
+        filter.set(sizeProperty, Qt.rect(0, 0, document.size.width, document.size.height));
     }
 
     function setTextAreaHeight() {
         switch (filter.get('overflow-y')) {
         case '':
-            scrollView.height = filterRect.height >= profile.height? Math.max(filterRect.height, textArea.contentHeight) : filterRect.height
+            scrollView.height = filterRect.height >= profile.height ? Math.max(filterRect.height, textArea.contentHeight) : filterRect.height;
             break;
-        case '0': // hidden
-            scrollView.height = filterRect.height
+        case '0':
+            // hidden
+            scrollView.height = filterRect.height;
             break;
-        default: // visible
-            scrollView.height = Math.max(filterRect.height, textArea.contentHeight)
+        default:
+            // visible
+            scrollView.height = Math.max(filterRect.height, textArea.contentHeight);
         }
     }
 
     function updateTextSize() {
-        filter.set(sizeProperty, Qt.rect(0, 0, document.size.width, document.size.height))
+        filter.set(sizeProperty, Qt.rect(0, 0, document.size.width, document.size.height));
+    }
+
+    Component.onCompleted: {
+        setRectangleControl();
+        filter.set('_hide', 1);
+        background.color = filter.get('bgcolour');
+        setTextAreaHeight();
+        textArea.text = filter.get('html');
+        fontSizeSpinBox.value = document.fontSize;
+        toolbar.expanded = filter.get('_shotcut:toolbarCollapsed') !== '1';
     }
 
     Flickable {
         id: flickable
+
         anchors.fill: parent
         flickableDirection: Flickable.VerticalFlick
         interactive: false
@@ -134,6 +138,7 @@ Shotcut.VuiBase {
 
         Item {
             id: videoItem
+
             x: video.rect.x
             y: video.rect.y
             width: video.rect.width
@@ -142,6 +147,7 @@ Shotcut.VuiBase {
 
             Rectangle {
                 id: background
+
                 x: rectangle.rectangle.x
                 y: rectangle.rectangle.y
                 width: rectangle.rectangle.width
@@ -150,6 +156,7 @@ Shotcut.VuiBase {
 
             ScrollView {
                 id: scrollView
+
                 transformOrigin: Item.TopLeft
                 scale: rectangle.heightScale
                 x: filterRect.x * scale
@@ -161,19 +168,47 @@ Shotcut.VuiBase {
 
                 TextArea {
                     id: textArea
+
                     padding: 0
                     textFormat: Qt.RichText
                     selectByMouse: true
                     persistentSelection: true
                     wrapMode: TextArea.Wrap
+                    baseUrl: 'qrc:/'
+                    text: '__empty__'
+                    Component.onCompleted: forceActiveFocus()
+                    onTextChanged: {
+                        if (text.indexOf('__empty__') > -1)
+                            return ;
+
+                        filter.set('html', text);
+                    }
+                    onContentWidthChanged: updateTextSize()
+                    onContentHeightChanged: updateTextSize()
+                    Keys.onPressed: {
+                        if (event.key === Qt.Key_V && (event.modifiers & Qt.ShiftModifier) && (event.modifiers & Qt.ControlModifier || event.modifiers & Qt.MetaModifier)) {
+                            event.accepted = true;
+                            document.pastePlain();
+                        }
+                    }
+
+                    MouseArea {
+                        acceptedButtons: Qt.RightButton
+                        anchors.fill: parent
+                        onClicked: contextMenu.popup()
+                    }
+
                     cursorDelegate: Rectangle {
                         id: cursor
+
                         visible: textArea.cursorVisible
-                        width: 2.5/scale
+                        width: 2.5 / scale
                         color: 'white'
+
                         SequentialAnimation {
                             running: cursor.visible
                             loops: Animation.Infinite
+
                             NumberAnimation {
                                 target: cursor
                                 property: 'opacity'
@@ -181,7 +216,11 @@ Shotcut.VuiBase {
                                 to: 1
                                 duration: 100
                             }
-                            PauseAnimation { duration: 400 }
+
+                            PauseAnimation {
+                                duration: 400
+                            }
+
                             NumberAnimation {
                                 target: cursor
                                 property: 'opacity'
@@ -189,116 +228,136 @@ Shotcut.VuiBase {
                                 to: 0
                                 duration: 100
                             }
-                            PauseAnimation { duration: 400 }
+
+                            PauseAnimation {
+                                duration: 400
+                            }
+
                         }
+
                     }
-                    baseUrl: 'qrc:/'
-                    MouseArea {
-                        acceptedButtons: Qt.RightButton
-                        anchors.fill: parent
-                        onClicked: contextMenu.popup()
-                    }
-                    text: '__empty__'
-                    Component.onCompleted: forceActiveFocus()
-                    onTextChanged: {
-                        if (text.indexOf('__empty__') > -1) return
-                        filter.set('html', text)
-                    }
-                    onContentWidthChanged: updateTextSize()
-                    onContentHeightChanged: updateTextSize()
-                    Keys.onPressed: {
-                        if (event.key === Qt.Key_V && (event.modifiers & Qt.ShiftModifier) &&
-                            (event.modifiers & Qt.ControlModifier || event.modifiers & Qt.MetaModifier)) {
-                            event.accepted = true
-                            document.pastePlain()
-                        }
-                    }
+
                 }
+
             }
 
             ToolBar {
                 id: toolbar
+
                 property bool expanded: filter.get('_shotcut:toolbarCollapsed') !== '1'
                 property real maxWidth: 500
+
                 x: Math.min((parent.width + parent.x - width), Math.max((-parent.x * scale), scrollView.x + rectangle.handleSize))
-                y: Math.min((parent.height + parent.y - height), Math.max((-parent.y * scale), (scrollView.mapToItem(vui, 0, 0).y > height)? (scrollView.y - height*scale) : (scrollView.y + rectangle.handleSize)))
-                Behavior on width {
-                    NumberAnimation{ duration: 100 }
-                }
+                y: Math.min((parent.height + parent.y - height), Math.max((-parent.y * scale), (scrollView.mapToItem(vui, 0, 0).y > height) ? (scrollView.y - height * scale) : (scrollView.y + rectangle.handleSize)))
                 anchors.margins: 0
                 opacity: 0.7
                 transformOrigin: Item.TopLeft
-                scale: 1/zoom
+                scale: 1 / zoom
 
                 RowLayout {
                     ToolButton {
                         id: hiddenButton
+
                         visible: false
+
                         action: Action {
                             icon.source: 'qrc:///icons/oxygen/32x32/actions/show-menu.png'
                         }
+
                     }
+
                     ToolButton {
-                        Shotcut.HoverTip { text: qsTr('Menu') }
-                        implicitWidth: smallIcons? smallIconSize : hiddenButton.implicitWidth
+                        implicitWidth: smallIcons ? smallIconSize : hiddenButton.implicitWidth
                         implicitHeight: implicitWidth
                         visible: toolbar.expanded
                         focusPolicy: Qt.NoFocus
+
+                        Shotcut.HoverTip {
+                            text: qsTr('Menu')
+                        }
+
                         action: Action {
                             icon.name: 'show-menu'
                             icon.source: 'qrc:///icons/oxygen/32x32/actions/show-menu.png'
                             onTriggered: menu.popup()
                         }
+
                     }
+
                     ToolButton {
                         action: boldAction
-                        implicitWidth: smallIcons? smallIconSize : hiddenButton.implicitWidth
+                        implicitWidth: smallIcons ? smallIconSize : hiddenButton.implicitWidth
                         implicitHeight: implicitWidth
                         visible: toolbar.expanded
                         focusPolicy: Qt.NoFocus
-                        Shotcut.HoverTip { text: parent.action.text }
+
+                        Shotcut.HoverTip {
+                            text: parent.action.text
+                        }
+
                     }
+
                     ToolButton {
                         action: italicAction
-                        implicitWidth: smallIcons? smallIconSize : hiddenButton.implicitWidth
+                        implicitWidth: smallIcons ? smallIconSize : hiddenButton.implicitWidth
                         implicitHeight: implicitWidth
                         visible: toolbar.expanded
                         focusPolicy: Qt.NoFocus
-                        Shotcut.HoverTip { text: parent.action.text }
+
+                        Shotcut.HoverTip {
+                            text: parent.action.text
+                        }
+
                     }
+
                     ToolButton {
                         action: underlineAction
-                        implicitWidth: smallIcons? smallIconSize : hiddenButton.implicitWidth
+                        implicitWidth: smallIcons ? smallIconSize : hiddenButton.implicitWidth
                         implicitHeight: implicitWidth
                         visible: toolbar.expanded
                         focusPolicy: Qt.NoFocus
-                        Shotcut.HoverTip { text: parent.action.text }
+
+                        Shotcut.HoverTip {
+                            text: parent.action.text
+                        }
+
                     }
-                    Button { // separator
+                    // separator
+
+                    Button {
                         enabled: false
                         implicitWidth: 2
-                        implicitHeight: smallIcons? 14 : (hiddenButton.implicitHeight - 8)
+                        implicitHeight: smallIcons ? 14 : (hiddenButton.implicitHeight - 8)
                         visible: toolbar.expanded
                     }
+
                     ToolButton {
-                        Shotcut.HoverTip { text: qsTr('Font') }
-                        implicitWidth: smallIcons? smallIconSize : hiddenButton.implicitWidth
+                        implicitWidth: smallIcons ? smallIconSize : hiddenButton.implicitWidth
                         implicitHeight: implicitWidth
                         visible: toolbar.expanded
                         focusPolicy: Qt.NoFocus
+
+                        Shotcut.HoverTip {
+                            text: qsTr('Font')
+                        }
+
                         action: Action {
                             icon.name: 'font'
                             icon.source: 'qrc:///icons/oxygen/32x32/actions/font.png'
                             onTriggered: {
-                                fontDialog.font.family = document.fontFamily
-                                fontDialog.font.pointSize = document.fontSize
-                                fontDialog.open()
+                                fontDialog.font.family = document.fontFamily;
+                                fontDialog.font.pointSize = document.fontSize;
+                                fontDialog.open();
                             }
                         }
+
                     }
+
                     Shotcut.DoubleSpinBox {
                         id: fontSizeSpinBox
-                        Shotcut.HoverTip { text: qsTr('Text size') }
+
+                        property bool blockValue: false
+
                         implicitWidth: 60
                         visible: toolbar.expanded
                         value: 72
@@ -306,110 +365,172 @@ Shotcut.VuiBase {
                         to: 1000
                         decimals: 0
                         focusPolicy: Qt.NoFocus
-                        property bool blockValue: false
                         onValueChanged: {
                             if (!blockValue) {
-                                blockValue = true
-                                document.fontSize = value
-                                blockValue = false
+                                blockValue = true;
+                                document.fontSize = value;
+                                blockValue = false;
                             }
                         }
+
+                        Shotcut.HoverTip {
+                            text: qsTr('Text size')
+                        }
+
                     }
+
                     ToolButton {
                         id: colorButton
-                        Shotcut.HoverTip { text: qsTr('Text color') }
+
+                        property var color: document.textColor
+
                         implicitWidth: toolbar.height - 4
                         implicitHeight: implicitWidth
                         visible: toolbar.expanded
                         focusPolicy: Qt.NoFocus
-                        property var color : document.textColor
+                        onClicked: {
+                            colorDialog.color = document.textColor;
+                            colorDialog.open();
+                        }
+
+                        Shotcut.HoverTip {
+                            text: qsTr('Text color')
+                        }
+
                         Rectangle {
                             id: colorRect
+
                             anchors.fill: parent
                             anchors.margins: 4
                             color: Qt.darker(document.textColor, colorButton.pressed ? 1.4 : 1)
                             border.width: 1
                             border.color: Qt.darker(colorRect.color, 2)
                         }
-                        onClicked: {
-                            colorDialog.color = document.textColor
-                            colorDialog.open()
-                        }
+
                     }
-                    Button { // separator
+                    // separator
+
+                    Button {
                         enabled: false
                         implicitWidth: 2
-                        implicitHeight: smallIcons? 14 : (hiddenButton.implicitHeight - 8)
+                        implicitHeight: smallIcons ? 14 : (hiddenButton.implicitHeight - 8)
                         visible: toolbar.expanded
                     }
+
                     ToolButton {
                         action: alignLeftAction
-                        implicitWidth: smallIcons? smallIconSize : hiddenButton.implicitWidth
+                        implicitWidth: smallIcons ? smallIconSize : hiddenButton.implicitWidth
                         implicitHeight: implicitWidth
                         visible: toolbar.expanded
                         focusPolicy: Qt.NoFocus
-                        Shotcut.HoverTip { text: parent.action.text }
+
+                        Shotcut.HoverTip {
+                            text: parent.action.text
+                        }
+
                     }
+
                     ToolButton {
                         action: alignCenterAction
-                        implicitWidth: smallIcons? smallIconSize : hiddenButton.implicitWidth
+                        implicitWidth: smallIcons ? smallIconSize : hiddenButton.implicitWidth
                         implicitHeight: implicitWidth
                         visible: toolbar.expanded
                         focusPolicy: Qt.NoFocus
-                        Shotcut.HoverTip { text: parent.action.text }
+
+                        Shotcut.HoverTip {
+                            text: parent.action.text
+                        }
+
                     }
+
                     ToolButton {
                         action: alignRightAction
-                        implicitWidth: smallIcons? smallIconSize : hiddenButton.implicitWidth
+                        implicitWidth: smallIcons ? smallIconSize : hiddenButton.implicitWidth
                         implicitHeight: implicitWidth
                         visible: toolbar.expanded
                         focusPolicy: Qt.NoFocus
-                        Shotcut.HoverTip { text: parent.action.text }
+
+                        Shotcut.HoverTip {
+                            text: parent.action.text
+                        }
+
                     }
+
                     ToolButton {
                         action: alignJustifyAction
-                        implicitWidth: smallIcons? smallIconSize : hiddenButton.implicitWidth
+                        implicitWidth: smallIcons ? smallIconSize : hiddenButton.implicitWidth
                         implicitHeight: implicitWidth
                         visible: toolbar.expanded
                         focusPolicy: Qt.NoFocus
-                        Shotcut.HoverTip { text: parent.action.text }
+
+                        Shotcut.HoverTip {
+                            text: parent.action.text
+                        }
+
                     }
+
                     ToolButton {
                         action: decreaseIndentAction
-                        implicitWidth: smallIcons? smallIconSize : hiddenButton.implicitWidth
+                        implicitWidth: smallIcons ? smallIconSize : hiddenButton.implicitWidth
                         implicitHeight: implicitWidth
                         visible: toolbar.expanded
                         focusPolicy: Qt.NoFocus
-                        Shotcut.HoverTip { text: parent.action.text }
+
+                        Shotcut.HoverTip {
+                            text: parent.action.text
+                        }
+
                     }
+
                     ToolButton {
                         action: increaseIndentAction
-                        implicitWidth: smallIcons? smallIconSize : hiddenButton.implicitWidth
+                        implicitWidth: smallIcons ? smallIconSize : hiddenButton.implicitWidth
                         implicitHeight: implicitWidth
                         visible: toolbar.expanded
                         focusPolicy: Qt.NoFocus
-                        Shotcut.HoverTip { text: parent.action.text }
+
+                        Shotcut.HoverTip {
+                            text: parent.action.text
+                        }
+
                     }
+
                     ToolButton {
                         id: expandCollapseButton
-                        implicitWidth: smallIcons? smallIconSize : hiddenButton.implicitWidth
+
+                        implicitWidth: smallIcons ? smallIconSize : hiddenButton.implicitWidth
                         implicitHeight: implicitWidth
                         focusPolicy: Qt.NoFocus
-                        Shotcut.HoverTip { text: toolbar.expanded? qsTr('Collapse Toolbar') : qsTr('Expand Toolbar') }
+
+                        Shotcut.HoverTip {
+                            text: toolbar.expanded ? qsTr('Collapse Toolbar') : qsTr('Expand Toolbar')
+                        }
+
                         action: Action {
-                            icon.name: toolbar.expanded? 'media-seek-backward' : 'media-seek-forward'
-                            icon.source: toolbar.expanded? 'qrc:///icons/oxygen/32x32/actions/media-seek-backward.png' : 'qrc:///icons/oxygen/32x32/actions/media-seek-backward.png'
+                            icon.name: toolbar.expanded ? 'media-seek-backward' : 'media-seek-forward'
+                            icon.source: toolbar.expanded ? 'qrc:///icons/oxygen/32x32/actions/media-seek-backward.png' : 'qrc:///icons/oxygen/32x32/actions/media-seek-backward.png'
                             onTriggered: {
-                                toolbar.expanded = !toolbar.expanded
-                                filter.set('_shotcut:toolbarCollapsed', !toolbar.expanded)
+                                toolbar.expanded = !toolbar.expanded;
+                                filter.set('_shotcut:toolbarCollapsed', !toolbar.expanded);
                             }
                         }
+
                     }
+
                 }
+
+                Behavior on width {
+                    NumberAnimation {
+                        duration: 100
+                    }
+
+                }
+
             }
 
             Shotcut.RectangleControl {
                 id: rectangle
+
                 widthScale: video.rect.width / profile.width
                 heightScale: video.rect.height / profile.height
                 handleSize: Math.max(Math.round(8 / zoom), 4)
@@ -418,128 +539,226 @@ Shotcut.VuiBase {
                 onHeightScaleChanged: setHandles(filterRect)
                 onRectChanged: updateFilter(getPosition())
             }
+
         }
+
     }
 
     Menu {
         id: contextMenu
+
         width: 220
-        MenuItem { action: undoAction }
-        MenuItem { action: redoAction }
-        MenuSeparator {}
-        MenuItem { action: cutAction }
-        MenuItem { action: copyAction }
-        MenuItem { action: pasteAction }
-        MenuItem { action: pastePlainAction }
-        MenuItem { action: deleteAction }
-        MenuItem { action: clearAction }
-        MenuSeparator {}
-        MenuItem { action: selectAllAction }
+
+        MenuItem {
+            action: undoAction
+        }
+
+        MenuItem {
+            action: redoAction
+        }
+
+        MenuSeparator {
+        }
+
+        MenuItem {
+            action: cutAction
+        }
+
+        MenuItem {
+            action: copyAction
+        }
+
+        MenuItem {
+            action: pasteAction
+        }
+
+        MenuItem {
+            action: pastePlainAction
+        }
+
+        MenuItem {
+            action: deleteAction
+        }
+
+        MenuItem {
+            action: clearAction
+        }
+
+        MenuSeparator {
+        }
+
+        MenuItem {
+            action: selectAllAction
+        }
+
         MenuItem {
             text: qsTr('Cancel')
             onTriggered: contextMenu.dismiss()
         }
+
     }
 
     Menu {
         id: menu
+
         Menu {
             title: qsTr('File')
-            MenuItem { action: fileOpenAction }
-            MenuItem { action: fileSaveAsAction }
+
+            MenuItem {
+                action: fileOpenAction
+            }
+
+            MenuItem {
+                action: fileSaveAsAction
+            }
+
         }
+
         Menu {
             width: 220
             title: qsTr('Edit')
-            MenuItem { action: undoAction }
-            MenuItem { action: redoAction }
-            MenuSeparator {}
-            MenuItem { action: cutAction }
-            MenuItem { action: copyAction }
-            MenuItem { action: pasteAction }
-            MenuItem { action: pastePlainAction }
+
+            MenuItem {
+                action: undoAction
+            }
+
+            MenuItem {
+                action: redoAction
+            }
+
+            MenuSeparator {
+            }
+
+            MenuItem {
+                action: cutAction
+            }
+
+            MenuItem {
+                action: copyAction
+            }
+
+            MenuItem {
+                action: pasteAction
+            }
+
+            MenuItem {
+                action: pastePlainAction
+            }
+
         }
-        MenuItem { action: selectAllAction }
-        MenuItem { action: insertTableAction }
+
+        MenuItem {
+            action: selectAllAction
+        }
+
+        MenuItem {
+            action: insertTableAction
+        }
+
         MenuItem {
             text: qsTr('Cancel')
             onTriggered: menu.dismiss()
         }
+
     }
 
     Action {
         id: fileOpenAction
+
         text: qsTr('Open...')
         onTriggered: {
-            fileDialog.selectExisting = true
-            fileDialog.open()
+            fileDialog.selectExisting = true;
+            fileDialog.open();
         }
     }
+
     Action {
         id: fileSaveAsAction
+
         text: qsTr('Save As…')
         onTriggered: {
-            fileDialog.selectExisting = false
-            fileDialog.open()
+            fileDialog.selectExisting = false;
+            fileDialog.open();
         }
     }
+
     Action {
         id: menuAction
+
         icon.name: 'show-menu'
         icon.source: 'qrc:///icons/oxygen/32x32/actions/show-menu.png'
         onTriggered: menu.popup()
     }
+
     Action {
         id: undoAction
-        text: qsTr('Undo') + (application.OS === 'OS X'? '    ⌘Z' : ' (Ctrl+Z)')
+
+        text: qsTr('Undo') + (application.OS === 'OS X' ? '    ⌘Z' : ' (Ctrl+Z)')
         onTriggered: textArea.undo()
     }
+
     Action {
         id: redoAction
-        text: qsTr('Redo') + (application.OS === 'Windows'? ' (Ctrl+Y)' : application.OS === 'OS X'? '    ⇧⌘Z' : ' (Ctrl+Shift+Z)')
+
+        text: qsTr('Redo') + (application.OS === 'Windows' ? ' (Ctrl+Y)' : application.OS === 'OS X' ? '    ⇧⌘Z' : ' (Ctrl+Shift+Z)')
         onTriggered: textArea.redo()
     }
+
     Action {
         id: cutAction
-        text: qsTr('Cut') + (application.OS === 'OS X'? '    ⌘X' : ' (Ctrl+X)')
+
+        text: qsTr('Cut') + (application.OS === 'OS X' ? '    ⌘X' : ' (Ctrl+X)')
         onTriggered: textArea.cut()
     }
+
     Action {
         id: copyAction
-        text: qsTr('Copy') + (application.OS === 'OS X'? '    ⌘C' : ' (Ctrl+C)')
+
+        text: qsTr('Copy') + (application.OS === 'OS X' ? '    ⌘C' : ' (Ctrl+C)')
         onTriggered: textArea.copy()
     }
+
     Action {
         id: pasteAction
-        text: qsTr('Paste') + (application.OS === 'OS X'? '    ⌘V' : ' (Ctrl+V)')
+
+        text: qsTr('Paste') + (application.OS === 'OS X' ? '    ⌘V' : ' (Ctrl+V)')
         onTriggered: textArea.paste()
     }
+
     Action {
         id: pastePlainAction
-        text: qsTr('Paste Text Only') + (application.OS === 'OS X'? '    ⇧⌘V' : ' (Ctrl+Shift+V)')
+
+        text: qsTr('Paste Text Only') + (application.OS === 'OS X' ? '    ⇧⌘V' : ' (Ctrl+Shift+V)')
         onTriggered: document.pastePlain()
     }
+
     Action {
         id: deleteAction
+
         text: qsTr('Delete')
         onTriggered: textArea.remove(textArea.selectionStart, textArea.selectionEnd)
     }
+
     Action {
         id: clearAction
+
         text: qsTr('Clear')
         onTriggered: {
-            textArea.selectAll()
-            textArea.remove(textArea.selectionStart, textArea.selectionEnd)
+            textArea.selectAll();
+            textArea.remove(textArea.selectionStart, textArea.selectionEnd);
         }
     }
+
     Action {
         id: selectAllAction
-        text: qsTr('Select All') + (application.OS === 'OS X'? '    ⌘A' : ' (Ctrl+A)')
+
+        text: qsTr('Select All') + (application.OS === 'OS X' ? '    ⌘A' : ' (Ctrl+A)')
         onTriggered: textArea.selectAll()
     }
 
     Action {
         id: alignLeftAction
+
         text: qsTr('Left')
         icon.name: 'format-justify-left'
         icon.source: 'qrc:///icons/oxygen/32x32/actions/format-justify-left.png'
@@ -547,8 +766,10 @@ Shotcut.VuiBase {
         checkable: true
         checked: document.alignment == Qt.AlignLeft
     }
+
     Action {
         id: alignCenterAction
+
         text: qsTr('Center')
         icon.name: 'format-justify-center'
         icon.source: 'qrc:///icons/oxygen/32x32/actions/format-justify-center.png'
@@ -556,8 +777,10 @@ Shotcut.VuiBase {
         checkable: true
         checked: document.alignment == Qt.AlignHCenter
     }
+
     Action {
         id: alignRightAction
+
         text: qsTr('Right')
         icon.name: 'format-justify-right'
         icon.source: 'qrc:///icons/oxygen/32x32/actions/format-justify-right.png'
@@ -565,8 +788,10 @@ Shotcut.VuiBase {
         checkable: true
         checked: document.alignment == Qt.AlignRight
     }
+
     Action {
         id: alignJustifyAction
+
         text: qsTr('Justify')
         icon.name: 'format-justify-fill'
         icon.source: 'qrc:///icons/oxygen/32x32/actions/format-justify-fill.png'
@@ -574,8 +799,10 @@ Shotcut.VuiBase {
         checkable: true
         checked: document.alignment == Qt.AlignJustify
     }
+
     Action {
         id: boldAction
+
         text: qsTr('Bold')
         icon.name: 'format-text-bold'
         icon.source: 'qrc:///icons/oxygen/32x32/actions/format-text-bold.png'
@@ -583,8 +810,10 @@ Shotcut.VuiBase {
         checkable: true
         checked: document.bold
     }
+
     Action {
         id: italicAction
+
         text: qsTr('Italic')
         icon.name: 'format-text-italic'
         icon.source: 'qrc:///icons/oxygen/32x32/actions/format-text-italic.png'
@@ -592,8 +821,10 @@ Shotcut.VuiBase {
         checkable: true
         checked: document.italic
     }
+
     Action {
         id: underlineAction
+
         text: qsTr('Underline')
         icon.name: 'format-text-underline'
         icon.source: 'qrc:///icons/oxygen/32x32/actions/format-text-underline.png'
@@ -601,31 +832,39 @@ Shotcut.VuiBase {
         checkable: true
         checked: document.underline
     }
+
     Action {
         id: fontFamilyAction
+
         text: qsTr('Font')
         icon.name: 'font'
         icon.source: 'qrc:///icons/oxygen/32x32/actions/font.png'
         onTriggered: {
-            fontDialog.font.family = document.fontFamily
-            fontDialog.font.pointSize = document.fontSize
-            fontDialog.open()
+            fontDialog.font.family = document.fontFamily;
+            fontDialog.font.pointSize = document.fontSize;
+            fontDialog.open();
         }
     }
+
     Action {
         id: insertTableAction
+
         text: qsTr('Insert Table')
         onTriggered: tableDialog.open()
     }
+
     Action {
         id: decreaseIndentAction
+
         text: qsTr('Decrease Indent')
         icon.name: 'format-indent-less'
         icon.source: 'qrc:///icons/oxygen/32x32/actions/format-indent-less.png'
         onTriggered: document.indentLess()
     }
+
     Action {
         id: increaseIndentAction
+
         text: qsTr('Insert Indent')
         icon.name: 'format-indent-more'
         icon.source: 'qrc:///icons/oxygen/32x32/actions/format-indent-more.png'
@@ -634,40 +873,52 @@ Shotcut.VuiBase {
 
     FileDialog {
         id: fileDialog
+
         modality: application.dialogModality
         folder: settingsSavePath
         nameFilters: ["HTML files (*.html *.htm)", "Text files (*.txt)", "All files (*)"]
         onAccepted: {
             if (fileDialog.selectExisting)
-                document.fileUrl = fileUrl
+                document.fileUrl = fileUrl;
             else
-                document.saveAs(fileUrl, selectedNameFilter)
+                document.saveAs(fileUrl, selectedNameFilter);
         }
     }
 
     FontDialog {
         id: fontDialog
+
         modality: application.dialogModality
         onAccepted: {
-            document.fontFamily = font.family
-            document.fontSize = font.pointSize
+            document.fontFamily = font.family;
+            document.fontSize = font.pointSize;
         }
     }
+
     ColorDialog {
         id: colorDialog
+
         color: 'black'
         showAlphaChannel: true
         modality: application.dialogModality
     }
+
     MessageDialog {
         id: errorDialog
+
         modality: application.dialogModality
     }
+
     Dialog {
         id: tableDialog
+
         title: qsTr('Insert Table')
         standardButtons: StandardButton.Ok | StandardButton.Cancel
         modality: application.dialogModality
+        onAccepted: {
+            document.insertTable(rowsSpinner.value, columnsSpinner.value, borderSpinner.value);
+        }
+
         GridLayout {
             rows: 4
             columns: 2
@@ -678,8 +929,10 @@ Shotcut.VuiBase {
                 text: qsTr('Rows')
                 Layout.alignment: Qt.AlignRight
             }
+
             Shotcut.DoubleSpinBox {
                 id: rowsSpinner
+
                 implicitWidth: 75
                 value: 1
                 from: 1
@@ -688,12 +941,15 @@ Shotcut.VuiBase {
                 decimals: 0
                 focus: true
             }
+
             Label {
                 text: qsTr('Columns')
                 Layout.alignment: Qt.AlignRight
             }
+
             Shotcut.DoubleSpinBox {
                 id: columnsSpinner
+
                 implicitWidth: 75
                 value: 2
                 from: 1
@@ -701,12 +957,15 @@ Shotcut.VuiBase {
                 stepSize: 1
                 decimals: 0
             }
+
             Label {
                 text: qsTr('Border')
                 Layout.alignment: Qt.AlignRight
             }
+
             Shotcut.DoubleSpinBox {
                 id: borderSpinner
+
                 implicitWidth: 75
                 value: 0
                 from: 0
@@ -714,15 +973,19 @@ Shotcut.VuiBase {
                 stepSize: 1
                 decimals: 0
             }
-            Item { Layout.fillHeight: true; height: columnsSpinner.height }
+
+            Item {
+                Layout.fillHeight: true
+                height: columnsSpinner.height
+            }
+
         }
-        onAccepted: {
-            document.insertTable(rowsSpinner.value, columnsSpinner.value, borderSpinner.value)
-        }
+
     }
 
     RichText {
         id: document
+
         target: textArea
         cursorPosition: textArea.cursorPosition
         selectionStart: textArea.selectionStart
@@ -731,29 +994,34 @@ Shotcut.VuiBase {
         onTextChanged: textArea.text = text
         onFontSizeChanged: {
             if (!fontSizeSpinBox.blockValue) {
-                fontSizeSpinBox.blockValue = true
-                fontSizeSpinBox.value = document.fontSize
-                fontSizeSpinBox.blockValue = false
+                fontSizeSpinBox.blockValue = true;
+                fontSizeSpinBox.value = document.fontSize;
+                fontSizeSpinBox.blockValue = false;
             }
         }
         onError: {
-            errorDialog.text = message
-            errorDialog.visible = true
+            errorDialog.text = message;
+            errorDialog.visible = true;
         }
     }
 
     Connections {
-        target: filter
         function onChanged() {
-            setRectangleControl()
-            videoItem.enabled = filter.get('disable') !== '1'
-            background.color = filter.get('bgcolour')
-            setTextAreaHeight()
+            setRectangleControl();
+            videoItem.enabled = filter.get('disable') !== '1';
+            background.color = filter.get('bgcolour');
+            setTextAreaHeight();
         }
+
+        target: filter
     }
 
     Connections {
+        function onPositionChanged() {
+            setRectangleControl();
+        }
+
         target: producer
-        function onPositionChanged() { setRectangleControl() }
     }
+
 }

--- a/src/qml/filters/rotate/meta.qml
+++ b/src/qml/filters/rotate/meta.qml
@@ -9,6 +9,7 @@ Metadata {
     qml: "ui.qml"
     isFavorite: true
     isHidden: true
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -40,4 +41,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/rotate/ui.qml
+++ b/src/qml/filters/rotate/ui.qml
@@ -21,117 +21,116 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Shotcut.KeyframableFilter {
-    width: 350
-    height: 180
     property bool isAtLeastVersion4: filter.isAtLeastVersion('4')
 
-    keyframableParameters: ['transition.fix_rotate_x', 'transition.scale_x', 'transition.scale_y']
-    startValues: [0.0, 1.0, 1.0]
-    middleValues: [0.0, 1.0, 1.0]
-    endValues: [0.0, 1.0, 1.0]
-
-    Component.onCompleted: {
-        if (isAtLeastVersion4 && filter.get('transition.invert_scale') != 1) {
-            var scale = filter.getDouble('transition.scale_x')
-            if (scale !== 0.0)
-                filter.set('transition.scale_x', 1.0 / scale)
-            scale = filter.getDouble('transition.scale_y')
-            if (scale !== 0.0)
-                filter.set('transition.scale_y', 1.0 / scale)
-            filter.set('transition.invert_scale', 1)
-        }
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set('transition.fix_rotate_x', 0)
-            filter.set('transition.scale_x', 1)
-            filter.set('transition.scale_y', 1)
-            filter.set('transition.ox', 0)
-            filter.set('transition.oy', 0)
-            filter.set('transition.threads', 0)
-            filter.set('background', 'color:#00000000')
-            filter.savePreset(preset.parameters)
-        } else {
-            initializeSimpleKeyframes()
-        }
-        setControls()
-    }
-
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        rotationSlider.value = filter.getDouble('transition.fix_rotate_x', position)
-        rotationSlider.enabled = scaleSlider.enabled = isSimpleKeyframesActive()
-        rotationKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('transition.fix_rotate_x') > 0
-        var scale = filter.getDouble('transition.scale_x', position)
-        scaleSlider.value = isAtLeastVersion4? scale * 100 : 100 / scale
-        scaleKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('transition.scale_x') > 0
-        xOffsetSlider.value = filter.getDouble('transition.ox', position) * -1
-        xOffsetKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('transition.ox') > 0
-        yOffsetSlider.value = filter.getDouble('transition.oy', position) * -1
-        yOffsetKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('transition.oy') > 0
-        blockUpdate = false
-
-        var s = filter.get('background')
+        var position = getPosition();
+        blockUpdate = true;
+        rotationSlider.value = filter.getDouble('transition.fix_rotate_x', position);
+        rotationSlider.enabled = scaleSlider.enabled = isSimpleKeyframesActive();
+        rotationKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('transition.fix_rotate_x') > 0;
+        var scale = filter.getDouble('transition.scale_x', position);
+        scaleSlider.value = isAtLeastVersion4 ? scale * 100 : 100 / scale;
+        scaleKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('transition.scale_x') > 0;
+        xOffsetSlider.value = filter.getDouble('transition.ox', position) * -1;
+        xOffsetKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('transition.ox') > 0;
+        yOffsetSlider.value = filter.getDouble('transition.oy', position) * -1;
+        yOffsetKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('transition.oy') > 0;
+        blockUpdate = false;
+        var s = filter.get('background');
         if (s.substring(0, 6) === 'color:')
-            bgColor.value = s.substring(6)
-        else if  (s.substring(0, 7) === 'colour:')
-            bgColor.value = s.substring(7)
+            bgColor.value = s.substring(6);
+        else if (s.substring(0, 7) === 'colour:')
+            bgColor.value = s.substring(7);
     }
 
     function getScaleValue() {
-        if (isAtLeastVersion4) {
-            return scaleSlider.value / 100
-        } else {
-            return 100 / scaleSlider.value
-        }
+        if (isAtLeastVersion4)
+            return scaleSlider.value / 100;
+        else
+            return 100 / scaleSlider.value;
     }
 
     function updateFilterScale(position) {
-        if (blockUpdate) return
-        var value = getScaleValue()
-        var index = 1
+        if (blockUpdate)
+            return ;
 
+        var value = getScaleValue();
+        var index = 1;
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValues[index] = value
+                startValues[index] = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValues[index] = value
+                endValues[index] = value;
             else
-                middleValues[index] = value
+                middleValues[index] = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty('transition.scale_x')
-            filter.resetProperty('transition.scale_y')
-            scaleKeyframesButton.checked = false
+            filter.resetProperty('transition.scale_x');
+            filter.resetProperty('transition.scale_y');
+            scaleKeyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set('transition.scale_x', startValues[index], 0)
-                filter.set('transition.scale_x', middleValues[index], filter.animateIn - 1)
-                filter.set('transition.scale_y', startValues[index], 0)
-                filter.set('transition.scale_y', middleValues[index], filter.animateIn - 1)
+                filter.set('transition.scale_x', startValues[index], 0);
+                filter.set('transition.scale_x', middleValues[index], filter.animateIn - 1);
+                filter.set('transition.scale_y', startValues[index], 0);
+                filter.set('transition.scale_y', middleValues[index], filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set('transition.scale_x', middleValues[index], filter.duration - filter.animateOut)
-                filter.set('transition.scale_x', endValues[index], filter.duration - 1)
-                filter.set('transition.scale_y', middleValues[index], filter.duration - filter.animateOut)
-                filter.set('transition.scale_y', endValues[index], filter.duration - 1)
+                filter.set('transition.scale_x', middleValues[index], filter.duration - filter.animateOut);
+                filter.set('transition.scale_x', endValues[index], filter.duration - 1);
+                filter.set('transition.scale_y', middleValues[index], filter.duration - filter.animateOut);
+                filter.set('transition.scale_y', endValues[index], filter.duration - 1);
             }
         } else if (!scaleKeyframesButton.checked) {
-            filter.resetProperty('transition.scale_x')
-            filter.set('transition.scale_x', middleValues[index])
-            filter.resetProperty('transition.scale_y')
-            filter.set('transition.scale_y', middleValues[index])
+            filter.resetProperty('transition.scale_x');
+            filter.set('transition.scale_x', middleValues[index]);
+            filter.resetProperty('transition.scale_y');
+            filter.set('transition.scale_y', middleValues[index]);
         } else if (position !== null) {
-            filter.set('transition.scale_x', value, position)
-            filter.set('transition.scale_y', value, position)
+            filter.set('transition.scale_x', value, position);
+            filter.set('transition.scale_y', value, position);
         }
     }
 
     function updateSimpleKeyframes() {
-        updateFilter('transition.fix_rotate_x', rotationSlider.value, rotationKeyframesButton, null)
-        updateFilterScale(null)
+        updateFilter('transition.fix_rotate_x', rotationSlider.value, rotationKeyframesButton, null);
+        updateFilterScale(null);
     }
-    
+
+    width: 350
+    height: 180
+    keyframableParameters: ['transition.fix_rotate_x', 'transition.scale_x', 'transition.scale_y']
+    startValues: [0, 1, 1]
+    middleValues: [0, 1, 1]
+    endValues: [0, 1, 1]
+    Component.onCompleted: {
+        if (isAtLeastVersion4 && filter.get('transition.invert_scale') != 1) {
+            var scale = filter.getDouble('transition.scale_x');
+            if (scale !== 0)
+                filter.set('transition.scale_x', 1 / scale);
+
+            scale = filter.getDouble('transition.scale_y');
+            if (scale !== 0)
+                filter.set('transition.scale_y', 1 / scale);
+
+            filter.set('transition.invert_scale', 1);
+        }
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set('transition.fix_rotate_x', 0);
+            filter.set('transition.scale_x', 1);
+            filter.set('transition.scale_y', 1);
+            filter.set('transition.ox', 0);
+            filter.set('transition.oy', 0);
+            filter.set('transition.threads', 0);
+            filter.set('background', 'color:#00000000');
+            filter.savePreset(preset.parameters);
+        } else {
+            initializeSimpleKeyframes();
+        }
+        setControls();
+    }
+
     GridLayout {
         anchors.fill: parent
         anchors.margins: 8
@@ -141,19 +140,21 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ['transition.fix_rotate_x', 'transition.scale_x', 'transition.ox', 'transition.oy', 'background']
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
-                filter.resetProperty('transition.ox')
-                filter.resetProperty('transition.oy')
+                resetSimpleKeyframes();
+                filter.resetProperty('transition.ox');
+                filter.resetProperty('transition.oy');
             }
             onPresetSelected: {
-                filter.set('transition.scale_y', filter.get('transition.scale_x'))
-                setControls()
-                initializeSimpleKeyframes()
+                filter.set('transition.scale_y', filter.get('transition.scale_x'));
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -161,8 +162,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Rotation')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: rotationSlider
+
             minimumValue: -360
             maximumValue: 360
             decimals: 1
@@ -170,14 +173,17 @@ Shotcut.KeyframableFilter {
             suffix: qsTr(' deg', 'degrees')
             onValueChanged: updateFilter('transition.fix_rotate_x', value, rotationKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: rotationSlider.value = 0
         }
+
         Shotcut.KeyframesButton {
             id: rotationKeyframesButton
+
             onToggled: {
-                toggleKeyframes(checked, 'transition.fix_rotate_x', rotationSlider.value)
-                setControls()
+                toggleKeyframes(checked, 'transition.fix_rotate_x', rotationSlider.value);
+                setControls();
             }
         }
 
@@ -185,8 +191,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Scale')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: scaleSlider
+
             minimumValue: 0.1
             maximumValue: 1000
             decimals: 1
@@ -194,32 +202,35 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilterScale(getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: scaleSlider.value = 100
         }
+
         Shotcut.KeyframesButton {
             id: scaleKeyframesButton
+
             onToggled: {
-                var value = getScaleValue()
+                var value = getScaleValue();
                 if (checked) {
-                    blockUpdate = true
+                    blockUpdate = true;
                     if (filter.animateIn > 0 || filter.animateOut > 0) {
-                        resetSimpleKeyframes()
-                        filter.animateIn = filter.animateOut = 0
+                        resetSimpleKeyframes();
+                        filter.animateIn = filter.animateOut = 0;
                     } else {
-                        filter.clearSimpleAnimation('transition.scale_x')
-                        filter.clearSimpleAnimation('transition.scale_y')
+                        filter.clearSimpleAnimation('transition.scale_x');
+                        filter.clearSimpleAnimation('transition.scale_y');
                     }
-                    blockUpdate = false
-                    filter.set('transition.scale_x', value, getPosition())
-                    filter.set('transition.scale_y', value, getPosition())
+                    blockUpdate = false;
+                    filter.set('transition.scale_x', value, getPosition());
+                    filter.set('transition.scale_y', value, getPosition());
                 } else {
-                    filter.resetProperty('transition.scale_x')
-                    filter.resetProperty('transition.scale_y')
-                    filter.set('transition.scale_x', value)
-                    filter.set('transition.scale_y', value)
+                    filter.resetProperty('transition.scale_x');
+                    filter.resetProperty('transition.scale_y');
+                    filter.set('transition.scale_x', value);
+                    filter.set('transition.scale_y', value);
                 }
-                setControls()
+                setControls();
             }
         }
 
@@ -227,29 +238,36 @@ Shotcut.KeyframableFilter {
             text: qsTr('X offset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: xOffsetSlider
+
             minimumValue: -5000
             maximumValue: 5000
             spinnerWidth: 110
-            onValueChanged: if (!blockUpdate) {
-                if (xOffsetKeyframesButton.checked)
-                    filter.set('transition.ox', -value, getPosition())
-                else
-                    filter.set('transition.ox', -value)
+            onValueChanged: {
+                if (!blockUpdate) {
+                    if (xOffsetKeyframesButton.checked)
+                        filter.set('transition.ox', -value, getPosition());
+                    else
+                        filter.set('transition.ox', -value);
+                }
             }
         }
+
         Shotcut.UndoButton {
             onClicked: xOffsetSlider.value = 0
         }
+
         Shotcut.KeyframesButton {
             id: xOffsetKeyframesButton
+
             onToggled: {
                 if (checked) {
-                    filter.set('transition.ox', -xOffsetSlider.value, getPosition())
+                    filter.set('transition.ox', -xOffsetSlider.value, getPosition());
                 } else {
-                    filter.resetProperty('transition.ox')
-                    filter.set('transition.ox', -xOffsetSlider.value)
+                    filter.resetProperty('transition.ox');
+                    filter.set('transition.ox', -xOffsetSlider.value);
                 }
             }
         }
@@ -258,29 +276,36 @@ Shotcut.KeyframableFilter {
             text: qsTr('Y offset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: yOffsetSlider
+
             minimumValue: -5000
             maximumValue: 5000
             spinnerWidth: 110
-            onValueChanged: if (!blockUpdate) {
-                if (yOffsetKeyframesButton.checked)
-                    filter.set('transition.oy', -value, getPosition())
-                else
-                    filter.set('transition.oy', -value)
+            onValueChanged: {
+                if (!blockUpdate) {
+                    if (yOffsetKeyframesButton.checked)
+                        filter.set('transition.oy', -value, getPosition());
+                    else
+                        filter.set('transition.oy', -value);
+                }
             }
         }
+
         Shotcut.UndoButton {
             onClicked: yOffsetSlider.value = 0
         }
+
         Shotcut.KeyframesButton {
             id: yOffsetKeyframesButton
+
             onToggled: {
                 if (checked) {
-                    filter.set('transition.oy', -yOffsetSlider.value, getPosition())
+                    filter.set('transition.oy', -yOffsetSlider.value, getPosition());
                 } else {
-                    filter.resetProperty('transition.oy')
-                    filter.set('transition.oy', -yOffsetSlider.value)
+                    filter.resetProperty('transition.oy');
+                    filter.set('transition.oy', -yOffsetSlider.value);
                 }
             }
         }
@@ -289,16 +314,20 @@ Shotcut.KeyframableFilter {
             text: qsTr('Background color')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ColorPicker {
             id: bgColor
+
             eyedropper: true
             alpha: true
             onValueChanged: filter.set('background', 'color:' + value)
         }
+
         Shotcut.UndoButton {
             visible: bgColor.visible
             onClicked: bgColor.value = '#00000000'
         }
+
         Item {
             Layout.fillWidth: true
         }
@@ -306,28 +335,52 @@ Shotcut.KeyframableFilter {
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
-        target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged(name) { setControls() }
-    }
-
-    Connections {
-        target: producer
-        function onPositionChanged() { setControls() }
-    }
-
-    Connections {
-        target: parameters
-        function onKeyframeAdded() {
-            var n = filter.getDouble(parameter, position)
-            filter.set(parameter, n, position)
+        function onChanged() {
+            setControls();
         }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
+        target: filter
     }
+
+    Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
+        target: producer
+    }
+
+    Connections {
+        function onKeyframeAdded() {
+            var n = filter.getDouble(parameter, position);
+            filter.set(parameter, n, position);
+        }
+
+        target: parameters
+    }
+
 }

--- a/src/qml/filters/saturation/meta_frei0r.qml
+++ b/src/qml/filters/saturation/meta_frei0r.qml
@@ -7,6 +7,7 @@ Metadata {
     mlt_service: "frei0r.saturat0r"
     qml: "ui_frei0r.qml"
     gpuAlt: "movit.saturation"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -21,4 +22,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/saturation/meta_movit.qml
+++ b/src/qml/filters/saturation/meta_movit.qml
@@ -7,6 +7,7 @@ Metadata {
     mlt_service: "movit.saturation"
     needsGPU: true
     qml: "ui_movit.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -21,4 +22,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/saturation/ui_frei0r.qml
+++ b/src/qml/filters/saturation/ui_frei0r.qml
@@ -21,8 +21,6 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 350
-    height: 50
     property string saturationParameter: '0'
     property real frei0rMaximum: 800
     property bool blockUpdate: true
@@ -30,67 +28,71 @@ Item {
     property double middleValue: 0.125
     property double endValue: 0.125
 
-    Component.onCompleted: {
-        filter.set('threads', 0)
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set(saturationParameter, 0)
-            filter.savePreset(preset.parameters, qsTr('Grayscale'))
-            filter.set(saturationParameter, 100 / frei0rMaximum)
-            filter.savePreset(preset.parameters)
-        } else {
-            middleValue = filter.getDouble(saturationParameter, filter.animateIn)
-            if (filter.animateIn > 0)
-                startValue = filter.getDouble(saturationParameter, 0)
-            if (filter.animateOut > 0)
-                endValue = filter.getDouble(saturationParameter, filter.duration - 1)
-        }
-        setControls()
-    }
-
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        slider.value = filter.getDouble(saturationParameter, position) * frei0rMaximum
-        keyframesButton.checked = filter.keyframeCount(saturationParameter) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-        blockUpdate = false
-        slider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        slider.value = filter.getDouble(saturationParameter, position) * frei0rMaximum;
+        keyframesButton.checked = filter.keyframeCount(saturationParameter) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+        blockUpdate = false;
+        slider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function updateFilter(position) {
-        if (blockUpdate) return
-        var value = slider.value / frei0rMaximum
+        if (blockUpdate)
+            return ;
 
+        var value = slider.value / frei0rMaximum;
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValue = value
+                startValue = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValue = value
+                endValue = value;
             else
-                middleValue = value
+                middleValue = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(saturationParameter)
-            keyframesButton.checked = false
+            filter.resetProperty(saturationParameter);
+            keyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set(saturationParameter, startValue, 0)
-                filter.set(saturationParameter, middleValue, filter.animateIn - 1)
+                filter.set(saturationParameter, startValue, 0);
+                filter.set(saturationParameter, middleValue, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(saturationParameter, middleValue, filter.duration - filter.animateOut)
-                filter.set(saturationParameter, endValue, filter.duration - 1)
+                filter.set(saturationParameter, middleValue, filter.duration - filter.animateOut);
+                filter.set(saturationParameter, endValue, filter.duration - 1);
             }
         } else if (!keyframesButton.checked) {
-            filter.resetProperty(saturationParameter)
-            filter.set(saturationParameter, middleValue)
+            filter.resetProperty(saturationParameter);
+            filter.set(saturationParameter, middleValue);
         } else if (position !== null) {
-            filter.set(saturationParameter, value, position)
+            filter.set(saturationParameter, value, position);
         }
+    }
+
+    width: 350
+    height: 50
+    Component.onCompleted: {
+        filter.set('threads', 0);
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set(saturationParameter, 0);
+            filter.savePreset(preset.parameters, qsTr('Grayscale'));
+            filter.set(saturationParameter, 100 / frei0rMaximum);
+            filter.savePreset(preset.parameters);
+        } else {
+            middleValue = filter.getDouble(saturationParameter, filter.animateIn);
+            if (filter.animateIn > 0)
+                startValue = filter.getDouble(saturationParameter, 0);
+
+            if (filter.animateOut > 0)
+                endValue = filter.getDouble(saturationParameter, filter.duration - 1);
+
+        }
+        setControls();
     }
 
     GridLayout {
@@ -102,20 +104,24 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: 3
             parameters: [saturationParameter]
             onBeforePresetLoaded: {
-                filter.resetProperty(saturationParameter)
+                filter.resetProperty(saturationParameter);
             }
             onPresetSelected: {
-                setControls()
-                middleValue = filter.getDouble(saturationParameter, filter.animateIn)
+                setControls();
+                middleValue = filter.getDouble(saturationParameter, filter.animateIn);
                 if (filter.animateIn > 0)
-                    startValue = filter.getDouble(saturationParameter, 0)
+                    startValue = filter.getDouble(saturationParameter, 0);
+
                 if (filter.animateOut > 0)
-                    endValue = filter.getDouble(saturationParameter, filter.duration - 1)
+                    endValue = filter.getDouble(saturationParameter, filter.duration - 1);
+
             }
         }
 
@@ -123,28 +129,33 @@ Item {
             text: qsTr('Level')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slider
+
             minimumValue: 0
             maximumValue: 300
             suffix: ' %'
             onValueChanged: updateFilter(getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: slider.value = 100
         }
+
         Shotcut.KeyframesButton {
             id: keyframesButton
+
             onToggled: {
-                var value = slider.value / frei0rMaximum
+                var value = slider.value / frei0rMaximum;
                 if (checked) {
-                    blockUpdate = true
-                    filter.clearSimpleAnimation(saturationParameter)
-                    blockUpdate = false
-                    filter.set(saturationParameter, value, getPosition())
+                    blockUpdate = true;
+                    filter.clearSimpleAnimation(saturationParameter);
+                    blockUpdate = false;
+                    filter.set(saturationParameter, value, getPosition());
                 } else {
-                    filter.resetProperty(saturationParameter)
-                    filter.set(saturationParameter, value)
+                    filter.resetProperty(saturationParameter);
+                    filter.set(saturationParameter, value);
                 }
             }
         }
@@ -152,29 +163,54 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            setControls();
+            updateFilter(null);
+        }
+
+        function onOutChanged() {
+            setControls();
+            updateFilter(null);
+        }
+
+        function onAnimateInChanged() {
+            setControls();
+            updateFilter(null);
+        }
+
+        function onAnimateOutChanged() {
+            setControls();
+            updateFilter(null);
+        }
+
+        function onPropertyChanged() {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { setControls(); updateFilter(null) }
-        function onOutChanged() { setControls(); updateFilter(null) }
-        function onAnimateInChanged()  { setControls(); updateFilter(null) }
-        function onAnimateOutChanged()  { setControls(); updateFilter(null) }
-        function onPropertyChanged() { setControls() }
     }
 
     Connections {
-        target: producer
         function onPositionChanged() {
             if (filter.animateIn > 0 || filter.animateOut > 0) {
-                setControls()
+                setControls();
             } else {
-                blockUpdate = true
-                slider.value = filter.getDouble(saturationParameter, getPosition()) * frei0rMaximum
-                blockUpdate = false
-                slider.enabled = true
+                blockUpdate = true;
+                slider.value = filter.getDouble(saturationParameter, getPosition()) * frei0rMaximum;
+                blockUpdate = false;
+                slider.enabled = true;
             }
         }
+
+        target: producer
     }
+
 }

--- a/src/qml/filters/saturation/ui_movit.qml
+++ b/src/qml/filters/saturation/ui_movit.qml
@@ -21,74 +21,76 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 350
-    height: 50
     property string saturationParameter: 'saturation'
     property bool blockUpdate: true
-    property double startValue: 1.0
-    property double middleValue: 1.0
-    property double endValue: 1.0
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set(saturationParameter, 0)
-            filter.savePreset(preset.parameters, qsTr('Grayscale'))
-            filter.set(saturationParameter, 1.0)
-            filter.savePreset(preset.parameters)
-        } else {
-            middleValue = filter.getDouble(saturationParameter, filter.animateIn)
-            if (filter.animateIn > 0)
-                startValue = filter.getDouble(saturationParameter, 0)
-            if (filter.animateOut > 0)
-                endValue = filter.getDouble(saturationParameter, filter.duration - 1)
-        }
-        setControls()
-    }
+    property double startValue: 1
+    property double middleValue: 1
+    property double endValue: 1
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        slider.value = filter.getDouble(saturationParameter, position) * 100
-        keyframesButton.checked = filter.keyframeCount(saturationParameter) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-        blockUpdate = false
-        slider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        slider.value = filter.getDouble(saturationParameter, position) * 100;
+        keyframesButton.checked = filter.keyframeCount(saturationParameter) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+        blockUpdate = false;
+        slider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function updateFilter(position) {
-        if (blockUpdate) return
-        var value = slider.value / 100
+        if (blockUpdate)
+            return ;
 
+        var value = slider.value / 100;
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValue = value
+                startValue = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValue = value
+                endValue = value;
             else
-                middleValue = value
+                middleValue = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(saturationParameter)
-            keyframesButton.checked = false
+            filter.resetProperty(saturationParameter);
+            keyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set(saturationParameter, startValue, 0)
-                filter.set(saturationParameter, middleValue, filter.animateIn - 1)
+                filter.set(saturationParameter, startValue, 0);
+                filter.set(saturationParameter, middleValue, filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(saturationParameter, middleValue, filter.duration - filter.animateOut)
-                filter.set(saturationParameter, endValue, filter.duration - 1)
+                filter.set(saturationParameter, middleValue, filter.duration - filter.animateOut);
+                filter.set(saturationParameter, endValue, filter.duration - 1);
             }
         } else if (!keyframesButton.checked) {
-            filter.resetProperty(saturationParameter)
-            filter.set(saturationParameter, middleValue)
+            filter.resetProperty(saturationParameter);
+            filter.set(saturationParameter, middleValue);
         } else if (position !== null) {
-            filter.set(saturationParameter, value, position)
+            filter.set(saturationParameter, value, position);
         }
+    }
+
+    width: 350
+    height: 50
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set(saturationParameter, 0);
+            filter.savePreset(preset.parameters, qsTr('Grayscale'));
+            filter.set(saturationParameter, 1);
+            filter.savePreset(preset.parameters);
+        } else {
+            middleValue = filter.getDouble(saturationParameter, filter.animateIn);
+            if (filter.animateIn > 0)
+                startValue = filter.getDouble(saturationParameter, 0);
+
+            if (filter.animateOut > 0)
+                endValue = filter.getDouble(saturationParameter, filter.duration - 1);
+
+        }
+        setControls();
     }
 
     GridLayout {
@@ -100,76 +102,112 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: 3
             parameters: [saturationParameter]
             onBeforePresetLoaded: {
-                filter.resetProperty(saturationParameter)
+                filter.resetProperty(saturationParameter);
             }
             onPresetSelected: {
-                setControls()
-                middleValue = filter.getDouble(saturationParameter, filter.animateIn)
+                setControls();
+                middleValue = filter.getDouble(saturationParameter, filter.animateIn);
                 if (filter.animateIn > 0)
-                    startValue = filter.getDouble(saturationParameter, 0)
+                    startValue = filter.getDouble(saturationParameter, 0);
+
                 if (filter.animateOut > 0)
-                    endValue = filter.getDouble(saturationParameter, filter.duration - 1)
+                    endValue = filter.getDouble(saturationParameter, filter.duration - 1);
+
             }
         }
 
-        Label { text: qsTr('Level') }
+        Label {
+            text: qsTr('Level')
+        }
+
         Shotcut.SliderSpinner {
             id: slider
+
             minimumValue: 0
             maximumValue: 300
             suffix: ' %'
             onValueChanged: updateFilter(getPosition())
         }
+
         Shotcut.UndoButton {
             onClicked: slider.value = 100
         }
+
         Shotcut.KeyframesButton {
             id: keyframesButton
+
             onToggled: {
-                var value = slider.value / 100
+                var value = slider.value / 100;
                 if (checked) {
-                    blockUpdate = true
-                    filter.clearSimpleAnimation(saturationParameter)
-                    blockUpdate = false
-                    filter.set(saturationParameter, value, getPosition())
+                    blockUpdate = true;
+                    filter.clearSimpleAnimation(saturationParameter);
+                    blockUpdate = false;
+                    filter.set(saturationParameter, value, getPosition());
                 } else {
-                    filter.resetProperty(saturationParameter)
-                    filter.set(saturationParameter, value)
+                    filter.resetProperty(saturationParameter);
+                    filter.set(saturationParameter, value);
                 }
             }
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            setControls();
+            updateFilter(null);
+        }
+
+        function onOutChanged() {
+            setControls();
+            updateFilter(null);
+        }
+
+        function onAnimateInChanged() {
+            setControls();
+            updateFilter(null);
+        }
+
+        function onAnimateOutChanged() {
+            setControls();
+            updateFilter(null);
+        }
+
+        function onPropertyChanged() {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { setControls(); updateFilter(null) }
-        function onOutChanged() { setControls(); updateFilter(null) }
-        function onAnimateInChanged()  { setControls(); updateFilter(null) }
-        function onAnimateOutChanged()  { setControls(); updateFilter(null) }
-        function onPropertyChanged() { setControls() }
     }
 
     Connections {
-        target: producer
         function onPositionChanged() {
             if (filter.animateIn > 0 || filter.animateOut > 0) {
-                setControls()
+                setControls();
             } else {
-                blockUpdate = true
-                slider.value = filter.getDouble(saturationParameter, getPosition()) * 100
-                blockUpdate = false
-                slider.enabled = true
+                blockUpdate = true;
+                slider.value = filter.getDouble(saturationParameter, getPosition()) * 100;
+                blockUpdate = false;
+                slider.enabled = true;
             }
         }
+
+        target: producer
     }
+
 }

--- a/src/qml/filters/select0r/ui.qml
+++ b/src/qml/filters/select0r/ui.qml
@@ -24,7 +24,7 @@ Item {
     property string keyColorParam: '0'
     property string keyColorDefault: '#00cc00'
     property string invertParam: '1'
-    property bool   invertDefault: true
+    property bool invertDefault: true
     property string deltaRParam: '2'
     property double deltaRDefault: 0.2
     property string deltaGParam: '3'
@@ -32,73 +32,70 @@ Item {
     property string deltaBParam: '4'
     property double deltaBDefault: 0.2
     property string slopeParam: '5'
-    property double slopeDefault: 0.0
+    property double slopeDefault: 0
     property string colorspaceParam: '6'
-    property double colorspaceDefault: 0.0
+    property double colorspaceDefault: 0
     property string shapeParam: '7'
     property double shapeDefault: 0.5
     property string edgeParam: '8'
     property double edgeDefault: 0.9
     property string operationParam: '9'
-    property double operationDefault: 0.0
+    property double operationDefault: 0
+    property var defaultParameters: [keyColorParam, invertParam, deltaRParam, deltaGParam, deltaBParam, slopeParam, colorspaceParam, shapeParam, edgeParam, operationParam]
 
-    property var defaultParameters: [keyColorParam, invertParam, deltaRParam,
-        deltaGParam, deltaBParam, slopeParam, colorspaceParam, shapeParam,
-        edgeParam, operationParam]
+    function setControls() {
+        keyColorPicker.value = filter.get(keyColorParam);
+        if (filter.getDouble(colorspaceParam) === 0)
+            rgbRadioButton.checked = true;
+        else
+            hciRadioButton.checked = true;
+        deltaRSlider.value = filter.getDouble(deltaRParam) * 100;
+        deltaGSlider.value = filter.getDouble(deltaGParam) * 100;
+        deltaBSlider.value = filter.getDouble(deltaBParam) * 100;
+        var currentShape = filter.getDouble(shapeParam);
+        var i;
+        for (; i < shapeModel.count; ++i) {
+            if (shapeModel.get(i).value === currentShape) {
+                shapeCombo.currentIndex = i;
+                break;
+            }
+        }
+        var currentEdge = filter.getDouble(edgeParam);
+        for (; i < edgeModel.count; ++i) {
+            if (edgeModel.get(i).value === currentEdge) {
+                edgeCombo.currentIndex = i;
+                break;
+            }
+        }
+        slopeSlider.value = filter.getDouble(slopeParam) * 100;
+        var currentOp = filter.getDouble(operationParam);
+        for (; i < operationModel.count; ++i) {
+            if (operationModel.get(i).value === currentOp) {
+                operationCombo.currentIndex = i;
+                break;
+            }
+        }
+        invertCheckbox.checked = !parseInt(filter.get(invertParam));
+    }
 
     width: 200
     height: 300
     Component.onCompleted: {
-        filter.set('threads', 0)
+        filter.set('threads', 0);
         if (filter.isNew) {
-            filter.set(keyColorParam, keyColorDefault)
-            filter.set(invertParam, invertDefault)
-            filter.set(deltaRParam, deltaRDefault)
-            filter.set(deltaGParam, deltaGDefault)
-            filter.set(deltaBParam, deltaBDefault)
-            filter.set(slopeParam, slopeDefault)
-            filter.set(colorspaceParam, colorspaceDefault)
-            filter.set(shapeParam, shapeDefault)
-            filter.set(edgeParam, edgeDefault)
-            filter.set(operationParam, operationDefault)
-            filter.savePreset(defaultParameters)
+            filter.set(keyColorParam, keyColorDefault);
+            filter.set(invertParam, invertDefault);
+            filter.set(deltaRParam, deltaRDefault);
+            filter.set(deltaGParam, deltaGDefault);
+            filter.set(deltaBParam, deltaBDefault);
+            filter.set(slopeParam, slopeDefault);
+            filter.set(colorspaceParam, colorspaceDefault);
+            filter.set(shapeParam, shapeDefault);
+            filter.set(edgeParam, edgeDefault);
+            filter.set(operationParam, operationDefault);
+            filter.savePreset(defaultParameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        keyColorPicker.value = filter.get(keyColorParam)
-        if (filter.getDouble(colorspaceParam) === 0.0)
-            rgbRadioButton.checked = true
-        else
-            hciRadioButton.checked = true
-        deltaRSlider.value = filter.getDouble(deltaRParam) * 100
-        deltaGSlider.value = filter.getDouble(deltaGParam) * 100
-        deltaBSlider.value = filter.getDouble(deltaBParam) * 100
-        var currentShape = filter.getDouble(shapeParam)
-        var i;
-        for (i = 0; i < shapeModel.count; ++i) {
-            if (shapeModel.get(i).value === currentShape) {
-                shapeCombo.currentIndex = i
-                break
-            }
-        }
-        var currentEdge = filter.getDouble(edgeParam)
-        for (i = 0; i < edgeModel.count; ++i) {
-            if (edgeModel.get(i).value === currentEdge) {
-                edgeCombo.currentIndex = i
-                break
-            }
-        }
-        slopeSlider.value = filter.getDouble(slopeParam) * 100
-        var currentOp = filter.getDouble(operationParam)
-        for (i = 0; i < operationModel.count; ++i) {
-            if (operationModel.get(i).value === currentOp) {
-                operationCombo.currentIndex = i
-                break
-            }
-        }
-        invertCheckbox.checked = !parseInt(filter.get(invertParam))
+        setControls();
     }
 
     GridLayout {
@@ -110,8 +107,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: presetItem
+
             Layout.columnSpan: 2
             parameters: defaultParameters
             onPresetSelected: setControls()
@@ -121,13 +120,16 @@ Item {
             text: qsTr('Key color')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ColorPicker {
             id: keyColorPicker
+
             property bool isReady: false
+
             Component.onCompleted: isReady = true
             onValueChanged: {
                 if (isReady) {
-                    filter.set(keyColorParam, value)
+                    filter.set(keyColorParam, value);
                     filter.set("disable", 0);
                 }
             }
@@ -136,6 +138,7 @@ Item {
             }
             onPickCancelled: filter.set('disable', 0)
         }
+
         Shotcut.UndoButton {
             onClicked: keyColorPicker.value = keyColorDefault
         }
@@ -144,31 +147,50 @@ Item {
             text: qsTr('Color space')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
-            ButtonGroup { id: colorspaceGroup }
+            ButtonGroup {
+                id: colorspaceGroup
+            }
+
             RadioButton {
                 id: rgbRadioButton
+
                 text: qsTr('Red-Green-Blue')
                 ButtonGroup.group: colorspaceGroup
-                onCheckedChanged: if (checked) filter.set(colorspaceParam, 0.0)
+                onCheckedChanged: {
+                    if (checked)
+                        filter.set(colorspaceParam, 0);
+
+                }
             }
+
             RadioButton {
                 id: hciRadioButton
+
                 text: qsTr('Hue-Chroma-Intensity')
                 ButtonGroup.group: colorspaceGroup
-                onCheckedChanged: if (checked) filter.set(colorspaceParam, 1.0)
+                onCheckedChanged: {
+                    if (checked)
+                        filter.set(colorspaceParam, 1);
+
+                }
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: rgbRadioButton.checked = true
         }
 
         Label {
-            text: rgbRadioButton.checked? qsTr('Red delta') : qsTr('Hue delta')
+            text: rgbRadioButton.checked ? qsTr('Red delta') : qsTr('Hue delta')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: deltaRSlider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -176,16 +198,19 @@ Item {
             value: filter.getDouble(deltaRDefault) * 100
             onValueChanged: filter.set(deltaRParam, value / 100)
         }
+
         Shotcut.UndoButton {
             onClicked: deltaRSlider.value = deltaRDefault * 100
         }
 
         Label {
-            text: rgbRadioButton.checked? qsTr('Green delta') : qsTr('Chroma delta')
+            text: rgbRadioButton.checked ? qsTr('Green delta') : qsTr('Chroma delta')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: deltaGSlider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -193,16 +218,19 @@ Item {
             value: filter.getDouble(deltaGDefault) * 100
             onValueChanged: filter.set(deltaGParam, value / 100)
         }
+
         Shotcut.UndoButton {
             onClicked: deltaGSlider.value = deltaGDefault * 100
         }
 
         Label {
-            text: rgbRadioButton.checked? qsTr('Blue delta') : qsTr('Intensity delta')
+            text: rgbRadioButton.checked ? qsTr('Blue delta') : qsTr('Intensity delta')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: deltaBSlider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -210,6 +238,7 @@ Item {
             value: filter.getDouble(deltaBDefault) * 100
             onValueChanged: filter.set(deltaBParam, value / 100)
         }
+
         Shotcut.UndoButton {
             onClicked: deltaBSlider.value = deltaBDefault * 100
         }
@@ -218,22 +247,40 @@ Item {
             text: qsTr('Shape')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: shapeCombo
+
             implicitWidth: 180
-            model: ListModel {
-                id: shapeModel
-                ListElement { text: qsTr('Box');       value: 0.0 }
-                ListElement { text: qsTr('Ellipsoid'); value: 0.5 }
-                ListElement { text: qsTr('Diamond');   value: 1.0 }
-            }
             textRole: 'text'
             onActivated: filter.set(shapeParam, shapeModel.get(currentIndex).value)
+
+            model: ListModel {
+                id: shapeModel
+
+                ListElement {
+                    text: qsTr('Box')
+                    value: 0
+                }
+
+                ListElement {
+                    text: qsTr('Ellipsoid')
+                    value: 0.5
+                }
+
+                ListElement {
+                    text: qsTr('Diamond')
+                    value: 1
+                }
+
+            }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filter.set(shapeParam, shapeModel.get(1).value)
-                shapeCombo.currentIndex = 1
+                filter.set(shapeParam, shapeModel.get(1).value);
+                shapeCombo.currentIndex = 1;
             }
         }
 
@@ -241,24 +288,50 @@ Item {
             text: qsTr('Edge')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: edgeCombo
+
             implicitWidth: 180
-            model: ListModel {
-                id: edgeModel
-                ListElement { text: qsTr('Hard', 'Chroma Key Advanced filter');   value: 0.0 }
-                ListElement { text: qsTr('Fat');    value: 0.35 }
-                ListElement { text: qsTr('Normal'); value: 0.6 }
-                ListElement { text: qsTr('Thin');   value: 0.7 }
-                ListElement { text: qsTr('Slope');  value: 0.9 }
-            }
             textRole: 'text'
             onActivated: filter.set(edgeParam, edgeModel.get(currentIndex).value)
+
+            model: ListModel {
+                id: edgeModel
+
+                ListElement {
+                    text: qsTr('Hard', 'Chroma Key Advanced filter')
+                    value: 0
+                }
+
+                ListElement {
+                    text: qsTr('Fat')
+                    value: 0.35
+                }
+
+                ListElement {
+                    text: qsTr('Normal')
+                    value: 0.6
+                }
+
+                ListElement {
+                    text: qsTr('Thin')
+                    value: 0.7
+                }
+
+                ListElement {
+                    text: qsTr('Slope')
+                    value: 0.9
+                }
+
+            }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filter.set(edgeParam, edgeModel.get(4).value)
-                edgeCombo.currentIndex = 4
+                filter.set(edgeParam, edgeModel.get(4).value);
+                edgeCombo.currentIndex = 4;
             }
         }
 
@@ -266,8 +339,10 @@ Item {
             text: qsTr('Slope')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: slopeSlider
+
             minimumValue: 0
             maximumValue: 100
             decimals: 1
@@ -275,6 +350,7 @@ Item {
             value: filter.getDouble(slopeParam) * 100
             onValueChanged: filter.set(slopeParam, value / 100)
         }
+
         Shotcut.UndoButton {
             onClicked: slopeSlider.value = slopeDefault * 100
         }
@@ -283,24 +359,50 @@ Item {
             text: qsTr('Operation')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: operationCombo
+
             implicitWidth: 180
+            textRole: 'text'
+            onActivated: filter.set(operationParam, operationModel.get(currentIndex).value)
+
             model: ListModel {
                 id: operationModel
-                ListElement { text: qsTr('Overwrite'); value: 0.0 }
-                ListElement { text: qsTr('Maximum');   value: 0.3 }
-                ListElement { text: qsTr('Minimum');   value: 0.5 }
-                ListElement { text: qsTr('Add');       value: 0.7 }
-                ListElement { text: qsTr('Subtract');  value: 1.0 }
+
+                ListElement {
+                    text: qsTr('Overwrite')
+                    value: 0
+                }
+
+                ListElement {
+                    text: qsTr('Maximum')
+                    value: 0.3
+                }
+
+                ListElement {
+                    text: qsTr('Minimum')
+                    value: 0.5
+                }
+
+                ListElement {
+                    text: qsTr('Add')
+                    value: 0.7
+                }
+
+                ListElement {
+                    text: qsTr('Subtract')
+                    value: 1
+                }
+
             }
-            textRole: 'text'
-            onActivated: filter.set(operationParam, operationModel.get(currentIndex).value )
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filter.set(operationParam, operationModel.get(0).value )
-                operationCombo.currentIndex = 0
+                filter.set(operationParam, operationModel.get(0).value);
+                operationCombo.currentIndex = 0;
             }
         }
 
@@ -311,13 +413,19 @@ Item {
 
         CheckBox {
             id: invertCheckbox
+
             text: qsTr('Invert')
             onCheckedChanged: filter.set(invertParam, !checked)
         }
+
         Shotcut.UndoButton {
             onClicked: invertCheckbox.checked = !invertDefault
         }
 
-        Item { Layout.fillHeight: true }
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
+
 }

--- a/src/qml/filters/sepia/ui.qml
+++ b/src/qml/filters/sepia/ui.qml
@@ -26,7 +26,8 @@ Item {
     height: 100
     Component.onCompleted: {
         if (filter.isNew)
-            filter.savePreset(preset.parameters)
+            filter.savePreset(preset.parameters);
+
     }
 
     GridLayout {
@@ -38,13 +39,15 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: 2
             parameters: ['u', 'v']
             onPresetSelected: {
-                sliderBlue.value = filter.getDouble('u')
-                sliderRed.value = filter.getDouble('v')
+                sliderBlue.value = filter.getDouble('u');
+                sliderRed.value = filter.getDouble('v');
             }
         }
 
@@ -52,13 +55,16 @@ Item {
             text: qsTr('Yellow-Blue')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderBlue
+
             minimumValue: 0
             maximumValue: 255
             value: filter.getDouble('u')
-            onValueChanged:filter.set('u', value)
+            onValueChanged: filter.set('u', value)
         }
+
         Shotcut.UndoButton {
             onClicked: sliderBlue.value = 75
         }
@@ -67,13 +73,16 @@ Item {
             text: qsTr('Cyan-Red')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sliderRed
+
             minimumValue: 0
             maximumValue: 255
             value: filter.getDouble('v')
             onValueChanged: filter.set('v', value)
         }
+
         Shotcut.UndoButton {
             onClicked: sliderRed.value = 150
         }
@@ -81,5 +90,7 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/sharpen/meta_frei0r.qml
+++ b/src/qml/filters/sharpen/meta_frei0r.qml
@@ -7,6 +7,7 @@ Metadata {
     mlt_service: "frei0r.sharpness"
     qml: "ui_frei0r.qml"
     gpuAlt: "movit.sharpen"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -28,4 +29,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/sharpen/meta_movit.qml
+++ b/src/qml/filters/sharpen/meta_movit.qml
@@ -7,6 +7,7 @@ Metadata {
     mlt_service: "movit.sharpen"
     needsGPU: true
     qml: "ui_movit.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -42,4 +43,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/sharpen/ui_frei0r.qml
+++ b/src/qml/filters/sharpen/ui_frei0r.qml
@@ -25,122 +25,126 @@ Item {
     property string paramSize: '1'
     property var defaultParameters: [paramAmount, paramSize]
     property bool blockUpdate: true
-    property var startValues:  [0.3, 0.5]
+    property var startValues: [0.3, 0.5]
     property var middleValues: [0.5, 0.5]
-    property var endValues:    [0.3, 0.5]
-    width: 350
-    height: 100
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set(paramAmount, 0.5)
-            filter.set(paramSize, 0.5)
-            filter.savePreset(defaultParameters)
-        } else {
-            initSimpleAnimation()
-        }
-        setControls()
-    }
+    property var endValues: [0.3, 0.5]
 
     function initSimpleAnimation() {
-        middleValues = [filter.getDouble(defaultParameters[0], filter.animateIn),
-                        filter.getDouble(defaultParameters[1], filter.animateIn)]
-        if (filter.animateIn > 0) {
-            startValues = [filter.getDouble(defaultParameters[0], 0),
-                           filter.getDouble(defaultParameters[1], 0)]
-        }
-        if (filter.animateOut > 0) {
-            endValues = [filter.getDouble(defaultParameters[0], filter.duration - 1),
-                         filter.getDouble(defaultParameters[1], filter.duration - 1)]
-        }
+        middleValues = [filter.getDouble(defaultParameters[0], filter.animateIn), filter.getDouble(defaultParameters[1], filter.animateIn)];
+        if (filter.animateIn > 0)
+            startValues = [filter.getDouble(defaultParameters[0], 0), filter.getDouble(defaultParameters[1], 0)];
+
+        if (filter.animateOut > 0)
+            endValues = [filter.getDouble(defaultParameters[0], filter.duration - 1), filter.getDouble(defaultParameters[1], filter.duration - 1)];
+
     }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        amountSlider.value = filter.getDouble(paramAmount, position) * 100.0
-        amountKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramAmount) > 0
-        sizeSlider.value = filter.getDouble(paramSize, position) * 100.0
-        sizeKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramSize) > 0
-        blockUpdate = false
-        amountSlider.enabled = sizeSlider.enabled
-            = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        amountSlider.value = filter.getDouble(paramAmount, position) * 100;
+        amountKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramAmount) > 0;
+        sizeSlider.value = filter.getDouble(paramSize, position) * 100;
+        sizeKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(paramSize) > 0;
+        blockUpdate = false;
+        amountSlider.enabled = sizeSlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function updateFilter(parameter, value, position, button) {
-        if (blockUpdate) return
-        var index = defaultParameters.indexOf(parameter)
+        if (blockUpdate)
+            return ;
 
+        var index = defaultParameters.indexOf(parameter);
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValues[index] = value
+                startValues[index] = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValues[index] = value
+                endValues[index] = value;
             else
-                middleValues[index] = value
+                middleValues[index] = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(parameter)
-            button.checked = false
+            filter.resetProperty(parameter);
+            button.checked = false;
             if (filter.animateIn > 0) {
-                filter.set(parameter, startValues[index], 0)
-                filter.set(parameter, middleValues[index], filter.animateIn - 1)
+                filter.set(parameter, startValues[index], 0);
+                filter.set(parameter, middleValues[index], filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(parameter, middleValues[index], filter.duration - filter.animateOut)
-                filter.set(parameter, endValues[index], filter.duration - 1)
+                filter.set(parameter, middleValues[index], filter.duration - filter.animateOut);
+                filter.set(parameter, endValues[index], filter.duration - 1);
             }
         } else if (!button.checked) {
-            filter.resetProperty(parameter)
-            filter.set(parameter, middleValues[index])
+            filter.resetProperty(parameter);
+            filter.set(parameter, middleValues[index]);
         } else if (position !== null) {
-            filter.set(parameter, value, position)
+            filter.set(parameter, value, position);
         }
     }
 
     function onKeyframesButtonClicked(checked, parameter, value) {
         if (checked) {
-            blockUpdate = true
-            amountSlider.enabled = sizeSlider.enabled = true
+            blockUpdate = true;
+            amountSlider.enabled = sizeSlider.enabled = true;
             if (filter.animateIn > 0 || filter.animateOut > 0) {
-                filter.resetProperty(defaultParameters[0])
-                filter.resetProperty(defaultParameters[1])
-                filter.animateIn = filter.animateOut = 0
+                filter.resetProperty(defaultParameters[0]);
+                filter.resetProperty(defaultParameters[1]);
+                filter.animateIn = filter.animateOut = 0;
             } else {
-                filter.clearSimpleAnimation(parameter)
+                filter.clearSimpleAnimation(parameter);
             }
-            blockUpdate = false
-            filter.set(parameter, value, getPosition())
+            blockUpdate = false;
+            filter.set(parameter, value, getPosition());
         } else {
-            filter.resetProperty(parameter)
-            filter.set(parameter, value)
+            filter.resetProperty(parameter);
+            filter.set(parameter, value);
         }
+    }
+
+    function updateSimpleAnimation() {
+        setControls();
+        updateFilter(paramAmount, amountSlider.value / 100, null, amountKeyframesButton);
+        updateFilter(paramSize, sizeSlider.value / 100, null, sizeKeyframesButton);
+    }
+
+    width: 350
+    height: 100
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set(paramAmount, 0.5);
+            filter.set(paramSize, 0.5);
+            filter.savePreset(defaultParameters);
+        } else {
+            initSimpleAnimation();
+        }
+        setControls();
     }
 
     GridLayout {
         columns: 4
         anchors.fill: parent
         anchors.margins: 8
-        
+
         Label {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             Layout.columnSpan: 3
             parameters: defaultParameters
             onBeforePresetLoaded: {
-                filter.resetProperty(paramAmount)
-                filter.resetProperty(paramSize)
+                filter.resetProperty(paramAmount);
+                filter.resetProperty(paramSize);
             }
             onPresetSelected: {
-                setControls()
-                initSimpleAnimation()
+                setControls();
+                initSimpleAnimation();
             }
         }
 
@@ -148,65 +152,92 @@ Item {
             text: qsTr('Amount')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: amountSlider
+
             minimumValue: 0
             maximumValue: 100
             suffix: ' %'
             decimals: 1
-            onValueChanged: updateFilter(paramAmount, value / 100.0, getPosition(), amountKeyframesButton)
+            onValueChanged: updateFilter(paramAmount, value / 100, getPosition(), amountKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: amountSlider.value = 50
         }
+
         Shotcut.KeyframesButton {
             id: amountKeyframesButton
-            onToggled: onKeyframesButtonClicked(checked, paramAmount, amountSlider.value / 100.0)
+
+            onToggled: onKeyframesButtonClicked(checked, paramAmount, amountSlider.value / 100)
         }
 
         Label {
             text: qsTr('Size')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: sizeSlider
+
             minimumValue: 0
             maximumValue: 100
             suffix: ' %'
             decimals: 1
-            onValueChanged: updateFilter(paramSize, value / 100.0, getPosition(), sizeKeyframesButton)
+            onValueChanged: updateFilter(paramSize, value / 100, getPosition(), sizeKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: sizeSlider.value = 50
         }
+
         Shotcut.KeyframesButton {
             id: sizeKeyframesButton
-            onToggled: onKeyframesButtonClicked(checked, paramSize, sizeSlider.value / 100.0)
+
+            onToggled: onKeyframesButtonClicked(checked, paramSize, sizeSlider.value / 100)
         }
 
         Item {
             Layout.fillHeight: true
         }
-    }
 
-    function updateSimpleAnimation() {
-        setControls()
-        updateFilter(paramAmount, amountSlider.value / 100.0, null, amountKeyframesButton)
-        updateFilter(paramSize, sizeSlider.value / 100.0, null, sizeKeyframesButton)
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onOutChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleAnimation() }
-        function onOutChanged() { updateSimpleAnimation() }
-        function onAnimateInChanged() { updateSimpleAnimation() }
-        function onAnimateOutChanged() { updateSimpleAnimation() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/sharpen/ui_movit.qml
+++ b/src/qml/filters/sharpen/ui_movit.qml
@@ -21,136 +21,134 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    property var defaultParameters: ['circle_radius','gaussian_radius', 'correlation', 'noise']
+    property var defaultParameters: ['circle_radius', 'gaussian_radius', 'correlation', 'noise']
     property bool blockUpdate: true
-    property var startValues:  [0.0, 0.0, 0.0,  0.0 ]
-    property var middleValues: [2.0, 0.0, 0.95, 0.01]
-    property var endValues:    [0.0, 0.0, 0.0,  0.0 ]
-    width: 350
-    height: 150
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            filter.set('circle_radius', 2.0)
-            filter.set('gaussian_radius', 0.0)
-            filter.set('correlation', 0.95)
-            filter.set('noise', 0.01)
-            filter.savePreset(defaultParameters)
-        } else {
-            initSimpleAnimation()
-        }
-        setControls()
-    }
+    property var startValues: [0, 0, 0, 0]
+    property var middleValues: [2, 0, 0.95, 0.01]
+    property var endValues: [0, 0, 0, 0]
 
     function initSimpleAnimation() {
-        middleValues = [filter.getDouble(defaultParameters[0], filter.animateIn),
-                        filter.getDouble(defaultParameters[1], filter.animateIn),
-                        filter.getDouble(defaultParameters[2], filter.animateIn),
-                        filter.getDouble(defaultParameters[3], filter.animateIn)]
-        if (filter.animateIn > 0) {
-            startValues = [filter.getDouble(defaultParameters[0], 0),
-                           filter.getDouble(defaultParameters[1], 0),
-                           filter.getDouble(defaultParameters[2], 0),
-                           filter.getDouble(defaultParameters[3], 0)]
-        }
-        if (filter.animateOut > 0) {
-            endValues = [filter.getDouble(defaultParameters[0], filter.duration - 1),
-                         filter.getDouble(defaultParameters[1], filter.duration - 1),
-                         filter.getDouble(defaultParameters[2], filter.duration - 1),
-                         filter.getDouble(defaultParameters[3], filter.duration - 1)]
-        }
+        middleValues = [filter.getDouble(defaultParameters[0], filter.animateIn), filter.getDouble(defaultParameters[1], filter.animateIn), filter.getDouble(defaultParameters[2], filter.animateIn), filter.getDouble(defaultParameters[3], filter.animateIn)];
+        if (filter.animateIn > 0)
+            startValues = [filter.getDouble(defaultParameters[0], 0), filter.getDouble(defaultParameters[1], 0), filter.getDouble(defaultParameters[2], 0), filter.getDouble(defaultParameters[3], 0)];
+
+        if (filter.animateOut > 0)
+            endValues = [filter.getDouble(defaultParameters[0], filter.duration - 1), filter.getDouble(defaultParameters[1], filter.duration - 1), filter.getDouble(defaultParameters[2], filter.duration - 1), filter.getDouble(defaultParameters[3], filter.duration - 1)];
+
     }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        circleSlider.value = filter.getDouble("circle_radius", position)
-        circleKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('circle_radius') > 0
-        gaussianSlider.value = filter.getDouble("gaussian_radius", position)
-        gaussianKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('gaussian_radius') > 0
-        correlationSlider.value = filter.getDouble("correlation", position)
-        correlationKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('correlation') > 0
-        noiseSlider.value = filter.getDouble("noise", position)
-        noiseKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('noise') > 0
-        blockUpdate = false
-        circleSlider.enabled = gaussianSlider.enabled = correlationSlider.enabled = noiseSlider.enabled
-            = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        circleSlider.value = filter.getDouble("circle_radius", position);
+        circleKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('circle_radius') > 0;
+        gaussianSlider.value = filter.getDouble("gaussian_radius", position);
+        gaussianKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('gaussian_radius') > 0;
+        correlationSlider.value = filter.getDouble("correlation", position);
+        correlationKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('correlation') > 0;
+        noiseSlider.value = filter.getDouble("noise", position);
+        noiseKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('noise') > 0;
+        blockUpdate = false;
+        circleSlider.enabled = gaussianSlider.enabled = correlationSlider.enabled = noiseSlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function updateFilter(parameter, value, position, button) {
-        if (blockUpdate) return
-        var index = defaultParameters.indexOf(parameter)
+        if (blockUpdate)
+            return ;
 
+        var index = defaultParameters.indexOf(parameter);
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValues[index] = value
+                startValues[index] = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValues[index] = value
+                endValues[index] = value;
             else
-                middleValues[index] = value
+                middleValues[index] = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(parameter)
-            button.checked = false
+            filter.resetProperty(parameter);
+            button.checked = false;
             if (filter.animateIn > 0) {
-                filter.set(parameter, startValues[index], 0)
-                filter.set(parameter, middleValues[index], filter.animateIn - 1)
+                filter.set(parameter, startValues[index], 0);
+                filter.set(parameter, middleValues[index], filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(parameter, middleValues[index], filter.duration - filter.animateOut)
-                filter.set(parameter, endValues[index], filter.duration - 1)
+                filter.set(parameter, middleValues[index], filter.duration - filter.animateOut);
+                filter.set(parameter, endValues[index], filter.duration - 1);
             }
         } else if (!button.checked) {
-            filter.resetProperty(parameter)
-            filter.set(parameter, middleValues[index])
+            filter.resetProperty(parameter);
+            filter.set(parameter, middleValues[index]);
         } else if (position !== null) {
-            filter.set(parameter, value, position)
+            filter.set(parameter, value, position);
         }
     }
 
     function onKeyframesButtonClicked(checked, parameter, value) {
         if (checked) {
-            blockUpdate = true
-            circleSlider.enabled = gaussianSlider.enabled = correlationSlider.enabled = noiseSlider.enabled = true
+            blockUpdate = true;
+            circleSlider.enabled = gaussianSlider.enabled = correlationSlider.enabled = noiseSlider.enabled = true;
             if (filter.animateIn > 0 || filter.animateOut > 0) {
-                for (var i = 0; i < defaultParameters.length; i++)
-                    filter.resetProperty(defaultParameters[i])
-                filter.animateIn = filter.animateOut = 0
+                for (var i = 0; i < defaultParameters.length; i++) filter.resetProperty(defaultParameters[i])
+                filter.animateIn = filter.animateOut = 0;
             } else {
-                filter.clearSimpleAnimation(parameter)
+                filter.clearSimpleAnimation(parameter);
             }
-            blockUpdate = false
-            filter.set(parameter, value, getPosition())
+            blockUpdate = false;
+            filter.set(parameter, value, getPosition());
         } else {
-            filter.resetProperty(parameter)
-            filter.set(parameter, value)
+            filter.resetProperty(parameter);
+            filter.set(parameter, value);
         }
+    }
+
+    function updateSimpleAnimation() {
+        setControls();
+        updateFilter('circle_radius', circleSlider.value, null, circleKeyframesButton);
+        updateFilter('gaussian_radius', gaussianSlider.value, null, gaussianKeyframesButton);
+        updateFilter('correlation', correlationSlider.value, null, correlationKeyframesButton);
+        updateFilter('noise', noiseSlider.value, null, noiseKeyframesButton);
+    }
+
+    width: 350
+    height: 150
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            filter.set('circle_radius', 2);
+            filter.set('gaussian_radius', 0);
+            filter.set('correlation', 0.95);
+            filter.set('noise', 0.01);
+            filter.savePreset(defaultParameters);
+        } else {
+            initSimpleAnimation();
+        }
+        setControls();
     }
 
     GridLayout {
         columns: 4
         anchors.fill: parent
         anchors.margins: 8
-        
+
         Label {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             Layout.columnSpan: 3
             parameters: defaultParameters
             onBeforePresetLoaded: {
-                for (var i = 0; i < defaultParameters.length; i++)
-                    filter.resetProperty(defaultParameters[i])
+                for (var i = 0; i < defaultParameters.length; i++) filter.resetProperty(defaultParameters[i])
             }
             onPresetSelected: {
-                setControls()
-                initSimpleAnimation()
+                setControls();
+                initSimpleAnimation();
             }
         }
 
@@ -159,19 +157,24 @@ Item {
             text: qsTr('Circle radius')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: circleSlider
+
             minimumValue: 0
             maximumValue: 99.99
             decimals: 2
             stepSize: 0.1
             onValueChanged: updateFilter('circle_radius', value, getPosition(), circleKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: circleSlider.value = 2
         }
+
         Shotcut.KeyframesButton {
             id: circleKeyframesButton
+
             onToggled: onKeyframesButtonClicked(checked, 'circle_radius', circleSlider.value)
         }
 
@@ -180,19 +183,24 @@ Item {
             text: qsTr('Gaussian radius')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: gaussianSlider
+
             minimumValue: 0
             maximumValue: 99.99
             decimals: 2
             stepSize: 0.1
             onValueChanged: updateFilter('gaussian_radius', value, getPosition(), gaussianKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: gaussianSlider.value = 0
         }
+
         Shotcut.KeyframesButton {
             id: gaussianKeyframesButton
+
             onToggled: onKeyframesButtonClicked(checked, 'gaussian_radius', gaussianSlider.value)
         }
 
@@ -201,18 +209,23 @@ Item {
             text: qsTr('Correlation')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: correlationSlider
-            minimumValue: 0.0
-            maximumValue: 1.0
+
+            minimumValue: 0
+            maximumValue: 1
             decimals: 2
             onValueChanged: updateFilter('correlation', value, getPosition(), correlationKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: correlationSlider.value = 0.95
         }
+
         Shotcut.KeyframesButton {
             id: correlationKeyframesButton
+
             onToggled: onKeyframesButtonClicked(checked, 'correlation', correlationSlider.value)
         }
 
@@ -221,46 +234,66 @@ Item {
             text: qsTr('Noise')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: noiseSlider
-            minimumValue: 0.0
-            maximumValue: 1.0
+
+            minimumValue: 0
+            maximumValue: 1
             decimals: 2
             onValueChanged: updateFilter('noise', value, getPosition(), noiseKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: noiseSlider.value = 0.01
         }
+
         Shotcut.KeyframesButton {
             id: noiseKeyframesButton
+
             onToggled: onKeyframesButtonClicked(checked, 'noise', noiseSlider.value)
         }
 
         Item {
             Layout.fillHeight: true
         }
-    }
 
-    function updateSimpleAnimation() {
-        setControls()
-        updateFilter('circle_radius', circleSlider.value, null, circleKeyframesButton)
-        updateFilter('gaussian_radius', gaussianSlider.value, null, gaussianKeyframesButton)
-        updateFilter('correlation', correlationSlider.value, null, correlationKeyframesButton)
-        updateFilter('noise', noiseSlider.value, null, noiseKeyframesButton)
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onOutChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleAnimation() }
-        function onOutChanged() { updateSimpleAnimation() }
-        function onAnimateInChanged() { updateSimpleAnimation() }
-        function onAnimateOutChanged() { updateSimpleAnimation() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/size_position/SizePositionUI.qml
+++ b/src/qml/filters/size_position/SizePositionUI.qml
@@ -32,437 +32,410 @@ Item {
     property rect filterRect
     property string startValue: '_shotcut:startValue'
     property string middleValue: '_shotcut:middleValue'
-    property string endValue:  '_shotcut:endValue'
+    property string endValue: '_shotcut:endValue'
     property string rotationStartValue: '_shotcut:rotationStartValue'
     property string rotationMiddleValue: '_shotcut:rotationMiddleValue'
-    property string rotationEndValue:  '_shotcut:rotationEndValue'
+    property string rotationEndValue: '_shotcut:rotationEndValue'
     property bool blockUpdate: true
     property rect defaultRect
     property real aspectRatio: producer.displayAspectRatio
 
-    width: 425
-    height: 250
-
-    Component.onCompleted: {
-        if (rotationProperty) {
-            preset.parameters.push(rotationProperty)
-        }
-
-        filter.blockSignals = true
-        filter.set(middleValue, Qt.rect(0, 0, profile.width, profile.height))
-        filter.set(startValue, Qt.rect(0, 0, profile.width, profile.height))
-        filter.set(endValue, Qt.rect(0, 0, profile.width, profile.height))
-        // Compute the default rectangle used also for parameter undos
-        // Enforce the aspect ratio for fill mode
-        if (producer.displayAspectRatio > profile.aspectRatio) {
-            defaultRect.width = profile.width
-            defaultRect.height = defaultRect.width * profile.sar / producer.displayAspectRatio
-        } else {
-            defaultRect.height = profile.height
-            defaultRect.width = defaultRect.height / profile.sar * producer.displayAspectRatio
-        }
-        defaultRect.x = Math.round((profile.width - defaultRect.width) / 2)
-        defaultRect.y = Math.round((profile.height - defaultRect.height) / 2)
-        if (filter.isNew) {
-            filter.set(fillProperty, 0)
-            filter.set(distortProperty, 0)
-
-            filter.set(rectProperty,   '0%/50%:50%x50%')
-            filter.set(valignProperty, 'bottom')
-            filter.set(halignProperty, 'left')
-            filter.savePreset(preset.parameters, qsTr('Bottom Left'))
-
-            filter.set(rectProperty,   '50%/50%:50%x50%')
-            filter.set(valignProperty, 'bottom')
-            filter.set(halignProperty, 'right')
-            filter.savePreset(preset.parameters, qsTr('Bottom Right'))
-
-            filter.set(rectProperty,   '0%/0%:50%x50%')
-            filter.set(valignProperty, 'top')
-            filter.set(halignProperty, 'left')
-            filter.savePreset(preset.parameters, qsTr('Top Left'))
-
-            filter.set(rectProperty,   '50%/0%:50%x50%')
-            filter.set(valignProperty, 'top')
-            filter.set(halignProperty, 'right')
-            filter.savePreset(preset.parameters, qsTr('Top Right'))
-
-            // Add some animated presets.
-            filter.set(valignProperty, 'middle')
-            filter.set(halignProperty, 'center')
-            filter.animateIn = Math.round(profile.fps)
-            filter.set(rectProperty,   '0=-100%/0%:100%x100%; :1.0=0%/0%:100%x100%')
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slide In From Left'))
-            filter.set(rectProperty,   '0=100%/0%:100%x100%; :1.0=0%/0%:100%x100%')
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slide In From Right'))
-            filter.set(rectProperty,   '0=0%/-100%:100%x100%; :1.0=0%/0%:100%x100%')
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slide In From Top'))
-            filter.set(rectProperty,   '0=0%/100%:100%x100%; :1.0=0%/0%:100%x100%')
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slide In From Bottom'))
-            filter.animateIn = 0
-            filter.animateOut = Math.round(profile.fps)
-            filter.set(rectProperty,   ':-1.0=0%/0%:100%x100%; -1=-100%/0%:100%x100%')
-            filter.savePreset(preset.parameters.concat('shotcut:animOut'), qsTr('Slide Out Left'))
-            filter.set(rectProperty,   ':-1.0=0%/0%:100%x100%; -1=100%/0%:100%x100%')
-            filter.savePreset(preset.parameters.concat('shotcut:animOut'), qsTr('Slide Out Right'))
-            filter.set(rectProperty,   ':-1.0=0%/0%:100%x100%; -1=0%/-100%:100%x100%')
-            filter.savePreset(preset.parameters.concat('shotcut:animOut'), qsTr('Slide Out Top'))
-            filter.set(rectProperty,   ':-1.0=0%/0%:100%x100%; -1=0%/100%:100%x100%')
-            filter.savePreset(preset.parameters.concat('shotcut:animOut'), qsTr('Slide Out Bottom'))
-            filter.set(fillProperty, 1)
-            filter.animateOut = 0
-            filter.animateIn = filter.duration
-            filter.set(rectProperty,   '0=0%/0%:100%x100%; -1=-5%/-5%:110%x110%')
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom In'))
-            filter.set(rectProperty,   '0=-5%/-5%:110%x110%; -1=0%/0%:100%x100%')
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom Out'))
-            filter.set(rectProperty,   '0=-5%/-5%:110%x110%; -1=-10%/-5%:110%x110%')
-            filter.deletePreset(qsTr('Slow Pan Left'))
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Move Left'))
-            filter.set(rectProperty,   '0=-5%/-5%:110%x110%; -1=0%/-5%:110%x110%')
-            filter.deletePreset(qsTr('Slow Pan Right'))
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Move Right'))
-            filter.set(rectProperty,   '0=-5%/-5%:110%x110%; -1=-5%/-10%:110%x110%')
-            filter.deletePreset(qsTr('Slow Pan Up'))
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Move Up'))
-            filter.set(rectProperty,   '0=-5%/-5%:110%x110%; -1=-5%/0%:110%x110%')
-            filter.deletePreset(qsTr('Slow Pan Down'))
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Move Down'))
-            filter.set(rectProperty,   '0=0%/0%:100%x100%; -1=-10%/-10%:110%x110%')
-            filter.deletePreset(qsTr('Slow Zoom In, Pan Up Left'))
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom In, Move Up Left'))
-            filter.set(rectProperty,   '0=0%/0%:100%x100%; -1=0%/0%:110%x110%')
-            filter.deletePreset(qsTr('Slow Zoom In, Pan Down Right'))
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom In, Move Down Right'))
-            filter.set(rectProperty,   '0=-10%/0%:110%x110%; -1=0%/0%:100%x100%')
-            filter.deletePreset(qsTr('Slow Zoom Out, Pan Up Right'))
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom Out, Move Up Right'))
-            filter.set(rectProperty,   '0=0%/-10%:110%x110%; -1=0%/0%:100%x100%')
-            filter.deletePreset(qsTr('Slow Zoom Out, Pan Down Left'))
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom Out, Move Down Left'))
-            filter.set(rectProperty,   '0=0%/0%:100%x100%; -1=-5%/-10%:110%x110%')
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom In, Hold Bottom'))
-            filter.set(rectProperty,   '0=0%/0%:100%x100%; -1=-5%/0%:110%x110%')
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom In, Hold Top'))
-            filter.set(rectProperty,   '0=0%/0%:100%x100%; -1=0%/-5%:110%x110%')
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom In, Hold Left'))
-            filter.set(rectProperty,   '0=0%/0%:100%x100%; -1=-10%/-5%:110%x110%')
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom In, Hold Right'))
-            filter.set(rectProperty,   '0=-5%/-10%:110%x110%; -1=0%/0%:100%x100%')
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom Out, Hold Bottom'))
-            filter.set(rectProperty,   '0=-5%/0%:110%x110%; -1=0%/0%:100%x100%')
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom Out, Hold Top'))
-            filter.set(rectProperty,   '0=0%/-5%:110%x110%; -1=0%/0%:100%x100%')
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom Out, Hold Left'))
-            filter.set(rectProperty,   '0=-10%/-5%:110%x110%; -1=0%/0%:100%x100%')
-            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom Out, Hold Right'))
-            filter.animateIn = 0
-            filter.resetProperty(rectProperty)
-
-            filter.set('_shotcut:test_locale', 0.1)
-            if (filter.get('_shotcut:test_locale') === '0,1') {
-                filter.set(rectProperty,
-                      '00:00:00,000= -7,937%  -7,648% 115% 115%; 00:00:00,080= -7,781% -11,815% 115% 115%;'
-                    + '00:00:00,160= -0,094% -13,019% 115% 115%; 00:00:00,240= -7,313%  -9,037% 115% 115%;'
-                    + '00:00:00,320= -7,469% -13,760% 115% 115%; 00:00:00,400=-10,229%  -5,593% 115% 115%;'
-                    + '00:00:00,480= -6,615% -11,074% 115% 115%; 00:00:00,560= -5,031%  -6,074% 115% 115%;'
-                    + '00:00:00,640= -2,990%  -6,074% 115% 115%; 00:00:00,720= -3,260%  -3,574% 115% 115%;'
-                    + '00:00:00,800= -5,229%  -7,093% 115% 115%; 00:00:00,880= -5,906%  -3,574% 115% 115%;'
-                    + '00:00:00,960=-10,958%  -9,315% 115% 115%; 00:00:01,040= -7,500%  -7,500% 115% 115%')
-                filter.savePreset(preset.parameters, qsTr('Shake 1 Second - Scaled'))
-                filter.set(rectProperty,
-                     '00:00:00,000=  -0,437%  -0,148% 100% 100%; 00:00:00,080= -0,281%  -4,315% 100% 100%;'
-                   + '00:00:00,160=   7,406%  -5,519% 100% 100%; 00:00:00,240=  0,187%  -1,537% 100% 100%;'
-                   + '00:00:00,320=   0,031%  -6,260% 100% 100%; 00:00:00,400= -2,729%   1,907% 100% 100%;'
-                   + '00:00:00,480=   0,885%  -3,574% 100% 100%; 00:00:00,560=  2,469%   1,426% 100% 100%;'
-                   + '00:00:00,640=   4,510%   1,426% 100% 100%; 00:00:00,720=  4,240%   3,926% 100% 100%;'
-                   + '00:00:00,800=   2,271%   0,407% 100% 100%; 00:00:00,880=  1,594%   3,926% 100% 100%;'
-                   + '00:00:00,960=  -3,458%  -1,815% 100% 100%; 00:00:01,040=  0,000%   0,000% 100% 100%')
-                filter.savePreset(preset.parameters, qsTr('Shake 1 Second - Unscaled'))
-            } else {
-                filter.set(rectProperty,
-                      '00:00:00.000= -7.937%  -7.648% 115% 115%; 00:00:00.080= -7.781% -11.815% 115% 115%;'
-                    + '00:00:00.160= -0.094% -13.019% 115% 115%; 00:00:00.240= -7.313%  -9.037% 115% 115%;'
-                    + '00:00:00.320= -7.469% -13.760% 115% 115%; 00:00:00.400=-10.229%  -5.593% 115% 115%;'
-                    + '00:00:00.480= -6.615% -11.074% 115% 115%; 00:00:00.560= -5.031%  -6.074% 115% 115%;'
-                    + '00:00:00.640= -2.990%  -6.074% 115% 115%; 00:00:00.720= -3.260%  -3.574% 115% 115%;'
-                    + '00:00:00.800= -5.229%  -7.093% 115% 115%; 00:00:00.880= -5.906%  -3.574% 115% 115%;'
-                    + '00:00:00.960=-10.958%  -9.315% 115% 115%; 00:00:01.040= -7.500%  -7.500% 115% 115%')
-                filter.savePreset(preset.parameters, qsTr('Shake 1 Second - Scaled'))
-                filter.set(rectProperty,
-                     '00:00:00.000=  -0.437%  -0.148% 100% 100%; 00:00:00.080= -0.281%  -4.315% 100% 100%;'
-                   + '00:00:00.160=   7.406%  -5.519% 100% 100%; 00:00:00.240=  0.187%  -1.537% 100% 100%;'
-                   + '00:00:00.320=   0.031%  -6.260% 100% 100%; 00:00:00.400= -2.729%   1.907% 100% 100%;'
-                   + '00:00:00.480=   0.885%  -3.574% 100% 100%; 00:00:00.560=  2.469%   1.426% 100% 100%;'
-                   + '00:00:00.640=   4.510%   1.426% 100% 100%; 00:00:00.720=  4.240%   3.926% 100% 100%;'
-                   + '00:00:00.800=   2.271%   0.407% 100% 100%; 00:00:00.880=  1.594%   3.926% 100% 100%;'
-                   + '00:00:00.960=  -3.458%  -1.815% 100% 100%; 00:00:01.040=  0.000%   0.000% 100% 100%')
-                filter.savePreset(preset.parameters, qsTr('Shake 1 Second - Unscaled'))
-            }
-            filter.resetProperty('_shotcut:test_locale')
-            filter.resetProperty(rectProperty)
-
-            // Add default preset.
-            if (backgroundProperty)
-                filter.set(backgroundProperty, 'color:#00000000')
-            filter.set(rectProperty, defaultRect)
-            filter.get(rectProperty)
-            filter.savePreset(preset.parameters)
-        } else {
-            if (legacyRectProperty !== '') {
-                var old = filter.get(legacyRectProperty)
-                if (old && old.length > 0) {
-                    filter.resetProperty(legacyRectProperty)
-                    filter.set(rectProperty, old)
-                }
-            }
-            filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1))
-            if (filter.animateIn > 0)
-                filter.set(startValue, filter.getRect(rectProperty, 0))
-            if (filter.animateOut > 0)
-                filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1))
-            filter.set(rotationMiddleValue, filter.getDouble(rotationProperty, filter.animateIn + 1))
-            if (filter.animateIn > 0)
-                filter.set(rotationStartValue, filter.getDouble(rotationProperty, 0))
-            if (filter.animateOut > 0)
-                filter.set(rotationEndValue, filter.getRect(rotationProperty, filter.duration - 1))
-        }
-        updateAspectRatio()
-        filter.blockSignals = false
-        setControls()
-        setKeyframedControls()
-        if (filter.isNew)
-            setFilter(getPosition())
-    }
-
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function isFitMode() {
-        return filter.get(fillProperty) === '0' && filter.get(distortProperty) === '0'
+        return filter.get(fillProperty) === '0' && filter.get(distortProperty) === '0';
     }
 
     function isFillMode() {
-        return filter.get(fillProperty) === '1' && filter.get(distortProperty) !== '1'
+        return filter.get(fillProperty) === '1' && filter.get(distortProperty) !== '1';
     }
 
     function updateAspectRatio() {
         if (filter.get(fillProperty) === '1' && filter.get(distortProperty) === '0') {
-            aspectRatio = producer.displayAspectRatio
+            aspectRatio = producer.displayAspectRatio;
         } else {
-            var rect = filter.getRect(rectProperty, getPosition())
-            aspectRatio = rect.width / Math.max(rect.height, 1)
+            var rect = filter.getRect(rectProperty, getPosition());
+            aspectRatio = rect.width / Math.max(rect.height, 1);
         }
     }
 
     function setFilter(position) {
         if (position !== null) {
-            filter.blockSignals = true
+            filter.blockSignals = true;
             if (position <= 0 && filter.animateIn > 0)
-                filter.set(startValue, filterRect)
+                filter.set(startValue, filterRect);
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                filter.set(endValue, filterRect)
+                filter.set(endValue, filterRect);
             else
-                filter.set(middleValue, filterRect)
-            filter.blockSignals = false
+                filter.set(middleValue, filterRect);
+            filter.blockSignals = false;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(rectProperty)
-            positionKeyframesButton.checked = false
+            filter.resetProperty(rectProperty);
+            positionKeyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set(rectProperty, filter.getRect(startValue), 0)
-                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1)
+                filter.set(rectProperty, filter.getRect(startValue), 0);
+                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut)
-                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1)
+                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut);
+                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1);
             }
         } else if (!positionKeyframesButton.checked) {
-            filter.resetProperty(rectProperty)
-            filter.set(rectProperty, filter.getRect(middleValue))
+            filter.resetProperty(rectProperty);
+            filter.set(rectProperty, filter.getRect(middleValue));
         } else if (position !== null) {
-            filter.set(rectProperty, filterRect, position)
+            filter.set(rectProperty, filterRect, position);
         }
     }
 
     function updateRotation(position) {
-        if (blockUpdate) return
-        if (position !== null) {
-            filter.blockSignals = true
-            if (position <= 0 && filter.animateIn > 0) {
-                filter.set(rotationStartValue, rotationSlider.value)
-            } else if (position >= filter.duration - 1 && filter.animateOut > 0) {
-                filter.set(rotationEndValue, rotationSlider.value)
-            } else {
-                filter.set(rotationMiddleValue, rotationSlider.value)
-            }
-            filter.blockSignals = false
-        }
+        if (blockUpdate)
+            return ;
 
+        if (position !== null) {
+            filter.blockSignals = true;
+            if (position <= 0 && filter.animateIn > 0)
+                filter.set(rotationStartValue, rotationSlider.value);
+            else if (position >= filter.duration - 1 && filter.animateOut > 0)
+                filter.set(rotationEndValue, rotationSlider.value);
+            else
+                filter.set(rotationMiddleValue, rotationSlider.value);
+            filter.blockSignals = false;
+        }
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(rotationProperty)
-            rotationKeyframesButton.checked = false
+            filter.resetProperty(rotationProperty);
+            rotationKeyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set(rotationProperty, filter.getDouble(rotationStartValue), 0)
-                filter.set(rotationProperty, filter.getDouble(rotationMiddleValue), filter.animateIn - 1)
+                filter.set(rotationProperty, filter.getDouble(rotationStartValue), 0);
+                filter.set(rotationProperty, filter.getDouble(rotationMiddleValue), filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(rotationProperty, filter.getDouble(rotationMiddleValue), filter.duration - filter.animateOut)
-                filter.set(rotationProperty, filter.getDouble(rotationEndValue), filter.duration - 1)
+                filter.set(rotationProperty, filter.getDouble(rotationMiddleValue), filter.duration - filter.animateOut);
+                filter.set(rotationProperty, filter.getDouble(rotationEndValue), filter.duration - 1);
             }
         } else if (!rotationKeyframesButton.checked) {
-            filter.resetProperty(rotationProperty)
-            filter.set(rotationProperty, filter.getDouble(rotationMiddleValue))
+            filter.resetProperty(rotationProperty);
+            filter.set(rotationProperty, filter.getDouble(rotationMiddleValue));
         } else if (position !== null) {
-            filter.set(rotationProperty, rotationSlider.value, position)
+            filter.set(rotationProperty, rotationSlider.value, position);
         }
     }
 
     function setControls() {
         if (filter.get(distortProperty) === '1')
-            distortRadioButton.checked = true
+            distortRadioButton.checked = true;
         else if (filter.get(fillProperty) === '1')
-            fillRadioButton.checked = true
+            fillRadioButton.checked = true;
         else
-            fitRadioButton.checked = true
-        var align = filter.get(halignProperty)
+            fitRadioButton.checked = true;
+        var align = filter.get(halignProperty);
         if (align === 'left')
-            leftRadioButton.checked = true
+            leftRadioButton.checked = true;
         else if (align === 'center' || align === 'middle')
-            centerRadioButton.checked = true
+            centerRadioButton.checked = true;
         else if (align === 'right')
-            rightRadioButton.checked = true
-        align = filter.get(valignProperty)
+            rightRadioButton.checked = true;
+        align = filter.get(valignProperty);
         if (align === 'top')
-            topRadioButton.checked = true
+            topRadioButton.checked = true;
         else if (align === 'center' || align === 'middle')
-            middleRadioButton.checked = true
+            middleRadioButton.checked = true;
         else if (align === 'bottom')
-            bottomRadioButton.checked = true
+            bottomRadioButton.checked = true;
         if (backgroundProperty) {
-            var s = filter.get(backgroundProperty)
+            var s = filter.get(backgroundProperty);
             if (s.substring(0, 6) === 'color:')
-                bgColor.value = s.substring(6)
-            else if  (s.substring(0, 7) === 'colour:')
-                bgColor.value = s.substring(7)
+                bgColor.value = s.substring(6);
+            else if (s.substring(0, 7) === 'colour:')
+                bgColor.value = s.substring(7);
         }
     }
 
     function isSimpleKeyframesActive() {
-        var position = getPosition()
-        return  position <= 0
-            || (position >= (filter.animateIn - 1) &&
-                position <= (filter.duration - filter.animateOut))
-            ||  position >= (filter.duration - 1)
+        var position = getPosition();
+        return position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function setKeyframedControls() {
-        var enabled = isSimpleKeyframesActive()
-        var position = getPosition()
-        var newValue = filter.getRect(rectProperty, position)
+        var enabled = isSimpleKeyframesActive();
+        var position = getPosition();
+        var newValue = filter.getRect(rectProperty, position);
         if (filterRect !== newValue) {
-            updateAspectRatio()
+            updateAspectRatio();
             if (isFillMode()) {
                 // enforce the aspect ratio
-                if (producer.displayAspectRatio > profile.aspectRatio) {
-                    newValue.height = newValue.width * profile.sar / producer.displayAspectRatio
-                } else {
-                    newValue.width = newValue.height / profile.sar * producer.displayAspectRatio
-                }
+                if (producer.displayAspectRatio > profile.aspectRatio)
+                    newValue.height = newValue.width * profile.sar / producer.displayAspectRatio;
+                else
+                    newValue.width = newValue.height / profile.sar * producer.displayAspectRatio;
             }
-            filterRect = newValue
-            rectX.value = filterRect.x.toFixed()
-            rectY.value = filterRect.y.toFixed()
-            rectW.value = filterRect.width.toFixed()
-            rectH.value = filterRect.height.toFixed()
-            blockUpdate = true
-            scaleSlider.update()
+            filterRect = newValue;
+            rectX.value = filterRect.x.toFixed();
+            rectY.value = filterRect.y.toFixed();
+            rectW.value = filterRect.width.toFixed();
+            rectH.value = filterRect.height.toFixed();
+            blockUpdate = true;
+            scaleSlider.update();
         }
-        positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
+        positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
         if (rotationProperty) {
-            blockUpdate = true
-            rotationSlider.value = filter.getDouble(rotationProperty, position)
-            rotationSlider.enabled = enabled
-            rotationKeyframesButton.checked = filter.keyframeCount(rotationProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
+            blockUpdate = true;
+            rotationSlider.value = filter.getDouble(rotationProperty, position);
+            rotationSlider.enabled = enabled;
+            rotationKeyframesButton.checked = filter.keyframeCount(rotationProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
         }
-        blockUpdate = false
-        rectX.enabled = enabled
-        rectY.enabled = enabled
-        rectW.enabled = enabled
-        rectH.enabled = enabled
+        blockUpdate = false;
+        rectX.enabled = enabled;
+        rectY.enabled = enabled;
+        rectW.enabled = enabled;
+        rectH.enabled = enabled;
     }
 
     function toggleKeyframes(isEnabled, parameter, value) {
         if (isEnabled) {
-            blockUpdate = true
+            blockUpdate = true;
             if (filter.animateIn > 0 || filter.animateOut > 0) {
                 // Reset all of the simple keyframes.
-                resetSimpleKeyframes()
-                filter.animateIn = 0
-                blockUpdate = false
-                filter.animateOut = 0
+                resetSimpleKeyframes();
+                filter.animateIn = 0;
+                blockUpdate = false;
+                filter.animateOut = 0;
             } else {
-                filter.clearSimpleAnimation(parameter)
-                blockUpdate = false
+                filter.clearSimpleAnimation(parameter);
+                blockUpdate = false;
             }
             // Set this keyframe value.
-            filter.set(parameter, value, getPosition())
+            filter.set(parameter, value, getPosition());
         } else {
             // Remove keyframes and set the parameter.
-            filter.resetProperty(parameter)
-            filter.set(parameter, value)
+            filter.resetProperty(parameter);
+            filter.set(parameter, value);
         }
     }
 
     function scaleByWidth(value) {
-        var centerX = filterRect.x + filterRect.width / 2
-        var rightX = filterRect.x + filterRect.width
-        filterRect.width = value
-        if (centerRadioButton.checked) {
-            filterRect.x = rectX.value = centerX - filterRect.width / 2
-        } else if (rightRadioButton.checked) {
-            filterRect.x = rectX.value = rightX - filterRect.width
-        }
-        var middleY = filterRect.y + filterRect.height / 2
-        var bottomY = filterRect.y + filterRect.height
-        filterRect.height = rectH.value = value / Math.max(aspectRatio, 1.0e-6)
-        if (middleRadioButton.checked) {
-            filterRect.y = rectY.value = middleY - filterRect.height / 2
-        }
-        else if (bottomRadioButton.checked) {
-            filterRect.y = rectY.value = bottomY - filterRect.height
-        }
-        scaleSlider.update()
-        setFilter(getPosition())
+        var centerX = filterRect.x + filterRect.width / 2;
+        var rightX = filterRect.x + filterRect.width;
+        filterRect.width = value;
+        if (centerRadioButton.checked)
+            filterRect.x = rectX.value = centerX - filterRect.width / 2;
+        else if (rightRadioButton.checked)
+            filterRect.x = rectX.value = rightX - filterRect.width;
+        var middleY = filterRect.y + filterRect.height / 2;
+        var bottomY = filterRect.y + filterRect.height;
+        filterRect.height = rectH.value = value / Math.max(aspectRatio, 1e-06);
+        if (middleRadioButton.checked)
+            filterRect.y = rectY.value = middleY - filterRect.height / 2;
+        else if (bottomRadioButton.checked)
+            filterRect.y = rectY.value = bottomY - filterRect.height;
+        scaleSlider.update();
+        setFilter(getPosition());
     }
 
     function scaleByHeight(value) {
-        var middleY = filterRect.y + filterRect.height / 2
-        var bottomY = filterRect.y + filterRect.height
-        filterRect.height = value
-        if (middleRadioButton.checked) {
-            filterRect.y = rectY.value = middleY - filterRect.height / 2
-        } else if (bottomRadioButton.checked) {
-            filterRect.y = rectY.value = bottomY - filterRect.height
-        }
-        var centerX = filterRect.x + filterRect.width / 2
-        var rightX = filterRect.x + filterRect.width
-        filterRect.width = rectW.value = value * aspectRatio
-        if (centerRadioButton.checked) {
-            filterRect.x = rectX.value = centerX - filterRect.width / 2
-        }
-        else if (rightRadioButton.checked) {
-            filterRect.x = rectX.value = rightX - filterRect.width
-        }
-        scaleSlider.update()
-        setFilter(getPosition())
+        var middleY = filterRect.y + filterRect.height / 2;
+        var bottomY = filterRect.y + filterRect.height;
+        filterRect.height = value;
+        if (middleRadioButton.checked)
+            filterRect.y = rectY.value = middleY - filterRect.height / 2;
+        else if (bottomRadioButton.checked)
+            filterRect.y = rectY.value = bottomY - filterRect.height;
+        var centerX = filterRect.x + filterRect.width / 2;
+        var rightX = filterRect.x + filterRect.width;
+        filterRect.width = rectW.value = value * aspectRatio;
+        if (centerRadioButton.checked)
+            filterRect.x = rectX.value = centerX - filterRect.width / 2;
+        else if (rightRadioButton.checked)
+            filterRect.x = rectX.value = rightX - filterRect.width;
+        scaleSlider.update();
+        setFilter(getPosition());
     }
 
-    ButtonGroup { id: sizeGroup }
-    ButtonGroup { id: halignGroup }
-    ButtonGroup { id: valignGroup }
+    function updateSimpleKeyframes() {
+        if (rotationProperty)
+            updateRotation(null);
+
+        setFilter(null);
+    }
+
+    width: 425
+    height: 250
+    Component.onCompleted: {
+        if (rotationProperty)
+            preset.parameters.push(rotationProperty);
+
+        filter.blockSignals = true;
+        filter.set(middleValue, Qt.rect(0, 0, profile.width, profile.height));
+        filter.set(startValue, Qt.rect(0, 0, profile.width, profile.height));
+        filter.set(endValue, Qt.rect(0, 0, profile.width, profile.height));
+        // Compute the default rectangle used also for parameter undos
+        // Enforce the aspect ratio for fill mode
+        if (producer.displayAspectRatio > profile.aspectRatio) {
+            defaultRect.width = profile.width;
+            defaultRect.height = defaultRect.width * profile.sar / producer.displayAspectRatio;
+        } else {
+            defaultRect.height = profile.height;
+            defaultRect.width = defaultRect.height / profile.sar * producer.displayAspectRatio;
+        }
+        defaultRect.x = Math.round((profile.width - defaultRect.width) / 2);
+        defaultRect.y = Math.round((profile.height - defaultRect.height) / 2);
+        if (filter.isNew) {
+            filter.set(fillProperty, 0);
+            filter.set(distortProperty, 0);
+            filter.set(rectProperty, '0%/50%:50%x50%');
+            filter.set(valignProperty, 'bottom');
+            filter.set(halignProperty, 'left');
+            filter.savePreset(preset.parameters, qsTr('Bottom Left'));
+            filter.set(rectProperty, '50%/50%:50%x50%');
+            filter.set(valignProperty, 'bottom');
+            filter.set(halignProperty, 'right');
+            filter.savePreset(preset.parameters, qsTr('Bottom Right'));
+            filter.set(rectProperty, '0%/0%:50%x50%');
+            filter.set(valignProperty, 'top');
+            filter.set(halignProperty, 'left');
+            filter.savePreset(preset.parameters, qsTr('Top Left'));
+            filter.set(rectProperty, '50%/0%:50%x50%');
+            filter.set(valignProperty, 'top');
+            filter.set(halignProperty, 'right');
+            filter.savePreset(preset.parameters, qsTr('Top Right'));
+            // Add some animated presets.
+            filter.set(valignProperty, 'middle');
+            filter.set(halignProperty, 'center');
+            filter.animateIn = Math.round(profile.fps);
+            filter.set(rectProperty, '0=-100%/0%:100%x100%; :1.0=0%/0%:100%x100%');
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slide In From Left'));
+            filter.set(rectProperty, '0=100%/0%:100%x100%; :1.0=0%/0%:100%x100%');
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slide In From Right'));
+            filter.set(rectProperty, '0=0%/-100%:100%x100%; :1.0=0%/0%:100%x100%');
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slide In From Top'));
+            filter.set(rectProperty, '0=0%/100%:100%x100%; :1.0=0%/0%:100%x100%');
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slide In From Bottom'));
+            filter.animateIn = 0;
+            filter.animateOut = Math.round(profile.fps);
+            filter.set(rectProperty, ':-1.0=0%/0%:100%x100%; -1=-100%/0%:100%x100%');
+            filter.savePreset(preset.parameters.concat('shotcut:animOut'), qsTr('Slide Out Left'));
+            filter.set(rectProperty, ':-1.0=0%/0%:100%x100%; -1=100%/0%:100%x100%');
+            filter.savePreset(preset.parameters.concat('shotcut:animOut'), qsTr('Slide Out Right'));
+            filter.set(rectProperty, ':-1.0=0%/0%:100%x100%; -1=0%/-100%:100%x100%');
+            filter.savePreset(preset.parameters.concat('shotcut:animOut'), qsTr('Slide Out Top'));
+            filter.set(rectProperty, ':-1.0=0%/0%:100%x100%; -1=0%/100%:100%x100%');
+            filter.savePreset(preset.parameters.concat('shotcut:animOut'), qsTr('Slide Out Bottom'));
+            filter.set(fillProperty, 1);
+            filter.animateOut = 0;
+            filter.animateIn = filter.duration;
+            filter.set(rectProperty, '0=0%/0%:100%x100%; -1=-5%/-5%:110%x110%');
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom In'));
+            filter.set(rectProperty, '0=-5%/-5%:110%x110%; -1=0%/0%:100%x100%');
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom Out'));
+            filter.set(rectProperty, '0=-5%/-5%:110%x110%; -1=-10%/-5%:110%x110%');
+            filter.deletePreset(qsTr('Slow Pan Left'));
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Move Left'));
+            filter.set(rectProperty, '0=-5%/-5%:110%x110%; -1=0%/-5%:110%x110%');
+            filter.deletePreset(qsTr('Slow Pan Right'));
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Move Right'));
+            filter.set(rectProperty, '0=-5%/-5%:110%x110%; -1=-5%/-10%:110%x110%');
+            filter.deletePreset(qsTr('Slow Pan Up'));
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Move Up'));
+            filter.set(rectProperty, '0=-5%/-5%:110%x110%; -1=-5%/0%:110%x110%');
+            filter.deletePreset(qsTr('Slow Pan Down'));
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Move Down'));
+            filter.set(rectProperty, '0=0%/0%:100%x100%; -1=-10%/-10%:110%x110%');
+            filter.deletePreset(qsTr('Slow Zoom In, Pan Up Left'));
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom In, Move Up Left'));
+            filter.set(rectProperty, '0=0%/0%:100%x100%; -1=0%/0%:110%x110%');
+            filter.deletePreset(qsTr('Slow Zoom In, Pan Down Right'));
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom In, Move Down Right'));
+            filter.set(rectProperty, '0=-10%/0%:110%x110%; -1=0%/0%:100%x100%');
+            filter.deletePreset(qsTr('Slow Zoom Out, Pan Up Right'));
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom Out, Move Up Right'));
+            filter.set(rectProperty, '0=0%/-10%:110%x110%; -1=0%/0%:100%x100%');
+            filter.deletePreset(qsTr('Slow Zoom Out, Pan Down Left'));
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom Out, Move Down Left'));
+            filter.set(rectProperty, '0=0%/0%:100%x100%; -1=-5%/-10%:110%x110%');
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom In, Hold Bottom'));
+            filter.set(rectProperty, '0=0%/0%:100%x100%; -1=-5%/0%:110%x110%');
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom In, Hold Top'));
+            filter.set(rectProperty, '0=0%/0%:100%x100%; -1=0%/-5%:110%x110%');
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom In, Hold Left'));
+            filter.set(rectProperty, '0=0%/0%:100%x100%; -1=-10%/-5%:110%x110%');
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom In, Hold Right'));
+            filter.set(rectProperty, '0=-5%/-10%:110%x110%; -1=0%/0%:100%x100%');
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom Out, Hold Bottom'));
+            filter.set(rectProperty, '0=-5%/0%:110%x110%; -1=0%/0%:100%x100%');
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom Out, Hold Top'));
+            filter.set(rectProperty, '0=0%/-5%:110%x110%; -1=0%/0%:100%x100%');
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom Out, Hold Left'));
+            filter.set(rectProperty, '0=-10%/-5%:110%x110%; -1=0%/0%:100%x100%');
+            filter.savePreset(preset.parameters.concat('shotcut:animIn'), qsTr('Slow Zoom Out, Hold Right'));
+            filter.animateIn = 0;
+            filter.resetProperty(rectProperty);
+            filter.set('_shotcut:test_locale', 0.1);
+            if (filter.get('_shotcut:test_locale') === '0,1') {
+                filter.set(rectProperty, '00:00:00,000= -7,937%  -7,648% 115% 115%; 00:00:00,080= -7,781% -11,815% 115% 115%;' + '00:00:00,160= -0,094% -13,019% 115% 115%; 00:00:00,240= -7,313%  -9,037% 115% 115%;' + '00:00:00,320= -7,469% -13,760% 115% 115%; 00:00:00,400=-10,229%  -5,593% 115% 115%;' + '00:00:00,480= -6,615% -11,074% 115% 115%; 00:00:00,560= -5,031%  -6,074% 115% 115%;' + '00:00:00,640= -2,990%  -6,074% 115% 115%; 00:00:00,720= -3,260%  -3,574% 115% 115%;' + '00:00:00,800= -5,229%  -7,093% 115% 115%; 00:00:00,880= -5,906%  -3,574% 115% 115%;' + '00:00:00,960=-10,958%  -9,315% 115% 115%; 00:00:01,040= -7,500%  -7,500% 115% 115%');
+                filter.savePreset(preset.parameters, qsTr('Shake 1 Second - Scaled'));
+                filter.set(rectProperty, '00:00:00,000=  -0,437%  -0,148% 100% 100%; 00:00:00,080= -0,281%  -4,315% 100% 100%;' + '00:00:00,160=   7,406%  -5,519% 100% 100%; 00:00:00,240=  0,187%  -1,537% 100% 100%;' + '00:00:00,320=   0,031%  -6,260% 100% 100%; 00:00:00,400= -2,729%   1,907% 100% 100%;' + '00:00:00,480=   0,885%  -3,574% 100% 100%; 00:00:00,560=  2,469%   1,426% 100% 100%;' + '00:00:00,640=   4,510%   1,426% 100% 100%; 00:00:00,720=  4,240%   3,926% 100% 100%;' + '00:00:00,800=   2,271%   0,407% 100% 100%; 00:00:00,880=  1,594%   3,926% 100% 100%;' + '00:00:00,960=  -3,458%  -1,815% 100% 100%; 00:00:01,040=  0,000%   0,000% 100% 100%');
+                filter.savePreset(preset.parameters, qsTr('Shake 1 Second - Unscaled'));
+            } else {
+                filter.set(rectProperty, '00:00:00.000= -7.937%  -7.648% 115% 115%; 00:00:00.080= -7.781% -11.815% 115% 115%;' + '00:00:00.160= -0.094% -13.019% 115% 115%; 00:00:00.240= -7.313%  -9.037% 115% 115%;' + '00:00:00.320= -7.469% -13.760% 115% 115%; 00:00:00.400=-10.229%  -5.593% 115% 115%;' + '00:00:00.480= -6.615% -11.074% 115% 115%; 00:00:00.560= -5.031%  -6.074% 115% 115%;' + '00:00:00.640= -2.990%  -6.074% 115% 115%; 00:00:00.720= -3.260%  -3.574% 115% 115%;' + '00:00:00.800= -5.229%  -7.093% 115% 115%; 00:00:00.880= -5.906%  -3.574% 115% 115%;' + '00:00:00.960=-10.958%  -9.315% 115% 115%; 00:00:01.040= -7.500%  -7.500% 115% 115%');
+                filter.savePreset(preset.parameters, qsTr('Shake 1 Second - Scaled'));
+                filter.set(rectProperty, '00:00:00.000=  -0.437%  -0.148% 100% 100%; 00:00:00.080= -0.281%  -4.315% 100% 100%;' + '00:00:00.160=   7.406%  -5.519% 100% 100%; 00:00:00.240=  0.187%  -1.537% 100% 100%;' + '00:00:00.320=   0.031%  -6.260% 100% 100%; 00:00:00.400= -2.729%   1.907% 100% 100%;' + '00:00:00.480=   0.885%  -3.574% 100% 100%; 00:00:00.560=  2.469%   1.426% 100% 100%;' + '00:00:00.640=   4.510%   1.426% 100% 100%; 00:00:00.720=  4.240%   3.926% 100% 100%;' + '00:00:00.800=   2.271%   0.407% 100% 100%; 00:00:00.880=  1.594%   3.926% 100% 100%;' + '00:00:00.960=  -3.458%  -1.815% 100% 100%; 00:00:01.040=  0.000%   0.000% 100% 100%');
+                filter.savePreset(preset.parameters, qsTr('Shake 1 Second - Unscaled'));
+            }
+            filter.resetProperty('_shotcut:test_locale');
+            filter.resetProperty(rectProperty);
+            // Add default preset.
+            if (backgroundProperty)
+                filter.set(backgroundProperty, 'color:#00000000');
+
+            filter.set(rectProperty, defaultRect);
+            filter.get(rectProperty);
+            filter.savePreset(preset.parameters);
+        } else {
+            if (legacyRectProperty !== '') {
+                var old = filter.get(legacyRectProperty);
+                if (old && old.length > 0) {
+                    filter.resetProperty(legacyRectProperty);
+                    filter.set(rectProperty, old);
+                }
+            }
+            filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1));
+            if (filter.animateIn > 0)
+                filter.set(startValue, filter.getRect(rectProperty, 0));
+
+            if (filter.animateOut > 0)
+                filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1));
+
+            filter.set(rotationMiddleValue, filter.getDouble(rotationProperty, filter.animateIn + 1));
+            if (filter.animateIn > 0)
+                filter.set(rotationStartValue, filter.getDouble(rotationProperty, 0));
+
+            if (filter.animateOut > 0)
+                filter.set(rotationEndValue, filter.getRect(rotationProperty, filter.duration - 1));
+
+        }
+        updateAspectRatio();
+        filter.blockSignals = false;
+        setControls();
+        setKeyframedControls();
+        if (filter.isNew)
+            setFilter(getPosition());
+
+    }
+
+    ButtonGroup {
+        id: sizeGroup
+    }
+
+    ButtonGroup {
+        id: halignGroup
+    }
+
+    ButtonGroup {
+        id: valignGroup
+    }
 
     GridLayout {
         columns: 6
@@ -473,31 +446,37 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [fillProperty, distortProperty, rectProperty, halignProperty, valignProperty]
             Layout.columnSpan: 5
             onBeforePresetLoaded: {
-                filter.resetProperty(rectProperty)
-                filter.resetProperty(rotationProperty)
+                filter.resetProperty(rectProperty);
+                filter.resetProperty(rotationProperty);
             }
             onPresetSelected: {
-                filter.removeRectPercents(rectProperty)
-                setControls()
-                setKeyframedControls()
-                positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-                filter.blockSignals = true
-                filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1))
+                filter.removeRectPercents(rectProperty);
+                setControls();
+                setKeyframedControls();
+                positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+                filter.blockSignals = true;
+                filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1));
                 if (filter.animateIn > 0)
-                    filter.set(startValue, filter.getRect(rectProperty, 0))
+                    filter.set(startValue, filter.getRect(rectProperty, 0));
+
                 if (filter.animateOut > 0)
-                    filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1))
-                filter.set(rotationMiddleValue, filter.getDouble(rotationProperty, filter.animateIn + 1))
+                    filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1));
+
+                filter.set(rotationMiddleValue, filter.getDouble(rotationProperty, filter.animateIn + 1));
                 if (filter.animateIn > 0)
-                    filter.set(rotationStartValue, filter.getDouble(rotationProperty, 0))
+                    filter.set(rotationStartValue, filter.getDouble(rotationProperty, 0));
+
                 if (filter.animateOut > 0)
-                    filter.set(rotationEndValue, filter.getRect(rotationProperty, filter.duration - 1))
-                filter.blockSignals = false
+                    filter.set(rotationEndValue, filter.getRect(rotationProperty, filter.duration - 1));
+
+                filter.blockSignals = false;
             }
         }
 
@@ -505,133 +484,167 @@ Item {
             text: qsTr('Position')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Layout.columnSpan: 3
+
             Shotcut.DoubleSpinBox {
                 id: rectX
+
                 horizontalAlignment: Qt.AlignRight
                 Layout.minimumWidth: 100
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
+                from: -1e+09
+                to: 1e+09
                 onValueModified: {
                     if (Math.abs(filterRect.x - value) >= 1) {
-                        filterRect.x = value
-                        setFilter(getPosition())
+                        filterRect.x = value;
+                        setFilter(getPosition());
                     }
                 }
             }
-            Label { text: ','; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: ','
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectY
+
                 horizontalAlignment: Qt.AlignRight
                 Layout.minimumWidth: 100
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
+                from: -1e+09
+                to: 1e+09
                 onValueModified: {
                     if (Math.abs(filterRect.y - value) >= 1) {
-                        filterRect.y = value
-                        setFilter(getPosition())
+                        filterRect.y = value;
+                        setFilter(getPosition());
                     }
                 }
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filterRect.x = rectX.value = defaultRect.x
-                filterRect.y = rectY.value = defaultRect.y
-                setFilter(getPosition())
+                filterRect.x = rectX.value = defaultRect.x;
+                filterRect.y = rectY.value = defaultRect.y;
+                setFilter(getPosition());
             }
         }
+
         ColumnLayout {
             Layout.rowSpan: 3
             height: positionKeyframesButton.height * 3
-            SystemPalette { id: activePalette }
+
+            SystemPalette {
+                id: activePalette
+            }
+
             Rectangle {
                 color: activePalette.text
                 width: 1
                 height: positionKeyframesButton.height
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             }
+
             Shotcut.KeyframesButton {
                 id: positionKeyframesButton
+
                 onToggled: {
                     if (checked) {
-                        blockUpdate = true
-                        filter.clearSimpleAnimation(rectProperty)
-                        blockUpdate = false
-                        filter.set(rectProperty, filterRect, getPosition())
+                        blockUpdate = true;
+                        filter.clearSimpleAnimation(rectProperty);
+                        blockUpdate = false;
+                        filter.set(rectProperty, filterRect, getPosition());
                     } else {
-                        filter.resetProperty(rectProperty)
-                        filter.set(rectProperty, filterRect)
+                        filter.resetProperty(rectProperty);
+                        filter.set(rectProperty, filterRect);
                     }
-                    checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
+                    checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
                 }
             }
+
             Rectangle {
                 color: activePalette.text
                 width: 1
                 height: positionKeyframesButton.height
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             }
+
         }
 
         Label {
             text: qsTr('Size')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Layout.columnSpan: 3
+
             Shotcut.DoubleSpinBox {
                 id: rectW
+
                 horizontalAlignment: Qt.AlignRight
                 Layout.minimumWidth: 100
                 decimals: 0
                 stepSize: 1
                 from: 0
-                to: 999999999
+                to: 1e+09
                 onValueModified: {
                     if (Math.abs(filterRect.width - value) >= 1) {
                         if (isFillMode()) {
-                            scaleByWidth(value)
+                            scaleByWidth(value);
                         } else {
-                            filterRect.width = value
-                            setFilter(getPosition())
+                            filterRect.width = value;
+                            setFilter(getPosition());
                         }
                     }
                 }
             }
-            Label { text: 'x'; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: 'x'
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectH
+
                 horizontalAlignment: Qt.AlignRight
                 Layout.minimumWidth: 100
                 decimals: 0
                 stepSize: 1
                 from: 0
-                to: 999999999
+                to: 1e+09
                 onValueModified: {
                     if (Math.abs(filterRect.height - value) >= 1) {
                         if (isFillMode()) {
-                            scaleByHeight(value)
+                            scaleByHeight(value);
                         } else {
-                            filterRect.height = value
-                            setFilter(getPosition())
+                            filterRect.height = value;
+                            setFilter(getPosition());
                         }
                     }
                 }
             }
+
         }
+
         Shotcut.UndoButton {
             id: sizeUndoButton
+
             onClicked: {
-                filterRect.width = rectW.value = defaultRect.width
-                filterRect.height = rectH.value = defaultRect.height
-                scaleSlider.update()
-                setFilter(getPosition())
+                filterRect.width = rectW.value = defaultRect.width;
+                filterRect.height = rectH.value = defaultRect.height;
+                scaleSlider.update();
+                setFilter(getPosition());
             }
         }
 
@@ -639,40 +652,42 @@ Item {
             text: qsTr('Zoom')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: scaleSlider
+
+            function update() {
+                blockUpdate = true;
+                scaleSlider.value = Math.min(filterRect.width / defaultRect.width * 100, scaleSlider.maximumValue);
+                blockUpdate = false;
+            }
+
             Layout.columnSpan: 3
             minimumValue: 0.1
             maximumValue: 1000
             decimals: 1
             suffix: ' %'
-            function update() {
-                blockUpdate = true
-                scaleSlider.value = Math.min(filterRect.width / defaultRect.width * 100, scaleSlider.maximumValue)
-                blockUpdate = false
-            }
             onValueChanged: {
                 if (!blockUpdate && Math.abs(value - filterRect.width / defaultRect.width * 100) > 0.1) {
-                    var centerX = filterRect.x + filterRect.width / 2
-                    var rightX = filterRect.x + filterRect.width
-                    filterRect.width = rectW.value = defaultRect.width * value / 100
-                    if (centerRadioButton.checked) {
-                        filterRect.x = rectX.value = centerX - filterRect.width / 2
-                    } else if (rightRadioButton.checked) {
-                        filterRect.x = rectX.value = rightX - filterRect.width
-                    }
-                    var middleY = filterRect.y + filterRect.height / 2
-                    var bottomY = filterRect.y + filterRect.height
-                    filterRect.height = rectH.value = Math.round(filterRect.width / Math.max(aspectRatio, 1.0e-6))
-                    if (middleRadioButton.checked) {
-                        filterRect.y = rectY.value = middleY - filterRect.height / 2
-                    } else if (bottomRadioButton.checked) {
-                        filterRect.y = rectY.value = bottomY - filterRect.height
-                    }
-                    setFilter(getPosition())
+                    var centerX = filterRect.x + filterRect.width / 2;
+                    var rightX = filterRect.x + filterRect.width;
+                    filterRect.width = rectW.value = defaultRect.width * value / 100;
+                    if (centerRadioButton.checked)
+                        filterRect.x = rectX.value = centerX - filterRect.width / 2;
+                    else if (rightRadioButton.checked)
+                        filterRect.x = rectX.value = rightX - filterRect.width;
+                    var middleY = filterRect.y + filterRect.height / 2;
+                    var bottomY = filterRect.y + filterRect.height;
+                    filterRect.height = rectH.value = Math.round(filterRect.width / Math.max(aspectRatio, 1e-06));
+                    if (middleRadioButton.checked)
+                        filterRect.y = rectY.value = middleY - filterRect.height / 2;
+                    else if (bottomRadioButton.checked)
+                        filterRect.y = rectY.value = bottomY - filterRect.height;
+                    setFilter(getPosition());
                 }
             }
         }
+
         Shotcut.UndoButton {
             enabled: scaleSlider.enabled
             onClicked: scaleSlider.value = 100
@@ -682,120 +697,151 @@ Item {
             text: qsTr('Size mode')
             Layout.alignment: Qt.AlignRight
         }
+
         RadioButton {
             id: fitRadioButton
+
             text: qsTr('Fit')
             ButtonGroup.group: sizeGroup
             onClicked: {
-                filter.set(fillProperty, 0)
-                filter.set(distortProperty, 0)
-                updateAspectRatio()
+                filter.set(fillProperty, 0);
+                filter.set(distortProperty, 0);
+                updateAspectRatio();
             }
         }
+
         RadioButton {
             id: fillRadioButton
+
             text: qsTr('Fill')
             ButtonGroup.group: sizeGroup
             onClicked: {
-                filter.set(fillProperty, 1)
-                filter.set(distortProperty, 0)
-                updateAspectRatio()
+                filter.set(fillProperty, 1);
+                filter.set(distortProperty, 0);
+                updateAspectRatio();
                 // enforce the aspect ratio
-                if (producer.displayAspectRatio > profile.aspectRatio) {
-                    filterRect.height = rectH.value = filterRect.width / producer.displayAspectRatio
-                } else {
-                    filterRect.width = rectW.value = filterRect.height * producer.displayAspectRatio
-                }
-                setFilter(getPosition())
+                if (producer.displayAspectRatio > profile.aspectRatio)
+                    filterRect.height = rectH.value = filterRect.width / producer.displayAspectRatio;
+                else
+                    filterRect.width = rectW.value = filterRect.height * producer.displayAspectRatio;
+                setFilter(getPosition());
             }
         }
+
         RadioButton {
             id: distortRadioButton
+
             text: qsTr('Distort')
             ButtonGroup.group: sizeGroup
             onClicked: {
-                filter.set(fillProperty, 1)
-                filter.set(distortProperty, 1)
-                updateAspectRatio()
+                filter.set(fillProperty, 1);
+                filter.set(distortProperty, 1);
+                updateAspectRatio();
             }
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                fitRadioButton.checked = true
-                filter.set(fillProperty, 0)
-                filter.set(distortProperty, 0)
-                updateAspectRatio()
+                fitRadioButton.checked = true;
+                filter.set(fillProperty, 0);
+                filter.set(distortProperty, 0);
+                updateAspectRatio();
             }
         }
-        Item { width: 1 }
+
+        Item {
+            width: 1
+        }
 
         Label {
             text: qsTr('Horizontal fit')
             Layout.alignment: Qt.AlignRight
         }
+
         RadioButton {
             id: leftRadioButton
+
             text: qsTr('Left')
             ButtonGroup.group: halignGroup
             onClicked: filter.set(halignProperty, 'left')
         }
+
         RadioButton {
             id: centerRadioButton
+
             text: qsTr('Center')
             ButtonGroup.group: halignGroup
             onClicked: filter.set(halignProperty, 'center')
         }
+
         RadioButton {
             id: rightRadioButton
+
             text: qsTr('Right')
             ButtonGroup.group: halignGroup
             onClicked: filter.set(halignProperty, 'right')
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                leftRadioButton.checked = true
-                filter.set(halignProperty, 'left')
+                leftRadioButton.checked = true;
+                filter.set(halignProperty, 'left');
             }
         }
-        Item { width: 1 }
+
+        Item {
+            width: 1
+        }
 
         Label {
             text: qsTr('Vertical fit')
             Layout.alignment: Qt.AlignRight
         }
+
         RadioButton {
             id: topRadioButton
+
             text: qsTr('Top')
             ButtonGroup.group: valignGroup
             onClicked: filter.set(valignProperty, 'top')
         }
+
         RadioButton {
             id: middleRadioButton
+
             text: qsTr('Middle', 'Size and Position video filter')
             ButtonGroup.group: valignGroup
             onClicked: filter.set(valignProperty, 'middle')
         }
+
         RadioButton {
             id: bottomRadioButton
+
             text: qsTr('Bottom')
             ButtonGroup.group: valignGroup
             onClicked: filter.set(valignProperty, 'bottom')
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                topRadioButton.checked = true
-                filter.set(valignProperty, 'top')
+                topRadioButton.checked = true;
+                filter.set(valignProperty, 'top');
             }
         }
-        Item { width: 1 }
+
+        Item {
+            width: 1
+        }
 
         Label {
             text: qsTr('Rotation')
             Layout.alignment: Qt.AlignRight
             visible: !!rotationProperty
         }
+
         Shotcut.SliderSpinner {
             id: rotationSlider
+
             Layout.columnSpan: 3
             visible: !!rotationProperty
             minimumValue: -360
@@ -804,16 +850,19 @@ Item {
             suffix: qsTr(' °', 'degrees')
             onValueChanged: updateRotation(getPosition())
         }
+
         Shotcut.UndoButton {
             visible: !!rotationProperty
             onClicked: rotationSlider.value = 0
         }
+
         Shotcut.KeyframesButton {
             id: rotationKeyframesButton
+
             visible: !!rotationProperty
             onToggled: {
-                toggleKeyframes(checked, rotationProperty, rotationSlider.value)
-                setControls()
+                toggleKeyframes(checked, rotationProperty, rotationSlider.value);
+                setControls();
             }
         }
 
@@ -822,55 +871,78 @@ Item {
             Layout.alignment: Qt.AlignRight
             visible: bgColor.visible
         }
+
         Shotcut.ColorPicker {
             id: bgColor
+
             visible: !!backgroundProperty
             Layout.columnSpan: 3
             eyedropper: true
             alpha: true
             onValueChanged: filter.set(backgroundProperty, 'color:' + value)
         }
+
         Shotcut.UndoButton {
             visible: bgColor.visible
             onClicked: bgColor.value = '#00000000'
         }
+
         Item {
             width: 1
             visible: bgColor.visible
         }
 
-        Item { Layout.fillHeight: true }
-    }
-
-    function updateSimpleKeyframes() {
-        if (rotationProperty) {
-            updateRotation(null)
+        Item {
+            Layout.fillHeight: true
         }
-        setFilter(null)
+
     }
 
     Connections {
+        function onChanged() {
+            setKeyframedControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged() {
+            setKeyframedControls();
+        }
+
         target: filter
-        function onChanged() { setKeyframedControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged() { setKeyframedControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setKeyframedControls();
+        }
+
         target: producer
-        function onPositionChanged() { setKeyframedControls() }
     }
 
     Connections {
-        target: parameters
         function onKeyframeAdded() {
             if (parameter == rotationProperty) {
-                var n = filter.getDouble(parameter, position)
-                filter.set(parameter, n, position)
+                var n = filter.getDouble(parameter, position);
+                filter.set(parameter, n, position);
             }
         }
+
+        target: parameters
     }
+
 }

--- a/src/qml/filters/size_position/SizePositionVUI.qml
+++ b/src/qml/filters/size_position/SizePositionVUI.qml
@@ -25,204 +25,205 @@ Shotcut.VuiBase {
     property string halignProperty
     property string valignProperty
     property string rotationProperty
-    property real zoom: (video.zoom > 0)? video.zoom : 1.0
+    property real zoom: (video.zoom > 0) ? video.zoom : 1
     property rect filterRect: Qt.rect(-1, -1, -1, -1)
     property bool blockUpdate: false
     property string startValue: '_shotcut:startValue'
     property string middleValue: '_shotcut:middleValue'
-    property string endValue:  '_shotcut:endValue'
+    property string endValue: '_shotcut:endValue'
     property string rotationStartValue: '_shotcut:rotationStartValue'
     property string rotationMiddleValue: '_shotcut:rotationMiddleValue'
-    property string rotationEndValue:  '_shotcut:rotationEndValue'
+    property string rotationEndValue: '_shotcut:rotationEndValue'
 
     function getAspectRatio() {
-        return (filter.get(fillProperty) === '1' && filter.get(distortProperty) === '0')? producer.displayAspectRatio : 0.0
-    }
-
-    Component.onCompleted: {
-        application.showStatusMessage(
-            qsTr('Click in rectangle + hold Shift to drag, Wheel to zoom, or %1+Wheel to rotate')
-                .arg(application.OS === 'OS X'? 'Cmd' : 'Ctrl'))
-        rectangle.aspectRatio = getAspectRatio()
-        setRectangleControl()
+        return (filter.get(fillProperty) === '1' && filter.get(distortProperty) === '0') ? producer.displayAspectRatio : 0;
     }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setRectangleControl() {
-        if (blockUpdate) return
-        var position = getPosition()
-        var newValue = filter.getRect(rectProperty, position)
+        if (blockUpdate)
+            return ;
+
+        var position = getPosition();
+        var newValue = filter.getRect(rectProperty, position);
         if (filterRect !== newValue) {
-            filterRect = newValue
-            rectangle.setHandles(filterRect)
+            filterRect = newValue;
+            rectangle.setHandles(filterRect);
         }
-        if (rotationProperty) {
-            rectangle.rotation = filter.getDouble(rotationProperty, position)
-        }
-        rectangle.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        if (rotationProperty)
+            rectangle.rotation = filter.getDouble(rotationProperty, position);
+
+        rectangle.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function setFilter(position) {
-        blockUpdate = true
-        var rect = rectangle.rectangle
-        filterRect.x = rect.x / rectangle.widthScale
-        filterRect.y = rect.y / rectangle.heightScale
-        filterRect.width = rect.width / rectangle.widthScale
-        filterRect.height = rect.height / rectangle.heightScale
-
+        blockUpdate = true;
+        var rect = rectangle.rectangle;
+        filterRect.x = rect.x / rectangle.widthScale;
+        filterRect.y = rect.y / rectangle.heightScale;
+        filterRect.width = rect.width / rectangle.widthScale;
+        filterRect.height = rect.height / rectangle.heightScale;
         if (position !== null) {
-            filter.blockSignals = true
+            filter.blockSignals = true;
             if (position <= 0 && filter.animateIn > 0)
-                filter.set(startValue, filterRect)
+                filter.set(startValue, filterRect);
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                filter.set(endValue, filterRect)
+                filter.set(endValue, filterRect);
             else
-                filter.set(middleValue, filterRect)
-            filter.blockSignals = false
+                filter.set(middleValue, filterRect);
+            filter.blockSignals = false;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(rectProperty)
+            filter.resetProperty(rectProperty);
             if (filter.animateIn > 0) {
-                filter.set(rectProperty, filter.getRect(startValue), 0)
-                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1)
+                filter.set(rectProperty, filter.getRect(startValue), 0);
+                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut)
-                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1)
+                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut);
+                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1);
             }
         } else if (filter.keyframeCount(rectProperty) <= 0) {
-            filter.resetProperty(rectProperty)
-            filter.set(rectProperty, filter.getRect(middleValue))
+            filter.resetProperty(rectProperty);
+            filter.set(rectProperty, filter.getRect(middleValue));
         } else if (position !== null) {
-            filter.set(rectProperty, filterRect, position)
+            filter.set(rectProperty, filterRect, position);
         }
-        blockUpdate = false
+        blockUpdate = false;
     }
 
     function updateRotation(value) {
-        var position = getPosition()
+        var position = getPosition();
         if (position !== null) {
-            filter.blockSignals = true
+            filter.blockSignals = true;
             if (position <= 0 && filter.animateIn > 0)
-                filter.set(rotationStartValue, value)
+                filter.set(rotationStartValue, value);
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                filter.set(rotationEndValue, value)
+                filter.set(rotationEndValue, value);
             else
-                filter.set(rotationMiddleValue, value)
-            filter.blockSignals = false
+                filter.set(rotationMiddleValue, value);
+            filter.blockSignals = false;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(rotationProperty)
+            filter.resetProperty(rotationProperty);
             if (filter.animateIn > 0) {
-                filter.set(rotationProperty, filter.getDouble(rotationStartValue), 0)
-                filter.set(rotationProperty, filter.getDouble(rotationMiddleValue), filter.animateIn - 1)
+                filter.set(rotationProperty, filter.getDouble(rotationStartValue), 0);
+                filter.set(rotationProperty, filter.getDouble(rotationMiddleValue), filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(rotationProperty, filter.getDouble(rotationMiddleValue), filter.duration - filter.animateOut)
-                filter.set(rotationProperty, filter.getDouble(rotationEndValue), filter.duration - 1)
+                filter.set(rotationProperty, filter.getDouble(rotationMiddleValue), filter.duration - filter.animateOut);
+                filter.set(rotationProperty, filter.getDouble(rotationEndValue), filter.duration - 1);
             }
         } else if (filter.keyframeCount(rotationProperty) <= 0) {
-            filter.resetProperty(rotationProperty)
-            filter.set(rotationProperty, filter.getDouble(rotationMiddleValue))
+            filter.resetProperty(rotationProperty);
+            filter.set(rotationProperty, filter.getDouble(rotationMiddleValue));
         } else if (position !== null) {
-            filter.set(rotationProperty, value, position)
+            filter.set(rotationProperty, value, position);
         }
     }
 
     function updateScale(scale) {
         if (scale > 0.0001 && Math.abs(scale - filterRect.width / profile.width) > 0.01) {
-            var aspectRatio = filterRect.width / Math.max(filterRect.height, 1)
-            var align = filter.get(halignProperty)
-            var centerX = filterRect.x + filterRect.width / 2
-            var rightX = filterRect.x + filterRect.width
-            filterRect.width = (profile.width * scale)
-            if (align === 'center' || align === 'middle') {
-                filterRect.x = centerX - filterRect.width / 2
-            } else if (align === 'right') {
-                filterRect.x = rightX - filterRect.width
-            }
-            var middleY = filterRect.y + filterRect.height / 2
-            var bottomY = filterRect.y + filterRect.height
-            align = filter.get(valignProperty)
-            filterRect.height = filterRect.width / Math.max(aspectRatio, 1.0e-6)
-            if (align === 'center' || align === 'middle') {
-                filterRect.y = middleY - filterRect.height / 2
-            } else if (align === 'bottom') {
-                filterRect.y = bottomY - filterRect.height
-            }
-            rectangle.setHandles(filterRect)
-            setFilter(getPosition())
+            var aspectRatio = filterRect.width / Math.max(filterRect.height, 1);
+            var align = filter.get(halignProperty);
+            var centerX = filterRect.x + filterRect.width / 2;
+            var rightX = filterRect.x + filterRect.width;
+            filterRect.width = (profile.width * scale);
+            if (align === 'center' || align === 'middle')
+                filterRect.x = centerX - filterRect.width / 2;
+            else if (align === 'right')
+                filterRect.x = rightX - filterRect.width;
+            var middleY = filterRect.y + filterRect.height / 2;
+            var bottomY = filterRect.y + filterRect.height;
+            align = filter.get(valignProperty);
+            filterRect.height = filterRect.width / Math.max(aspectRatio, 1e-06);
+            if (align === 'center' || align === 'middle')
+                filterRect.y = middleY - filterRect.height / 2;
+            else if (align === 'bottom')
+                filterRect.y = bottomY - filterRect.height;
+            rectangle.setHandles(filterRect);
+            setFilter(getPosition());
         }
     }
 
     function snapRotation(degrees, strength) {
-        if ((Math.abs(degrees) + strength) % 90 < strength * 2) {
-            degrees = Math.round(degrees / 90) * 90
-        }
-        return degrees
+        if ((Math.abs(degrees) + strength) % 90 < strength * 2)
+            degrees = Math.round(degrees / 90) * 90;
+
+        return degrees;
+    }
+
+    Component.onCompleted: {
+        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag, Wheel to zoom, or %1+Wheel to rotate').arg(application.OS === 'OS X' ? 'Cmd' : 'Ctrl'));
+        rectangle.aspectRatio = getAspectRatio();
+        setRectangleControl();
     }
 
     PinchArea {
+        // Pinch zoom conflicts too much with mouse wheel
+        //            if (!blockUpdate) {
+        //                var scale = currentScale + (pinch.scale - 2) / 3
+        //                if (Math.abs(scale - 1.0) < 0.05)
+        //                    scale = 1.0
+        //                updateScale(Math.min(scale, 10))
+        //            }
+
+        property real currentScale: 1
+        property real currentRotation: 0
+        property bool noModifiers: true
+
         anchors.fill: parent
         pinch.minimumRotation: -360
         pinch.maximumRotation: 360
         pinch.minimumScale: 0.1
         pinch.maximumScale: 10
-        property real currentScale: 1
-        property real currentRotation: 0
-        property bool noModifiers: true
         Keys.onPressed: {
-            noModifiers = event.modifiers === Qt.NoModifier
+            noModifiers = event.modifiers === Qt.NoModifier;
         }
         Keys.onReleased: {
-            noModifiers = event.modifiers === Qt.NoModifier
+            noModifiers = event.modifiers === Qt.NoModifier;
         }
         onPinchStarted: {
-            currentRotation = rectangle.rotation
-            currentScale = filterRect.width / profile.width
+            currentRotation = rectangle.rotation;
+            currentScale = filterRect.width / profile.width;
         }
-        onPinchUpdated: if (noModifiers) {
-            if (rotationProperty && Math.abs(pinch.rotation - 0) > 0.01) {
-                var degrees = currentRotation + pinch.rotation
-                rectangle.rotation = snapRotation(degrees, 4)
-                blockUpdate = true
-                updateRotation(rectangle.rotation % 360)
-                blockUpdate = false
+        onPinchUpdated: {
+            if (noModifiers) {
+                if (rotationProperty && Math.abs(pinch.rotation - 0) > 0.01) {
+                    var degrees = currentRotation + pinch.rotation;
+                    rectangle.rotation = snapRotation(degrees, 4);
+                    blockUpdate = true;
+                    updateRotation(rectangle.rotation % 360);
+                    blockUpdate = false;
+                }
             }
-            // Pinch zoom conflicts too much with mouse wheel
-//            if (!blockUpdate) {
-//                var scale = currentScale + (pinch.scale - 2) / 3
-//                if (Math.abs(scale - 1.0) < 0.05)
-//                    scale = 1.0
-//                updateScale(Math.min(scale, 10))
-//            }
         }
+
         MouseArea {
             anchors.fill: parent
             acceptedButtons: Qt.NoButton
             scrollGestureEnabled: true
             onWheel: {
                 if (rotationProperty && (wheel.modifiers & Qt.ControlModifier)) {
-                    var degrees = rectangle.rotation - wheel.angleDelta.y / 120 * 5
-                    if (!(wheel.modifiers & Qt.AltModifier)) {
-                        degrees = snapRotation(degrees, 1.5)
-                    }
-                    rectangle.rotation = degrees
-                    blockUpdate = true
-                    updateRotation(rectangle.rotation % 360)
-                    blockUpdate = false
+                    var degrees = rectangle.rotation - wheel.angleDelta.y / 120 * 5;
+                    if (!(wheel.modifiers & Qt.AltModifier))
+                        degrees = snapRotation(degrees, 1.5);
+
+                    rectangle.rotation = degrees;
+                    blockUpdate = true;
+                    updateRotation(rectangle.rotation % 360);
+                    blockUpdate = false;
                 } else if (!blockUpdate) {
-                    var scale = filterRect.width / profile.width
-                    scale += wheel.angleDelta.y / 120 / 10
-                    updateScale(Math.min(scale, 10))
+                    var scale = filterRect.width / profile.width;
+                    scale += wheel.angleDelta.y / 120 / 10;
+                    updateScale(Math.min(scale, 10));
                 }
             }
         }
+
     }
 
     Flickable {
@@ -236,6 +237,7 @@ Shotcut.VuiBase {
 
         Item {
             id: videoItem
+
             x: video.rect.x
             y: video.rect.y
             width: video.rect.width
@@ -244,6 +246,7 @@ Shotcut.VuiBase {
 
             Shotcut.RectangleControl {
                 id: rectangle
+
                 withRotation: !!rotationProperty
                 widthScale: video.rect.width / profile.width
                 heightScale: video.rect.height / profile.height
@@ -253,34 +256,41 @@ Shotcut.VuiBase {
                 onHeightScaleChanged: setHandles(filterRect)
                 onRectChanged: setFilter(getPosition())
                 onRotated: {
-                    if (!(mouse.modifiers & Qt.AltModifier)) {
-                        degrees = snapRotation(degrees, 4) % 360
-                    }
-                    blockUpdate = true
-                    updateRotation(degrees)
-                    blockUpdate = false
+                    if (!(mouse.modifiers & Qt.AltModifier))
+                        degrees = snapRotation(degrees, 4) % 360;
+
+                    blockUpdate = true;
+                    updateRotation(degrees);
+                    blockUpdate = false;
                 }
                 onRotationReleased: {
-                    rectangle.rotation = filter.getDouble(rotationProperty, getPosition())
+                    rectangle.rotation = filter.getDouble(rotationProperty, getPosition());
                 }
             }
+
         }
+
     }
 
     Connections {
-        target: filter
         function onChanged() {
-            setRectangleControl()
+            setRectangleControl();
             if (rectangle.aspectRatio !== getAspectRatio()) {
-                rectangle.aspectRatio = getAspectRatio()
-                rectangle.setHandles(filterRect)
+                rectangle.aspectRatio = getAspectRatio();
+                rectangle.setHandles(filterRect);
             }
-            videoItem.enabled = filter.get('disable') !== '1'
+            videoItem.enabled = filter.get('disable') !== '1';
         }
+
+        target: filter
     }
 
     Connections {
+        function onPositionChanged() {
+            setRectangleControl();
+        }
+
         target: producer
-        function onPositionChanged() { setRectangleControl() }
     }
+
 }

--- a/src/qml/filters/size_position/meta_affine.qml
+++ b/src/qml/filters/size_position/meta_affine.qml
@@ -10,6 +10,7 @@ Metadata {
     vui: 'vui_affine.qml'
     gpuAlt: 'movit.rect'
     isFavorite: true
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -29,4 +30,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/size_position/meta_movit.qml
+++ b/src/qml/filters/size_position/meta_movit.qml
@@ -11,6 +11,7 @@ Metadata {
     vui: 'vui_movit.qml'
     allowMultiple: false
     isFavorite: true
+
     keyframes {
         allowTrim: false
         allowAnimateIn: true
@@ -24,4 +25,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/size_position/ui_affine.qml
+++ b/src/qml/filters/size_position/ui_affine.qml
@@ -16,6 +16,7 @@
  */
 
 import QtQuick 2.12
+
 SizePositionUI {
     fillProperty: 'transition.fill'
     distortProperty: 'transition.distort'
@@ -26,8 +27,8 @@ SizePositionUI {
     backgroundProperty: 'background'
     rotationProperty: 'transition.fix_rotate_x'
     Component.onCompleted: {
-        if (filter.isNew) {
-            filter.set('transition.threads', 0)
-        }
+        if (filter.isNew)
+            filter.set('transition.threads', 0);
+
     }
 }

--- a/src/qml/filters/sketch/ui.qml
+++ b/src/qml/filters/sketch/ui.qml
@@ -22,26 +22,26 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
+    function setControls() {
+        xScatter.value = filter.get('x_scatter');
+        yScatter.value = filter.get('y_scatter');
+        scale.value = filter.getDouble('scale');
+        mix.value = filter.getDouble('mix');
+    }
+
     width: 350
     height: 100
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set('x_scatter', 2)
-            filter.set('y_scatter', 2)
-            filter.set('scale', 1.5)
-            filter.set('mix', 0)
-            filter.set('invert', 0)
-            filter.savePreset(preset.parameters)
+            filter.set('x_scatter', 2);
+            filter.set('y_scatter', 2);
+            filter.set('scale', 1.5);
+            filter.set('mix', 0);
+            filter.set('invert', 0);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        xScatter.value = filter.get('x_scatter')
-        yScatter.value = filter.get('y_scatter')
-        scale.value = filter.getDouble('scale')
-        mix.value = filter.getDouble('mix')
+        setControls();
     }
 
     GridLayout {
@@ -53,8 +53,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ['x_scatter', 'y_scatter', 'scale', 'mix']
             Layout.columnSpan: 2
             onPresetSelected: setControls()
@@ -64,8 +66,10 @@ Item {
             text: qsTr('Line Width')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: xScatter
+
             minimumValue: 1
             maximumValue: 10
             stepSize: 1
@@ -73,6 +77,7 @@ Item {
             value: filter.get('x_scatter')
             onValueChanged: filter.set('x_scatter', value)
         }
+
         Shotcut.UndoButton {
             onClicked: xScatter.value = 2
         }
@@ -81,8 +86,10 @@ Item {
             text: qsTr('Line Height')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: yScatter
+
             minimumValue: 1
             maximumValue: 10
             stepSize: 1
@@ -90,6 +97,7 @@ Item {
             value: filter.get('y_scatter')
             onValueChanged: filter.set('y_scatter', value)
         }
+
         Shotcut.UndoButton {
             onClicked: yScatter.value = 2
         }
@@ -98,8 +106,10 @@ Item {
             text: qsTr('Contrast')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: scale
+
             minimumValue: 0
             maximumValue: 10
             stepSize: 1
@@ -108,6 +118,7 @@ Item {
             value: filter.get('scale')
             onValueChanged: filter.set('scale', value)
         }
+
         Shotcut.UndoButton {
             onClicked: scale.value = 1.5
         }
@@ -116,8 +127,10 @@ Item {
             text: qsTr('Color')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: mix
+
             minimumValue: 0
             maximumValue: 10
             stepSize: 1
@@ -126,6 +139,7 @@ Item {
             value: filter.get('mix')
             onValueChanged: filter.set('mix', value)
         }
+
         Shotcut.UndoButton {
             onClicked: mix.value = 0
         }
@@ -133,5 +147,7 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/smartblur/ui.qml
+++ b/src/qml/filters/smartblur/ui.qml
@@ -23,29 +23,28 @@ import Shotcut.Controls 1.0 as Shotcut
 Item {
     property double radiusDefault: 2.5
     property double strengthDefault: 0.5
-    property double thresholdDefault: 3.0
-
+    property double thresholdDefault: 3
     property var defaultParameters: ["av.luma_radius", "av.chroma_radius", "av.luma_strength", "av.chroma_strength", "av.luma_threshold", "av.chroma_threshold"]
+
+    function setControls() {
+        radiusSlider.value = filter.getDouble("av.luma_radius");
+        strengthSlider.value = filter.getDouble("av.luma_strength");
+        thresholdSlider.value = filter.getDouble("av.luma_threshold");
+    }
 
     width: 200
     height: 125
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set("av.luma_radius", radiusDefault)
-            filter.set("av.chroma_radius", radiusDefault)
-            filter.set("av.luma_strength", strengthDefault)
-            filter.set("av.chroma_strength", strengthDefault)
-            filter.set("av.luma_threshold", thresholdDefault)
-            filter.set("av.chroma_threshold", thresholdDefault)
-            filter.savePreset(defaultParameters)
+            filter.set("av.luma_radius", radiusDefault);
+            filter.set("av.chroma_radius", radiusDefault);
+            filter.set("av.luma_strength", strengthDefault);
+            filter.set("av.chroma_strength", strengthDefault);
+            filter.set("av.luma_threshold", thresholdDefault);
+            filter.set("av.chroma_threshold", thresholdDefault);
+            filter.savePreset(defaultParameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        radiusSlider.value = filter.getDouble("av.luma_radius")
-        strengthSlider.value = filter.getDouble("av.luma_strength")
-        thresholdSlider.value = filter.getDouble("av.luma_threshold")
+        setControls();
     }
 
     GridLayout {
@@ -57,8 +56,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: presetItem
+
             Layout.columnSpan: 2
             parameters: defaultParameters
             onPresetSelected: setControls()
@@ -67,18 +68,25 @@ Item {
         Label {
             text: qsTr('Blur Radius')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The radius of the gaussian blur.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The radius of the gaussian blur.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: radiusSlider
+
             minimumValue: 0.1
-            maximumValue: 5.0
+            maximumValue: 5
             decimals: 1
             onValueChanged: {
-                filter.set("av.luma_radius", value)
-                filter.set("av.chroma_radius", value)
+                filter.set("av.luma_radius", value);
+                filter.set("av.chroma_radius", value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: radiusSlider.value = radiusDefault
         }
@@ -86,41 +94,59 @@ Item {
         Label {
             text: qsTr('Blur Strength')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('The strength of the gaussian blur.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('The strength of the gaussian blur.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: strengthSlider
-            minimumValue: 0.0
-            maximumValue: 1.0
+
+            minimumValue: 0
+            maximumValue: 1
             decimals: 1
             onValueChanged: {
-                filter.set("av.luma_strength", value)
-                filter.set("av.chroma_strength", value)
+                filter.set("av.luma_strength", value);
+                filter.set("av.chroma_strength", value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: strengthSlider.value = strengthDefault
         }
-        
+
         Label {
             text: qsTr('Threshold')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip {text: qsTr('If the difference between the original pixel and the blurred pixel is less than threshold, the pixel will be replaced with the blurred pixel.')}
+
+            Shotcut.HoverTip {
+                text: qsTr('If the difference between the original pixel and the blurred pixel is less than threshold, the pixel will be replaced with the blurred pixel.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
             id: thresholdSlider
-            minimumValue: 0.0
+
+            minimumValue: 0
             maximumValue: 30
             decimals: 0
             onValueChanged: {
-                filter.set("av.luma_threshold", value)
-                filter.set("av.chroma_threshold", value)
+                filter.set("av.luma_threshold", value);
+                filter.set("av.chroma_threshold", value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: thresholdSlider.value = thresholdDefault
         }
 
-        Item { Layout.fillHeight: true }
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
+
 }

--- a/src/qml/filters/spectrum/ui_spectrum.qml
+++ b/src/qml/filters/spectrum/ui_spectrum.qml
@@ -24,80 +24,75 @@ Item {
     property string rectProperty: "rect"
     property rect filterRect: filter.getRect(rectProperty)
     property var defaultParameters: [rectProperty, 'type', 'color.1', 'color.2', 'color.3', 'color.4', 'color.5', 'color.6', 'color.7', 'color.8', 'color.9', 'color.10', 'bgcolor', 'thickness', 'fill', 'mirror', 'reverse', 'tension', 'bands', 'frequency_low', 'frequency_high', 'threshold', 'segments', 'segment_gap']
-
     property int _minFreqDelta: 1000
     property bool _disableUpdate: true
 
-    width: 400
-    height: 475
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            filter.set(rectProperty, '0/50%:50%x50%')
-            filter.set('type', 'line')
-            filter.set('color.1', '#ffff0000')
-            filter.set('color.2', '#ffffff00')
-            filter.set('color.3', '#ff00ff00')
-            filter.set('color.4', '#ff00ff00')
-            filter.set('color.5', '#ff00ff00')
-            filter.set('color.6', '#ff00ff00')
-            filter.set('color.7', '#ff00ff00')
-            filter.set('bgcolor', '#00ffffff')
-            filter.set('thickness', '1')
-            filter.set('fill', '0')
-            filter.set('mirror', '0')
-            filter.set('reverse', '0')
-            filter.set('tension', '0.4')
-            filter.set('bands', '31')
-            filter.set('frequency_low', '20')
-            filter.set('frequency_high', '20000')
-            filter.set('threshold', '-60')
-            filter.set('segments', '7')
-            filter.set('segment_gap', '8')
-            filter.savePreset(defaultParameters)
-        }
-        setControls()
-    }
-
     function setFilter() {
-        var x = rectX.value
-        var y = rectY.value
-        var w = rectW.value
-        var h = rectH.value
-        if (x !== filterRect.x ||
-            y !== filterRect.y ||
-            w !== filterRect.width ||
-            h !== filterRect.height) {
-            filterRect.x = x
-            filterRect.y = y
-            filterRect.width = w
-            filterRect.height = h
-            filter.set(rectProperty, filterRect)
+        var x = rectX.value;
+        var y = rectY.value;
+        var w = rectW.value;
+        var h = rectH.value;
+        if (x !== filterRect.x || y !== filterRect.y || w !== filterRect.width || h !== filterRect.height) {
+            filterRect.x = x;
+            filterRect.y = y;
+            filterRect.width = w;
+            filterRect.height = h;
+            filter.set(rectProperty, filterRect);
         }
     }
 
     function setControls() {
-        _disableUpdate = true
-        fgGradient.colors = filter.getGradient('color')
-        bgColor.value = filter.get('bgcolor')
-        thicknessSlider.value = filter.getDouble('thickness')
-        fillCheckbox.checked = filter.get('fill') == 1
-        mirrorCheckbox.checked = filter.get('mirror') == 1
-        reverseCheckbox.checked = filter.get('reverse') == 1
-        tensionSlider.value = filter.getDouble('tension')
-        bandsSlider.value = filter.getDouble('bands')
-        freqLowSlider.value = filter.getDouble('frequency_low')
-        freqHighSlider.value = filter.getDouble('frequency_high')
-        thresholdSlider.value = filter.getDouble('threshold')
-        segmentsSlider.value = filter.getDouble('segments')
-        segmentGapSlider.value = filter.getDouble('segment_gap')
-        rectX.value = filterRect.x
-        rectY.value = filterRect.y
-        rectW.value = filterRect.width
-        rectH.value = filterRect.height
-        typeCombo.currentIndex = typeCombo.valueToIndex()
-        segmentsSlider.enabled = segmentGapSlider.enabled = (typeCombo.currentIndex == 2)
-        _disableUpdate = false
+        _disableUpdate = true;
+        fgGradient.colors = filter.getGradient('color');
+        bgColor.value = filter.get('bgcolor');
+        thicknessSlider.value = filter.getDouble('thickness');
+        fillCheckbox.checked = filter.get('fill') == 1;
+        mirrorCheckbox.checked = filter.get('mirror') == 1;
+        reverseCheckbox.checked = filter.get('reverse') == 1;
+        tensionSlider.value = filter.getDouble('tension');
+        bandsSlider.value = filter.getDouble('bands');
+        freqLowSlider.value = filter.getDouble('frequency_low');
+        freqHighSlider.value = filter.getDouble('frequency_high');
+        thresholdSlider.value = filter.getDouble('threshold');
+        segmentsSlider.value = filter.getDouble('segments');
+        segmentGapSlider.value = filter.getDouble('segment_gap');
+        rectX.value = filterRect.x;
+        rectY.value = filterRect.y;
+        rectW.value = filterRect.width;
+        rectH.value = filterRect.height;
+        typeCombo.currentIndex = typeCombo.valueToIndex();
+        segmentsSlider.enabled = segmentGapSlider.enabled = (typeCombo.currentIndex == 2);
+        _disableUpdate = false;
+    }
+
+    width: 400
+    height: 475
+    Component.onCompleted: {
+        if (filter.isNew) {
+            filter.set(rectProperty, '0/50%:50%x50%');
+            filter.set('type', 'line');
+            filter.set('color.1', '#ffff0000');
+            filter.set('color.2', '#ffffff00');
+            filter.set('color.3', '#ff00ff00');
+            filter.set('color.4', '#ff00ff00');
+            filter.set('color.5', '#ff00ff00');
+            filter.set('color.6', '#ff00ff00');
+            filter.set('color.7', '#ff00ff00');
+            filter.set('bgcolor', '#00ffffff');
+            filter.set('thickness', '1');
+            filter.set('fill', '0');
+            filter.set('mirror', '0');
+            filter.set('reverse', '0');
+            filter.set('tension', '0.4');
+            filter.set('bands', '31');
+            filter.set('frequency_low', '20');
+            filter.set('frequency_high', '20000');
+            filter.set('threshold', '-60');
+            filter.set('segments', '7');
+            filter.set('segment_gap', '8');
+            filter.savePreset(defaultParameters);
+        }
+        setControls();
     }
 
     GridLayout {
@@ -109,14 +104,16 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: defaultParameters
             Layout.columnSpan: 4
             onPresetSelected: setControls()
             onBeforePresetLoaded: {
                 // Clear all gradient colors before loading the new values
-                filter.setGradient('color', [])
+                filter.setGradient('color', []);
             }
         }
 
@@ -124,21 +121,28 @@ Item {
             text: qsTr('Type')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
-            Layout.columnSpan: 4
             id: typeCombo
-            model: [qsTr('Line'), qsTr('Bar'), qsTr('Segment')]
+
             property var values: ['line', 'bar', 'segment']
+
             function valueToIndex() {
-                var w = filter.get('type')
-                for (var i = 0; i < values.length; ++i)
-                    if (values[i] === w) break;
-                if (i === values.length) i = 0;
+                var w = filter.get('type');
+                for (var i = 0; i < values.length; ++i) if (values[i] === w) {
+                    break;
+                }
+                if (i === values.length)
+                    i = 0;
+
                 return i;
             }
+
+            Layout.columnSpan: 4
+            model: [qsTr('Line'), qsTr('Bar'), qsTr('Segment')]
             onActivated: {
-                filter.set('type', values[index])
-                segmentsSlider.enabled = segmentGapSlider.enabled = (typeCombo.currentIndex == 2)
+                filter.set('type', values[index]);
+                segmentsSlider.enabled = segmentGapSlider.enabled = (typeCombo.currentIndex == 2);
             }
         }
 
@@ -146,12 +150,16 @@ Item {
             text: qsTr('Spectrum Color')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.GradientControl {
-            Layout.columnSpan: 4
             id: fgGradient
+
+            Layout.columnSpan: 4
             onGradientChanged: {
-                 if (_disableUpdate) return
-                 filter.setGradient('color', colors)
+                if (_disableUpdate)
+                    return ;
+
+                filter.setGradient('color', colors);
             }
         }
 
@@ -159,9 +167,11 @@ Item {
             text: qsTr('Background Color')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ColorPicker {
-            Layout.columnSpan: 4
             id: bgColor
+
+            Layout.columnSpan: 4
             eyedropper: true
             alpha: true
             onValueChanged: filter.set('bgcolor', value)
@@ -171,15 +181,18 @@ Item {
             text: qsTr('Thickness')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: thicknessSlider
+
+            Layout.columnSpan: 3
             minimumValue: 0
             maximumValue: 100
             decimals: 0
             suffix: ' px'
             onValueChanged: filter.set("thickness", value)
         }
+
         Shotcut.UndoButton {
             onClicked: thicknessSlider.value = 1
         }
@@ -188,70 +201,110 @@ Item {
             text: qsTr('Position')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Layout.columnSpan: 4
+
             Shotcut.DoubleSpinBox {
                 id: rectX
+
                 value: filterRect.x
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.x !== value) setFilter()
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.x !== value)
+                        setFilter();
+
+                }
             }
-            Label { text: ','; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: ','
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectY
+
                 value: filterRect.y
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.y !== value) setFilter()
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.y !== value)
+                        setFilter();
+
+                }
             }
+
         }
 
         Label {
             text: qsTr('Size')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Layout.columnSpan: 4
+
             Shotcut.DoubleSpinBox {
                 id: rectW
+
                 value: filterRect.width
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.width !== value) setFilter()
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.width !== value)
+                        setFilter();
+
+                }
             }
-            Label { text: 'x'; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: 'x'
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectH
+
                 value: filterRect.height
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.height !== value) setFilter()
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.height !== value)
+                        setFilter();
+
+                }
             }
+
         }
 
         Label {
             Layout.alignment: Qt.AlignRight
         }
+
         CheckBox {
-            Layout.columnSpan: 4
             id: fillCheckbox
+
+            Layout.columnSpan: 4
             text: qsTr('Fill the area under the spectrum.')
             onClicked: filter.set('fill', checked ? 1 : 0)
         }
@@ -259,9 +312,11 @@ Item {
         Label {
             Layout.alignment: Qt.AlignRight
         }
+
         CheckBox {
-            Layout.columnSpan: 4
             id: mirrorCheckbox
+
+            Layout.columnSpan: 4
             text: qsTr('Mirror the spectrum.')
             onClicked: filter.set('mirror', checked ? 1 : 0)
         }
@@ -269,9 +324,11 @@ Item {
         Label {
             Layout.alignment: Qt.AlignRight
         }
+
         CheckBox {
-            Layout.columnSpan: 4
             id: reverseCheckbox
+
+            Layout.columnSpan: 4
             text: qsTr('Reverse the spectrum.')
             onClicked: filter.set('reverse', checked ? 1 : 0)
         }
@@ -280,14 +337,17 @@ Item {
             text: qsTr('Tension')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: tensionSlider
-            minimumValue: 0.0
-            maximumValue: 1.0
+
+            Layout.columnSpan: 3
+            minimumValue: 0
+            maximumValue: 1
             decimals: 1
             onValueChanged: filter.set("tension", value)
         }
+
         Shotcut.UndoButton {
             onClicked: tensionSlider.value = 0.4
         }
@@ -296,15 +356,22 @@ Item {
             text: qsTr('Segments')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: segmentsSlider
+
+            Layout.columnSpan: 3
             minimumValue: 2
             maximumValue: 100
             decimals: 0
             onValueChanged: filter.set("segments", value)
-            Shotcut.HoverTip { text: 'The number of segments in the segment graph' }
+
+            Shotcut.HoverTip {
+                text: 'The number of segments in the segment graph'
+            }
+
         }
+
         Shotcut.UndoButton {
             onClicked: segmentGapSlider.value = 8
         }
@@ -313,15 +380,22 @@ Item {
             text: qsTr('Segment Gap')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: segmentGapSlider
+
+            Layout.columnSpan: 3
             minimumValue: 0
             maximumValue: 100
             decimals: 0
             onValueChanged: filter.set("segment_gap", value)
-            Shotcut.HoverTip { text: 'Space between segments in the segment graph (in pixels)' }
+
+            Shotcut.HoverTip {
+                text: 'Space between segments in the segment graph (in pixels)'
+            }
+
         }
+
         Shotcut.UndoButton {
             onClicked: segmentGapSlider.value = 8
         }
@@ -330,14 +404,17 @@ Item {
             text: qsTr('Bands')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: bandsSlider
+
+            Layout.columnSpan: 3
             minimumValue: 2
             maximumValue: 100
             decimals: 0
             onValueChanged: filter.set("bands", value)
         }
+
         Shotcut.UndoButton {
             onClicked: bandsSlider.value = 31
         }
@@ -345,22 +422,29 @@ Item {
         Label {
             text: qsTr('Low Frequency')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The low end of the frequency range of the spectrum.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The low end of the frequency range of the spectrum.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: freqLowSlider
+
+            Layout.columnSpan: 3
             minimumValue: 20
             maximumValue: 20000 - _minFreqDelta
             decimals: 0
             suffix: ' Hz'
             onValueChanged: {
-                filter.set("frequency_low", value)
-                if (!_disableUpdate && (value + _minFreqDelta) > freqHighSlider.value) {
-                    freqHighSlider.value = value + _minFreqDelta
-                }
+                filter.set("frequency_low", value);
+                if (!_disableUpdate && (value + _minFreqDelta) > freqHighSlider.value)
+                    freqHighSlider.value = value + _minFreqDelta;
+
             }
         }
+
         Shotcut.UndoButton {
             onClicked: freqLowSlider.value = 20
         }
@@ -368,22 +452,29 @@ Item {
         Label {
             text: qsTr('High Frequency')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The high end of the frequency range of the spectrum.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The high end of the frequency range of the spectrum.')
+            }
+
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: freqHighSlider
+
+            Layout.columnSpan: 3
             minimumValue: 20 + _minFreqDelta
             maximumValue: 20000
             decimals: 0
             suffix: ' Hz'
             onValueChanged: {
-                filter.set("frequency_high", value)
-                if (!_disableUpdate && (value - _minFreqDelta) < freqLowSlider.value) {
-                    freqLowSlider.value = value - _minFreqDelta
-                }
+                filter.set("frequency_high", value);
+                if (!_disableUpdate && (value - _minFreqDelta) < freqLowSlider.value)
+                    freqLowSlider.value = value - _minFreqDelta;
+
             }
         }
+
         Shotcut.UndoButton {
             onClicked: freqHighSlider.value = 20000
         }
@@ -392,30 +483,38 @@ Item {
             text: qsTr('Threshold')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: thresholdSlider
+
+            Layout.columnSpan: 3
             minimumValue: -60
             maximumValue: 0
             decimals: 0
             suffix: ' dB'
             onValueChanged: filter.set("threshold", value)
         }
+
         Shotcut.UndoButton {
             onClicked: thresholdSlider.value = -60
         }
 
-        Item { Layout.fillHeight: true }
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
 
     Connections {
-        target: filter
         function onChanged() {
-            var newValue = filter.getRect(rectProperty)
+            var newValue = filter.getRect(rectProperty);
             if (filterRect !== newValue) {
-                filterRect = newValue
-                setControls()
+                filterRect = newValue;
+                setControls();
             }
         }
+
+        target: filter
     }
+
 }

--- a/src/qml/filters/spectrum/vui_spectrum.qml
+++ b/src/qml/filters/spectrum/vui_spectrum.qml
@@ -20,12 +20,12 @@ import Shotcut.Controls 1.0 as Shotcut
 
 Shotcut.VuiBase {
     property string rectProperty: "rect"
-    property real zoom: (video.zoom > 0)? video.zoom : 1.0
+    property real zoom: (video.zoom > 0) ? video.zoom : 1
     property rect filterRect: filter ? filter.getRect(rectProperty) : Qt.rect(0, 0, 0, 0)
 
     Component.onCompleted: {
-        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag'))
-        rectangle.setHandles(filter.getRect(rectProperty))
+        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag'));
+        rectangle.setHandles(filter.getRect(rectProperty));
     }
 
     Flickable {
@@ -39,6 +39,7 @@ Shotcut.VuiBase {
 
         Item {
             id: videoItem
+
             x: video.rect.x
             y: video.rect.y
             width: video.rect.width
@@ -47,32 +48,37 @@ Shotcut.VuiBase {
 
             Shotcut.RectangleControl {
                 id: rectangle
+
                 widthScale: video.rect.width / profile.width
                 heightScale: video.rect.height / profile.height
                 handleSize: Math.max(Math.round(8 / zoom), 4)
                 borderSize: Math.max(Math.round(1.33 / zoom), 1)
                 onWidthScaleChanged: setHandles(filter.getRect(rectProperty))
                 onHeightScaleChanged: setHandles(filter.getRect(rectProperty))
-                onRectChanged:  {
-                    filterRect.x = Math.round(rect.x / rectangle.widthScale)
-                    filterRect.y = Math.round(rect.y / rectangle.heightScale)
-                    filterRect.width = Math.round(rect.width / rectangle.widthScale)
-                    filterRect.height = Math.round(rect.height / rectangle.heightScale)
-                    filter.set(rectProperty, filterRect)
+                onRectChanged: {
+                    filterRect.x = Math.round(rect.x / rectangle.widthScale);
+                    filterRect.y = Math.round(rect.y / rectangle.heightScale);
+                    filterRect.width = Math.round(rect.width / rectangle.widthScale);
+                    filterRect.height = Math.round(rect.height / rectangle.heightScale);
+                    filter.set(rectProperty, filterRect);
                 }
             }
+
         }
+
     }
 
     Connections {
-        target: filter
         function onChanged() {
-            var newRect = filter.getRect(rectProperty)
+            var newRect = filter.getRect(rectProperty);
             if (filterRect !== newRect) {
-                filterRect = newRect
-                rectangle.setHandles(filterRect)
+                filterRect = newRect;
+                rectangle.setHandles(filterRect);
             }
-            videoItem.enabled = filter.get('disable') !== '1'
+            videoItem.enabled = filter.get('disable') !== '1';
         }
+
+        target: filter
     }
+
 }

--- a/src/qml/filters/spillsuppress/ui.qml
+++ b/src/qml/filters/spillsuppress/ui.qml
@@ -23,38 +23,51 @@ import Shotcut.Controls 1.0 as Shotcut
 Item {
     property string typeParam: '0'
     property double typeDefault: 0
+
     width: 200
     height: 50
     Component.onCompleted: {
-        filter.set('threads', 0)
-        if (filter.isNew) {
-            filter.set(typeParam, typeDefault)
-        }
-        if (filter.getDouble(typeParam) === 0.0)
-            greenRadioButton.checked = true
+        filter.set('threads', 0);
+        if (filter.isNew)
+            filter.set(typeParam, typeDefault);
+
+        if (filter.getDouble(typeParam) === 0)
+            greenRadioButton.checked = true;
         else
-            blueRadioButton.checked = true
+            blueRadioButton.checked = true;
     }
+
     ColumnLayout {
         anchors.fill: parent
         anchors.margins: 8
 
         RowLayout {
-            ButtonGroup { id: typeGroup }
+            ButtonGroup {
+                id: typeGroup
+            }
+
             RadioButton {
                 id: greenRadioButton
+
                 text: qsTr('Green')
                 ButtonGroup.group: typeGroup
                 onClicked: filter.set(typeParam, 0)
             }
+
             RadioButton {
                 id: blueRadioButton
+
                 text: qsTr('Blue')
                 ButtonGroup.group: typeGroup
                 onClicked: filter.set(typeParam, 1)
             }
+
         }
 
-        Item { Layout.fillHeight: true }
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
+
 }

--- a/src/qml/filters/spot_remover/meta.qml
+++ b/src/qml/filters/spot_remover/meta.qml
@@ -8,6 +8,7 @@ Metadata {
     mlt_service: 'spot_remover'
     qml: 'ui.qml'
     vui: 'vui.qml'
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -20,4 +21,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/spot_remover/ui.qml
+++ b/src/qml/filters/spot_remover/ui.qml
@@ -25,66 +25,39 @@ Item {
     property rect filterRect
     property string startValue: '_shotcut:startValue'
     property string middleValue: '_shotcut:middleValue'
-    property string endValue:  '_shotcut:endValue'
-
-    width: 350
-    height: 180
-
-    Component.onCompleted: {
-        filter.blockSignals = true
-        filter.set(middleValue, Qt.rect(0, 0, profile.width, profile.height))
-        filter.set(startValue, Qt.rect(0, 0, profile.width, profile.height))
-        filter.set(endValue, Qt.rect(0, 0, profile.width, profile.height))
-        if (filter.isNew) {
-            // Add default preset.
-            filter.set(rectProperty,   '0%/0%:10%x10%')
-            filter.savePreset(preset.parameters)
-        } else {
-            filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1))
-            if (filter.animateIn > 0)
-                filter.set(startValue, filter.getRect(rectProperty, 0))
-            if (filter.animateOut > 0)
-                filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1))
-        }
-        filter.blockSignals = false
-        setControls()
-        setKeyframedControls()
-        if (filter.isNew)
-            filter.set(rectProperty, filter.getRect(rectProperty))
-    }
+    property string endValue: '_shotcut:endValue'
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setFilter(position) {
         if (position !== null) {
-            filter.blockSignals = true
+            filter.blockSignals = true;
             if (position <= 0 && filter.animateIn > 0)
-                filter.set(startValue, filterRect)
+                filter.set(startValue, filterRect);
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                filter.set(endValue, filterRect)
+                filter.set(endValue, filterRect);
             else
-                filter.set(middleValue, filterRect)
-            filter.blockSignals = false
+                filter.set(middleValue, filterRect);
+            filter.blockSignals = false;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(rectProperty)
-            positionKeyframesButton.checked = false
+            filter.resetProperty(rectProperty);
+            positionKeyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set(rectProperty, filter.getRect(startValue), 0)
-                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1)
+                filter.set(rectProperty, filter.getRect(startValue), 0);
+                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut)
-                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1)
+                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut);
+                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1);
             }
         } else if (!positionKeyframesButton.checked) {
-            filter.resetProperty(rectProperty)
-            filter.set(rectProperty, filter.getRect(middleValue))
+            filter.resetProperty(rectProperty);
+            filter.set(rectProperty, filter.getRect(middleValue));
         } else if (position !== null) {
-            filter.set(rectProperty, filterRect, position)
+            filter.set(rectProperty, filterRect, position);
         }
     }
 
@@ -92,21 +65,49 @@ Item {
     }
 
     function setKeyframedControls() {
-        var position = getPosition()
-        var newValue = filter.getRect(rectProperty, position)
+        var position = getPosition();
+        var newValue = filter.getRect(rectProperty, position);
         if (filterRect !== newValue) {
-            filterRect = newValue
-            rectX.value = filterRect.x.toFixed()
-            rectY.value = filterRect.y.toFixed()
-            rectW.value = filterRect.width.toFixed()
-            rectH.value = filterRect.height.toFixed()
+            filterRect = newValue;
+            rectX.value = filterRect.x.toFixed();
+            rectY.value = filterRect.y.toFixed();
+            rectW.value = filterRect.width.toFixed();
+            rectH.value = filterRect.height.toFixed();
         }
-        var enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
-        rectX.enabled = enabled
-        rectY.enabled = enabled
-        rectW.enabled = enabled
-        rectH.enabled = enabled
-        positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
+        var enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
+        rectX.enabled = enabled;
+        rectY.enabled = enabled;
+        rectW.enabled = enabled;
+        rectH.enabled = enabled;
+        positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+    }
+
+    width: 350
+    height: 180
+    Component.onCompleted: {
+        filter.blockSignals = true;
+        filter.set(middleValue, Qt.rect(0, 0, profile.width, profile.height));
+        filter.set(startValue, Qt.rect(0, 0, profile.width, profile.height));
+        filter.set(endValue, Qt.rect(0, 0, profile.width, profile.height));
+        if (filter.isNew) {
+            // Add default preset.
+            filter.set(rectProperty, '0%/0%:10%x10%');
+            filter.savePreset(preset.parameters);
+        } else {
+            filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1));
+            if (filter.animateIn > 0)
+                filter.set(startValue, filter.getRect(rectProperty, 0));
+
+            if (filter.animateOut > 0)
+                filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1));
+
+        }
+        filter.blockSignals = false;
+        setControls();
+        setKeyframedControls();
+        if (filter.isNew)
+            filter.set(rectProperty, filter.getRect(rectProperty));
+
     }
 
     GridLayout {
@@ -118,24 +119,28 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [rectProperty]
             Layout.columnSpan: 5
             onBeforePresetLoaded: {
-                filter.resetProperty(rectProperty)
+                filter.resetProperty(rectProperty);
             }
             onPresetSelected: {
-                setControls()
-                setKeyframedControls()
-                positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
-                filter.blockSignals = true
-                filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1))
+                setControls();
+                setKeyframedControls();
+                positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+                filter.blockSignals = true;
+                filter.set(middleValue, filter.getRect(rectProperty, filter.animateIn + 1));
                 if (filter.animateIn > 0)
-                    filter.set(startValue, filter.getRect(rectProperty, 0))
+                    filter.set(startValue, filter.getRect(rectProperty, 0));
+
                 if (filter.animateOut > 0)
-                    filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1))
-                filter.blockSignals = false
+                    filter.set(endValue, filter.getRect(rectProperty, filter.duration - 1));
+
+                filter.blockSignals = false;
             }
         }
 
@@ -143,55 +148,73 @@ Item {
             text: qsTr('Position')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Layout.columnSpan: 3
+
             Shotcut.DoubleSpinBox {
                 id: rectX
+
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.x !== value) {
-                    filterRect.x = value
-                    setFilter(getPosition())
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.x !== value) {
+                        filterRect.x = value;
+                        setFilter(getPosition());
+                    }
                 }
             }
-            Label { text: ','; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: ','
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectY
+
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.y !== value) {
-                    filterRect.y = value
-                    setFilter(getPosition())
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.y !== value) {
+                        filterRect.y = value;
+                        setFilter(getPosition());
+                    }
                 }
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                rectX.value = rectY.value = 0
-                filterRect.x = filterRect.y = 0
-                setFilter(getPosition())
+                rectX.value = rectY.value = 0;
+                filterRect.x = filterRect.y = 0;
+                setFilter(getPosition());
             }
         }
+
         Shotcut.KeyframesButton {
             id: positionKeyframesButton
+
             Layout.rowSpan: 2
             onToggled: {
                 if (checked) {
-                    filter.clearSimpleAnimation(rectProperty)
-                    filter.set(rectProperty, filterRect, getPosition())
+                    filter.clearSimpleAnimation(rectProperty);
+                    filter.set(rectProperty, filterRect, getPosition());
                 } else {
-                    filter.resetProperty(rectProperty)
-                    filter.set(rectProperty, filterRect)
+                    filter.resetProperty(rectProperty);
+                    filter.set(rectProperty, filterRect);
                 }
-                checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
+                checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
             }
         }
 
@@ -199,60 +222,102 @@ Item {
             text: qsTr('Size')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Layout.columnSpan: 3
+
             Shotcut.DoubleSpinBox {
                 id: rectW
+
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.width !== value) {
-                    filterRect.width = value
-                    setFilter(getPosition())
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.width !== value) {
+                        filterRect.width = value;
+                        setFilter(getPosition());
+                    }
                 }
             }
-            Label { text: 'x'; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: 'x'
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectH
+
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
-                onValueModified: if (filterRect.height !== value) {
-                    filterRect.height = value
-                    setFilter(getPosition())
+                from: -1e+09
+                to: 1e+09
+                onValueModified: {
+                    if (filterRect.height !== value) {
+                        filterRect.height = value;
+                        setFilter(getPosition());
+                    }
                 }
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                rectW.value = profile.width / 10
-                rectH.value = profile.height / 10
-                filterRect.width = profile.width / 10
-                filterRect.height = profile.height / 10
-                setFilter(getPosition())
+                rectW.value = profile.width / 10;
+                rectH.value = profile.height / 10;
+                filterRect.width = profile.width / 10;
+                filterRect.height = profile.height / 10;
+                setFilter(getPosition());
             }
         }
 
-        Item { Layout.fillHeight: true }
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
 
     Connections {
+        function onChanged() {
+            setKeyframedControls();
+        }
+
+        function onInChanged() {
+            setKeyframedControls();
+            setFilter(null);
+        }
+
+        function onOutChanged() {
+            setKeyframedControls();
+            setFilter(null);
+        }
+
+        function onAnimateInChanged() {
+            setKeyframedControls();
+            setFilter(null);
+        }
+
+        function onAnimateOutChanged() {
+            setKeyframedControls();
+            setFilter(null);
+        }
+
         target: filter
-        function onChanged() { setKeyframedControls() }
-        function onInChanged() { setKeyframedControls(); setFilter(null) }
-        function onOutChanged() { setKeyframedControls(); setFilter(null) }
-        function onAnimateInChanged() { setKeyframedControls(); setFilter(null) }
-        function onAnimateOutChanged() { setKeyframedControls(); setFilter(null) }
     }
 
     Connections {
+        function onPositionChanged() {
+            setKeyframedControls();
+        }
+
         target: producer
-        function onPositionChanged() { setKeyframedControls() }
     }
+
 }

--- a/src/qml/filters/spot_remover/vui.qml
+++ b/src/qml/filters/spot_remover/vui.qml
@@ -20,71 +20,71 @@ import Shotcut.Controls 1.0 as Shotcut
 
 Shotcut.VuiBase {
     property string rectProperty: 'rect'
-    property real zoom: (video.zoom > 0)? video.zoom : 1.0
+    property real zoom: (video.zoom > 0) ? video.zoom : 1
     property rect filterRect
     property bool blockUpdate: false
     property string startValue: '_shotcut:startValue'
     property string middleValue: '_shotcut:middleValue'
-    property string endValue:  '_shotcut:endValue'
-
-    Component.onCompleted: {
-        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag'))
-        filterRect = filter.getRect(rectProperty, getPosition())
-        rectangle.setHandles(filterRect)
-        setRectangleControl()
-    }
+    property string endValue: '_shotcut:endValue'
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setRectangleControl() {
-        if (blockUpdate) return
-        var position = getPosition()
-        var newValue = filter.getRect(rectProperty, position)
+        if (blockUpdate)
+            return ;
+
+        var position = getPosition();
+        var newValue = filter.getRect(rectProperty, position);
         if (filterRect !== newValue) {
-            filterRect = newValue
-            rectangle.setHandles(filterRect)
+            filterRect = newValue;
+            rectangle.setHandles(filterRect);
         }
-        rectangle.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        rectangle.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function setFilter(position) {
-        blockUpdate = true
-        var rect = rectangle.rectangle
-        filterRect.x = Math.round(rect.x / rectangle.widthScale)
-        filterRect.y = Math.round(rect.y / rectangle.heightScale)
-        filterRect.width = Math.round(rect.width / rectangle.widthScale)
-        filterRect.height = Math.round(rect.height / rectangle.heightScale)
-
+        blockUpdate = true;
+        var rect = rectangle.rectangle;
+        filterRect.x = Math.round(rect.x / rectangle.widthScale);
+        filterRect.y = Math.round(rect.y / rectangle.heightScale);
+        filterRect.width = Math.round(rect.width / rectangle.widthScale);
+        filterRect.height = Math.round(rect.height / rectangle.heightScale);
         if (position !== null) {
-            filter.blockSignals = true
+            filter.blockSignals = true;
             if (position <= 0 && filter.animateIn > 0)
-                filter.set(startValue, filterRect)
+                filter.set(startValue, filterRect);
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                filter.set(endValue, filterRect)
+                filter.set(endValue, filterRect);
             else
-                filter.set(middleValue, filterRect)
-            filter.blockSignals = false
+                filter.set(middleValue, filterRect);
+            filter.blockSignals = false;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(rectProperty)
+            filter.resetProperty(rectProperty);
             if (filter.animateIn > 0) {
-                filter.set(rectProperty, filter.getRect(startValue), 0)
-                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1)
+                filter.set(rectProperty, filter.getRect(startValue), 0);
+                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut)
-                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1)
+                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut);
+                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1);
             }
         } else if (filter.keyframeCount(rectProperty) <= 0) {
-            filter.resetProperty(rectProperty)
-            filter.set(rectProperty, filter.getRect(middleValue))
+            filter.resetProperty(rectProperty);
+            filter.set(rectProperty, filter.getRect(middleValue));
         } else if (position !== null) {
-            filter.set(rectProperty, filterRect, position)
+            filter.set(rectProperty, filterRect, position);
         }
-        blockUpdate = false
+        blockUpdate = false;
+    }
+
+    Component.onCompleted: {
+        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag'));
+        filterRect = filter.getRect(rectProperty, getPosition());
+        rectangle.setHandles(filterRect);
+        setRectangleControl();
     }
 
     Flickable {
@@ -98,6 +98,7 @@ Shotcut.VuiBase {
 
         Item {
             id: videoItem
+
             x: video.rect.x
             y: video.rect.y
             width: video.rect.width
@@ -106,6 +107,7 @@ Shotcut.VuiBase {
 
             Shotcut.RectangleControl {
                 id: rectangle
+
                 widthScale: video.rect.width / profile.width
                 heightScale: video.rect.height / profile.height
                 handleSize: Math.max(Math.round(8 / zoom), 4)
@@ -114,19 +116,26 @@ Shotcut.VuiBase {
                 onHeightScaleChanged: setHandles(filterRect)
                 onRectChanged: setFilter(getPosition())
             }
+
         }
+
     }
 
     Connections {
-        target: filter
         function onChanged() {
-            setRectangleControl()
-            videoItem.enabled = filter.get('disable') !== '1'
+            setRectangleControl();
+            videoItem.enabled = filter.get('disable') !== '1';
         }
+
+        target: filter
     }
 
     Connections {
+        function onPositionChanged() {
+            setRectangleControl();
+        }
+
         target: producer
-        function onPositionChanged() { setRectangleControl() }
     }
+
 }

--- a/src/qml/filters/stabilize/meta.qml
+++ b/src/qml/filters/stabilize/meta.qml
@@ -9,7 +9,9 @@ Metadata {
     isClipOnly: true
     allowMultiple: false
     isGpuCompatible: false
+
     keyframes {
         allowTrim: false
     }
+
 }

--- a/src/qml/filters/stabilize/ui.qml
+++ b/src/qml/filters/stabilize/ui.qml
@@ -23,94 +23,98 @@ import Shotcut.Controls 1.0 as Shotcut
 
 Item {
     id: stabilizeRoot
-    width: 350
-    height: 150
+
     property url settingsSavePath: 'file:///' + settings.savePath
     property string _analysisRequiredMessage: qsTr('Click Analyze to use this filter.')
-
-    Component.onCompleted: {
-        filter.set('analyze', 0)
-        shakinessSlider.value = filter.getDouble('shakiness')
-        accuracySlider.value = filter.getDouble('accuracy')
-        setStatus(false)
-    }
-
-    function hasAnalysisCompleted() {
-        return (filter.get("results").length > 0 &&
-                filter.get("filename").indexOf(filter.get("results")) !== -1)
-    }
-
-    function setStatus( inProgress ) {
-        if (inProgress) {
-            status.text = qsTr('Analyzing...')
-        }
-        else if (hasAnalysisCompleted()) {
-            status.text = qsTr('Analysis complete.')
-        }
-        else
-        {
-            status.text = _analysisRequiredMessage
-        }
-    }
-
-    function analyzeValueChanged() {
-        status.text = _analysisRequiredMessage
-    }
-
-    function startAnalyzeJob(filename) {
-        stabilizeRoot.fileSaved(filename)
-        filter.set('filename', filename)
-        filter.getHash()
-        setStatus(true)
-        filter.analyze();
-    }
 
     // This signal is used to workaround context properties not available in
     // the FileDialog onAccepted signal handler on Qt 5.5.
     signal fileSaved(string filename)
+
+    function hasAnalysisCompleted() {
+        return (filter.get("results").length > 0 && filter.get("filename").indexOf(filter.get("results")) !== -1);
+    }
+
+    function setStatus(inProgress) {
+        if (inProgress)
+            status.text = qsTr('Analyzing...');
+        else if (hasAnalysisCompleted())
+            status.text = qsTr('Analysis complete.');
+        else
+            status.text = _analysisRequiredMessage;
+    }
+
+    function analyzeValueChanged() {
+        status.text = _analysisRequiredMessage;
+    }
+
+    function startAnalyzeJob(filename) {
+        stabilizeRoot.fileSaved(filename);
+        filter.set('filename', filename);
+        filter.getHash();
+        setStatus(true);
+        filter.analyze();
+    }
+
+    width: 350
+    height: 150
+    Component.onCompleted: {
+        filter.set('analyze', 0);
+        shakinessSlider.value = filter.getDouble('shakiness');
+        accuracySlider.value = filter.getDouble('accuracy');
+        setStatus(false);
+    }
     onFileSaved: {
-        var lastPathSeparator = filename.lastIndexOf('/')
-        if (lastPathSeparator !== -1) {
-            settings.savePath = filename.substring(0, lastPathSeparator)
-        }
+        var lastPathSeparator = filename.lastIndexOf('/');
+        if (lastPathSeparator !== -1)
+            settings.savePath = filename.substring(0, lastPathSeparator);
+
     }
 
     Connections {
-        target: filter
         function onAnalyzeFinished() {
             filter.set("reload", 1);
-            setStatus(false)
+            setStatus(false);
         }
-        function onInChanged() { analyzeValueChanged() }
-        function onOutChanged() { analyzeValueChanged() }
+
+        function onInChanged() {
+            analyzeValueChanged();
+        }
+
+        function onOutChanged() {
+            analyzeValueChanged();
+        }
+
+        target: filter
     }
-    
+
     FileDialog {
+        // In Windows, the prefix is a little different
+
         id: fileDialog
-        title: qsTr( 'Select a file to store analysis results.' )
+
+        title: qsTr('Select a file to store analysis results.')
         modality: application.dialogModality
         selectExisting: false
         selectMultiple: false
         selectFolder: false
         folder: settingsSavePath
-        nameFilters: [ "Stabilize Results (*.stab)" ]
+        nameFilters: ["Stabilize Results (*.stab)"]
         selectedNameFilter: "Stabilize Results (*.stab)"
         onAccepted: {
-            var filename = fileDialog.fileUrl.toString()
+            var filename = fileDialog.fileUrl.toString();
             // Remove resource prefix ("file://")
-            filename = filename.substring(7)
-            if (filename.substring(2, 4) == ':/') {
-                // In Windows, the prefix is a little different
-                filename = filename.substring(1)
-            }
+            filename = filename.substring(7);
+            if (filename.substring(2, 4) == ':/')
+                filename = filename.substring(1);
 
             // Force file extension to ".stab"
-            var extension = ".stab"
-            var extIndex = filename.indexOf(extension, filename.length - extension.length)
-            if (extIndex == -1) {
-                filename += extension
-            }
-            startAnalyzeJob(filename)
+            var extension = ".stab";
+            var extIndex = filename.indexOf(extension, filename.length - extension.length);
+            if (extIndex == -1)
+                filename += extension;
+
+            startAnalyzeJob(filename);
         }
     }
 
@@ -128,16 +132,19 @@ Item {
             text: qsTr('Shakiness')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: shakinessSlider
+
             minimumValue: 1
             maximumValue: 10
             stepSize: 1
             onValueChanged: {
-                filter.set('shakiness', value)
-                analyzeValueChanged()
+                filter.set('shakiness', value);
+                analyzeValueChanged();
             }
         }
+
         Shotcut.UndoButton {
             onClicked: shakinessSlider.value = 4
         }
@@ -146,36 +153,42 @@ Item {
             text: qsTr('Accuracy')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: accuracySlider
+
             minimumValue: 1
             maximumValue: 15
             stepSize: 1
             onValueChanged: {
-                filter.set('accuracy', value)
-                analyzeValueChanged()
+                filter.set('accuracy', value);
+                analyzeValueChanged();
             }
         }
+
         Shotcut.UndoButton {
             onClicked: accuracySlider.value = 4
         }
 
         Shotcut.Button {
             id: button
+
             text: qsTr('Analyze')
             Layout.alignment: Qt.AlignRight
             onClicked: {
-                var filename = application.getNextProjectFile('stab')
+                var filename = application.getNextProjectFile('stab');
                 if (filename) {
-                    stabilizeRoot.fileSaved(filename)
-                    startAnalyzeJob(filename)
+                    stabilizeRoot.fileSaved(filename);
+                    startAnalyzeJob(filename);
                 } else {
-                    fileDialog.open()
+                    fileDialog.open();
                 }
             }
         }
+
         Label {
             id: status
+
             Layout.columnSpan: 2
         }
 
@@ -188,18 +201,21 @@ Item {
             text: qsTr('Zoom')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: zoomSlider
+
             minimumValue: -50
             maximumValue: 50
             decimals: 1
             suffix: ' %'
             value: filter.getDouble('zoom')
             onValueChanged: {
-                filter.set('zoom', value)
+                filter.set('zoom', value);
                 filter.set("refresh", 1);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: zoomSlider.value = 0
         }
@@ -208,22 +224,27 @@ Item {
             text: qsTr('Smoothing')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: smoothingSlider
+
             minimumValue: 0
             maximumValue: 100
             stepSize: 1
             value: filter.get('smoothing')
             onValueChanged: {
-                filter.set('smoothing', value)
+                filter.set('smoothing', value);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: smoothingSlider.value = 15
         }
 
         Item {
-            Layout.fillHeight: true;
+            Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/tcolor/ui.qml
+++ b/src/qml/filters/tcolor/ui.qml
@@ -22,21 +22,21 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
+    function setControls() {
+        bySlider.value = filter.get('oversaturate_cr');
+        rgSlider.value = filter.get('oversaturate_cb');
+    }
+
     width: 350
     height: 100
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set('oversaturate_cr', 190)
-            filter.set('oversaturate_cb', 190)
-            filter.savePreset(preset.parameters)
+            filter.set('oversaturate_cr', 190);
+            filter.set('oversaturate_cb', 190);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        bySlider.value = filter.get('oversaturate_cr')
-        rgSlider.value = filter.get('oversaturate_cb')
+        setControls();
     }
 
     GridLayout {
@@ -48,8 +48,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: ['oversaturate_cr', 'oversaturate_cb']
             Layout.columnSpan: 2
             onPresetSelected: setControls()
@@ -59,14 +61,17 @@ Item {
             text: qsTr('Green')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: bySlider
+
             minimumValue: -300
             maximumValue: 300
             value: filter.get('oversaturate_cr')
             label: qsTr(' Red')
             onValueChanged: filter.set('oversaturate_cr', value)
         }
+
         Shotcut.UndoButton {
             onClicked: bySlider.value = 190
         }
@@ -75,14 +80,17 @@ Item {
             text: qsTr('Yellow')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: rgSlider
+
             minimumValue: -300
             maximumValue: 300
             value: filter.get('oversaturate_cb')
             label: qsTr('Blue')
             onValueChanged: filter.set('oversaturate_cb', value)
         }
+
         Shotcut.UndoButton {
             onClicked: rgSlider.value = 190
         }
@@ -90,5 +98,7 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/threshold/meta.qml
+++ b/src/qml/filters/threshold/meta.qml
@@ -6,6 +6,7 @@ Metadata {
     name: qsTr("Threshold")
     mlt_service: "threshold"
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -20,4 +21,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/threshold/ui.qml
+++ b/src/qml/filters/threshold/ui.qml
@@ -24,44 +24,42 @@ Shotcut.KeyframableFilter {
     property string threshold: 'midpoint'
     property double thresholdDefault: 128
 
+    function setControls() {
+        setKeyframableControls();
+        invertCheckbox.checked = filter.get('invert') === '1';
+        useAlphaCheckbox.checked = filter.get('use_alpha') === '1';
+    }
+
+    function setKeyframableControls() {
+        var position = getPosition();
+        blockUpdate = true;
+        thresholdSlider.value = filter.getDouble(threshold, position) / 255 * thresholdSlider.maximumValue;
+        thresholdKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(threshold) > 0;
+        blockUpdate = false;
+        enableControls(isSimpleKeyframesActive());
+    }
+
+    function enableControls(enabled) {
+        thresholdSlider.enabled = enabled;
+    }
+
+    function updateSimpleKeyframes() {
+        setKeyframableControls();
+        updateFilter(threshold, thresholdSlider.value / thresholdSlider.maximumValue * 255, thresholdKeyframesButton, null);
+    }
+
     keyframableParameters: [threshold]
     startValues: [thresholdDefault]
     middleValues: [thresholdDefault]
     endValues: [thresholdDefault]
-
     width: 350
     height: 150
-
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set(threshold, thresholdDefault)
-            filter.savePreset(preset.parameters)
+            filter.set(threshold, thresholdDefault);
+            filter.savePreset(preset.parameters);
         }
-        setControls()
-    }
-
-    function setControls() {
-        setKeyframableControls()
-        invertCheckbox.checked = filter.get('invert') === '1'
-        useAlphaCheckbox.checked = filter.get('use_alpha') === '1'
-    }
-
-    function setKeyframableControls() {
-        var position = getPosition()
-        blockUpdate = true
-        thresholdSlider.value = filter.getDouble(threshold, position) / 255  * thresholdSlider.maximumValue
-        thresholdKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount(threshold) > 0
-        blockUpdate = false
-        enableControls(isSimpleKeyframesActive())
-    }
-
-    function enableControls(enabled) {
-        thresholdSlider.enabled = enabled
-    }
-
-    function updateSimpleKeyframes() {
-        setKeyframableControls()
-        updateFilter(threshold, thresholdSlider.value / thresholdSlider.maximumValue * 255, thresholdKeyframesButton, null)
+        setControls();
     }
 
     GridLayout {
@@ -73,16 +71,18 @@ Shotcut.KeyframableFilter {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [threshold, 'invert', 'use_alpha']
             Layout.columnSpan: 3
             onBeforePresetLoaded: {
-                resetSimpleKeyframes()
+                resetSimpleKeyframes();
             }
             onPresetSelected: {
-                setControls()
-                initializeSimpleKeyframes()
+                setControls();
+                initializeSimpleKeyframes();
             }
         }
 
@@ -90,8 +90,10 @@ Shotcut.KeyframableFilter {
             text: qsTr('Level')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: thresholdSlider
+
             minimumValue: 0
             maximumValue: 100
             stepSize: 1
@@ -99,56 +101,97 @@ Shotcut.KeyframableFilter {
             suffix: ' %'
             onValueChanged: updateFilter(threshold, thresholdSlider.value / thresholdSlider.maximumValue * 255, thresholdKeyframesButton, getPosition())
         }
+
         Shotcut.UndoButton {
-            onClicked: thresholdSlider.value = thresholdDefault / 255  * thresholdSlider.maximumValue
+            onClicked: thresholdSlider.value = thresholdDefault / 255 * thresholdSlider.maximumValue
         }
+
         Shotcut.KeyframesButton {
             id: thresholdKeyframesButton
+
             onToggled: {
-                enableControls(true)
-                toggleKeyframes(checked, threshold, thresholdSlider.value / thresholdSlider.maximumValue * 255)
+                enableControls(true);
+                toggleKeyframes(checked, threshold, thresholdSlider.value / thresholdSlider.maximumValue * 255);
             }
         }
 
-        Item { width: 1 }
+        Item {
+            width: 1
+        }
+
         CheckBox {
             id: invertCheckbox
+
             text: qsTr('Invert')
             onCheckedChanged: filter.set('invert', checked)
         }
+
         Shotcut.UndoButton {
             onClicked: invertCheckbox.checked = false
         }
-        Item { width: 1 }
 
-        Label {}
+        Item {
+            width: 1
+        }
+
+        Label {
+        }
+
         CheckBox {
             id: useAlphaCheckbox
+
             text: qsTr('Compare with alpha channel')
             onCheckedChanged: filter.set('use_alpha', checked)
         }
+
         Shotcut.UndoButton {
             onClicked: useAlphaCheckbox.checked = false
         }
-        Item { width: 1 }
+
+        Item {
+            width: 1
+        }
 
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
+        function onChanged() {
+            setKeyframableControls();
+        }
+
+        function onInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleKeyframes();
+        }
+
+        function onPropertyChanged() {
+            setKeyframableControls();
+        }
+
         target: filter
-        function onChanged() { setKeyframableControls() }
-        function onInChanged() { updateSimpleKeyframes() }
-        function onOutChanged() { updateSimpleKeyframes() }
-        function onAnimateInChanged() { updateSimpleKeyframes() }
-        function onAnimateOutChanged() { updateSimpleKeyframes() }
-        function onPropertyChanged() { setKeyframableControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setKeyframableControls();
+        }
+
         target: producer
-        function onPositionChanged() { setKeyframableControls() }
     }
+
 }

--- a/src/qml/filters/time_remap/meta.qml
+++ b/src/qml/filters/time_remap/meta.qml
@@ -9,6 +9,7 @@ Metadata {
     qml: "ui.qml"
     isFavorite: false
     allowMultiple: false
+
     keyframes {
         allowTrim: false
         allowAnimateIn: false
@@ -24,4 +25,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/time_remap/ui.qml
+++ b/src/qml/filters/time_remap/ui.qml
@@ -22,224 +22,243 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 200
-    height: 225
     property bool blockUpdate: true
 
+    function getPosition() {
+        return Math.max(producer.position - (filter.in - producer.in), 0);
+    }
+
+    function setControls() {
+        if (blockUpdate)
+            return ;
+
+        var outPosition = getPosition();
+        var inSeconds = filter.getDouble('map', outPosition);
+        var inPosition = Math.round(inSeconds * profile.fps);
+        blockUpdate = true;
+        mapSpinner.value = inPosition;
+        var current = filter.get('image_mode');
+        for (var i = 0; i < imageModeModel.count; ++i) {
+            if (imageModeModel.get(i).value === current) {
+                modeCombo.currentIndex = i;
+                break;
+            }
+        }
+        pitchCheckbox.checked = filter.get('pitch') === '1';
+        var speed = filter.getDouble('speed');
+        speedLabel.text = Math.abs(speed).toFixed(5) + "x";
+        if (speed < 0)
+            directionLabel.text = qsTr('Reverse');
+        else if (speed > 0)
+            directionLabel.text = qsTr('Forward');
+        else
+            directionLabel.text = qsTr('Freeze');
+        inputTimeLabel.text = qsTr("%L1s").arg(inSeconds);
+        outputTimeLabel.text = qsTr("%L1s").arg(outPosition / profile.fps);
+        blockUpdate = false;
+    }
+
+    width: 200
+    height: 225
     Component.onCompleted: {
         if (filter.isNew) {
             // Set default parameter values
-            filter.set('map', 0.0, 0)
-            filter.set('map', (filter.duration - 1) / profile.fps, filter.duration - 1)
-            filter.set('image_mode', 'nearest')
-            filter.set('pitch', 0)
-            filter.savePreset(preset.parameters)
-            application.showStatusMessage(qsTr('Hold %1 to drag a keyframe vertical only or %2 to drag horizontal only')
-                .arg(application.OS === 'OS X'? '⌘' : 'Ctrl')
-                .arg(application.OS === 'OS X'? '⌥' : 'Alt'))
+            filter.set('map', 0, 0);
+            filter.set('map', (filter.duration - 1) / profile.fps, filter.duration - 1);
+            filter.set('image_mode', 'nearest');
+            filter.set('pitch', 0);
+            filter.savePreset(preset.parameters);
+            application.showStatusMessage(qsTr('Hold %1 to drag a keyframe vertical only or %2 to drag horizontal only').arg(application.OS === 'OS X' ? '⌘' : 'Ctrl').arg(application.OS === 'OS X' ? '⌥' : 'Alt'));
         }
-        blockUpdate = false
-        timer.restart()
+        blockUpdate = false;
+        timer.restart();
     }
 
     Connections {
-        target: filter
         function onInChanged() {
-            timer.restart()
+            timer.restart();
         }
+
         function onOutChanged() {
-            timer.restart()
+            timer.restart();
         }
+
         function onPropertyChanged() {
-            timer.restart()
+            timer.restart();
         }
+
+        target: filter
     }
 
     Timer {
         id: timer
+
         interval: 200
         repeat: true
         triggeredOnStart: true
         onTriggered: {
-            setControls()
+            setControls();
         }
     }
 
     Connections {
-        target: producer
         function onPositionChanged() {
-            timer.restart()
+            timer.restart();
         }
-    }
 
-    function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
-    }
-
-    function setControls() {
-        if (blockUpdate) return
-        var outPosition = getPosition()
-        var inSeconds = filter.getDouble('map', outPosition)
-        var inPosition = Math.round(inSeconds * profile.fps)
-        blockUpdate = true
-        mapSpinner.value = inPosition
-        var current = filter.get('image_mode')
-        for (var i = 0; i < imageModeModel.count; ++i) {
-            if (imageModeModel.get(i).value === current) {
-                modeCombo.currentIndex = i
-                break
-            }
-        }
-        pitchCheckbox.checked = filter.get('pitch') === '1'
-        var speed = filter.getDouble('speed')
-        speedLabel.text = Math.abs(speed).toFixed(5) + "x"
-        if (speed < 0 ) {
-            directionLabel.text = qsTr('Reverse')
-        } else if (speed > 0 ) {
-            directionLabel.text = qsTr('Forward')
-        } else {
-            directionLabel.text = qsTr('Freeze')
-        }
-        inputTimeLabel.text = qsTr("%L1s").arg(inSeconds)
-        outputTimeLabel.text = qsTr("%L1s").arg(outPosition / profile.fps)
-        blockUpdate = false
+        target: producer
     }
 
     Dialog {
         id: speedDialog
+
         property var direction: 'after'
+
         title: direction == 'after' ? qsTr('Set Speed After') : qsTr('Set Speed Before')
         standardButtons: StandardButton.Ok | StandardButton.Cancel
         modality: application.dialogModality
         width: 400
         height: 95
-        ColumnLayout {
-            Shotcut.SliderSpinner {
-                id: speedSlider
-                Layout.bottomMargin: 8
-                Layout.preferredWidth: 400
-                value: 1.0
-                minimumValue: -3.0
-                maximumValue: 3.0
-                decimals: 6
-                stepSize: 0.1
-                suffix: "x"
-            }
-            Shotcut.ComboBox {
-                id: lockCombo
-                Layout.preferredWidth: 400
-                model: ListModel {
-                    id: lockModel
-                    ListElement { text: qsTr('Modify current mapping'); value: 'out' }
-                    ListElement { text: qsTr('Lock current mapping'); value: 'in' }
-                }
-                textRole: "text"
-                currentIndex: 0
-                function getLock() {
-                    return lockModel.get(currentIndex).value
-                }
-            }
-            Label {
-                Layout.bottomMargin: 12
-                Layout.preferredWidth: 400
-                wrapMode: Text.WordWrap
-                text: qsTr('"Modify current mapping" will modify the input time at the current position.\n' +
-                           '"Lock current mapping" will lock the input time at the current position and modify the value of an adjacent keyframe')
-            }
-        }
         onAccepted: {
-            var currPosition = getPosition()
-            var maxPosition = producer.out - producer.in
-            var currValue = filter.getDouble("map", currPosition)
-            var maxValue = (producer.length - producer.in) / profile.fps
-            var newValue = currValue
-            var newPosition = currPosition
-            var lock = lockCombo.getLock()
+            var currPosition = getPosition();
+            var maxPosition = producer.out - producer.in;
+            var currValue = filter.getDouble("map", currPosition);
+            var maxValue = (producer.length - producer.in) / profile.fps;
+            var newValue = currValue;
+            var newPosition = currPosition;
+            var lock = lockCombo.getLock();
             if (direction == 'after' && lock == 'out') {
-                var nextPosition = filter.getNextKeyframePosition("map", currPosition)
+                var nextPosition = filter.getNextKeyframePosition("map", currPosition);
                 if (nextPosition > currPosition) {
-                    var deltaTime = ((nextPosition - currPosition) / profile.fps) * speedSlider.value
-                    var nextValue = filter.getDouble("map", nextPosition)
+                    var deltaTime = ((nextPosition - currPosition) / profile.fps) * speedSlider.value;
+                    var nextValue = filter.getDouble("map", nextPosition);
                     newValue = nextValue - deltaTime;
                 }
             } else if (direction == 'before' && lock == 'out') {
-                var prevPosition = filter.getPrevKeyframePosition("map", currPosition)
+                var prevPosition = filter.getPrevKeyframePosition("map", currPosition);
                 if (prevPosition < currPosition && prevPosition >= 0) {
-                    var deltaTime = ((currPosition - prevPosition) / profile.fps) * speedSlider.value
-                    var prevValue = filter.getDouble("map", prevPosition)
+                    var deltaTime = ((currPosition - prevPosition) / profile.fps) * speedSlider.value;
+                    var prevValue = filter.getDouble("map", prevPosition);
                     newValue = prevValue + deltaTime;
                 }
             } else if (direction == 'after' && lock == 'in') {
                 // Lock the input value
-                filter.set('map', currValue, currPosition)
+                filter.set('map', currValue, currPosition);
                 // Calculate the value of the next keyframe
-                var nextPosition = filter.getNextKeyframePosition("map", currPosition)
-                if (nextPosition == -1 || nextPosition > maxPosition) {
-                    nextPosition = maxPosition
-                }
+                var nextPosition = filter.getNextKeyframePosition("map", currPosition);
+                if (nextPosition == -1 || nextPosition > maxPosition)
+                    nextPosition = maxPosition;
+
                 if (nextPosition > currPosition) {
-                    var deltaTime = ((nextPosition - currPosition) / profile.fps) * speedSlider.value
+                    var deltaTime = ((nextPosition - currPosition) / profile.fps) * speedSlider.value;
                     newValue = currValue + deltaTime;
-                    newPosition = nextPosition
+                    newPosition = nextPosition;
                 }
-                if (newValue > maxValue)
-                {
-                    var deltaPosition = ((maxValue - currValue) / speedSlider.value) * profile.fps
-                    newPosition = Math.floor(currPosition + deltaPosition)
-                    var deltaTime = ((newPosition - currPosition) / profile.fps) * speedSlider.value
+                if (newValue > maxValue) {
+                    var deltaPosition = ((maxValue - currValue) / speedSlider.value) * profile.fps;
+                    newPosition = Math.floor(currPosition + deltaPosition);
+                    var deltaTime = ((newPosition - currPosition) / profile.fps) * speedSlider.value;
                     newValue = currValue + deltaTime;
                 }
-                if (newValue < 0)
-                {
-                    var deltaPosition = ((0 - currValue) / speedSlider.value) * profile.fps
-                    newPosition = Math.floor(currPosition + deltaPosition)
-                    var deltaTime = ((newPosition - currPosition) / profile.fps) * speedSlider.value
+                if (newValue < 0) {
+                    var deltaPosition = ((0 - currValue) / speedSlider.value) * profile.fps;
+                    newPosition = Math.floor(currPosition + deltaPosition);
+                    var deltaTime = ((newPosition - currPosition) / profile.fps) * speedSlider.value;
                     newValue = currValue + deltaTime;
                 }
             } else if (direction == 'before' && lock == 'in') {
                 // Lock the input value
-                filter.set('map', currValue, currPosition)
+                filter.set('map', currValue, currPosition);
                 // Calculate the value of the next keyframe
-                var prevPosition = filter.getPrevKeyframePosition("map", currPosition)
-                if (prevPosition < 0 || prevPosition == currPosition) {
-                    prevPosition = 0
-                }
+                var prevPosition = filter.getPrevKeyframePosition("map", currPosition);
+                if (prevPosition < 0 || prevPosition == currPosition)
+                    prevPosition = 0;
+
                 if (prevPosition < currPosition && prevPosition >= 0) {
-                    var deltaTime = ((currPosition - prevPosition) / profile.fps) * speedSlider.value
+                    var deltaTime = ((currPosition - prevPosition) / profile.fps) * speedSlider.value;
                     newValue = currValue - deltaTime;
-                    newPosition = prevPosition
+                    newPosition = prevPosition;
                 }
-                if (newValue > maxValue)
-                {
-                    var deltaPosition = Math.ceil(((maxValue - currValue) / speedSlider.value) * profile.fps)
-                    newPosition = currPosition + deltaPosition
-                    var deltaTime = ((currPosition - newPosition) / profile.fps) * speedSlider.value
-                    newValue = currValue - deltaTime;
-                }
-                if (newValue < 0)
-                {
-                    var deltaPosition = Math.ceil(((0 - currValue) / speedSlider.value) * profile.fps)
-                    newPosition = currPosition + deltaPosition
-                    var deltaTime = ((currPosition - newPosition) / profile.fps) * speedSlider.value
+                if (newValue > maxValue) {
+                    var deltaPosition = Math.ceil(((maxValue - currValue) / speedSlider.value) * profile.fps);
+                    newPosition = currPosition + deltaPosition;
+                    var deltaTime = ((currPosition - newPosition) / profile.fps) * speedSlider.value;
                     newValue = currValue - deltaTime;
                 }
+                if (newValue < 0) {
+                    var deltaPosition = Math.ceil(((0 - currValue) / speedSlider.value) * profile.fps);
+                    newPosition = currPosition + deltaPosition;
+                    var deltaTime = ((currPosition - newPosition) / profile.fps) * speedSlider.value;
+                    newValue = currValue - deltaTime;
+                }
+            }
+            if (newValue < 0)
+                newValue = 0;
+
+            if (newValue > maxValue)
+                newValue = maxValue;
+
+            if (newPosition < 0)
+                newPosition = 0;
+
+            if (newPosition > maxPosition)
+                newPosition = maxPosition;
+
+            filter.set('map', newValue, newPosition);
+            timer.restart();
+        }
+
+        ColumnLayout {
+            Shotcut.SliderSpinner {
+                id: speedSlider
+
+                Layout.bottomMargin: 8
+                Layout.preferredWidth: 400
+                value: 1
+                minimumValue: -3
+                maximumValue: 3
+                decimals: 6
+                stepSize: 0.1
+                suffix: "x"
             }
 
-            if (newValue < 0) {
-                newValue = 0
+            Shotcut.ComboBox {
+                id: lockCombo
+
+                function getLock() {
+                    return lockModel.get(currentIndex).value;
+                }
+
+                Layout.preferredWidth: 400
+                textRole: "text"
+                currentIndex: 0
+
+                model: ListModel {
+                    id: lockModel
+
+                    ListElement {
+                        text: qsTr('Modify current mapping')
+                        value: 'out'
+                    }
+
+                    ListElement {
+                        text: qsTr('Lock current mapping')
+                        value: 'in'
+                    }
+
+                }
+
             }
-            if (newValue > maxValue) {
-                newValue = maxValue
+
+            Label {
+                Layout.bottomMargin: 12
+                Layout.preferredWidth: 400
+                wrapMode: Text.WordWrap
+                text: qsTr('"Modify current mapping" will modify the input time at the current position.\n' + '"Lock current mapping" will lock the input time at the current position and modify the value of an adjacent keyframe')
             }
-            if (newPosition < 0) {
-                newPosition = 0
-            }
-            if (newPosition > maxPosition) {
-                newPosition = maxPosition
-            }
-            filter.set('map', newValue, newPosition)
-            timer.restart()
+
         }
+
     }
 
     GridLayout {
@@ -251,108 +270,156 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: parent.columns - 1
             parameters: ['map', 'image_mode', 'pitch']
             onBeforePresetLoaded: {
-                filter.resetProperty(parameters[0])
+                filter.resetProperty(parameters[0]);
             }
             onPresetSelected: {
-                timer.restart()
-                mapKeyframesButton.checked = filter.keyframeCount(parameters[0]) > 0
+                timer.restart();
+                mapKeyframesButton.checked = filter.keyframeCount(parameters[0]) > 0;
             }
         }
 
         Label {
             text: qsTr('Time')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Map the specified input time to the current time. Use keyframes to vary the time mappings over time.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Map the specified input time to the current time. Use keyframes to vary the time mappings over time.')
+            }
+
         }
+
         Row {
             Shotcut.TimeSpinner {
                 id: mapSpinner
+
                 minimumValue: 0
                 maximumValue: producer.length - producer.in
                 saveButtonVisible: false
                 undoButtonVisible: false
                 onValueChanged: {
-                    if (blockUpdate) return
-                    filter.set('map', mapSpinner.value / profile.fps, getPosition())
-                    timer.restart()
+                    if (blockUpdate)
+                        return ;
+
+                    filter.set('map', mapSpinner.value / profile.fps, getPosition());
+                    timer.restart();
                 }
             }
+
             Shotcut.Button {
                 anchors.verticalCenter: parent.verticalCenter
                 icon.name: 'format-indent-less'
                 icon.source: 'qrc:///icons/oxygen/32x32/actions/format-indent-less.png'
-                Shotcut.HoverTip { text: qsTr('Set the input time to achieve a desired speed before the current frame.') }
                 implicitWidth: 20
                 implicitHeight: 20
                 onClicked: {
-                    speedDialog.direction = 'before'
-                    speedDialog.open()
+                    speedDialog.direction = 'before';
+                    speedDialog.open();
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Set the input time to achieve a desired speed before the current frame.')
+                }
+
             }
+
             Shotcut.Button {
                 anchors.verticalCenter: parent.verticalCenter
                 icon.name: 'format-indent-more'
                 icon.source: 'qrc:///icons/oxygen/32x32/actions/format-indent-more.png'
-                Shotcut.HoverTip { text: qsTr('Set the input time to achieve a desired speed after the current frame.') }
                 implicitWidth: 20
                 implicitHeight: 20
                 onClicked: {
-                    speedDialog.direction = 'after'
-                    speedDialog.open()
+                    speedDialog.direction = 'after';
+                    speedDialog.open();
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Set the input time to achieve a desired speed after the current frame.')
+                }
+
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                filter.blockSignals = true
-                filter.resetProperty('map')
-                filter.set('map', 0.0, 0)
-                filter.set('map', filter.duration / profile.fps, filter.duration)
-                filter.blockSignals = false
-                filter.changed('map')
-                timer.restart()
+                filter.blockSignals = true;
+                filter.resetProperty('map');
+                filter.set('map', 0, 0);
+                filter.set('map', filter.duration / profile.fps, filter.duration);
+                filter.blockSignals = false;
+                filter.changed('map');
+                timer.restart();
             }
         }
 
         Label {
             text: qsTr('Image mode')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('Use the specified image selection mode. Nearest will output the image that is nearest to the mapped time. Blend will blend all images that occur during the mapped time.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('Use the specified image selection mode. Nearest will output the image that is nearest to the mapped time. Blend will blend all images that occur during the mapped time.')
+            }
+
         }
+
         Shotcut.ComboBox {
             id: modeCombo
+
             Layout.columnSpan: parent.columns - 2
             implicitWidth: 180
-            model: ListModel {
-                id: imageModeModel
-                ListElement { text: qsTr('Nearest'); value: 'nearest' }
-                ListElement { text: qsTr('Blend'); value: 'blend' }
-            }
             textRole: "text"
             onCurrentIndexChanged: {
-                if (blockUpdate) return
-                filter.set('image_mode', imageModeModel.get(currentIndex).value)
+                if (blockUpdate)
+                    return ;
+
+                filter.set('image_mode', imageModeModel.get(currentIndex).value);
             }
+
+            model: ListModel {
+                id: imageModeModel
+
+                ListElement {
+                    text: qsTr('Nearest')
+                    value: 'nearest'
+                }
+
+                ListElement {
+                    text: qsTr('Blend')
+                    value: 'blend'
+                }
+
+            }
+
         }
+
         Shotcut.UndoButton {
             onClicked: modeCombo.currentIndex = 0
         }
 
-        Label {}
+        Label {
+        }
+
         CheckBox {
             id: pitchCheckbox
+
             Layout.columnSpan: parent.columns - 2
             text: qsTr('Enable pitch compensation')
             onCheckedChanged: {
-                if (blockUpdate) return
-                filter.set('pitch', checked)
+                if (blockUpdate)
+                    return ;
+
+                filter.set('pitch', checked);
             }
         }
+
         Shotcut.UndoButton {
             onClicked: pitchCheckbox.checked = false
         }
@@ -362,6 +429,7 @@ Item {
             Layout.fillWidth: true
             Layout.minimumHeight: 12
             color: 'transparent'
+
             Rectangle {
                 anchors.verticalCenter: parent.verticalCenter
                 width: parent.width
@@ -369,50 +437,77 @@ Item {
                 radius: 2
                 color: activePalette.text
             }
+
         }
 
         Label {
             text: qsTr('Speed:')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The instantaneous speed of the last frame that was processed.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The instantaneous speed of the last frame that was processed.')
+            }
+
         }
+
         Label {
             id: speedLabel
+
             Layout.columnSpan: parent.columns - 1
         }
 
         Label {
             text: qsTr('Direction:')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The instantaneous direction of the last frame that was processed.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The instantaneous direction of the last frame that was processed.')
+            }
+
         }
+
         Label {
             id: directionLabel
+
             Layout.columnSpan: parent.columns - 1
         }
 
         Label {
             text: qsTr('Input Time:')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The original clip time of the frame.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The original clip time of the frame.')
+            }
+
         }
+
         Label {
             id: inputTimeLabel
+
             Layout.columnSpan: parent.columns - 1
         }
 
         Label {
             text: qsTr('Output Time:')
             Layout.alignment: Qt.AlignRight
-            Shotcut.HoverTip { text: qsTr('The mapped output time for the input frame.') }
+
+            Shotcut.HoverTip {
+                text: qsTr('The mapped output time for the input frame.')
+            }
+
         }
+
         Label {
             id: outputTimeLabel
+
             Layout.columnSpan: parent.columns - 1
         }
 
         Item {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/timer/ClockSpinner.qml
+++ b/src/qml/filters/timer/ClockSpinner.qml
@@ -16,156 +16,195 @@
  */
 
 import QtQuick 2.12
-import QtQuick.Layouts 1.12
 import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 import org.shotcut.qml 1.0
 
 Item {
     id: root
-    property double minimumValue: 0.0
-    property double maximumValue: 1000.0
+
+    property double minimumValue: 0
+    property double maximumValue: 1000
     property alias timeStr: timeField.text
+
     signal setDefaultClicked()
 
-    implicitHeight: timeField.implicitHeight
-    implicitWidth: timeField.implicitWidth + decrementButton.implicitWidth + incrementButton.implicitWidth + undoButton.implicitWidth
-
     function setValueSeconds(seconds) {
-        timeStr = secondsToTime(seconds)
+        timeStr = secondsToTime(seconds);
     }
 
     function getValueSeconds() {
-        return timeToSeconds(timeStr)
+        return timeToSeconds(timeStr);
     }
 
     function timeToSeconds(time) {
-        var fields = time.split(":")
+        var fields = time.split(":");
         if (typeof fields[1] === 'undefined')
-            fields[1] = 0
+            fields[1] = 0;
+
         if (typeof fields[0] === 'undefined')
-            fields[0] = 0
+            fields[0] = 0;
+
         if (typeof fields[2] === 'undefined')
-            fields[2] = 0
-        var hSeconds = fields[0] * 60.0 * 60.0
-        var mSeconds = fields[1] * 60.0
-        var sSeconds = fields[2] * 1.0
-        return hSeconds + mSeconds + sSeconds
+            fields[2] = 0;
+
+        var hSeconds = fields[0] * 60 * 60;
+        var mSeconds = fields[1] * 60;
+        var sSeconds = fields[2] * 1;
+        return hSeconds + mSeconds + sSeconds;
     }
 
     function secondsToTime(seconds) {
-        var h = Math.floor(seconds / 3600.0)
-        var m = Math.floor((seconds - (h * 3600.0)) / 60.0)
-        var s = seconds - (h * 3600.0) - (m * 60.0)
-        return formatNum(h, 2, 0) + ":" + formatNum(m, 2, 0) + ":" + formatNum( s, 2, 3)
+        var h = Math.floor(seconds / 3600);
+        var m = Math.floor((seconds - (h * 3600)) / 60);
+        var s = seconds - (h * 3600) - (m * 60);
+        return formatNum(h, 2, 0) + ":" + formatNum(m, 2, 0) + ":" + formatNum(s, 2, 3);
     }
 
     function clamp(x, min, max) {
-        return Math.max(min, Math.min(max, x))
+        return Math.max(min, Math.min(max, x));
     }
 
     function formatNum(x, integerLen, fractionLen) {
         // Format a number as a string with specified padding zeros
-        var a = x.toFixed(fractionLen) + ""
-        var b = a.split(".")
+        var a = x.toFixed(fractionLen) + "";
+        var b = a.split(".");
         // Add leading zeros to the integer part (before decimal)
-        while (b[0].length < integerLen) {
-            b[0] = "0" + b[0]
-        }
+        while (b[0].length < integerLen)b[0] = "0" + b[0]
         if (fractionLen == 0)
-            return b[0]
+            return b[0];
+
         // Add trailing zeros to the fraction part (after decimal)
         if (typeof b[1] === 'undefined')
-            b[1] = ""
-        while (b[1].length < fractionLen) {
-            b[1] = b[1] + "0"
-        }
-        return b[0] + "." + b[1]
+            b[1] = "";
+
+        while (b[1].length < fractionLen)b[1] = b[1] + "0"
+        return b[0] + "." + b[1];
     }
+
+    implicitHeight: timeField.implicitHeight
+    implicitWidth: timeField.implicitWidth + decrementButton.implicitWidth + incrementButton.implicitWidth + undoButton.implicitWidth
 
     RowLayout {
         spacing: 0
 
         TextField {
             id: timeField
+
             text: "00:00:00.000"
             horizontalAlignment: TextInput.AlignRight
             selectByMouse: true
-            validator: RegExpValidator {regExp: /^\s*(\d*:){0,2}(\d*[.])?\d*\s*$/}
             onEditingFinished: {
-                console.log(text, timeToSeconds(text))
-                var seconds = clamp(timeToSeconds(text), minimumValue, maximumValue)
-                text = secondsToTime(seconds)
+                console.log(text, timeToSeconds(text));
+                var seconds = clamp(timeToSeconds(text), minimumValue, maximumValue);
+                text = secondsToTime(seconds);
             }
             Keys.onDownPressed: decrementAction.trigger()
             Keys.onUpPressed: incrementAction.trigger()
-            onFocusChanged: if (focus) selectAll()
+            onFocusChanged: {
+                if (focus)
+                    selectAll();
+
+            }
+
+            validator: RegExpValidator {
+                regExp: /^\s*(\d*:){0,2}(\d*[.])?\d*\s*$/
+            }
+
         }
+
         Shotcut.Button {
             id: decrementButton
+
             icon.name: 'list-remove'
             icon.source: 'qrc:///icons/oxygen/32x32/actions/list-remove.png'
-            Shotcut.HoverTip { text: qsTr('Decrement') }
             implicitWidth: 20
             implicitHeight: 20
+
+            Shotcut.HoverTip {
+                text: qsTr('Decrement')
+            }
+
             MouseArea {
                 anchors.fill: parent
                 onPressed: decrementAction.trigger()
                 onPressAndHold: decrementTimer.start()
                 onReleased: decrementTimer.stop()
             }
+
             Timer {
                 id: decrementTimer
+
                 repeat: true
                 interval: 200
                 triggeredOnStart: true
                 onTriggered: decrementAction.trigger()
             }
+
         }
+
         Shotcut.Button {
             id: incrementButton
+
             icon.name: 'list-add'
             icon.source: 'qrc:///icons/oxygen/32x32/actions/list-add.png'
-            Shotcut.HoverTip { text: qsTr('Increment') }
             implicitWidth: 20
             implicitHeight: 20
+
+            Shotcut.HoverTip {
+                text: qsTr('Increment')
+            }
+
             MouseArea {
                 anchors.fill: parent
                 onPressed: incrementAction.trigger()
                 onPressAndHold: incrementTimer.start()
                 onReleased: incrementTimer.stop()
             }
+
             Timer {
                 id: incrementTimer
+
                 repeat: true
                 interval: 200
                 triggeredOnStart: true
                 onTriggered: incrementAction.trigger()
             }
+
         }
+
         Shotcut.UndoButton {
             id: undoButton
+
             onClicked: root.setDefaultClicked()
         }
+
         Action {
             id: decrementAction
+
             onTriggered: {
                 var frames = filter.framesFromTime(timeStr) - 1;
-                if( frames < 0 )
-                    frames = 0
-                var newTime = filter.timeFromFrames(frames, Filter.TIME_CLOCK)
-                var seconds = clamp(timeToSeconds(newTime), minimumValue, maximumValue)
-                timeField.text = secondsToTime(seconds)
+                if (frames < 0)
+                    frames = 0;
+
+                var newTime = filter.timeFromFrames(frames, Filter.TIME_CLOCK);
+                var seconds = clamp(timeToSeconds(newTime), minimumValue, maximumValue);
+                timeField.text = secondsToTime(seconds);
             }
         }
+
         Action {
             id: incrementAction
+
             onTriggered: {
                 var frames = filter.framesFromTime(timeStr) + 1;
-                var newTime = filter.timeFromFrames(frames, Filter.TIME_CLOCK)
-                var seconds = clamp(timeToSeconds(newTime), minimumValue, maximumValue)
-                timeField.text = secondsToTime(seconds)
+                var newTime = filter.timeFromFrames(frames, Filter.TIME_CLOCK);
+                var seconds = clamp(timeToSeconds(newTime), minimumValue, maximumValue);
+                timeField.text = secondsToTime(seconds);
             }
         }
+
     }
+
 }

--- a/src/qml/filters/timer/meta.qml
+++ b/src/qml/filters/timer/meta.qml
@@ -9,6 +9,7 @@ Metadata {
     qml: "ui.qml"
     vui: 'vui.qml'
     isGpuCompatible: false
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -21,4 +22,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/timer/ui.qml
+++ b/src/qml/filters/timer/ui.qml
@@ -15,99 +15,96 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import QtQml.Models 2.12
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
-import QtQml.Models 2.12
 
 Item {
-    width: 500
-    height: 400
-
     property string _defaultStart: '00:00:00.000'
     property string _defaultDuration: '00:00:10.000'
     property string _defaultOffset: '00:00:00.000'
-    property double _defaultSpeed: 1.0
-
-    Component.onCompleted: {
-        filter.blockSignals = true
-        filter.set(textFilterUi.middleValue, Qt.rect(0, 0, profile.width, profile.height))
-        filter.set(textFilterUi.startValue, Qt.rect(0, 0, profile.width, profile.height))
-        filter.set(textFilterUi.endValue, Qt.rect(0, 0, profile.width, profile.height))
-        if (filter.isNew) {
-            filter.set("start", _defaultStart)
-            filter.set("duration", _defaultDuration)
-            filter.set("offset", _defaultOffset)
-            filter.set("speed", _defaultSpeed)
-
-            if (application.OS === 'Windows')
-                filter.set('family', 'Verdana')
-            filter.set('fgcolour', '#ffffffff')
-            filter.set('bgcolour', '#00000000')
-            filter.set('olcolour', '#ff000000')
-            filter.set('weight', 10 * Font.Normal)
-            filter.set('style', 'normal')
-            filter.set(textFilterUi.useFontSizeProperty, false)
-            filter.set('size', profile.height)
-
-            filter.set(textFilterUi.rectProperty,   '0%/75%:25%x25%')
-            filter.set(textFilterUi.valignProperty, 'bottom')
-            filter.set(textFilterUi.halignProperty, 'left')
-            filter.savePreset(preset.parameters, qsTr('Bottom Left'))
-
-            filter.set(textFilterUi.rectProperty,   '75%/75%:25%x25%')
-            filter.set(textFilterUi.valignProperty, 'bottom')
-            filter.set(textFilterUi.halignProperty, 'right')
-            filter.savePreset(preset.parameters, qsTr('Bottom Right'))
-
-            // Add default preset.
-            filter.set(textFilterUi.rectProperty, '0%/0%:100%x100%')
-            filter.savePreset(preset.parameters)
-        } else {
-            filter.set(textFilterUi.middleValue, filter.getRect(textFilterUi.rectProperty, filter.animateIn + 1))
-            if (filter.animateIn > 0)
-                filter.set(textFilterUi.startValue, filter.getRect(textFilterUi.rectProperty, 0))
-            if (filter.animateOut > 0)
-                filter.set(textFilterUi.endValue, filter.getRect(textFilterUi.rectProperty, filter.duration - 1))
-        }
-        filter.blockSignals = false
-        setControls()
-        if (filter.isNew)
-            filter.set(textFilterUi.rectProperty, filter.getRect(textFilterUi.rectProperty))
-    }
+    property double _defaultSpeed: 1
 
     function setControls() {
         var formatIndex = 0;
-        var format = filter.get('format')
+        var format = filter.get('format');
         for (var i = 0; i < formatCombo.model.count; i++) {
             if (formatCombo.model.get(i).format === format) {
-                formatIndex = i
-                break
+                formatIndex = i;
+                break;
             }
         }
-        formatCombo.currentIndex = formatIndex
-
+        formatCombo.currentIndex = formatIndex;
         var directionIndex = 0;
-        var direction = filter.get('direction')
-        for (i = 0; i < directionCombo.model.count; i++) {
+        var direction = filter.get('direction');
+        for (; i < directionCombo.model.count; i++) {
             if (directionCombo.model.get(i).direction === direction) {
-                directionIndex = i
-                break
+                directionIndex = i;
+                break;
             }
         }
-        directionCombo.currentIndex = directionIndex
+        directionCombo.currentIndex = directionIndex;
+        startSpinner.timeStr = filter.get("start");
+        durationSpinner.timeStr = filter.get("duration");
+        offsetSpinner.timeStr = filter.get("offset");
+        speedSpinner.value = filter.getDouble("speed");
+        textFilterUi.setControls();
+    }
 
-        startSpinner.timeStr = filter.get("start")
-        durationSpinner.timeStr = filter.get("duration")
-        offsetSpinner.timeStr = filter.get("offset")
-        speedSpinner.value = filter.getDouble("speed")
+    width: 500
+    height: 400
+    Component.onCompleted: {
+        filter.blockSignals = true;
+        filter.set(textFilterUi.middleValue, Qt.rect(0, 0, profile.width, profile.height));
+        filter.set(textFilterUi.startValue, Qt.rect(0, 0, profile.width, profile.height));
+        filter.set(textFilterUi.endValue, Qt.rect(0, 0, profile.width, profile.height));
+        if (filter.isNew) {
+            filter.set("start", _defaultStart);
+            filter.set("duration", _defaultDuration);
+            filter.set("offset", _defaultOffset);
+            filter.set("speed", _defaultSpeed);
+            if (application.OS === 'Windows')
+                filter.set('family', 'Verdana');
 
-        textFilterUi.setControls()
+            filter.set('fgcolour', '#ffffffff');
+            filter.set('bgcolour', '#00000000');
+            filter.set('olcolour', '#ff000000');
+            filter.set('weight', 10 * Font.Normal);
+            filter.set('style', 'normal');
+            filter.set(textFilterUi.useFontSizeProperty, false);
+            filter.set('size', profile.height);
+            filter.set(textFilterUi.rectProperty, '0%/75%:25%x25%');
+            filter.set(textFilterUi.valignProperty, 'bottom');
+            filter.set(textFilterUi.halignProperty, 'left');
+            filter.savePreset(preset.parameters, qsTr('Bottom Left'));
+            filter.set(textFilterUi.rectProperty, '75%/75%:25%x25%');
+            filter.set(textFilterUi.valignProperty, 'bottom');
+            filter.set(textFilterUi.halignProperty, 'right');
+            filter.savePreset(preset.parameters, qsTr('Bottom Right'));
+            // Add default preset.
+            filter.set(textFilterUi.rectProperty, '0%/0%:100%x100%');
+            filter.savePreset(preset.parameters);
+        } else {
+            filter.set(textFilterUi.middleValue, filter.getRect(textFilterUi.rectProperty, filter.animateIn + 1));
+            if (filter.animateIn > 0)
+                filter.set(textFilterUi.startValue, filter.getRect(textFilterUi.rectProperty, 0));
+
+            if (filter.animateOut > 0)
+                filter.set(textFilterUi.endValue, filter.getRect(textFilterUi.rectProperty, filter.duration - 1));
+
+        }
+        filter.blockSignals = false;
+        setControls();
+        if (filter.isNew)
+            filter.set(textFilterUi.rectProperty, filter.getRect(textFilterUi.rectProperty));
+
     }
 
     GridLayout {
         id: textGrid
+
         columns: 2
         anchors.fill: parent
         anchors.margins: 8
@@ -116,21 +113,25 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
-            parameters: textFilterUi.parameterList.concat(['format', 'direction','start','duration'])
+
+            parameters: textFilterUi.parameterList.concat(['format', 'direction', 'start', 'duration'])
             onBeforePresetLoaded: {
-                filter.resetProperty(textFilterUi.rectProperty)
+                filter.resetProperty(textFilterUi.rectProperty);
             }
             onPresetSelected: {
-                setControls()
-                filter.blockSignals = true
-                filter.set(textFilterUi.middleValue, filter.getRect(textFilterUi.rectProperty, filter.animateIn + 1))
+                setControls();
+                filter.blockSignals = true;
+                filter.set(textFilterUi.middleValue, filter.getRect(textFilterUi.rectProperty, filter.animateIn + 1));
                 if (filter.animateIn > 0)
-                    filter.set(textFilterUi.startValue, filter.getRect(textFilterUi.rectProperty, 0))
+                    filter.set(textFilterUi.startValue, filter.getRect(textFilterUi.rectProperty, 0));
+
                 if (filter.animateOut > 0)
-                    filter.set(textFilterUi.endValue, filter.getRect(textFilterUi.rectProperty, filter.duration - 1))
-                filter.blockSignals = false
+                    filter.set(textFilterUi.endValue, filter.getRect(textFilterUi.rectProperty, filter.duration - 1));
+
+                filter.blockSignals = false;
             }
         }
 
@@ -138,132 +139,217 @@ Item {
             text: qsTr('Format')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: formatCombo
-            model: ListModel {
-                ListElement { text: QT_TR_NOOP('HH:MM:SS'); format: "HH:MM:SS" }
-                ListElement { text: QT_TR_NOOP('HH:MM:SS.S'); format: "HH:MM:SS.S" }
-                ListElement { text: QT_TR_NOOP('MM:SS'); format: "MM:SS" }
-                ListElement { text: QT_TR_NOOP('MM:SS.SS'); format: "MM:SS.SS" }
-                ListElement { text: QT_TR_NOOP('MM:SS.SSS'); format: "MM:SS.SSS" }
-                ListElement { text: QT_TR_NOOP('SS'); format: "SS" }
-                ListElement { text: QT_TR_NOOP('SS.S'); format: "SS.S" }
-                ListElement { text: QT_TR_NOOP('SS.SS'); format: "SS.SS" }
-                ListElement { text: QT_TR_NOOP('SS.SSS'); format: "SS.SSS" }
-            }
+
             textRole: 'text'
             onActivated: {
-                filter.set('format', model.get(currentIndex).format)
+                filter.set('format', model.get(currentIndex).format);
             }
+
+            model: ListModel {
+                ListElement {
+                    text: QT_TR_NOOP('HH:MM:SS')
+                    format: "HH:MM:SS"
+                }
+
+                ListElement {
+                    text: QT_TR_NOOP('HH:MM:SS.S')
+                    format: "HH:MM:SS.S"
+                }
+
+                ListElement {
+                    text: QT_TR_NOOP('MM:SS')
+                    format: "MM:SS"
+                }
+
+                ListElement {
+                    text: QT_TR_NOOP('MM:SS.SS')
+                    format: "MM:SS.SS"
+                }
+
+                ListElement {
+                    text: QT_TR_NOOP('MM:SS.SSS')
+                    format: "MM:SS.SSS"
+                }
+
+                ListElement {
+                    text: QT_TR_NOOP('SS')
+                    format: "SS"
+                }
+
+                ListElement {
+                    text: QT_TR_NOOP('SS.S')
+                    format: "SS.S"
+                }
+
+                ListElement {
+                    text: QT_TR_NOOP('SS.SS')
+                    format: "SS.SS"
+                }
+
+                ListElement {
+                    text: QT_TR_NOOP('SS.SSS')
+                    format: "SS.SSS"
+                }
+
+            }
+
         }
 
         Label {
             text: qsTr('Direction')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: directionCombo
-            model: ListModel {
-                ListElement { text: QT_TR_NOOP('Up'); direction: "up" }
-                ListElement { text: QT_TR_NOOP('Down'); direction: "down" }
-            }
+
             textRole: 'text'
             onActivated: {
-                filter.set('direction', model.get(currentIndex).direction)
+                filter.set('direction', model.get(currentIndex).direction);
             }
+
+            model: ListModel {
+                ListElement {
+                    text: QT_TR_NOOP('Up')
+                    direction: "up"
+                }
+
+                ListElement {
+                    text: QT_TR_NOOP('Down')
+                    direction: "down"
+                }
+
+            }
+
         }
 
         Label {
             text: qsTr('Start Delay')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             spacing: 0
+
             ClockSpinner {
                 id: startSpinner
+
                 maximumValue: 100 * 60 * 60 - 0.001 // 99:59:59.999
                 onTimeStrChanged: {
-                    filter.set('start', startSpinner.timeStr)
+                    filter.set('start', startSpinner.timeStr);
                 }
                 onSetDefaultClicked: {
-                    startSpinner.timeStr = _defaultStart
+                    startSpinner.timeStr = _defaultStart;
                 }
-                Shotcut.HoverTip { text: qsTr('The timer will be frozen from the beginning of the filter until the Start Delay time has elapsed.') }
+
+                Shotcut.HoverTip {
+                    text: qsTr('The timer will be frozen from the beginning of the filter until the Start Delay time has elapsed.')
+                }
+
             }
+
             Shotcut.Button {
                 icon.name: 'insert'
                 icon.source: 'qrc:///icons/oxygen/32x32/actions/insert.png'
-                Shotcut.HoverTip { text: qsTr('Set start to begin at the current position') }
                 implicitWidth: 20
                 implicitHeight: 20
                 onClicked: startSpinner.setValueSeconds((producer.position - (filter.in - producer.in)) / profile.fps)
+
+                Shotcut.HoverTip {
+                    text: qsTr('Set start to begin at the current position')
+                }
+
             }
+
         }
 
         Label {
             text: qsTr('Duration')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             spacing: 0
+
             ClockSpinner {
                 id: durationSpinner
+
                 maximumValue: 100 * 60 * 60 - 0.001 // 99:59:59.999
                 onTimeStrChanged: {
-                    filter.set('duration', durationSpinner.timeStr)
+                    filter.set('duration', durationSpinner.timeStr);
                 }
                 onSetDefaultClicked: {
-                    durationSpinner.timeStr = _defaultDuration
+                    durationSpinner.timeStr = _defaultDuration;
                 }
-                Shotcut.HoverTip { text: qsTr('The timer will be frozen after the Duration has elapsed.') +
-                                         '\n' +
-                                         qsTr('A value of 0 will run the timer to the end of the filter')
+
+                Shotcut.HoverTip {
+                    text: qsTr('The timer will be frozen after the Duration has elapsed.') + '\n' + qsTr('A value of 0 will run the timer to the end of the filter')
                 }
+
             }
+
             Shotcut.Button {
                 icon.name: 'insert'
                 icon.source: 'qrc:///icons/oxygen/32x32/actions/insert.png'
-                Shotcut.HoverTip { text: qsTr('Set duration to end at the current position') }
                 implicitWidth: 20
                 implicitHeight: 20
                 onClicked: {
-                    var startTime = startSpinner.getValueSeconds()
-                    var endTime = (producer.position - (filter.in - producer.in)) / profile.fps
-                    if (endTime > startTime) {
-                        durationSpinner.setValueSeconds(endTime - startTime)
-                    }
+                    var startTime = startSpinner.getValueSeconds();
+                    var endTime = (producer.position - (filter.in - producer.in)) / profile.fps;
+                    if (endTime > startTime)
+                        durationSpinner.setValueSeconds(endTime - startTime);
+
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Set duration to end at the current position')
+                }
+
             }
+
         }
 
         Label {
             text: qsTr('Offset')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             spacing: 0
+
             ClockSpinner {
                 id: offsetSpinner
+
                 maximumValue: 100 * 60 * 60 - 0.001 // 99:59:59.999
                 onTimeStrChanged: {
-                    filter.set('offset', offsetSpinner.timeStr)
+                    filter.set('offset', offsetSpinner.timeStr);
                 }
                 onSetDefaultClicked: {
-                    offsetSpinner.timeStr = _defaultOffset
+                    offsetSpinner.timeStr = _defaultOffset;
                 }
-                Shotcut.HoverTip { text: qsTr('When the direction is Down, the timer will count down to Offset.\nWhen the direction is Up, the timer will count up starting from Offset.') }
+
+                Shotcut.HoverTip {
+                    text: qsTr('When the direction is Down, the timer will count down to Offset.\nWhen the direction is Up, the timer will count up starting from Offset.')
+                }
+
             }
+
         }
 
         Label {
             text: qsTr('Speed')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             spacing: 0
 
             Shotcut.DoubleSpinBox {
                 id: speedSpinner
+
                 horizontalAlignment: Qt.AlignRight
                 Layout.minimumWidth: 100
                 decimals: 5
@@ -271,17 +357,27 @@ Item {
                 from: 0
                 to: 1000
                 onValueChanged: {
-                    filter.set("speed", speedSpinner.value)
+                    filter.set("speed", speedSpinner.value);
                 }
-                Shotcut.HoverTip { text: qsTr('Timer seconds per playback second. Scales Duration but does not affect Start Delay or Offset.') }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Timer seconds per playback second. Scales Duration but does not affect Start Delay or Offset.')
+                }
+
             }
+
         }
 
         Shotcut.TextFilterUi {
             id: textFilterUi
+
             Layout.columnSpan: 2
         }
 
-        Item { Layout.fillHeight: true }
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
+
 }

--- a/src/qml/filters/trails/ui.qml
+++ b/src/qml/filters/trails/ui.qml
@@ -21,25 +21,24 @@ import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Item {
-    width: 350
-    height: 100
     property string amount: 'av.frames'
     property int amountDefault: 2
 
-    Component.onCompleted: {
-        if (filter.isNew) {
-            updateFilter(amountDefault)
-            filter.savePreset(preset.parameters)
-        }
-        amountSlider.value = filter.get(amount)
+    function updateFilter(value) {
+        filter.set(amount, value);
+        var weights = [];
+        for (var i = 1; i <= value; i++) weights.push(i)
+        filter.set('av.weights', weights.join(' '));
     }
 
-    function updateFilter(value) {
-        filter.set(amount, value)
-        var weights = []
-        for (var i = 1; i <= value; i++)
-            weights.push(i)
-        filter.set('av.weights', weights.join(' '))
+    width: 350
+    height: 100
+    Component.onCompleted: {
+        if (filter.isNew) {
+            updateFilter(amountDefault);
+            filter.savePreset(preset.parameters);
+        }
+        amountSlider.value = filter.get(amount);
     }
 
     GridLayout {
@@ -51,8 +50,10 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: [amount]
             Layout.columnSpan: parent.columns - 1
             onPresetSelected: amountSlider.value = filter.get(amount)
@@ -62,8 +63,10 @@ Item {
             text: qsTr('Amount')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: amountSlider
+
             minimumValue: 2
             maximumValue: Math.round(profile.fps)
             stepSize: 1
@@ -71,10 +74,15 @@ Item {
             spinnerWidth: 110
             onValueChanged: updateFilter(value)
         }
+
         Shotcut.UndoButton {
             onClicked: amountSlider.value = amountDefault
         }
 
-        Item { Layout.fillHeight: true}
+        Item {
+            Layout.fillHeight: true
+        }
+
     }
+
 }

--- a/src/qml/filters/unpremultiply/ui.qml
+++ b/src/qml/filters/unpremultiply/ui.qml
@@ -18,12 +18,14 @@
 import QtQuick 2.1
 
 Item {
+    // Unpremultiply
+
     width: 350
     height: 10
     Component.onCompleted: {
-        filter.set('threads', 0)
-        if (filter.isNew) {
-            filter.set('0', 1) // Unpremultiply
-        }
+        filter.set('threads', 0);
+        if (filter.isNew)
+            filter.set('0', 1);
+
     }
 }

--- a/src/qml/filters/vaguedenoiser/meta.qml
+++ b/src/qml/filters/vaguedenoiser/meta.qml
@@ -16,10 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 import QtQuick 2.2
 import org.shotcut.qml 1.0
-
 
 Metadata {
     type: Metadata.Filter

--- a/src/qml/filters/vaguedenoiser/ui.qml
+++ b/src/qml/filters/vaguedenoiser/ui.qml
@@ -16,189 +16,179 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 import QtQuick.Window 2.12
 import Shotcut.Controls 1.0 as Shotcut
 
-
 Item {
     property string methodParam: 'av.method'
     property string methodDefault: 'garrote'
     property var methodValues: ['soft', 'garrote', 'hard']
-
     property string nstepsParam: 'av.nsteps'
     property int nstepsDefault: 7
-
     property string thresholdParam: 'av.threshold'
     property double thresholdDefault: 10
-
     property string percentParam: 'av.percent'
     property double percentDefault: 85
-
     property var allParams: [methodParam, nstepsParam, thresholdParam, percentParam]
 
+    function getComboIndex(value, values) {
+        for (var i = 0; i < values.length; ++i) {
+            if (values[i] === value)
+                return i;
+
+        }
+        return -1;
+    }
+
+    function setControls() {
+        idMethod.currentIndex = getComboIndex(filter.get(methodParam), methodValues);
+        idNsteps.value = parseInt(filter.get(nstepsParam));
+        idThreshold.value = filter.getDouble(thresholdParam);
+        idPercent.value = filter.getDouble(percentParam);
+    }
+
+    function getMaxSteps() {
+        var min = Math.min(profile.width, profile.height);
+        var i = 1;
+        while (Math.pow(2, i) <= min)++i
+        return i - 1;
+    }
 
     width: 350
     height: 200
-
-
-    function getComboIndex (value, values) {
-        for ( var i = 0 ; i < values.length ; ++i ) {
-            if ( values[i] === value ) {
-                return i
-            }
-        }
-        return -1
-    }
-
-
-    function setControls () {
-        idMethod.currentIndex = getComboIndex(filter.get(methodParam), methodValues)
-        idNsteps.value = parseInt(filter.get(nstepsParam))
-        idThreshold.value = filter.getDouble(thresholdParam)
-        idPercent.value = filter.getDouble(percentParam)
-    }
-
-
-    function getMaxSteps () {
-        var min = Math.min(profile.width, profile.height)
-
-        var i = 1
-        while ( Math.pow(2,i) <= min ) {
-            ++i
-        }
-
-        return i - 1
-    }
-
-
     Component.onCompleted: {
-        filter.blockSignals = true
-        if ( filter.isNew ) {
+        filter.blockSignals = true;
+        if (filter.isNew) {
             // Custom preset
-            filter.set(methodParam, 'garrote')
-            filter.set(nstepsParam, 5)
-            filter.set(thresholdParam, 7)
-            filter.set(percentParam, 85)
-            filter.savePreset(allParams, qsTr('Light'))
-
+            filter.set(methodParam, 'garrote');
+            filter.set(nstepsParam, 5);
+            filter.set(thresholdParam, 7);
+            filter.set(percentParam, 85);
+            filter.savePreset(allParams, qsTr('Light'));
             // Custom preset
-            filter.set(methodParam, 'garrote')
-            filter.set(nstepsParam, 7)
-            filter.set(thresholdParam, 10)
-            filter.set(percentParam, 85)
-            filter.savePreset(allParams, qsTr('Medium'))
-
+            filter.set(methodParam, 'garrote');
+            filter.set(nstepsParam, 7);
+            filter.set(thresholdParam, 10);
+            filter.set(percentParam, 85);
+            filter.savePreset(allParams, qsTr('Medium'));
             // Custom preset
-            filter.set(methodParam, 'garrote')
-            filter.set(nstepsParam, 8)
-            filter.set(thresholdParam, 16)
-            filter.set(percentParam, 85)
-            filter.savePreset(allParams, qsTr('Heavy'))
-
+            filter.set(methodParam, 'garrote');
+            filter.set(nstepsParam, 8);
+            filter.set(thresholdParam, 16);
+            filter.set(percentParam, 85);
+            filter.savePreset(allParams, qsTr('Heavy'));
             // Default preset
-            filter.set(methodParam, methodDefault)
-            filter.set(nstepsParam, nstepsDefault)
-            filter.set(thresholdParam, thresholdDefault)
-            filter.set(percentParam, percentDefault)
-            filter.savePreset(allParams)
+            filter.set(methodParam, methodDefault);
+            filter.set(nstepsParam, nstepsDefault);
+            filter.set(thresholdParam, thresholdDefault);
+            filter.set(percentParam, percentDefault);
+            filter.savePreset(allParams);
         }
-        filter.blockSignals = false
-
-        setControls()
+        filter.blockSignals = false;
+        setControls();
     }
-
 
     GridLayout {
+        // Row split
+        // Row split
+        // Row split
+        // Row split
+        // Row split
+        // Row split
+        // Row split
+        // Filler
+
         columns: 3
         anchors.fill: parent
         anchors.margins: 8
-
-        // Row split
 
         Label {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: idPreset
+
             Layout.columnSpan: 2
             parameters: allParams
             onPresetSelected: setControls()
         }
 
-        // Row split
-
         Label {
             text: qsTr('Method')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ComboBox {
             id: idMethod
+
             implicitWidth: 180
             model: [qsTr('Soft'), qsTr('Garrote'), qsTr('Hard', 'Remove Noise Wavelet filter')]
             onActivated: filter.set(methodParam, methodValues[currentIndex])
         }
+
         Shotcut.UndoButton {
             onClicked: {
-                idMethod.currentIndex = getComboIndex(methodDefault, methodValues)
-                filter.set(methodParam, methodValues[idMethod.currentIndex])
+                idMethod.currentIndex = getComboIndex(methodDefault, methodValues);
+                filter.set(methodParam, methodValues[idMethod.currentIndex]);
             }
         }
-
-        // Row split
 
         Label {
             text: qsTr('Decompose')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: idNsteps
+
             minimumValue: 1
             maximumValue: 32
             onValueChanged: filter.set(nstepsParam, value)
         }
+
         Shotcut.UndoButton {
             onClicked: idNsteps.value = nstepsDefault
         }
-
-        // Row split
 
         Label {
             text: qsTr('Threshold')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: idThreshold
+
             minimumValue: 0
             maximumValue: 64
             onValueChanged: filter.set(thresholdParam, value)
         }
+
         Shotcut.UndoButton {
             onClicked: idThreshold.value = thresholdDefault
         }
-
-        // Row split
 
         Label {
             text: qsTr('Percent')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: idPercent
+
             minimumValue: 0
             maximumValue: 100
             suffix: ' %'
             onValueChanged: filter.set(percentParam, value)
         }
+
         Shotcut.UndoButton {
             onClicked: idPercent.value = percentDefault
         }
-
-        // Row split
 
         Label {
             text: qsTr('Max decompositions for the current video mode') + ': ' + getMaxSteps()
@@ -206,12 +196,11 @@ Item {
             Layout.columnSpan: 3
         }
 
-        // Row split
-
         Label {
             text: qsTr('More information') + ': <a href="http://ffmpeg.org/ffmpeg-all.html#vaguedenoiser">FFmpeg vaguedenoiser</a>'
             Layout.alignment: Qt.AlignHCenter
             Layout.columnSpan: 3
+            onLinkActivated: Qt.openUrlExternally(link)
 
             MouseArea {
                 anchors.fill: parent
@@ -219,14 +208,13 @@ Item {
                 cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
             }
 
-            onLinkActivated: Qt.openUrlExternally(link)
         }
-
-        // Filler
 
         Item {
             Layout.columnSpan: 3
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/vertigo/meta.qml
+++ b/src/qml/filters/vertigo/meta.qml
@@ -24,6 +24,7 @@ Metadata {
     objectName: 'vertigo'
     mlt_service: "frei0r.vertigo"
     qml: "ui.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -45,4 +46,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/vignette/meta_movit.qml
+++ b/src/qml/filters/vignette/meta_movit.qml
@@ -7,6 +7,7 @@ Metadata {
     mlt_service: "movit.vignette"
     needsGPU: true
     qml: "ui_movit.qml"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -28,4 +29,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/vignette/meta_oldfilm.qml
+++ b/src/qml/filters/vignette/meta_oldfilm.qml
@@ -7,6 +7,7 @@ Metadata {
     mlt_service: "vignette"
     qml: "ui_oldfilm.qml"
     gpuAlt: "movit.vignette"
+
     keyframes {
         allowAnimateIn: true
         allowAnimateOut: true
@@ -36,4 +37,5 @@ Metadata {
             }
         ]
     }
+
 }

--- a/src/qml/filters/vignette/ui_movit.qml
+++ b/src/qml/filters/vignette/ui_movit.qml
@@ -23,102 +23,101 @@ import Shotcut.Controls 1.0 as Shotcut
 Item {
     property var defaultParameters: ['radius', 'inner_radius']
     property bool blockUpdate: true
-    property var startValues:  [0.0, 0.0]
+    property var startValues: [0, 0]
     property var middleValues: [0.5, 0.5]
-    property var endValues:    [0.0, 0.0]
-
-    width: 350
-    height: 100
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            for (var i = 0; i < defaultParameters.length; i++)
-                filter.set(defaultParameters[i], middleValues[i])
-            filter.savePreset(defaultParameters)
-        } else {
-            initSimpleAnimation()
-        }
-        setControls()
-    }
+    property var endValues: [0, 0]
 
     function initSimpleAnimation() {
-        middleValues = [filter.getDouble(defaultParameters[0], filter.animateIn),
-                        filter.getDouble(defaultParameters[1], filter.animateIn)]
-        if (filter.animateIn > 0) {
-            startValues = [filter.getDouble(defaultParameters[0], 0),
-                           filter.getDouble(defaultParameters[1], 0)]
-        }
-        if (filter.animateOut > 0) {
-            endValues = [filter.getDouble(defaultParameters[0], filter.duration - 1),
-                         filter.getDouble(defaultParameters[1], filter.duration - 1)]
-        }
+        middleValues = [filter.getDouble(defaultParameters[0], filter.animateIn), filter.getDouble(defaultParameters[1], filter.animateIn)];
+        if (filter.animateIn > 0)
+            startValues = [filter.getDouble(defaultParameters[0], 0), filter.getDouble(defaultParameters[1], 0)];
+
+        if (filter.animateOut > 0)
+            endValues = [filter.getDouble(defaultParameters[0], filter.duration - 1), filter.getDouble(defaultParameters[1], filter.duration - 1)];
+
     }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setControls() {
-        var position = getPosition()
-        blockUpdate = true
-        radiusSlider.value = filter.getDouble('radius', position) * 100.0
-        radiusKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('radius') > 0
-        innerSlider.value = filter.getDouble('inner_radius', position) * 100.0
-        innerKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('inner_radius') > 0
-        blockUpdate = false
-        radiusSlider.enabled = innerSlider.enabled
-            = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        radiusSlider.value = filter.getDouble('radius', position) * 100;
+        radiusKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('radius') > 0;
+        innerSlider.value = filter.getDouble('inner_radius', position) * 100;
+        innerKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('inner_radius') > 0;
+        blockUpdate = false;
+        radiusSlider.enabled = innerSlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function updateFilter(parameter, value, position, button) {
-        if (blockUpdate) return
-        var index = defaultParameters.indexOf(parameter)
+        if (blockUpdate)
+            return ;
 
+        var index = defaultParameters.indexOf(parameter);
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValues[index] = value
+                startValues[index] = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValues[index] = value
+                endValues[index] = value;
             else
-                middleValues[index] = value
+                middleValues[index] = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(parameter)
-            button.checked = false
+            filter.resetProperty(parameter);
+            button.checked = false;
             if (filter.animateIn > 0) {
-                filter.set(parameter, startValues[index], 0)
-                filter.set(parameter, middleValues[index], filter.animateIn - 1)
+                filter.set(parameter, startValues[index], 0);
+                filter.set(parameter, middleValues[index], filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(parameter, middleValues[index], filter.duration - filter.animateOut)
-                filter.set(parameter, endValues[index], filter.duration - 1)
+                filter.set(parameter, middleValues[index], filter.duration - filter.animateOut);
+                filter.set(parameter, endValues[index], filter.duration - 1);
             }
         } else if (!button.checked) {
-            filter.resetProperty(parameter)
-            filter.set(parameter, middleValues[index])
+            filter.resetProperty(parameter);
+            filter.set(parameter, middleValues[index]);
         } else if (position !== null) {
-            filter.set(parameter, value, position)
+            filter.set(parameter, value, position);
         }
     }
 
     function onKeyframesButtonClicked(checked, parameter, value) {
         if (checked) {
-            blockUpdate = true
-            radiusSlider.enabled = innerSlider.enabled = true
+            blockUpdate = true;
+            radiusSlider.enabled = innerSlider.enabled = true;
             if (filter.animateIn > 0 || filter.animateOut > 0) {
-                for (var i = 0; i < defaultParameters.length; i++)
-                    filter.resetProperty(defaultParameters[i])
-                filter.animateIn = filter.animateOut = 0
+                for (var i = 0; i < defaultParameters.length; i++) filter.resetProperty(defaultParameters[i])
+                filter.animateIn = filter.animateOut = 0;
             } else {
-                filter.clearSimpleAnimation(parameter)
+                filter.clearSimpleAnimation(parameter);
             }
-            blockUpdate = false
-            filter.set(parameter, value, getPosition())
+            blockUpdate = false;
+            filter.set(parameter, value, getPosition());
         } else {
-            filter.resetProperty(parameter)
-            filter.set(parameter, value)
+            filter.resetProperty(parameter);
+            filter.set(parameter, value);
         }
+    }
+
+    function updateSimpleAnimation() {
+        setControls();
+        updateFilter('radius', radiusSlider.value / 100, null, radiusKeyframesButton);
+        updateFilter('inner_radius', innerSlider.value / 100, null, innerKeyframesButton);
+    }
+
+    width: 350
+    height: 100
+    Component.onCompleted: {
+        if (filter.isNew) {
+            for (var i = 0; i < defaultParameters.length; i++) filter.set(defaultParameters[i], middleValues[i])
+            filter.savePreset(defaultParameters);
+        } else {
+            initSimpleAnimation();
+        }
+        setControls();
     }
 
     GridLayout {
@@ -130,17 +129,18 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: 3
             parameters: defaultParameters
             onBeforePresetLoaded: {
-                for (var i = 0; i < defaultParameters.length; i++)
-                    filter.resetProperty(defaultParameters[i])
+                for (var i = 0; i < defaultParameters.length; i++) filter.resetProperty(defaultParameters[i])
             }
             onPresetSelected: {
-                setControls()
-                initSimpleAnimation()
+                setControls();
+                initSimpleAnimation();
             }
         }
 
@@ -148,63 +148,90 @@ Item {
             text: qsTr('Outer radius')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: radiusSlider
+
             minimumValue: 0
             maximumValue: 100
             suffix: ' %'
-            onValueChanged: updateFilter('radius', value / 100.0, getPosition(), radiusKeyframesButton)
+            onValueChanged: updateFilter('radius', value / 100, getPosition(), radiusKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: radiusSlider.value = 50
         }
+
         Shotcut.KeyframesButton {
             id: radiusKeyframesButton
-            onToggled: onKeyframesButtonClicked(checked, 'radius', radiusSlider.value / 100.0)
+
+            onToggled: onKeyframesButtonClicked(checked, 'radius', radiusSlider.value / 100)
         }
 
         Label {
             text: qsTr('Inner radius')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: innerSlider
+
             minimumValue: 0
             maximumValue: 100
             suffix: ' %'
-            onValueChanged: updateFilter('inner_radius', value / 100.0, getPosition(), innerKeyframesButton)
+            onValueChanged: updateFilter('inner_radius', value / 100, getPosition(), innerKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: innerSlider.value = 50
         }
+
         Shotcut.KeyframesButton {
             id: innerKeyframesButton
-            onToggled: onKeyframesButtonClicked(checked, 'inner_radius', innerSlider.value / 100.0)
+
+            onToggled: onKeyframesButtonClicked(checked, 'inner_radius', innerSlider.value / 100)
         }
 
         Item {
             Layout.fillHeight: true
         }
-    }
 
-    function updateSimpleAnimation() {
-        setControls()
-        updateFilter('radius', radiusSlider.value / 100.0, null, radiusKeyframesButton)
-        updateFilter('inner_radius', innerSlider.value / 100.0, null, innerKeyframesButton)
     }
 
     Connections {
+        function onChanged() {
+            setControls();
+        }
+
+        function onInChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onOutChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onPropertyChanged(name) {
+            setControls();
+        }
+
         target: filter
-        function onChanged() { setControls() }
-        function onInChanged() { updateSimpleAnimation() }
-        function onOutChanged() { updateSimpleAnimation() }
-        function onAnimateInChanged() { updateSimpleAnimation() }
-        function onAnimateOutChanged() { updateSimpleAnimation() }
-        function onPropertyChanged(name) { setControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setControls();
+        }
+
         target: producer
-        function onPositionChanged() { setControls() }
     }
+
 }

--- a/src/qml/filters/vignette/ui_oldfilm.qml
+++ b/src/qml/filters/vignette/ui_oldfilm.qml
@@ -23,114 +23,111 @@ import Shotcut.Controls 1.0 as Shotcut
 Item {
     property var defaultParameters: ['radius', 'smooth', 'opacity', 'mode']
     property bool blockUpdate: true
-    property var startValues:  [1.0, 0.0, 0.0]
-    property var middleValues: [0.5, 2.0, 0.0]
-    property var endValues:    [1.0, 0.0, 0.0]
-
-    width: 350
-    height: 150
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            // Set default parameter values
-            for (var i = 0; i < 3; i++)
-                filter.set(defaultParameters[i], middleValues[i])
-            filter.set('mode', 1)
-            filter.savePreset(defaultParameters)
-        } else {
-            initSimpleAnimation()
-        }
-        setControls()
-        setKeyframedControls()
-    }
+    property var startValues: [1, 0, 0]
+    property var middleValues: [0.5, 2, 0]
+    property var endValues: [1, 0, 0]
 
     function initSimpleAnimation() {
-        middleValues = [filter.getDouble(defaultParameters[0], filter.animateIn),
-                        filter.getDouble(defaultParameters[1], filter.animateIn),
-                        filter.getDouble(defaultParameters[2], filter.animateIn)]
-        if (filter.animateIn > 0) {
-            startValues = [filter.getDouble(defaultParameters[0], 0),
-                           filter.getDouble(defaultParameters[1], 0),
-                           filter.getDouble(defaultParameters[2], 0)]
-        }
-        if (filter.animateOut > 0) {
-            endValues = [filter.getDouble(defaultParameters[0], filter.duration - 1),
-                         filter.getDouble(defaultParameters[1], filter.duration - 1),
-                         filter.getDouble(defaultParameters[2], filter.duration - 1)]
-        }
+        middleValues = [filter.getDouble(defaultParameters[0], filter.animateIn), filter.getDouble(defaultParameters[1], filter.animateIn), filter.getDouble(defaultParameters[2], filter.animateIn)];
+        if (filter.animateIn > 0)
+            startValues = [filter.getDouble(defaultParameters[0], 0), filter.getDouble(defaultParameters[1], 0), filter.getDouble(defaultParameters[2], 0)];
+
+        if (filter.animateOut > 0)
+            endValues = [filter.getDouble(defaultParameters[0], filter.duration - 1), filter.getDouble(defaultParameters[1], filter.duration - 1), filter.getDouble(defaultParameters[2], filter.duration - 1)];
+
     }
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setKeyframedControls() {
-        var position = getPosition()
-        blockUpdate = true
-        radiusSlider.value = filter.getDouble('radius', position) * 100.0
-        radiusKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('radius') > 0
-        smoothSlider.value = filter.getDouble('smooth', position) * 100.0
-        smoothKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('smooth') > 0
-        opacitySlider.value = (1.0 - filter.getDouble('opacity', position)) * 100.0
-        opacityKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('opacity') > 0
-        blockUpdate = false
-        radiusSlider.enabled = smoothSlider.enabled = opacitySlider.enabled
-            = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        var position = getPosition();
+        blockUpdate = true;
+        radiusSlider.value = filter.getDouble('radius', position) * 100;
+        radiusKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('radius') > 0;
+        smoothSlider.value = filter.getDouble('smooth', position) * 100;
+        smoothKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('smooth') > 0;
+        opacitySlider.value = (1 - filter.getDouble('opacity', position)) * 100;
+        opacityKeyframesButton.checked = filter.animateIn <= 0 && filter.animateOut <= 0 && filter.keyframeCount('opacity') > 0;
+        blockUpdate = false;
+        radiusSlider.enabled = smoothSlider.enabled = opacitySlider.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function setControls() {
-        modeCheckBox.checked = filter.get('mode') === '1'
+        modeCheckBox.checked = filter.get('mode') === '1';
     }
 
     function updateFilter(parameter, value, position, button) {
-        if (blockUpdate) return
-        var index = defaultParameters.indexOf(parameter)
+        if (blockUpdate)
+            return ;
 
+        var index = defaultParameters.indexOf(parameter);
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValues[index] = value
+                startValues[index] = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValues[index] = value
+                endValues[index] = value;
             else
-                middleValues[index] = value
+                middleValues[index] = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(parameter)
-            button.checked = false
+            filter.resetProperty(parameter);
+            button.checked = false;
             if (filter.animateIn > 0) {
-                filter.set(parameter, startValues[index], 0)
-                filter.set(parameter, middleValues[index], filter.animateIn - 1)
+                filter.set(parameter, startValues[index], 0);
+                filter.set(parameter, middleValues[index], filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(parameter, middleValues[index], filter.duration - filter.animateOut)
-                filter.set(parameter, endValues[index], filter.duration - 1)
+                filter.set(parameter, middleValues[index], filter.duration - filter.animateOut);
+                filter.set(parameter, endValues[index], filter.duration - 1);
             }
         } else if (!button.checked) {
-            filter.resetProperty(parameter)
-            filter.set(parameter, middleValues[index])
+            filter.resetProperty(parameter);
+            filter.set(parameter, middleValues[index]);
         } else if (position !== null) {
-            filter.set(parameter, value, position)
+            filter.set(parameter, value, position);
         }
     }
 
     function onKeyframesButtonClicked(checked, parameter, value) {
         if (checked) {
-            radiusSlider.enabled = smoothSlider.enabled = opacitySlider.enabled = true
-            blockUpdate = true
+            radiusSlider.enabled = smoothSlider.enabled = opacitySlider.enabled = true;
+            blockUpdate = true;
             if (filter.animateIn > 0 || filter.animateOut > 0) {
-                for (var i = 0; i < 3; i++)
-                    filter.resetProperty(defaultParameters[i])
-                filter.animateIn = filter.animateOut = 0
+                for (var i = 0; i < 3; i++) filter.resetProperty(defaultParameters[i])
+                filter.animateIn = filter.animateOut = 0;
             } else {
-                filter.clearSimpleAnimation(parameter)
+                filter.clearSimpleAnimation(parameter);
             }
-            blockUpdate = false
-            filter.set(parameter, value, getPosition())
+            blockUpdate = false;
+            filter.set(parameter, value, getPosition());
         } else {
-            filter.resetProperty(parameter)
-            filter.set(parameter, value)
+            filter.resetProperty(parameter);
+            filter.set(parameter, value);
         }
+    }
+
+    function updateSimpleAnimation() {
+        setKeyframedControls();
+        updateFilter('radius', radiusSlider.value / 100, null, radiusKeyframesButton);
+        updateFilter('smooth', smoothSlider.value / 100, null, smoothKeyframesButton);
+        updateFilter('opacity', 1 - opacitySlider.value / 100, null, opacityKeyframesButton);
+    }
+
+    width: 350
+    height: 150
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            for (var i = 0; i < 3; i++) filter.set(defaultParameters[i], middleValues[i])
+            filter.set('mode', 1);
+            filter.savePreset(defaultParameters);
+        } else {
+            initSimpleAnimation();
+        }
+        setControls();
+        setKeyframedControls();
     }
 
     GridLayout {
@@ -138,22 +135,23 @@ Item {
         anchors.fill: parent
         anchors.margins: 8
 
-        Label{
+        Label {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: 3
             parameters: defaultParameters
             onBeforePresetLoaded: {
-                for (var i = 0; i < 3; i++)
-                    filter.resetProperty(defaultParameters[i])
+                for (var i = 0; i < 3; i++) filter.resetProperty(defaultParameters[i])
             }
             onPresetSelected: {
-                setControls()
-                setKeyframedControls()
-                initSimpleAnimation()
+                setControls();
+                setKeyframedControls();
+                initSimpleAnimation();
             }
         }
 
@@ -161,50 +159,65 @@ Item {
             text: qsTr('Radius')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: radiusSlider
+
             minimumValue: 0
             maximumValue: 100
             suffix: ' %'
-            onValueChanged: updateFilter('radius', value / 100.0, getPosition(), radiusKeyframesButton)
+            onValueChanged: updateFilter('radius', value / 100, getPosition(), radiusKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: radiusSlider.value = 50
         }
+
         Shotcut.KeyframesButton {
             id: radiusKeyframesButton
-            onToggled: onKeyframesButtonClicked(checked, 'radius', radiusSlider.value / 100.0)
+
+            onToggled: onKeyframesButtonClicked(checked, 'radius', radiusSlider.value / 100)
         }
 
         Label {
             text: qsTr('Feathering')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: smoothSlider
+
             minimumValue: 0
             maximumValue: 500
             suffix: ' %'
-            onValueChanged: updateFilter('smooth', value / 100.0, getPosition(), smoothKeyframesButton)
+            onValueChanged: updateFilter('smooth', value / 100, getPosition(), smoothKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: smoothSlider.value = 200
         }
+
         Shotcut.KeyframesButton {
             id: smoothKeyframesButton
-            onToggled: onKeyframesButtonClicked(checked, 'smooth', smoothSlider.value / 100.0)
+
+            onToggled: onKeyframesButtonClicked(checked, 'smooth', smoothSlider.value / 100)
         }
 
-        Label {}
+        Label {
+        }
+
         CheckBox {
             id: modeCheckBox
+
+            property bool isReady: false
+
             text: qsTr('Non-linear feathering')
             Layout.columnSpan: 3
-            property bool isReady: false
             Component.onCompleted: isReady = true
             onClicked: {
                 if (isReady)
-                    filter.set('mode', checked)
+                    filter.set('mode', checked);
+
             }
         }
 
@@ -212,45 +225,66 @@ Item {
             text: qsTr('Opacity')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: opacitySlider
+
             minimumValue: 0
             maximumValue: 100
             suffix: ' %'
-            onValueChanged: updateFilter('opacity', 1.0 - value / 100.0, getPosition(), opacityKeyframesButton)
+            onValueChanged: updateFilter('opacity', 1 - value / 100, getPosition(), opacityKeyframesButton)
         }
+
         Shotcut.UndoButton {
             onClicked: opacitySlider.value = 100
         }
+
         Shotcut.KeyframesButton {
             id: opacityKeyframesButton
-            onToggled: onKeyframesButtonClicked(checked, 'opacity', 1.0 - opacitySlider.value / 100.0)
+
+            onToggled: onKeyframesButtonClicked(checked, 'opacity', 1 - opacitySlider.value / 100)
         }
 
         Item {
             Layout.fillHeight: true
         }
-    }
 
-    function updateSimpleAnimation() {
-        setKeyframedControls()
-        updateFilter('radius', radiusSlider.value / 100.0, null, radiusKeyframesButton)
-        updateFilter('smooth', smoothSlider.value / 100.0, null, smoothKeyframesButton)
-        updateFilter('opacity', 1.0 - opacitySlider.value / 100.0, null, opacityKeyframesButton)
     }
 
     Connections {
+        function onChanged() {
+            setKeyframedControls();
+        }
+
+        function onInChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onOutChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onAnimateInChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onAnimateOutChanged() {
+            updateSimpleAnimation();
+        }
+
+        function onPropertyChanged(name) {
+            setKeyframedControls();
+        }
+
         target: filter
-        function onChanged() { setKeyframedControls() }
-        function onInChanged() { updateSimpleAnimation() }
-        function onOutChanged() { updateSimpleAnimation() }
-        function onAnimateInChanged() { updateSimpleAnimation() }
-        function onAnimateOutChanged() { updateSimpleAnimation() }
-        function onPropertyChanged(name) { setKeyframedControls() }
     }
 
     Connections {
+        function onPositionChanged() {
+            setKeyframedControls();
+        }
+
         target: producer
-        function onPositionChanged() { setKeyframedControls() }
     }
+
 }

--- a/src/qml/filters/wave/ui.qml
+++ b/src/qml/filters/wave/ui.qml
@@ -24,14 +24,13 @@ import Shotcut.Controls 1.0 as Shotcut
 Item {
     width: 350
     height: 150
-
     Component.onCompleted: {
         if (filter.isNew) {
-            filter.set('wave', 10)
-            filter.set('speed', 5)
-            filter.set('deformX', 1)
-            filter.set('deformY', 1)
-            filter.savePreset(preset.parameters)
+            filter.set('wave', 10);
+            filter.set('speed', 5);
+            filter.set('deformX', 1);
+            filter.set('deformY', 1);
+            filter.savePreset(preset.parameters);
         }
     }
 
@@ -44,15 +43,17 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             Layout.columnSpan: 2
             parameters: ['wave', 'speed', 'deformX', 'deformX']
             onPresetSelected: {
-                waveSlider.value = filter.getDouble('wave')
-                speedSlider.value = filter.getDouble('speed')
-                deformXCheckBox.checked = filter.get('deformX') === '1'
-                deformYCheckBox.checked = filter.get('deformY') === '1'
+                waveSlider.value = filter.getDouble('wave');
+                speedSlider.value = filter.getDouble('speed');
+                deformXCheckBox.checked = filter.get('deformX') === '1';
+                deformYCheckBox.checked = filter.get('deformY') === '1';
             }
         }
 
@@ -60,13 +61,16 @@ Item {
             text: qsTr('Amplitude')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: waveSlider
+
             minimumValue: 1
             maximumValue: 500
             value: filter.getDouble('wave')
             onValueChanged: filter.set('wave', value)
         }
+
         Shotcut.UndoButton {
             onClicked: waveSlider.value = 10
         }
@@ -75,47 +79,62 @@ Item {
             text: qsTr('Speed')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
             id: speedSlider
+
             minimumValue: 0
             maximumValue: 1000
             value: filter.getDouble('speed')
             onValueChanged: filter.set('speed', value)
         }
+
         Shotcut.UndoButton {
             onClicked: speedSlider.value = 5
         }
 
-        Label {}
+        Label {
+        }
+
         CheckBox {
             id: deformXCheckBox
+
+            property bool isReady: false
+
             text: qsTr('Deform horizontally?')
             Layout.columnSpan: 2
             checked: filter.get('deformX') === '1'
-            property bool isReady: false
             Component.onCompleted: isReady = true
             onClicked: {
                 if (isReady)
-                    filter.set('deformX', checked)
+                    filter.set('deformX', checked);
+
             }
         }
 
-        Label {}
+        Label {
+        }
+
         CheckBox {
             id: deformYCheckBox
+
+            property bool isReady: false
+
             text: qsTr('Deform vertically?')
             Layout.columnSpan: 2
             checked: filter.get('deformY') === '1'
-            property bool isReady: false
             Component.onCompleted: isReady = true
             onClicked: {
                 if (isReady)
-                    filter.set('deformY', checked)
+                    filter.set('deformY', checked);
+
             }
         }
 
         Item {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/filters/waveform/ui.qml
+++ b/src/qml/filters/waveform/ui.qml
@@ -26,53 +26,49 @@ Item {
     property var defaultParameters: [rectProperty, 'color.1', 'color.2', 'color.3', 'color.4', 'color.5', 'color.6', 'color.7', 'color.8', 'color.9', 'color.10', 'bgcolor', 'thickness', 'fill', 'show_channel', 'window']
     property bool _disableUpdate: true
 
-    width: 425
-    height: 270
-
-    Component.onCompleted: {
-        if (filter.isNew) {
-            filter.set(rectProperty, '0/50%:50%x50%')
-            filter.set('color.1', '#ffffffff')
-            filter.set('bgcolor', '#00ffffff')
-            filter.set('thickness', '1')
-            filter.set('fill', '0')
-            filter.set('show_channel', '-1')
-            filter.set('window', '0')
-            filter.savePreset(defaultParameters)
-        }
-        setControls()
-    }
-
     function setFilter() {
-        var x = rectX.value
-        var y = rectY.value
-        var w = rectW.value
-        var h = rectH.value
-        if (x !== filterRect.x ||
-            y !== filterRect.y ||
-            w !== filterRect.width ||
-            h !== filterRect.height) {
-            filterRect.x = x
-            filterRect.y = y
-            filterRect.width = w
-            filterRect.height = h
-            filter.set(rectProperty, filterRect)
+        var x = rectX.value;
+        var y = rectY.value;
+        var w = rectW.value;
+        var h = rectH.value;
+        if (x !== filterRect.x || y !== filterRect.y || w !== filterRect.width || h !== filterRect.height) {
+            filterRect.x = x;
+            filterRect.y = y;
+            filterRect.width = w;
+            filterRect.height = h;
+            filter.set(rectProperty, filterRect);
         }
     }
 
     function setControls() {
-        _disableUpdate = true
-        fgGradient.colors = filter.getGradient('color')
-        bgColor.value = filter.get('bgcolor')
-        thicknessSlider.value = filter.getDouble('thickness')
-        fillCheckbox.checked = filter.get('fill') == 1
-        combineCheckbox.checked = filter.get('show_channel') == -1
-        windowSlider.value = filter.getDouble('window')
-        rectX.value = filterRect.x
-        rectY.value = filterRect.y
-        rectW.value = filterRect.width
-        rectH.value = filterRect.height
-        _disableUpdate = false
+        _disableUpdate = true;
+        fgGradient.colors = filter.getGradient('color');
+        bgColor.value = filter.get('bgcolor');
+        thicknessSlider.value = filter.getDouble('thickness');
+        fillCheckbox.checked = filter.get('fill') == 1;
+        combineCheckbox.checked = filter.get('show_channel') == -1;
+        windowSlider.value = filter.getDouble('window');
+        rectX.value = filterRect.x;
+        rectY.value = filterRect.y;
+        rectW.value = filterRect.width;
+        rectH.value = filterRect.height;
+        _disableUpdate = false;
+    }
+
+    width: 425
+    height: 270
+    Component.onCompleted: {
+        if (filter.isNew) {
+            filter.set(rectProperty, '0/50%:50%x50%');
+            filter.set('color.1', '#ffffffff');
+            filter.set('bgcolor', '#00ffffff');
+            filter.set('thickness', '1');
+            filter.set('fill', '0');
+            filter.set('show_channel', '-1');
+            filter.set('window', '0');
+            filter.savePreset(defaultParameters);
+        }
+        setControls();
     }
 
     GridLayout {
@@ -84,14 +80,16 @@ Item {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: preset
+
             parameters: defaultParameters
             Layout.columnSpan: 4
             onPresetSelected: setControls()
             onBeforePresetLoaded: {
                 // Clear all gradient colors before loading the new values
-                filter.setGradient('color', [])
+                filter.setGradient('color', []);
             }
         }
 
@@ -99,12 +97,16 @@ Item {
             text: qsTr('Waveform Color')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.GradientControl {
-            Layout.columnSpan: 4
             id: fgGradient
+
+            Layout.columnSpan: 4
             onGradientChanged: {
-                if (_disableUpdate) return
-                filter.setGradient('color', colors)
+                if (_disableUpdate)
+                    return ;
+
+                filter.setGradient('color', colors);
             }
         }
 
@@ -112,9 +114,11 @@ Item {
             text: qsTr('Background Color')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ColorPicker {
-            Layout.columnSpan: 4
             id: bgColor
+
+            Layout.columnSpan: 4
             eyedropper: true
             alpha: true
             onValueChanged: filter.set('bgcolor', value)
@@ -124,15 +128,18 @@ Item {
             text: qsTr('Thickness')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: thicknessSlider
+
+            Layout.columnSpan: 3
             minimumValue: 0
             maximumValue: 20
             decimals: 0
             suffix: ' px'
             onValueChanged: filter.set("thickness", value)
         }
+
         Shotcut.UndoButton {
             onClicked: thicknessSlider.value = 1
         }
@@ -141,70 +148,94 @@ Item {
             text: qsTr('Position')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Layout.columnSpan: 4
+
             Shotcut.DoubleSpinBox {
                 id: rectX
+
                 value: filterRect.x
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
+                from: -1e+09
+                to: 1e+09
                 onValueModified: setFilter()
             }
-            Label { text: ','; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: ','
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectY
+
                 value: filterRect.y
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
+                from: -1e+09
+                to: 1e+09
                 onValueModified: setFilter()
             }
+
         }
 
         Label {
             text: qsTr('Size')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Layout.columnSpan: 4
+
             Shotcut.DoubleSpinBox {
                 id: rectW
+
                 value: filterRect.width
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
+                from: -1e+09
+                to: 1e+09
                 onValueModified: setFilter()
             }
-            Label { text: 'x'; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+            Label {
+                text: 'x'
+                Layout.minimumWidth: 20
+                horizontalAlignment: Qt.AlignHCenter
+            }
+
             Shotcut.DoubleSpinBox {
                 id: rectH
+
                 value: filterRect.height
                 Layout.minimumWidth: 100
                 horizontalAlignment: Qt.AlignRight
                 decimals: 0
                 stepSize: 1
-                from: -999999999
-                to: 999999999
+                from: -1e+09
+                to: 1e+09
                 onValueModified: setFilter()
             }
+
         }
-        
+
         Label {
             Layout.alignment: Qt.AlignRight
         }
+
         CheckBox {
-            Layout.columnSpan: 4
             id: fillCheckbox
+
+            Layout.columnSpan: 4
             text: qsTr('Fill the area under the waveform.')
             onClicked: filter.set('fill', checked ? 1 : 0)
         }
@@ -212,9 +243,11 @@ Item {
         Label {
             Layout.alignment: Qt.AlignRight
         }
+
         CheckBox {
-            Layout.columnSpan: 4
             id: combineCheckbox
+
+            Layout.columnSpan: 4
             text: qsTr('Combine all channels into one waveform.')
             onClicked: filter.set('show_channel', checked ? -1 : 0)
         }
@@ -223,15 +256,18 @@ Item {
             text: qsTr('Window')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.SliderSpinner {
-            Layout.columnSpan: 3
             id: windowSlider
+
+            Layout.columnSpan: 3
             minimumValue: 0
             maximumValue: 1000
             suffix: ' ms'
             decimals: 0
             onValueChanged: filter.set("window", value)
         }
+
         Shotcut.UndoButton {
             onClicked: windowSlider.value = 0.4
         }
@@ -239,16 +275,19 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
 
     Connections {
-        target: filter
         function onChanged() {
-            var newValue = filter.getRect(rectProperty)
+            var newValue = filter.getRect(rectProperty);
             if (filterRect !== newValue) {
-                filterRect = newValue
-                setControls()
+                filterRect = newValue;
+                setControls();
             }
         }
+
+        target: filter
     }
+
 }

--- a/src/qml/filters/waveform/vui.qml
+++ b/src/qml/filters/waveform/vui.qml
@@ -20,12 +20,12 @@ import Shotcut.Controls 1.0 as Shotcut
 
 Shotcut.VuiBase {
     property string rectProperty: "rect"
-    property real zoom: (video.zoom > 0)? video.zoom : 1.0
+    property real zoom: (video.zoom > 0) ? video.zoom : 1
     property rect filterRect: filter.getRect(rectProperty)
 
     Component.onCompleted: {
-        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag'))
-        rectangle.setHandles(filter.getRect(rectProperty))
+        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag'));
+        rectangle.setHandles(filter.getRect(rectProperty));
     }
 
     Flickable {
@@ -39,6 +39,7 @@ Shotcut.VuiBase {
 
         Item {
             id: videoItem
+
             x: video.rect.x
             y: video.rect.y
             width: video.rect.width
@@ -47,32 +48,37 @@ Shotcut.VuiBase {
 
             Shotcut.RectangleControl {
                 id: rectangle
+
                 widthScale: video.rect.width / profile.width
                 heightScale: video.rect.height / profile.height
                 handleSize: Math.max(Math.round(8 / zoom), 4)
                 borderSize: Math.max(Math.round(1.33 / zoom), 1)
                 onWidthScaleChanged: setHandles(filter.getRect(rectProperty))
                 onHeightScaleChanged: setHandles(filter.getRect(rectProperty))
-                onRectChanged:  {
-                    filterRect.x = Math.round(rect.x / rectangle.widthScale)
-                    filterRect.y = Math.round(rect.y / rectangle.heightScale)
-                    filterRect.width = Math.round(rect.width / rectangle.widthScale)
-                    filterRect.height = Math.round(rect.height / rectangle.heightScale)
-                    filter.set(rectProperty, filterRect)
+                onRectChanged: {
+                    filterRect.x = Math.round(rect.x / rectangle.widthScale);
+                    filterRect.y = Math.round(rect.y / rectangle.heightScale);
+                    filterRect.width = Math.round(rect.width / rectangle.widthScale);
+                    filterRect.height = Math.round(rect.height / rectangle.heightScale);
+                    filter.set(rectProperty, filterRect);
                 }
             }
+
         }
+
     }
 
     Connections {
-        target: filter
         function onChanged() {
-            var newRect = filter.getRect(rectProperty)
+            var newRect = filter.getRect(rectProperty);
             if (filterRect !== newRect) {
-                filterRect = newRect
-                rectangle.setHandles(filterRect)
+                filterRect = newRect;
+                rectangle.setHandles(filterRect);
             }
-            videoItem.enabled = filter.get('disable') !== '1'
+            videoItem.enabled = filter.get('disable') !== '1';
         }
+
+        target: filter
     }
+
 }

--- a/src/qml/filters/white/ui.qml
+++ b/src/qml/filters/white/ui.qml
@@ -25,67 +25,72 @@ Item {
     property var neutralParam: ""
     property var tempParam: ""
     property var defaultNeutral: "#7f7f7f"
-    property var defaultTemp: 6500.0
-    property var tempScale: 15000.0
+    property var defaultTemp: 6500
+    property var tempScale: 15000
+
     width: 350
     height: 100
     Component.onCompleted: {
-        if (filter.get("mlt_service").indexOf("movit.") == 0 ) {
+        if (filter.get("mlt_service").indexOf("movit.") == 0) {
             // Movit filter
-            neutralParam = "neutral_color"
-            tempParam = "color_temperature"
+            neutralParam = "neutral_color";
+            tempParam = "color_temperature";
             tempScale = 1;
         } else {
             // Frei0r filter
-            neutralParam = "0"
-            tempParam = "1"
-            tempScale = 15000.0
-            filter.set('threads', 0)
+            neutralParam = "0";
+            tempParam = "1";
+            tempScale = 15000;
+            filter.set('threads', 0);
         }
-        defaultParameters = [neutralParam, tempParam]
-        presetItem.parameters = defaultParameters
-
+        defaultParameters = [neutralParam, tempParam];
+        presetItem.parameters = defaultParameters;
         if (filter.isNew) {
             // Set default parameter values
-            filter.set(neutralParam, defaultNeutral)
-            filter.set(tempParam, defaultTemp / tempScale)
-            filter.savePreset(defaultParameters)
+            filter.set(neutralParam, defaultNeutral);
+            filter.set(tempParam, defaultTemp / tempScale);
+            filter.savePreset(defaultParameters);
         }
-        tempslider.value = filter.getDouble(tempParam) * tempScale
-        tempspinner.value = filter.getDouble(tempParam) * tempScale
-        colorPicker.value = filter.get(neutralParam)
+        tempslider.value = filter.getDouble(tempParam) * tempScale;
+        tempspinner.value = filter.getDouble(tempParam) * tempScale;
+        colorPicker.value = filter.get(neutralParam);
     }
 
     GridLayout {
         columns: 3
         anchors.fill: parent
         anchors.margins: 8
-        
+
         Label {
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.Preset {
             id: presetItem
+
             Layout.columnSpan: 2
             onPresetSelected: {
-                tempslider.value = filter.getDouble(tempParam) * tempScale
-                colorPicker.value = filter.get(neutralParam)
+                tempslider.value = filter.getDouble(tempParam) * tempScale;
+                colorPicker.value = filter.get(neutralParam);
             }
         }
-        
+
         // Row 1
         Label {
             text: qsTr('Neutral color')
             Layout.alignment: Qt.AlignRight
         }
+
         Shotcut.ColorPicker {
             id: colorPicker
+
             property bool isReady: false
+
             Component.onCompleted: isReady = true
             onValueChanged: {
                 if (isReady) {
-                    filter.set(neutralParam, ""+value)
+                    filter.set(neutralParam, "" + value);
                     filter.set("disable", 0);
                 }
             }
@@ -94,6 +99,7 @@ Item {
             }
             onPickCancelled: filter.set('disable', 0)
         }
+
         Shotcut.UndoButton {
             onClicked: colorPicker.value = defaultNeutral
         }
@@ -103,25 +109,55 @@ Item {
             text: qsTr('Color temperature')
             Layout.alignment: Qt.AlignRight
         }
+
         RowLayout {
             Slider {
                 id: tempslider
+
+                property bool isReady: false
+
                 Layout.fillWidth: true
                 implicitHeight: tempspinner.implicitHeight
                 padding: 0
+                from: 1000
+                to: 15000
+                Component.onCompleted: isReady = true
+                onValueChanged: {
+                    if (isReady) {
+                        tempspinner.value = value;
+                        filter.set(tempParam, value / tempScale);
+                    }
+                }
+
                 background: Rectangle {
                     height: tempslider.availableHeight / 2
                     width: tempslider.availableWidth
                     x: tempslider.leftPadding
                     y: tempslider.topPadding + tempslider.availableHeight / 2 - height / 2
+                    radius: 4
+
                     gradient: Gradient {
                         orientation: Gradient.Horizontal
-                        GradientStop { position: 0.000; color: "#FFC500" }
-                        GradientStop { position: 0.392; color: "#FFFFFF" }
-                        GradientStop { position: 1.000; color: "#DDFFFE" }
+
+                        GradientStop {
+                            position: 0
+                            color: "#FFC500"
+                        }
+
+                        GradientStop {
+                            position: 0.392
+                            color: "#FFFFFF"
+                        }
+
+                        GradientStop {
+                            position: 1
+                            color: "#DDFFFE"
+                        }
+
                     }
-                    radius: 4
+
                 }
+
                 handle: Rectangle {
                     x: tempslider.leftPadding + tempslider.visualPosition * (tempslider.availableWidth - width)
                     y: tempslider.topPadding + tempslider.availableHeight / 2 - height / 2
@@ -132,28 +168,23 @@ Item {
                     height: tempslider.height
                     radius: 4
                 }
-                from: 1000.0
-                to: 15000.0
-                property bool isReady: false
-                Component.onCompleted: isReady = true
-                onValueChanged: {
-                    if (isReady) {
-                        tempspinner.value = value
-                        filter.set(tempParam, value / tempScale)
-                    }
-                }
+
             }
+
             Shotcut.DoubleSpinBox {
                 id: tempspinner
+
                 Layout.minimumWidth: 150
-                from: 1000.0
-                to: 15000.0
+                from: 1000
+                to: 15000
                 stepSize: 10
                 decimals: 0
                 suffix: qsTr('degrees')
                 onValueModified: tempslider.value = value
             }
+
         }
+
         Shotcut.UndoButton {
             onClicked: tempslider.value = defaultTemp
         }
@@ -161,5 +192,7 @@ Item {
         Item {
             Layout.fillHeight: true
         }
+
     }
+
 }

--- a/src/qml/modules/Shotcut/Controls/Button.qml
+++ b/src/qml/modules/Shotcut/Controls/Button.qml
@@ -22,11 +22,13 @@ Button {
     verticalPadding: text ? 4 : 2
     horizontalPadding: text ? 10 : 2
     hoverEnabled: true
-
-    SystemPalette { id: activePalette }
     palette.buttonText: activePalette.buttonText
     palette.button: checked ? activePalette.highlight : activePalette.button
-
     Keys.onReturnPressed: clicked()
     Keys.onEnterPressed: clicked()
+
+    SystemPalette {
+        id: activePalette
+    }
+
 }

--- a/src/qml/modules/Shotcut/Controls/ColorPicker.qml
+++ b/src/qml/modules/Shotcut/Controls/ColorPicker.qml
@@ -25,68 +25,86 @@ RowLayout {
     property string value: "white"
     property bool alpha: false
     property alias eyedropper: pickerButton.visible
-    
-    signal pickStarted
-    signal pickCancelled
-    
-    SystemPalette { id: activePalette; colorGroup: SystemPalette.Active }
-    
+
+    signal pickStarted()
+    signal pickCancelled()
+
+    SystemPalette {
+        id: activePalette
+
+        colorGroup: SystemPalette.Active
+    }
+
     Shotcut.ColorPickerItem {
         id: pickerItem
+
         onColorPicked: {
-            value = color
-            pickerButton.checked = false
+            value = color;
+            pickerButton.checked = false;
         }
         onCancelled: pickCancelled()
     }
-    
+
     Shotcut.Button {
         id: colorButton
+
         implicitWidth: 20
         implicitHeight: 20
+        onClicked: colorDialog.visible = true
+
+        Shotcut.HoverTip {
+            text: qsTr('Click to open color dialog')
+        }
+
         background: Rectangle {
             border.width: 1
             border.color: 'gray'
             radius: pickerButton.background.radius
             color: value
         }
-        Shotcut.HoverTip { text: qsTr('Click to open color dialog') }
-        onClicked: colorDialog.visible = true
+
     }
-    
+
     ColorDialog {
         id: colorDialog
+
         title: qsTr("Please choose a color")
         showAlphaChannel: alpha
         color: value
         onAccepted: {
             // Make a copy of the current value.
-            var myColor = Qt.darker(value, 1.0)
+            var myColor = Qt.darker(value, 1);
             // Ignore alpha when comparing.
-            myColor.a = currentColor.a
+            myColor.a = currentColor.a;
             // If the user changed color but left alpha at 0,
             // they probably want to reset alpha to opaque.
-            if (currentColor.a === 0 && (!Qt.colorEqual(currentColor, myColor) ||
-                                         (Qt.colorEqual(currentColor, 'transparent') && Qt.colorEqual(value, 'transparent'))))
-                currentColor.a = 1.0
+            if (currentColor.a === 0 && (!Qt.colorEqual(currentColor, myColor) || (Qt.colorEqual(currentColor, 'transparent') && Qt.colorEqual(value, 'transparent'))))
+                currentColor.a = 1;
+
             // Assign the new color value. Unlike docs say, using currentColor
             // is actually more cross-platform compatible.
-            value = currentColor
+            value = currentColor;
         }
         modality: application.dialogModality
     }
-    
+
     Shotcut.Button {
         id: pickerButton
+
         icon.name: 'color-picker'
         icon.source: 'qrc:///icons/oxygen/32x32/actions/color-picker.png'
-        Shotcut.HoverTip { text: '<p>' + qsTr("Pick a color on the screen. By pressing the mouse button and then moving your mouse you can select a section of the screen from which to get an average color.") + '</p>' }
         implicitWidth: 20
         implicitHeight: 20
         checkable: true
         onClicked: {
-            pickStarted()
-            pickerItem.pickColor()
+            pickStarted();
+            pickerItem.pickColor();
         }
+
+        Shotcut.HoverTip {
+            text: '<p>' + qsTr("Pick a color on the screen. By pressing the mouse button and then moving your mouse you can select a section of the screen from which to get an average color.") + '</p>'
+        }
+
     }
+
 }

--- a/src/qml/modules/Shotcut/Controls/ComboBox.qml
+++ b/src/qml/modules/Shotcut/Controls/ComboBox.qml
@@ -14,14 +14,18 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 
 ComboBox {
-    // workaround incorrect color of chosen combo item on Fusion theme
-    SystemPalette { id: activePalette }
     palette.buttonText: activePalette.buttonText
     focusPolicy: Qt.NoFocus
     hoverEnabled: focusReason !== Qt.TabFocusReason && focusReason !== Qt.BacktabFocusReason
+
+    // workaround incorrect color of chosen combo item on Fusion theme
+    SystemPalette {
+        id: activePalette
+    }
+
 }

--- a/src/qml/modules/Shotcut/Controls/EditMenu.qml
+++ b/src/qml/modules/Shotcut/Controls/EditMenu.qml
@@ -19,66 +19,96 @@ import QtQuick 2.12
 import QtQuick.Controls 2.12
 
 Menu {
+    id: menu
+
     property var control: parent
 
-    id: menu
     width: 220
 
     MenuItem {
+
         action: Action {
-            text: qsTr('Undo') + (application.OS === 'OS X'? '    ⌘Z' : ' (Ctrl+Z)')
+            text: qsTr('Undo') + (application.OS === 'OS X' ? '    ⌘Z' : ' (Ctrl+Z)')
             onTriggered: control.undo()
         }
+
     }
+
     MenuItem {
+
         action: Action {
-            text: qsTr('Redo') + (application.OS === 'Windows'? ' (Ctrl+Y)' : application.OS === 'OS X'? '    ⇧⌘Z' : ' (Ctrl+Shift+Z)')
+            text: qsTr('Redo') + (application.OS === 'Windows' ? ' (Ctrl+Y)' : application.OS === 'OS X' ? '    ⇧⌘Z' : ' (Ctrl+Shift+Z)')
             onTriggered: control.redo()
         }
+
     }
-    MenuSeparator {}
+
+    MenuSeparator {
+    }
+
     MenuItem {
+
         action: Action {
-            text: qsTr('Cut') + (application.OS === 'OS X'? '    ⌘X' : ' (Ctrl+X)')
+            text: qsTr('Cut') + (application.OS === 'OS X' ? '    ⌘X' : ' (Ctrl+X)')
             onTriggered: control.cut()
         }
+
     }
+
     MenuItem {
+
         action: Action {
-            text: qsTr('Copy') + (application.OS === 'OS X'? '    ⌘C' : ' (Ctrl+C)')
+            text: qsTr('Copy') + (application.OS === 'OS X' ? '    ⌘C' : ' (Ctrl+C)')
             onTriggered: control.copy()
         }
+
     }
+
     MenuItem {
+
         action: Action {
-            text: qsTr('Paste') + (application.OS === 'OS X'? '    ⌘V' : ' (Ctrl+V)')
+            text: qsTr('Paste') + (application.OS === 'OS X' ? '    ⌘V' : ' (Ctrl+V)')
             onTriggered: control.paste()
         }
+
     }
+
     MenuItem {
+
         action: Action {
             text: qsTr('Delete')
             onTriggered: parent.control(control.selectionStart, control.selectionEnd)
         }
+
     }
+
     MenuItem {
+
         action: Action {
             text: qsTr('Clear')
             onTriggered: {
-                control.selectAll()
-                control.remove(control.selectionStart, control.selectionEnd)
+                control.selectAll();
+                control.remove(control.selectionStart, control.selectionEnd);
             }
         }
+
     }
-    MenuSeparator {}
+
+    MenuSeparator {
+    }
+
     MenuItem {
+
         action: Action {
-            text: qsTr('Select All') + (application.OS === 'OS X'? '    ⌘A' : ' (Ctrl+A)')
+            text: qsTr('Select All') + (application.OS === 'OS X' ? '    ⌘A' : ' (Ctrl+A)')
             onTriggered: control.selectAll()
         }
+
     }
+
     MenuItem {
         text: qsTr('Cancel')
         onTriggered: menu.dismiss()
     }
+
 }

--- a/src/qml/modules/Shotcut/Controls/Gauge.qml
+++ b/src/qml/modules/Shotcut/Controls/Gauge.qml
@@ -20,6 +20,7 @@ import QtQuick.Controls 2.12
 
 Grid {
     id: root
+
     property alias from: slider.from
     property alias value: slider.value
     property alias to: slider.to
@@ -27,16 +28,54 @@ Grid {
     property int decimals: 1
     property int orientation: Qt.Horizontal
 
-    SystemPalette { id: activePalette }
     padding: 0
     spacing: 0
     rows: 3
     columns: 1
     layoutDirection: Qt.LeftToRight
     state: orientation == Qt.Horizontal ? "horizontal" : "vertical"
+    states: [
+        State {
+            name: "horizontal"
+
+            PropertyChanges {
+                target: root
+                rows: 3
+                columns: 1
+                layoutDirection: Qt.LeftToRight
+            }
+
+            PropertyChanges {
+                target: slider
+                orientation: Qt.Horizontal
+            }
+
+        },
+        State {
+            name: "vertical"
+
+            PropertyChanges {
+                target: root
+                rows: 1
+                columns: 3
+                layoutDirection: Qt.RightToLeft
+            }
+
+            PropertyChanges {
+                target: slider
+                orientation: Qt.Vertical
+            }
+
+        }
+    ]
+
+    SystemPalette {
+        id: activePalette
+    }
 
     Slider {
         id: slider
+
         enabled: false
         orientation: root.orientation
         implicitHeight: orientation == Qt.Horizontal ? 18 : parent.height
@@ -50,71 +89,85 @@ Grid {
             height: parent.height
 
             Rectangle {
-                anchors {
-                    top: orientation == Qt.Horizontal ? parent.top : undefined
-                    bottom: orientation == Qt.Horizontal ? parent.bottom : undefined
-                    left: orientation == Qt.Horizontal ? undefined : parent.left
-                    right:  orientation == Qt.Horizontal ? undefined : parent.right
-                    margins: 1
-                }
                 radius: parent.radius
                 width: orientation == Qt.Horizontal ? 4 : parent.width
                 height: orientation == Qt.Horizontal ? parent.height : 4
                 x: orientation == Qt.Horizontal ? (parent.width - 5) * slider.visualPosition : 0
                 y: orientation == Qt.Horizontal ? 0 : (parent.height - 5) * slider.visualPosition
                 color: activePalette.highlight
+
+                anchors {
+                    top: orientation == Qt.Horizontal ? parent.top : undefined
+                    bottom: orientation == Qt.Horizontal ? parent.bottom : undefined
+                    left: orientation == Qt.Horizontal ? undefined : parent.left
+                    right: orientation == Qt.Horizontal ? undefined : parent.right
+                    margins: 1
+                }
+
             }
+
         }
 
-        handle: Rectangle {}
+        handle: Rectangle {
+        }
+
     }
 
     Item {
         id: tickItem
+
         implicitHeight: orientation == Qt.Horizontal ? 7 : parent.height
-        implicitWidth: orientation == Qt.Horizontal ? parent.width: 7
+        implicitWidth: orientation == Qt.Horizontal ? parent.width : 7
+
         Repeater {
             model: 11
+
             Rectangle {
                 property int lineSize: (index % 5) == 0 ? 6 : 3
+
                 y: orientation == Qt.Horizontal ? 1 : index * tickItem.height / 10
                 x: orientation == Qt.Horizontal ? index * tickItem.width / 10 : 1
                 width: orientation == Qt.Horizontal ? 1 : lineSize
                 height: orientation == Qt.Horizontal ? lineSize : 1
                 color: 'gray'
             }
+
         }
+
     }
 
     Item {
-        implicitHeight: orientation == Qt.Horizontal ? textItem.implicitHeight : parent.height
-        implicitWidth: orientation == Qt.Horizontal ? parent.width : widestText()
-
         function widestText() {
             var widest = 0;
             for (var i = 0; i < children.length; i++) {
-                if (children[i].implicitWidth > widest) {
-                    widest = children[i].implicitWidth
-                }
+                if (children[i].implicitWidth > widest)
+                    widest = children[i].implicitWidth;
+
             }
-            return widest
+            return widest;
         }
+
+        implicitHeight: orientation == Qt.Horizontal ? textItem.implicitHeight : parent.height
+        implicitWidth: orientation == Qt.Horizontal ? parent.width : widestText()
 
         Text {
             id: textItem
+
             anchors.fill: parent
             color: activePalette.text
             text: Number(slider.from).toLocaleString(Qt.locale(), 'f', decimals)
             horizontalAlignment: orientation == Qt.Horizontal ? Text.AlignLeft : Text.AlignRight
             verticalAlignment: orientation == Qt.Horizontal ? Text.AlignVCenter : Text.AlignBottom
         }
+
         Text {
             anchors.fill: parent
             color: activePalette.text
-            text: Number((slider.to + slider.from) / 2.0).toLocaleString(Qt.locale(), 'f', decimals)
+            text: Number((slider.to + slider.from) / 2).toLocaleString(Qt.locale(), 'f', decimals)
             horizontalAlignment: orientation == Qt.Horizontal ? Text.AlignHCenter : Text.AlignRight
             verticalAlignment: Text.AlignVCenter
         }
+
         Text {
             anchors.fill: parent
             color: activePalette.text
@@ -122,18 +175,7 @@ Grid {
             horizontalAlignment: Text.AlignRight
             verticalAlignment: orientation == Qt.Horizontal ? Text.AlignVCenter : Text.AlignTop
         }
+
     }
 
-    states: [
-        State {
-            name: "horizontal"
-            PropertyChanges { target: root; rows: 3; columns: 1; layoutDirection: Qt.LeftToRight }
-            PropertyChanges { target: slider; orientation: Qt.Horizontal }
-        },
-        State {
-            name: "vertical"
-            PropertyChanges { target: root; rows: 1; columns: 3; layoutDirection: Qt.RightToLeft }
-            PropertyChanges { target: slider; orientation: Qt.Vertical }
-        }
-    ]
 }

--- a/src/qml/modules/Shotcut/Controls/HoverTip.qml
+++ b/src/qml/modules/Shotcut/Controls/HoverTip.qml
@@ -19,21 +19,27 @@ import QtQuick 2.12
 import QtQuick.Controls 2.12
 
 MouseArea {
-    anchors.fill: parent
     property alias text: tip.text
     property alias metrics: fontMetrics
+
+    anchors.fill: parent
     propagateComposedEvents: true
     acceptedButtons: Qt.NoButton
 
     ToolTip {
         id: tip
+
         visible: text ? parent.containsMouse & parent.enabled : false
         delay: 1000
         timeout: 5000
         Component.onCompleted: parent.hoverEnabled = true
+
         FontMetrics {
             id: fontMetrics
+
             font: tip.font
         }
+
     }
+
 }

--- a/src/qml/modules/Shotcut/Controls/KeyframableFilter.qml
+++ b/src/qml/modules/Shotcut/Controls/KeyframableFilter.qml
@@ -23,113 +23,112 @@ Item {
     // The following 4 arrays should be the same length and aligned to the
     // same parameters added to keyframableParameters. They should be set
     // by the filter that inherits this item.
-    property var keyframableParameters: [] // strings of MLT property names
+    property var keyframableParameters: []
+    // strings of MLT property names
     // The following 3 arrays are for simple keyframes.
     property var startValues: []
     property var middleValues: []
     property var endValues: []
-
     // Set this property true to guard against updateFilter() getting
     // called when setting a control value in code. Do not forget to reset it
     // to false when you are done setting controls' values.
     property bool blockUpdate: true
 
-    Component.onCompleted: {
-        if (!filter.isNew)
-            initializeSimpleKeyframes()
-    }
-
     // This function should be called in your Preset.beforePresetSelected handler.
     function resetSimpleKeyframes() {
-        for (var i in keyframableParameters)
-            filter.resetProperty(keyframableParameters[i])
+        for (var i in keyframableParameters) filter.resetProperty(keyframableParameters[i])
     }
 
     // This function should be called in your Preset.presetSelected handler.
     function initializeSimpleKeyframes() {
         for (var i in keyframableParameters) {
-            var parameter = keyframableParameters[i]
-            middleValues[i] = filter.getDouble(parameter, filter.animateIn)
+            var parameter = keyframableParameters[i];
+            middleValues[i] = filter.getDouble(parameter, filter.animateIn);
             if (filter.animateIn > 0)
-                startValues[i] = filter.getDouble(parameter, 0)
+                startValues[i] = filter.getDouble(parameter, 0);
+
             if (filter.animateOut > 0)
-                endValues[i] = filter.getDouble(parameter, filter.duration - 1)
+                endValues[i] = filter.getDouble(parameter, filter.duration - 1);
+
         }
     }
 
     // This function should be called when calling updateFilter() (except
     // in filter Connections).
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     // This function can be called in your setControls() function to determine
     // whether to enable keyframable controls.
     function isSimpleKeyframesActive() {
-        var position = getPosition()
-        return  position <= 0
-            || (position >= (filter.animateIn - 1) && 
-                position <= (filter.duration - filter.animateOut))
-            ||  position >= (filter.duration - 1)
+        var position = getPosition();
+        return position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     // This function should be called in your controls' valueChanged handler.
     function updateFilter(parameter, value, button, position) {
-        if (blockUpdate) return
-        var index = keyframableParameters.indexOf(parameter)
-        if (index < 0) {
-            console.log("ERROR: Parameter not found in keyframableParameters:", parameter)
-            return
-        }
+        if (blockUpdate)
+            return ;
 
+        var index = keyframableParameters.indexOf(parameter);
+        if (index < 0) {
+            console.log("ERROR: Parameter not found in keyframableParameters:", parameter);
+            return ;
+        }
         if (position !== null) {
             if (position <= 0 && filter.animateIn > 0)
-                startValues[index] = value
+                startValues[index] = value;
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                endValues[index] = value
+                endValues[index] = value;
             else
-                middleValues[index] = value
+                middleValues[index] = value;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(parameter)
-            button.checked = false
+            filter.resetProperty(parameter);
+            button.checked = false;
             if (filter.animateIn > 0) {
-                filter.set(parameter, startValues[index], 0)
-                filter.set(parameter, middleValues[index], filter.animateIn - 1)
+                filter.set(parameter, startValues[index], 0);
+                filter.set(parameter, middleValues[index], filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(parameter, middleValues[index], filter.duration - filter.animateOut)
-                filter.set(parameter, endValues[index], filter.duration - 1)
+                filter.set(parameter, middleValues[index], filter.duration - filter.animateOut);
+                filter.set(parameter, endValues[index], filter.duration - 1);
             }
         } else if (!button.checked) {
-            filter.resetProperty(parameter)
-            filter.set(parameter, middleValues[index])
+            filter.resetProperty(parameter);
+            filter.set(parameter, middleValues[index]);
         } else if (position !== null) {
-            filter.set(parameter, value, position)
+            filter.set(parameter, value, position);
         }
     }
 
     // This function should be called in the KeyframesButton.toggled handler.
     function toggleKeyframes(isEnabled, parameter, value) {
         if (isEnabled) {
-            blockUpdate = true
+            blockUpdate = true;
             if (filter.animateIn > 0 || filter.animateOut > 0) {
                 // Reset all of the simple keyframes.
-                resetSimpleKeyframes()
-                filter.animateIn = 0
-                blockUpdate = false
-                filter.animateOut = 0
+                resetSimpleKeyframes();
+                filter.animateIn = 0;
+                blockUpdate = false;
+                filter.animateOut = 0;
             } else {
-                filter.clearSimpleAnimation(parameter)
-                blockUpdate = false
+                filter.clearSimpleAnimation(parameter);
+                blockUpdate = false;
             }
             // Set this keyframe value.
-            filter.set(parameter, value, getPosition())
+            filter.set(parameter, value, getPosition());
         } else {
             // Remove keyframes and set the parameter.
-            filter.resetProperty(parameter)
-            filter.set(parameter, value)
+            filter.resetProperty(parameter);
+            filter.set(parameter, value);
         }
+    }
+
+    Component.onCompleted: {
+        if (!filter.isNew)
+            initializeSimpleKeyframes();
+
     }
 }

--- a/src/qml/modules/Shotcut/Controls/KeyframesButton.qml
+++ b/src/qml/modules/Shotcut/Controls/KeyframesButton.qml
@@ -22,54 +22,46 @@ import Shotcut.Controls 1.0 as Shotcut
 
 ToolButton {
     id: checkbox
-    enabled: metadata !== null && metadata.keyframes.enabled
-    opacity: enabled? 1.0 : 0.0
 
     signal toggled()
 
+    enabled: metadata !== null && metadata.keyframes.enabled
+    opacity: enabled ? 1 : 0
     padding: 2
     checkable: true
     hoverEnabled: true
-
-    SystemPalette { id: activePalette }
     palette.buttonText: activePalette.buttonText
-
-    Shotcut.HoverTip { text: qsTr('Use Keyframes for this parameter') }
-
-    background: Rectangle {
-        implicitWidth: 20
-        implicitHeight: 20
-        radius: 3
-        color: checked? activePalette.highlight : activePalette.button
-        border.color: activePalette.shadow
-        border.width: 1
-    }
-
     icon.name: 'chronometer'
     icon.source: 'qrc:///icons/oxygen/32x32/actions/chronometer.png'
-
     onClicked: {
         if (!checked) {
-           checked = true
-           confirmRemoveAdvancedDialog.visible = true
+            checked = true;
+            confirmRemoveAdvancedDialog.visible = true;
         } else {
             if (parameters.simpleKeyframesInUse()) {
-                checked = false
-                confirmRemoveSimpleDialog.visible = true
+                checked = false;
+                confirmRemoveSimpleDialog.visible = true;
             }
             if (checked) {
-                application.showStatusMessage(qsTr('Hold %1 to drag a keyframe vertical only or %2 to drag horizontal only')
-                    .arg(application.OS === 'OS X'? '⌘' : 'Ctrl')
-                    .arg(application.OS === 'OS X'? '⌥' : 'Alt'))
-                keyframes.show()
-                keyframes.raise()
-                toggled()
+                application.showStatusMessage(qsTr('Hold %1 to drag a keyframe vertical only or %2 to drag horizontal only').arg(application.OS === 'OS X' ? '⌘' : 'Ctrl').arg(application.OS === 'OS X' ? '⌥' : 'Alt'));
+                keyframes.show();
+                keyframes.raise();
+                toggled();
             }
         }
     }
 
+    SystemPalette {
+        id: activePalette
+    }
+
+    Shotcut.HoverTip {
+        text: qsTr('Use Keyframes for this parameter')
+    }
+
     MessageDialog {
         id: confirmRemoveAdvancedDialog
+
         visible: false
         modality: application.dialogModality
         icon: StandardIcon.Question
@@ -77,17 +69,18 @@ ToolButton {
         text: qsTr('This will remove all keyframes for this parameter.<p>Do you still want to do this?')
         standardButtons: StandardButton.Yes | StandardButton.No
         onYes: {
-            checkbox.checked = false
-            checkbox.toggled()
-            parameters.reload()
+            checkbox.checked = false;
+            checkbox.toggled();
+            parameters.reload();
         }
         onNo: {
-            checkbox.checked = true
+            checkbox.checked = true;
         }
     }
 
     MessageDialog {
         id: confirmRemoveSimpleDialog
+
         visible: false
         modality: application.dialogModality
         icon: StandardIcon.Question
@@ -95,12 +88,22 @@ ToolButton {
         text: qsTr('This will remove all simple keyframes for all parameters.<p>Simple keyframes will be converted to advanced keyframes.<p>Do you still want to do this?')
         standardButtons: StandardButton.Yes | StandardButton.No
         onYes: {
-            checkbox.checked = true
-            parameters.removeSimpleKeyframes()
-            parameters.reload()
+            checkbox.checked = true;
+            parameters.removeSimpleKeyframes();
+            parameters.reload();
         }
         onNo: {
-            checkbox.checked = false
+            checkbox.checked = false;
         }
     }
+
+    background: Rectangle {
+        implicitWidth: 20
+        implicitHeight: 20
+        radius: 3
+        color: checked ? activePalette.highlight : activePalette.button
+        border.color: activePalette.shadow
+        border.width: 1
+    }
+
 }

--- a/src/qml/modules/Shotcut/Controls/MarkerBar.qml
+++ b/src/qml/modules/Shotcut/Controls/MarkerBar.qml
@@ -19,13 +19,16 @@ import QtQuick 2.12
 
 Repeater {
     id: markerbar
-    property real timeScale: 1.0
+
+    property real timeScale: 1
     property var snapper
+
     signal editRequested(int index)
     signal deleteRequested(int index)
     signal exited()
     signal mouseStatusChanged(int mouseX, int mouseY, var text, int start, int end)
     signal seekRequested(int pos)
+
     Marker {
         timeScale: parent.timeScale
         snapper: markerbar.snapper
@@ -40,4 +43,5 @@ Repeater {
         onMouseStatusChanged: markerbar.mouseStatusChanged(mouseX, mouseY, text, start, end)
         onSeekRequested: markerbar.seekRequested(pos)
     }
+
 }

--- a/src/qml/modules/Shotcut/Controls/Preset.qml
+++ b/src/qml/modules/Shotcut/Controls/Preset.qml
@@ -29,11 +29,12 @@ RowLayout {
     signal presetSelected()
 
     Component.onCompleted: {
-        filter.loadPresets()
+        filter.loadPresets();
     }
 
     Shotcut.ComboBox {
         id: presetCombo
+
         Layout.fillWidth: true
         Layout.minimumWidth: 100
         Layout.maximumWidth: 300
@@ -42,136 +43,169 @@ RowLayout {
             if (currentText.length > 0) {
                 // toggling focus works around a weird bug involving sticky
                 // input event focus on the ComboBox
-                enabled = false
-                filter.blockSignals = true
-                filter.animateIn = 0
-                filter.animateOut = 0
-                beforePresetLoaded()
-                filter.preset(currentText)
-                presetSelected()
-                filter.blockSignals = false
-                filter.changed()
-                filter.animateInChanged()
-                filter.animateOutChanged()
-                enabled = true
+                enabled = false;
+                filter.blockSignals = true;
+                filter.animateIn = 0;
+                filter.animateOut = 0;
+                beforePresetLoaded();
+                filter.preset(currentText);
+                presetSelected();
+                filter.blockSignals = false;
+                filter.changed();
+                filter.animateInChanged();
+                filter.animateOutChanged();
+                enabled = true;
             }
         }
     }
+
     Shotcut.Button {
         id: saveButton
+
         icon.name: 'list-add'
         icon.source: 'qrc:///icons/oxygen/32x32/actions/list-add.png'
-        Shotcut.HoverTip { text: qsTr('Save') }
         implicitWidth: 20
         implicitHeight: 20
         onClicked: nameDialog.show()
+
+        Shotcut.HoverTip {
+            text: qsTr('Save')
+        }
+
     }
+
     Shotcut.Button {
         id: deleteButton
+
         icon.name: 'list-remove'
         icon.source: 'qrc:///icons/oxygen/32x32/actions/list-remove.png'
-        Shotcut.HoverTip { text: qsTr('Delete') }
         implicitWidth: 20
         implicitHeight: 20
         onClicked: confirmDialog.show()
+
+        Shotcut.HoverTip {
+            text: qsTr('Delete')
+        }
+
     }
 
-    SystemPalette { id: dialogPalette; colorGroup: SystemPalette.Active }
+    SystemPalette {
+        id: dialogPalette
+
+        colorGroup: SystemPalette.Active
+    }
+
     Window {
         id: nameDialog
+
+        function acceptName() {
+            var params = parameters;
+            params.push('shotcut:animIn');
+            params.push('shotcut:animOut');
+            presetCombo.currentIndex = filter.savePreset(params, nameField.text);
+            nameDialog.close();
+        }
+
         flags: Qt.Dialog
         color: dialogPalette.window
         modality: application.dialogModality
         title: qsTr('Save Preset')
         width: 200
         height: 100
-
-        function acceptName() {
-            var params = parameters
-            params.push('shotcut:animIn')
-            params.push('shotcut:animOut')
-            presetCombo.currentIndex = filter.savePreset(params, nameField.text)
-            nameDialog.close()
-        }
+        Component.onCompleted: nameField.forceActiveFocus(Qt.TabFocusReason)
 
         ColumnLayout {
             anchors.fill: parent
             anchors.margins: 10
-            
+
             Label {
                 text: qsTr('Name:')
             }
+
             TextField {
                 id: nameField
+
                 Layout.fillWidth: true
                 selectByMouse: true
                 onAccepted: nameDialog.acceptName()
                 Keys.onPressed: {
                     if (event.key === Qt.Key_Escape) {
-                        nameDialog.close()
-                        event.accepted = true
+                        nameDialog.close();
+                        event.accepted = true;
                     }
                 }
             }
 
-            Item { Layout.fillHeight: true }
+            Item {
+                Layout.fillHeight: true
+            }
 
             RowLayout {
                 Layout.alignment: Qt.AlignRight
                 focus: true
+
                 Shotcut.Button {
                     text: qsTr('OK')
                     onClicked: nameDialog.acceptName()
                 }
+
                 Shotcut.Button {
                     text: qsTr('Cancel')
                     onClicked: nameDialog.close()
                 }
+
             }
+
         }
 
-        Component.onCompleted: nameField.forceActiveFocus(Qt.TabFocusReason)
     }
 
     Window {
         id: confirmDialog
+
         flags: Qt.Dialog
         color: dialogPalette.window
         modality: application.dialogModality
         title: qsTr('Delete Preset')
         width: 300
         height: 90
+        Component.onCompleted: confirmDialogOk.forceActiveFocus(Qt.TabFocusReason)
 
         ColumnLayout {
             anchors.fill: parent
             anchors.margins: 10
-            
+
             Label {
                 text: qsTr('Are you sure you want to delete %1?').arg(presetCombo.currentText)
                 wrapMode: Text.Wrap
             }
-            
+
             RowLayout {
                 Layout.alignment: Qt.AlignRight
+
                 Shotcut.Button {
                     id: confirmDialogOk
+
                     text: qsTr('OK')
                     focus: true
                     onClicked: {
                         if (presetCombo.currentText !== ' ') {
-                            filter.deletePreset(presetCombo.currentText)
-                            presetCombo.currentIndex = 0
+                            filter.deletePreset(presetCombo.currentText);
+                            presetCombo.currentIndex = 0;
                         }
-                        confirmDialog.close()
+                        confirmDialog.close();
                     }
                 }
+
                 Shotcut.Button {
                     text: qsTr('Cancel')
                     onClicked: confirmDialog.close()
                 }
+
             }
+
         }
 
-        Component.onCompleted: confirmDialogOk.forceActiveFocus(Qt.TabFocusReason)
     }
+
 }

--- a/src/qml/modules/Shotcut/Controls/RectangleControl.qml
+++ b/src/qml/modules/Shotcut/Controls/RectangleControl.qml
@@ -18,16 +18,20 @@
 import QtQuick 2.1
 
 Item {
-    id: item
-    anchors.fill: parent
+    // 80/90% Safe Areas
+    // EBU R95 Safe Areas
+    // 80/90% Safe Areas
+    // EBU R95 Safe Areas
 
-    property real widthScale: 1.0
-    property real heightScale: 1.0
-    property real aspectRatio: 0.0
+    id: item
+
+    property real widthScale: 1
+    property real heightScale: 1
+    property real aspectRatio: 0
     property int handleSize: 10
     property int borderSize: 2
     property alias rectangle: rectangle
-    property color handleColor: Qt.rgba(1, 1, 1, enabled? 0.9 : 0.2)
+    property color handleColor: Qt.rgba(1, 1, 1, enabled ? 0.9 : 0.2)
     property int snapMargin: 10
     property alias withRotation: rotationHandle.visible
     property alias rotation: rotationGroup.rotation
@@ -38,113 +42,110 @@ Item {
     signal rotated(real degrees, var mouse)
     signal rotationReleased()
 
-    Component.onCompleted: {
-        _positionDragLocked = filter.get('_shotcut:positionDragLocked') === '1'
-    }
-
     function setHandles(rect) {
-        if ( rect.width < 0 || rect.height < 0)
-            return
-        topLeftHandle.x = (rect.x * widthScale)
-        topLeftHandle.y = (rect.y * heightScale)
-        if (aspectRatio === 0.0) {
-            bottomRightHandle.x = topLeftHandle.x + (rect.width * widthScale) - handleSize
-            bottomRightHandle.y = topLeftHandle.y + (rect.height * heightScale) - handleSize
-        } else if (aspectRatio > 1.0) {
-            bottomRightHandle.x = topLeftHandle.x + (rect.width * widthScale) - handleSize
-            bottomRightHandle.y = topLeftHandle.y + (rect.width * widthScale / aspectRatio) - handleSize
-        } else {
-            bottomRightHandle.x = topLeftHandle.x + (rect.height * heightScale * aspectRatio) - handleSize
-            bottomRightHandle.y = topLeftHandle.y + (rect.height * heightScale) - handleSize
-        }
-        topRightHandle.x = bottomRightHandle.x
-        topRightHandle.y = topLeftHandle.y
-        bottomLeftHandle.x = topLeftHandle.x
-        bottomLeftHandle.y = bottomRightHandle.y
+        if (rect.width < 0 || rect.height < 0)
+            return ;
 
-        topHandle.x = topLeftHandle.x + (rect.width * widthScale) / 2 - (handleSize / 2)
-        topHandle.y = topLeftHandle.y
-        bottomHandle.x = topLeftHandle.x + (rect.width * widthScale) / 2 - (handleSize / 2)
-        bottomHandle.y = bottomRightHandle.y
-        leftHandle.x = topLeftHandle.x
-        leftHandle.y = topLeftHandle.y + (rect.height * heightScale) / 2 - (handleSize / 2)
-        rightHandle.x = bottomRightHandle.x
-        rightHandle.y = topLeftHandle.y + (rect.height * heightScale) / 2 - (handleSize / 2)
+        topLeftHandle.x = (rect.x * widthScale);
+        topLeftHandle.y = (rect.y * heightScale);
+        if (aspectRatio === 0) {
+            bottomRightHandle.x = topLeftHandle.x + (rect.width * widthScale) - handleSize;
+            bottomRightHandle.y = topLeftHandle.y + (rect.height * heightScale) - handleSize;
+        } else if (aspectRatio > 1) {
+            bottomRightHandle.x = topLeftHandle.x + (rect.width * widthScale) - handleSize;
+            bottomRightHandle.y = topLeftHandle.y + (rect.width * widthScale / aspectRatio) - handleSize;
+        } else {
+            bottomRightHandle.x = topLeftHandle.x + (rect.height * heightScale * aspectRatio) - handleSize;
+            bottomRightHandle.y = topLeftHandle.y + (rect.height * heightScale) - handleSize;
+        }
+        topRightHandle.x = bottomRightHandle.x;
+        topRightHandle.y = topLeftHandle.y;
+        bottomLeftHandle.x = topLeftHandle.x;
+        bottomLeftHandle.y = bottomRightHandle.y;
+        topHandle.x = topLeftHandle.x + (rect.width * widthScale) / 2 - (handleSize / 2);
+        topHandle.y = topLeftHandle.y;
+        bottomHandle.x = topLeftHandle.x + (rect.width * widthScale) / 2 - (handleSize / 2);
+        bottomHandle.y = bottomRightHandle.y;
+        leftHandle.x = topLeftHandle.x;
+        leftHandle.y = topLeftHandle.y + (rect.height * heightScale) / 2 - (handleSize / 2);
+        rightHandle.x = bottomRightHandle.x;
+        rightHandle.y = topLeftHandle.y + (rect.height * heightScale) / 2 - (handleSize / 2);
     }
 
     function snapGrid(v, gridSize) {
-        var polarity = (v < 0) ? -1 : 1
-        v = v * polarity
-        var delta = v % gridSize
-        if (delta < snapMargin) {
-            v = v - delta
-        } else if ((gridSize - delta) < snapMargin) {
-            v = v + gridSize - delta
-        }
-        return v * polarity
+        var polarity = (v < 0) ? -1 : 1;
+        v = v * polarity;
+        var delta = v % gridSize;
+        if (delta < snapMargin)
+            v = v - delta;
+        else if ((gridSize - delta) < snapMargin)
+            v = v + gridSize - delta;
+        return v * polarity;
     }
 
     function snapX(x) {
-        if (!video.snapToGrid || video.grid === 0) {
-            return x
-        }
+        if (!video.snapToGrid || video.grid === 0)
+            return x;
+
         if (video.grid !== 95 && video.grid !== 8090) {
-            var n = (video.grid > 10000) ? parent.width / (profile.width / (video.grid - 10000)) : parent.width / video.grid
-            return snapGrid(x, n)
+            var n = (video.grid > 10000) ? parent.width / (profile.width / (video.grid - 10000)) : parent.width / video.grid;
+            return snapGrid(x, n);
         } else {
-            var deltas = null
-            if (video.grid === 8090) {
-                // 80/90% Safe Areas
-                deltas = [0.0, 0.05, 0.1, 0.9, 0.95, 1.0]
-            } else if (video.grid === 95) {
-                // EBU R95 Safe Areas
-                deltas = [0.0, 0.035, 0.05, 0.95, 0.965, 1.0]
-            }
+            var deltas = null;
+            if (video.grid === 8090)
+                deltas = [0, 0.05, 0.1, 0.9, 0.95, 1];
+            else if (video.grid === 95)
+                deltas = [0, 0.035, 0.05, 0.95, 0.965, 1];
             if (deltas) {
                 for (var i = 0; i < deltas.length; i++) {
-                    var delta = x - deltas[i] * parent.width
+                    var delta = x - deltas[i] * parent.width;
                     if (Math.abs(delta) < snapMargin)
-                        return x - delta
+                        return x - delta;
+
                 }
             }
         }
-        return x
+        return x;
     }
 
     function snapY(y) {
-        if (!video.snapToGrid || video.grid === 0) {
-            return y
-        }
+        if (!video.snapToGrid || video.grid === 0)
+            return y;
+
         if (video.grid !== 95 && video.grid !== 8090) {
-            var n = (video.grid > 10000) ? parent.height / (profile.height / (video.grid - 10000)) : parent.height / video.grid
-            return snapGrid(y, n)
+            var n = (video.grid > 10000) ? parent.height / (profile.height / (video.grid - 10000)) : parent.height / video.grid;
+            return snapGrid(y, n);
         } else {
-            var deltas = null
-            if (video.grid === 8090) {
-                // 80/90% Safe Areas
-                deltas = [0.0, 0.05, 0.1, 0.9, 0.95, 1.0]
-            } else if (video.grid === 95) {
-                // EBU R95 Safe Areas
-                deltas = [0.0, 0.035, 0.05, 0.95, 0.965, 1.0]
-            }
+            var deltas = null;
+            if (video.grid === 8090)
+                deltas = [0, 0.05, 0.1, 0.9, 0.95, 1];
+            else if (video.grid === 95)
+                deltas = [0, 0.035, 0.05, 0.95, 0.965, 1];
             if (deltas) {
                 for (var i = 0; i < deltas.length; i++) {
-                    var delta = y - deltas[i] * parent.height
+                    var delta = y - deltas[i] * parent.height;
                     if (Math.abs(delta) < snapMargin)
-                        return y - delta
+                        return y - delta;
+
                 }
             }
         }
-        return y
+        return y;
     }
 
     function isRotated() {
         //Math.abs(rotationGroup.rotation - 0) > 0.0001
-        return rotationGroup.rotation !== 0 || rotationLine.rotation !== 0
+        return rotationGroup.rotation !== 0 || rotationLine.rotation !== 0;
+    }
+
+    anchors.fill: parent
+    Component.onCompleted: {
+        _positionDragLocked = filter.get('_shotcut:positionDragLocked') === '1';
     }
 
     Rectangle {
         id: rectangle
+
         visible: !isRotated()
         color: 'transparent'
         border.width: borderSize
@@ -155,33 +156,40 @@ Item {
         anchors.bottom: bottomRightHandle.bottom
         focus: true
         Keys.onPressed: {
-            if (event.key === Qt.Key_Shift) {
-                _positionDragEnabled = true
-            }
+            if (event.key === Qt.Key_Shift)
+                _positionDragEnabled = true;
+
         }
         Keys.onReleased: {
-            if (event.key === Qt.Key_Shift) {
-                _positionDragEnabled = false
-            }
+            if (event.key === Qt.Key_Shift)
+                _positionDragEnabled = false;
+
         }
     }
+
     Rectangle {
         // Provides contrasting thick line to above rectangle.
         visible: !isRotated()
         color: 'transparent'
         border.width: handleSize - borderSize
-        border.color: Qt.rgba(0, 0, 0, item.enabled? 0.4 : 0.2)
+        border.color: Qt.rgba(0, 0, 0, item.enabled ? 0.4 : 0.2)
         anchors.fill: rectangle
         anchors.margins: borderSize
     }
 
     Item {
         id: rotationGroup
+
         anchors.fill: rectangle
 
         Rectangle {
             id: positionHandle
-            opacity: item.enabled? 0.5 : 0.2
+
+            function centerX() {
+                return x + width / 2;
+            }
+
+            opacity: item.enabled ? 0.5 : 0.2
             border.width: borderSize
             border.color: handleColor
             width: handleSize * 2
@@ -189,88 +197,95 @@ Item {
             radius: width / 2
             anchors.centerIn: parent
             z: 1
+
             gradient: Gradient {
                 GradientStop {
-                    position: (_positionDragLocked || _positionDragEnabled || positionMouseArea.pressed)? 0.0 : 1.0
+                    position: (_positionDragLocked || _positionDragEnabled || positionMouseArea.pressed) ? 0 : 1
                     color: 'black'
                 }
+
                 GradientStop {
-                    position: (_positionDragLocked || _positionDragEnabled || positionMouseArea.pressed)? 1.0 : 0.0
+                    position: (_positionDragLocked || _positionDragEnabled || positionMouseArea.pressed) ? 1 : 0
                     color: 'white'
                 }
+
             }
-            function centerX() { return x + width / 2 }
+
         }
 
         MouseArea {
             id: positionMouseArea
-            anchors.fill: (_positionDragLocked || _positionDragEnabled)? parent : positionHandle
+
+            anchors.fill: (_positionDragLocked || _positionDragEnabled) ? parent : positionHandle
             acceptedButtons: Qt.LeftButton
             cursorShape: Qt.SizeAllCursor
             drag.target: rectangle
             onDoubleClicked: {
-                _positionDragLocked = !_positionDragLocked
-                filter.set('_shotcut:positionDragLocked', _positionDragLocked)
+                _positionDragLocked = !_positionDragLocked;
+                filter.set('_shotcut:positionDragLocked', _positionDragLocked);
             }
             onEntered: {
-                rectangle.anchors.top = undefined
-                rectangle.anchors.left = undefined
-                rectangle.anchors.right = undefined
-                rectangle.anchors.bottom = undefined
-                topLeftHandle.anchors.left = rectangle.left
-                topLeftHandle.anchors.top = rectangle.top
-                topRightHandle.anchors.right = rectangle.right
-                topRightHandle.anchors.top = rectangle.top
-                bottomLeftHandle.anchors.left = rectangle.left
-                bottomLeftHandle.anchors.bottom = rectangle.bottom
-                bottomRightHandle.anchors.right = rectangle.right
-                bottomRightHandle.anchors.bottom = rectangle.bottom
- 
-                topHandle.anchors.horizontalCenter = rectangle.horizontalCenter
-                topHandle.anchors.top = rectangle.top
-                bottomHandle.anchors.horizontalCenter = rectangle.horizontalCenter
-                bottomHandle.anchors.bottom = rectangle.bottom
-                leftHandle.anchors.verticalCenter = rectangle.verticalCenter
-                leftHandle.anchors.left = rectangle.left
-                rightHandle.anchors.verticalCenter = rectangle.verticalCenter
-                rightHandle.anchors.right = rectangle.right
+                rectangle.anchors.top = undefined;
+                rectangle.anchors.left = undefined;
+                rectangle.anchors.right = undefined;
+                rectangle.anchors.bottom = undefined;
+                topLeftHandle.anchors.left = rectangle.left;
+                topLeftHandle.anchors.top = rectangle.top;
+                topRightHandle.anchors.right = rectangle.right;
+                topRightHandle.anchors.top = rectangle.top;
+                bottomLeftHandle.anchors.left = rectangle.left;
+                bottomLeftHandle.anchors.bottom = rectangle.bottom;
+                bottomRightHandle.anchors.right = rectangle.right;
+                bottomRightHandle.anchors.bottom = rectangle.bottom;
+                topHandle.anchors.horizontalCenter = rectangle.horizontalCenter;
+                topHandle.anchors.top = rectangle.top;
+                bottomHandle.anchors.horizontalCenter = rectangle.horizontalCenter;
+                bottomHandle.anchors.bottom = rectangle.bottom;
+                leftHandle.anchors.verticalCenter = rectangle.verticalCenter;
+                leftHandle.anchors.left = rectangle.left;
+                rightHandle.anchors.verticalCenter = rectangle.verticalCenter;
+                rightHandle.anchors.right = rectangle.right;
             }
             onPositionChanged: {
-                rectangle.x = snapX(rectangle.x + rectangle.width / 2) - rectangle.width / 2
-                rectangle.y = snapY(rectangle.y + rectangle.height / 2) - rectangle.height / 2
-                rectChanged(rectangle)
+                rectangle.x = snapX(rectangle.x + rectangle.width / 2) - rectangle.width / 2;
+                rectangle.y = snapY(rectangle.y + rectangle.height / 2) - rectangle.height / 2;
+                rectChanged(rectangle);
             }
             onReleased: {
-                rectChanged(rectangle)
-                rectangle.anchors.top = topLeftHandle.top
-                rectangle.anchors.left = topLeftHandle.left
-                rectangle.anchors.right = bottomRightHandle.right
-                rectangle.anchors.bottom = bottomRightHandle.bottom
-                topLeftHandle.anchors.left = undefined
-                topLeftHandle.anchors.top = undefined
-                topRightHandle.anchors.right = undefined
-                topRightHandle.anchors.top = undefined
-                bottomLeftHandle.anchors.left = undefined
-                bottomLeftHandle.anchors.bottom = undefined
-                bottomRightHandle.anchors.right = undefined
-                bottomRightHandle.anchors.bottom = undefined
-
-                topHandle.anchors.horizontalCenter = undefined
-                topHandle.anchors.top = undefined
-                bottomHandle.anchors.horizontalCenter = undefined
-                bottomHandle.anchors.bottom = undefined
-                leftHandle.anchors.verticalCenter = undefined
-                leftHandle.anchors.left = undefined
-                rightHandle.anchors.verticalCenter = undefined
-                rightHandle.anchors.right = undefined
+                rectChanged(rectangle);
+                rectangle.anchors.top = topLeftHandle.top;
+                rectangle.anchors.left = topLeftHandle.left;
+                rectangle.anchors.right = bottomRightHandle.right;
+                rectangle.anchors.bottom = bottomRightHandle.bottom;
+                topLeftHandle.anchors.left = undefined;
+                topLeftHandle.anchors.top = undefined;
+                topRightHandle.anchors.right = undefined;
+                topRightHandle.anchors.top = undefined;
+                bottomLeftHandle.anchors.left = undefined;
+                bottomLeftHandle.anchors.bottom = undefined;
+                bottomRightHandle.anchors.right = undefined;
+                bottomRightHandle.anchors.bottom = undefined;
+                topHandle.anchors.horizontalCenter = undefined;
+                topHandle.anchors.top = undefined;
+                bottomHandle.anchors.horizontalCenter = undefined;
+                bottomHandle.anchors.bottom = undefined;
+                leftHandle.anchors.verticalCenter = undefined;
+                leftHandle.anchors.left = undefined;
+                rightHandle.anchors.verticalCenter = undefined;
+                rightHandle.anchors.right = undefined;
             }
         }
 
         Rectangle {
             id: rotationHandle
+
+            function centerX() {
+                return x + width / 2;
+            }
+
             visible: false
             color: handleColor
-            opacity: item.enabled? 0.5 : 0.2
+            opacity: item.enabled ? 0.5 : 0.2
             width: handleSize * 1.5
             height: handleSize * 1.5
             radius: width / 2
@@ -278,41 +293,47 @@ Item {
             anchors.centerIn: rotationGroup
             anchors.verticalCenterOffset: -item.height / 4
             border.width: borderSize
-            border.color: Qt.rgba(0, 0, 0, enabled? 0.9 : 0.2)
-            function centerX() { return x + width / 2 }
+            border.color: Qt.rgba(0, 0, 0, enabled ? 0.9 : 0.2)
+
             MouseArea {
                 id: rotationMouseArea
-                anchors.fill: parent
-                acceptedButtons: Qt.LeftButton
-                cursorShape: pressed? Qt.ClosedHandCursor : Qt.OpenHandCursor
-                drag.target: parent
+
                 property real startRotation: 0
+
                 function getRotationDegrees() {
-                    var radians = Math.atan2(rotationHandle.centerX() - positionHandle.centerX(), positionHandle.y - rotationHandle.y)
+                    var radians = Math.atan2(rotationHandle.centerX() - positionHandle.centerX(), positionHandle.y - rotationHandle.y);
                     if (radians < 0)
-                        radians += 2 * Math.PI
-                    return 180 / Math.PI * radians
+                        radians += 2 * Math.PI;
+
+                    return 180 / Math.PI * radians;
                 }
 
+                anchors.fill: parent
+                acceptedButtons: Qt.LeftButton
+                cursorShape: pressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor
+                drag.target: parent
                 onPressed: {
-                    parent.anchors.centerIn = undefined
-                    startRotation = rotationGroup.rotation
+                    parent.anchors.centerIn = undefined;
+                    startRotation = rotationGroup.rotation;
                 }
                 onPositionChanged: {
-                    var degrees = getRotationDegrees()
-                    rotated(startRotation + degrees, mouse)
-                    rotationLine.rotation = degrees
+                    var degrees = getRotationDegrees();
+                    rotated(startRotation + degrees, mouse);
+                    rotationLine.rotation = degrees;
                 }
                 onReleased: {
-                    rotationLine.rotation = 0
-                    rotationGroup.rotation = startRotation + getRotationDegrees()
-                    parent.anchors.centerIn = rotationGroup
-                    rotationReleased()
+                    rotationLine.rotation = 0;
+                    rotationGroup.rotation = startRotation + getRotationDegrees();
+                    parent.anchors.centerIn = rotationGroup;
+                    rotationReleased();
                 }
             }
+
         }
+
         Rectangle {
             id: rotationLine
+
             height: -rotationHandle.anchors.verticalCenterOffset - rotationHandle.height + positionHandle.height / 2
             anchors.horizontalCenter: positionHandle.horizontalCenter
             anchors.bottom: positionHandle.verticalCenter
@@ -322,367 +343,381 @@ Item {
             visible: rotationHandle.visible
             antialiasing: true
         }
+
     }
 
     Rectangle {
         id: topLeftHandle
+
         visible: !isRotated()
         color: handleColor
         width: handleSize
         height: handleSize
+
         MouseArea {
             anchors.fill: parent
             acceptedButtons: Qt.LeftButton
             cursorShape: Qt.SizeFDiagCursor
             drag.target: parent
             onEntered: {
-                rectangle.anchors.top = parent.top
-                rectangle.anchors.left = parent.left
-                rectangle.anchors.bottom = bottomRightHandle.bottom
-                rectangle.anchors.right = bottomRightHandle.right
-                topRightHandle.anchors.top = rectangle.top
-                bottomLeftHandle.anchors.left = rectangle.left
- 
-                topHandle.anchors.horizontalCenter = rectangle.horizontalCenter
-                topHandle.anchors.top = rectangle.top
-                bottomHandle.anchors.horizontalCenter = rectangle.horizontalCenter
-                bottomHandle.anchors.bottom = rectangle.bottom
-                leftHandle.anchors.verticalCenter = rectangle.verticalCenter
-                leftHandle.anchors.left = rectangle.left
-                rightHandle.anchors.verticalCenter = rectangle.verticalCenter
-                rightHandle.anchors.right = rectangle.right
+                rectangle.anchors.top = parent.top;
+                rectangle.anchors.left = parent.left;
+                rectangle.anchors.bottom = bottomRightHandle.bottom;
+                rectangle.anchors.right = bottomRightHandle.right;
+                topRightHandle.anchors.top = rectangle.top;
+                bottomLeftHandle.anchors.left = rectangle.left;
+                topHandle.anchors.horizontalCenter = rectangle.horizontalCenter;
+                topHandle.anchors.top = rectangle.top;
+                bottomHandle.anchors.horizontalCenter = rectangle.horizontalCenter;
+                bottomHandle.anchors.bottom = rectangle.bottom;
+                leftHandle.anchors.verticalCenter = rectangle.verticalCenter;
+                leftHandle.anchors.left = rectangle.left;
+                rightHandle.anchors.verticalCenter = rectangle.verticalCenter;
+                rightHandle.anchors.right = rectangle.right;
             }
             onPositionChanged: {
-                topLeftHandle.x = snapX(topLeftHandle.x)
-                topLeftHandle.y = snapY(topLeftHandle.y)
-                if (aspectRatio !== 0.0)
-                    parent.x = topRightHandle.x + handleSize - rectangle.height * aspectRatio
-                parent.x = Math.min(parent.x, bottomRightHandle.x)
-                parent.y = Math.min(parent.y, bottomRightHandle.y)
-                rectChanged(rectangle)
+                topLeftHandle.x = snapX(topLeftHandle.x);
+                topLeftHandle.y = snapY(topLeftHandle.y);
+                if (aspectRatio !== 0)
+                    parent.x = topRightHandle.x + handleSize - rectangle.height * aspectRatio;
+
+                parent.x = Math.min(parent.x, bottomRightHandle.x);
+                parent.y = Math.min(parent.y, bottomRightHandle.y);
+                rectChanged(rectangle);
             }
             onReleased: {
-                rectChanged(rectangle)
-                topRightHandle.anchors.top = undefined
-                bottomLeftHandle.anchors.left = undefined
-
-                topHandle.anchors.horizontalCenter = undefined
-                topHandle.anchors.top = undefined
-                bottomHandle.anchors.horizontalCenter = undefined
-                bottomHandle.anchors.bottom = undefined
-                leftHandle.anchors.verticalCenter = undefined
-                leftHandle.anchors.left = undefined
-                rightHandle.anchors.verticalCenter = undefined
-                rightHandle.anchors.right = undefined
+                rectChanged(rectangle);
+                topRightHandle.anchors.top = undefined;
+                bottomLeftHandle.anchors.left = undefined;
+                topHandle.anchors.horizontalCenter = undefined;
+                topHandle.anchors.top = undefined;
+                bottomHandle.anchors.horizontalCenter = undefined;
+                bottomHandle.anchors.bottom = undefined;
+                leftHandle.anchors.verticalCenter = undefined;
+                leftHandle.anchors.left = undefined;
+                rightHandle.anchors.verticalCenter = undefined;
+                rightHandle.anchors.right = undefined;
             }
         }
+
     }
 
     Rectangle {
         id: topHandle
+
         color: handleColor
         width: handleSize
         height: handleSize
-        visible: aspectRatio !== 0.0 ? false : !isRotated()  
+        visible: aspectRatio !== 0 ? false : !isRotated()
+
         MouseArea {
             anchors.fill: parent
             acceptedButtons: Qt.LeftButton
             cursorShape: Qt.SizeVerCursor
             drag.target: parent
             onEntered: {
-                rectangle.anchors.top = parent.top
-                topLeftHandle.anchors.top = rectangle.top
-                topRightHandle.anchors.top = rectangle.top
-
-                leftHandle.anchors.verticalCenter = rectangle.verticalCenter
-                rightHandle.anchors.verticalCenter = rectangle.verticalCenter
+                rectangle.anchors.top = parent.top;
+                topLeftHandle.anchors.top = rectangle.top;
+                topRightHandle.anchors.top = rectangle.top;
+                leftHandle.anchors.verticalCenter = rectangle.verticalCenter;
+                rightHandle.anchors.verticalCenter = rectangle.verticalCenter;
             }
             onPositionChanged: {
-                topHandle.x = topLeftHandle.x + rectangle.width / 2 - (handleSize / 2)
-                topHandle.y = snapY(topHandle.y)
-                parent.x = Math.min(parent.x, bottomHandle.x)
-                parent.y = Math.min(parent.y, bottomHandle.y)
-                rectChanged(rectangle)
+                topHandle.x = topLeftHandle.x + rectangle.width / 2 - (handleSize / 2);
+                topHandle.y = snapY(topHandle.y);
+                parent.x = Math.min(parent.x, bottomHandle.x);
+                parent.y = Math.min(parent.y, bottomHandle.y);
+                rectChanged(rectangle);
             }
             onReleased: {
-                rectChanged(rectangle)
-                topLeftHandle.anchors.top = undefined
-                topRightHandle.anchors.top = undefined
-
-                leftHandle.anchors.verticalCenter = undefined
-                rightHandle.anchors.verticalCenter = undefined
+                rectChanged(rectangle);
+                topLeftHandle.anchors.top = undefined;
+                topRightHandle.anchors.top = undefined;
+                leftHandle.anchors.verticalCenter = undefined;
+                rightHandle.anchors.verticalCenter = undefined;
             }
         }
+
     }
 
     Rectangle {
         id: bottomHandle
+
         color: handleColor
         width: handleSize
         height: handleSize
-        visible: aspectRatio !== 0.0 ? false : !isRotated()  
+        visible: aspectRatio !== 0 ? false : !isRotated()
+
         MouseArea {
             anchors.fill: parent
             acceptedButtons: Qt.LeftButton
             cursorShape: Qt.SizeVerCursor
             drag.target: parent
             onEntered: {
-                rectangle.anchors.bottom = parent.bottom
-                bottomLeftHandle.anchors.bottom = rectangle.bottom
-                bottomRightHandle.anchors.bottom = rectangle.bottom
-
-                leftHandle.anchors.verticalCenter = rectangle.verticalCenter
-                rightHandle.anchors.verticalCenter = rectangle.verticalCenter
+                rectangle.anchors.bottom = parent.bottom;
+                bottomLeftHandle.anchors.bottom = rectangle.bottom;
+                bottomRightHandle.anchors.bottom = rectangle.bottom;
+                leftHandle.anchors.verticalCenter = rectangle.verticalCenter;
+                rightHandle.anchors.verticalCenter = rectangle.verticalCenter;
             }
             onPositionChanged: {
-                bottomHandle.x = topLeftHandle.x + rectangle.width / 2 - (handleSize / 2)
-                bottomHandle.y = snapY(bottomHandle.y + handleSize) - handleSize
-                parent.x = Math.max(parent.x, topHandle.x)
-                parent.y = Math.max(parent.y, topHandle.y)
-                rectChanged(rectangle)
+                bottomHandle.x = topLeftHandle.x + rectangle.width / 2 - (handleSize / 2);
+                bottomHandle.y = snapY(bottomHandle.y + handleSize) - handleSize;
+                parent.x = Math.max(parent.x, topHandle.x);
+                parent.y = Math.max(parent.y, topHandle.y);
+                rectChanged(rectangle);
             }
             onReleased: {
-                rectChanged(rectangle)
-                bottomLeftHandle.anchors.bottom = undefined
-                bottomRightHandle.anchors.bottom = undefined
-
-                leftHandle.anchors.verticalCenter = undefined
-                rightHandle.anchors.verticalCenter = undefined
+                rectChanged(rectangle);
+                bottomLeftHandle.anchors.bottom = undefined;
+                bottomRightHandle.anchors.bottom = undefined;
+                leftHandle.anchors.verticalCenter = undefined;
+                rightHandle.anchors.verticalCenter = undefined;
             }
         }
+
     }
 
     Rectangle {
         id: leftHandle
+
         color: handleColor
         width: handleSize
         height: handleSize
-        visible: aspectRatio !== 0.0 ? false : !isRotated()  
+        visible: aspectRatio !== 0 ? false : !isRotated()
+
         MouseArea {
             anchors.fill: parent
             acceptedButtons: Qt.LeftButton
             cursorShape: Qt.SizeHorCursor
             drag.target: parent
             onEntered: {
-                rectangle.anchors.left = parent.left
-                topLeftHandle.anchors.left = rectangle.left
-                bottomLeftHandle.anchors.left = rectangle.left
-
-                topHandle.anchors.horizontalCenter = rectangle.horizontalCenter
-                bottomHandle.anchors.horizontalCenter = rectangle.horizontalCenter
+                rectangle.anchors.left = parent.left;
+                topLeftHandle.anchors.left = rectangle.left;
+                bottomLeftHandle.anchors.left = rectangle.left;
+                topHandle.anchors.horizontalCenter = rectangle.horizontalCenter;
+                bottomHandle.anchors.horizontalCenter = rectangle.horizontalCenter;
             }
             onPositionChanged: {
-                leftHandle.x = snapX(leftHandle.x)
-                leftHandle.y = topLeftHandle.y + rectangle.height / 2 - (handleSize / 2)
-                parent.x = Math.min(parent.x, rightHandle.x)
-                parent.y = Math.min(parent.y, rightHandle.y)
-                rectChanged(rectangle)
+                leftHandle.x = snapX(leftHandle.x);
+                leftHandle.y = topLeftHandle.y + rectangle.height / 2 - (handleSize / 2);
+                parent.x = Math.min(parent.x, rightHandle.x);
+                parent.y = Math.min(parent.y, rightHandle.y);
+                rectChanged(rectangle);
             }
             onReleased: {
-                rectChanged(rectangle)
-                topLeftHandle.anchors.left = undefined
-                bottomLeftHandle.anchors.left = undefined
-
-                topHandle.anchors.horizontalCenter = undefined
-                bottomHandle.anchors.horizontalCenter = undefined
+                rectChanged(rectangle);
+                topLeftHandle.anchors.left = undefined;
+                bottomLeftHandle.anchors.left = undefined;
+                topHandle.anchors.horizontalCenter = undefined;
+                bottomHandle.anchors.horizontalCenter = undefined;
             }
         }
+
     }
 
     Rectangle {
         id: rightHandle
+
         color: handleColor
         width: handleSize
         height: handleSize
-        visible: aspectRatio !== 0.0 ? false : !isRotated()  
+        visible: aspectRatio !== 0 ? false : !isRotated()
+
         MouseArea {
             anchors.fill: parent
             acceptedButtons: Qt.LeftButton
             cursorShape: Qt.SizeHorCursor
             drag.target: parent
             onEntered: {
-                rectangle.anchors.right = parent.right
-                topRightHandle.anchors.right = rectangle.right
-                bottomRightHandle.anchors.right = rectangle.right
-
-                topHandle.anchors.horizontalCenter = rectangle.horizontalCenter
-                bottomHandle.anchors.horizontalCenter = rectangle.horizontalCenter
+                rectangle.anchors.right = parent.right;
+                topRightHandle.anchors.right = rectangle.right;
+                bottomRightHandle.anchors.right = rectangle.right;
+                topHandle.anchors.horizontalCenter = rectangle.horizontalCenter;
+                bottomHandle.anchors.horizontalCenter = rectangle.horizontalCenter;
             }
             onPositionChanged: {
-                rightHandle.x = snapX(rightHandle.x + handleSize) - handleSize
-                rightHandle.y = topLeftHandle.y + rectangle.height / 2 - (handleSize / 2)
-                parent.x = Math.max(parent.x, leftHandle.x)
-                parent.y = Math.max(parent.y, leftHandle.y)
-                rectChanged(rectangle)
+                rightHandle.x = snapX(rightHandle.x + handleSize) - handleSize;
+                rightHandle.y = topLeftHandle.y + rectangle.height / 2 - (handleSize / 2);
+                parent.x = Math.max(parent.x, leftHandle.x);
+                parent.y = Math.max(parent.y, leftHandle.y);
+                rectChanged(rectangle);
             }
             onReleased: {
-                rectChanged(rectangle)
-                topRightHandle.anchors.right = undefined
-                bottomRightHandle.anchors.right = undefined
-
-                topHandle.anchors.horizontalCenter = undefined
-                bottomHandle.anchors.horizontalCenter = undefined
+                rectChanged(rectangle);
+                topRightHandle.anchors.right = undefined;
+                bottomRightHandle.anchors.right = undefined;
+                topHandle.anchors.horizontalCenter = undefined;
+                bottomHandle.anchors.horizontalCenter = undefined;
             }
         }
+
     }
 
     Rectangle {
         id: topRightHandle
+
         visible: !isRotated()
         color: handleColor
         width: handleSize
         height: handleSize
+
         MouseArea {
             anchors.fill: parent
             acceptedButtons: Qt.LeftButton
             cursorShape: Qt.SizeBDiagCursor
             drag.target: parent
             onEntered: {
-                rectangle.anchors.top = parent.top
-                rectangle.anchors.right = parent.right
-                rectangle.anchors.bottom = bottomLeftHandle.bottom
-                rectangle.anchors.left = bottomLeftHandle.left
-                topLeftHandle.anchors.top = rectangle.top
-                bottomRightHandle.anchors.right = rectangle.right
-
-                topHandle.anchors.horizontalCenter = rectangle.horizontalCenter
-                topHandle.anchors.top = rectangle.top
-                bottomHandle.anchors.horizontalCenter = rectangle.horizontalCenter
-                bottomHandle.anchors.bottom = rectangle.bottom
-                leftHandle.anchors.verticalCenter = rectangle.verticalCenter
-                leftHandle.anchors.left = rectangle.left
-                rightHandle.anchors.verticalCenter = rectangle.verticalCenter
-                rightHandle.anchors.right = rectangle.right
+                rectangle.anchors.top = parent.top;
+                rectangle.anchors.right = parent.right;
+                rectangle.anchors.bottom = bottomLeftHandle.bottom;
+                rectangle.anchors.left = bottomLeftHandle.left;
+                topLeftHandle.anchors.top = rectangle.top;
+                bottomRightHandle.anchors.right = rectangle.right;
+                topHandle.anchors.horizontalCenter = rectangle.horizontalCenter;
+                topHandle.anchors.top = rectangle.top;
+                bottomHandle.anchors.horizontalCenter = rectangle.horizontalCenter;
+                bottomHandle.anchors.bottom = rectangle.bottom;
+                leftHandle.anchors.verticalCenter = rectangle.verticalCenter;
+                leftHandle.anchors.left = rectangle.left;
+                rightHandle.anchors.verticalCenter = rectangle.verticalCenter;
+                rightHandle.anchors.right = rectangle.right;
             }
             onPositionChanged: {
-                topRightHandle.x = snapX(topRightHandle.x + handleSize) - handleSize
-                topRightHandle.y = snapY(topRightHandle.y)
-                if (aspectRatio !== 0.0)
-                    parent.x = topLeftHandle.x + rectangle.height * aspectRatio - handleSize
-                parent.x = Math.max(parent.x, bottomLeftHandle.x)
-                parent.y = Math.min(parent.y, bottomLeftHandle.y)
-                rectChanged(rectangle)
+                topRightHandle.x = snapX(topRightHandle.x + handleSize) - handleSize;
+                topRightHandle.y = snapY(topRightHandle.y);
+                if (aspectRatio !== 0)
+                    parent.x = topLeftHandle.x + rectangle.height * aspectRatio - handleSize;
+
+                parent.x = Math.max(parent.x, bottomLeftHandle.x);
+                parent.y = Math.min(parent.y, bottomLeftHandle.y);
+                rectChanged(rectangle);
             }
             onReleased: {
-                rectChanged(rectangle)
-                topLeftHandle.anchors.top = undefined
-                bottomRightHandle.anchors.right = undefined
-
-                topHandle.anchors.horizontalCenter = undefined
-                topHandle.anchors.top = undefined
-                bottomHandle.anchors.horizontalCenter = undefined
-                bottomHandle.anchors.bottom = undefined
-                leftHandle.anchors.verticalCenter = undefined
-                leftHandle.anchors.left = undefined
-                rightHandle.anchors.verticalCenter = undefined
-                rightHandle.anchors.right = undefined
+                rectChanged(rectangle);
+                topLeftHandle.anchors.top = undefined;
+                bottomRightHandle.anchors.right = undefined;
+                topHandle.anchors.horizontalCenter = undefined;
+                topHandle.anchors.top = undefined;
+                bottomHandle.anchors.horizontalCenter = undefined;
+                bottomHandle.anchors.bottom = undefined;
+                leftHandle.anchors.verticalCenter = undefined;
+                leftHandle.anchors.left = undefined;
+                rightHandle.anchors.verticalCenter = undefined;
+                rightHandle.anchors.right = undefined;
             }
         }
+
     }
 
     Rectangle {
         id: bottomLeftHandle
+
         visible: !isRotated()
         color: handleColor
         width: handleSize
         height: handleSize
+
         MouseArea {
             anchors.fill: parent
             acceptedButtons: Qt.LeftButton
             cursorShape: Qt.SizeBDiagCursor
             drag.target: parent
             onEntered: {
-                rectangle.anchors.bottom = parent.bottom
-                rectangle.anchors.left = parent.left
-                rectangle.anchors.top = topRightHandle.top
-                rectangle.anchors.right = topRightHandle.right
-                topLeftHandle.anchors.left = rectangle.left
-                bottomRightHandle.anchors.bottom = rectangle.bottom
-
-                topHandle.anchors.horizontalCenter = rectangle.horizontalCenter
-                topHandle.anchors.top = rectangle.top
-                bottomHandle.anchors.horizontalCenter = rectangle.horizontalCenter
-                bottomHandle.anchors.bottom = rectangle.bottom
-                leftHandle.anchors.verticalCenter = rectangle.verticalCenter
-                leftHandle.anchors.left = rectangle.left
-                rightHandle.anchors.verticalCenter = rectangle.verticalCenter
-                rightHandle.anchors.right = rectangle.right
+                rectangle.anchors.bottom = parent.bottom;
+                rectangle.anchors.left = parent.left;
+                rectangle.anchors.top = topRightHandle.top;
+                rectangle.anchors.right = topRightHandle.right;
+                topLeftHandle.anchors.left = rectangle.left;
+                bottomRightHandle.anchors.bottom = rectangle.bottom;
+                topHandle.anchors.horizontalCenter = rectangle.horizontalCenter;
+                topHandle.anchors.top = rectangle.top;
+                bottomHandle.anchors.horizontalCenter = rectangle.horizontalCenter;
+                bottomHandle.anchors.bottom = rectangle.bottom;
+                leftHandle.anchors.verticalCenter = rectangle.verticalCenter;
+                leftHandle.anchors.left = rectangle.left;
+                rightHandle.anchors.verticalCenter = rectangle.verticalCenter;
+                rightHandle.anchors.right = rectangle.right;
             }
             onPositionChanged: {
-                bottomLeftHandle.x = snapX(bottomLeftHandle.x)
-                bottomLeftHandle.y = snapY(bottomLeftHandle.y + handleSize) - handleSize
-                if (aspectRatio !== 0.0)
-                    parent.x = topRightHandle.x + handleSize - rectangle.height * aspectRatio
-                parent.x = Math.min(parent.x, topRightHandle.x)
-                parent.y = Math.max(parent.y, topRightHandle.y)
-                rectChanged(rectangle)
+                bottomLeftHandle.x = snapX(bottomLeftHandle.x);
+                bottomLeftHandle.y = snapY(bottomLeftHandle.y + handleSize) - handleSize;
+                if (aspectRatio !== 0)
+                    parent.x = topRightHandle.x + handleSize - rectangle.height * aspectRatio;
+
+                parent.x = Math.min(parent.x, topRightHandle.x);
+                parent.y = Math.max(parent.y, topRightHandle.y);
+                rectChanged(rectangle);
             }
             onReleased: {
-                rectChanged(rectangle)
-                topLeftHandle.anchors.left = undefined
-                bottomRightHandle.anchors.bottom = undefined
-
-                topHandle.anchors.horizontalCenter = undefined
-                topHandle.anchors.top = undefined
-                bottomHandle.anchors.horizontalCenter = undefined
-                bottomHandle.anchors.bottom = undefined
-                leftHandle.anchors.verticalCenter = undefined
-                leftHandle.anchors.left = undefined
-                rightHandle.anchors.verticalCenter = undefined
-                rightHandle.anchors.right = undefined
+                rectChanged(rectangle);
+                topLeftHandle.anchors.left = undefined;
+                bottomRightHandle.anchors.bottom = undefined;
+                topHandle.anchors.horizontalCenter = undefined;
+                topHandle.anchors.top = undefined;
+                bottomHandle.anchors.horizontalCenter = undefined;
+                bottomHandle.anchors.bottom = undefined;
+                leftHandle.anchors.verticalCenter = undefined;
+                leftHandle.anchors.left = undefined;
+                rightHandle.anchors.verticalCenter = undefined;
+                rightHandle.anchors.right = undefined;
             }
         }
+
     }
 
     Rectangle {
         id: bottomRightHandle
+
         visible: !isRotated()
         color: handleColor
         width: handleSize
         height: handleSize
+
         MouseArea {
             anchors.fill: parent
             acceptedButtons: Qt.LeftButton
             cursorShape: Qt.SizeFDiagCursor
             drag.target: parent
             onEntered: {
-                rectangle.anchors.bottom = parent.bottom
-                rectangle.anchors.right = parent.right
-                topRightHandle.anchors.right = rectangle.right
-                bottomLeftHandle.anchors.bottom = rectangle.bottom
-
-                topHandle.anchors.horizontalCenter = rectangle.horizontalCenter
-                topHandle.anchors.top = rectangle.top
-                bottomHandle.anchors.horizontalCenter = rectangle.horizontalCenter
-                bottomHandle.anchors.bottom = rectangle.bottom
-                leftHandle.anchors.verticalCenter = rectangle.verticalCenter
-                leftHandle.anchors.left = rectangle.left
-                rightHandle.anchors.verticalCenter = rectangle.verticalCenter
-                rightHandle.anchors.right = rectangle.right
+                rectangle.anchors.bottom = parent.bottom;
+                rectangle.anchors.right = parent.right;
+                topRightHandle.anchors.right = rectangle.right;
+                bottomLeftHandle.anchors.bottom = rectangle.bottom;
+                topHandle.anchors.horizontalCenter = rectangle.horizontalCenter;
+                topHandle.anchors.top = rectangle.top;
+                bottomHandle.anchors.horizontalCenter = rectangle.horizontalCenter;
+                bottomHandle.anchors.bottom = rectangle.bottom;
+                leftHandle.anchors.verticalCenter = rectangle.verticalCenter;
+                leftHandle.anchors.left = rectangle.left;
+                rightHandle.anchors.verticalCenter = rectangle.verticalCenter;
+                rightHandle.anchors.right = rectangle.right;
             }
             onPositionChanged: {
-                bottomRightHandle.x = snapX(bottomRightHandle.x + handleSize) - handleSize
-                bottomRightHandle.y = snapY(bottomRightHandle.y + handleSize) - handleSize
-                if (aspectRatio !== 0.0)
-                    parent.x = topLeftHandle.x + rectangle.height * aspectRatio - handleSize
-                parent.x = Math.max(parent.x, topLeftHandle.x)
-                parent.y = Math.max(parent.y, topLeftHandle.y)
-                rectChanged(rectangle)
+                bottomRightHandle.x = snapX(bottomRightHandle.x + handleSize) - handleSize;
+                bottomRightHandle.y = snapY(bottomRightHandle.y + handleSize) - handleSize;
+                if (aspectRatio !== 0)
+                    parent.x = topLeftHandle.x + rectangle.height * aspectRatio - handleSize;
+
+                parent.x = Math.max(parent.x, topLeftHandle.x);
+                parent.y = Math.max(parent.y, topLeftHandle.y);
+                rectChanged(rectangle);
             }
             onReleased: {
-                rectChanged(rectangle)
-                topRightHandle.anchors.right = undefined
-                bottomLeftHandle.anchors.bottom = undefined
-
-                topHandle.anchors.horizontalCenter = undefined
-                topHandle.anchors.top = undefined
-                bottomHandle.anchors.horizontalCenter = undefined
-                bottomHandle.anchors.bottom = undefined
-                leftHandle.anchors.verticalCenter = undefined
-                leftHandle.anchors.left = undefined
-                rightHandle.anchors.verticalCenter = undefined
-                rightHandle.anchors.right = undefined
+                rectChanged(rectangle);
+                topRightHandle.anchors.right = undefined;
+                bottomLeftHandle.anchors.bottom = undefined;
+                topHandle.anchors.horizontalCenter = undefined;
+                topHandle.anchors.top = undefined;
+                bottomHandle.anchors.horizontalCenter = undefined;
+                bottomHandle.anchors.bottom = undefined;
+                leftHandle.anchors.verticalCenter = undefined;
+                leftHandle.anchors.left = undefined;
+                rightHandle.anchors.verticalCenter = undefined;
+                rightHandle.anchors.right = undefined;
             }
         }
+
     }
+
 }

--- a/src/qml/modules/Shotcut/Controls/SaveDefaultButton.qml
+++ b/src/qml/modules/Shotcut/Controls/SaveDefaultButton.qml
@@ -21,7 +21,11 @@ import Shotcut.Controls 1.0 as Shotcut
 Shotcut.Button {
     icon.name: 'document-save'
     icon.source: 'qrc:///icons/oxygen/32x32/actions/document-save.png'
-    Shotcut.HoverTip { text: qsTr('Set as default') }
     implicitWidth: 20
     implicitHeight: 20
+
+    Shotcut.HoverTip {
+        text: qsTr('Set as default')
+    }
+
 }

--- a/src/qml/modules/Shotcut/Controls/SimplePropertyUI.qml
+++ b/src/qml/modules/Shotcut/Controls/SimplePropertyUI.qml
@@ -1,14 +1,15 @@
 import QtQuick 2.1
-import QtQuick.Layouts 1.0
 import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.0
 
 Column {
     id: root
+
+    property var properties: []
+
     Layout.columnSpan: 4
     Layout.fillWidth: true
     spacing: 4
-
-    property var properties: []
 
     Label {
         text: qsTr("Custom Properties")
@@ -21,21 +22,29 @@ Column {
         RowLayout {
             width: parent.width
             height: propField.height
+
             Label {
                 Layout.preferredWidth: editButton.width
                 Layout.minimumWidth: implicitWidth
+                text: modelData
+
                 anchors {
                     verticalCenter: propField.verticalCenter
                 }
-                text: modelData
+
             }
+
             TextField {
                 id: propField
+
                 Layout.fillWidth: true
                 selectByMouse: true
                 text: filter.get(modelData)
                 onTextChanged: filter.set(modelData, text)
             }
+
         }
+
     }
+
 }

--- a/src/qml/modules/Shotcut/Controls/SliderSpinner.qml
+++ b/src/qml/modules/Shotcut/Controls/SliderSpinner.qml
@@ -21,11 +21,10 @@ import QtQuick.Layouts 1.1
 import Shotcut.Controls 1.0 as Shotcut
 
 RowLayout {
-    spacing: -3
     property real value
     property alias minimumValue: slider.from
     property alias maximumValue: slider.to
-    property real  ratio: 1.0
+    property real ratio: 1
     property alias label: label.text
     property int decimals: 0
     property alias stepSize: spinner.stepSize
@@ -33,26 +32,31 @@ RowLayout {
     property alias suffix: spinner.suffix
     property alias prefix: spinner.prefix
 
-    SystemPalette { id: activePalette }
-
+    spacing: -3
     onValueChanged: spinner.value = value / ratio
+
+    SystemPalette {
+        id: activePalette
+    }
 
     Slider {
         id: slider
-        stepSize: spinner.stepSize
 
+        property bool isReady: false
+
+        stepSize: spinner.stepSize
         Layout.fillWidth: true
         activeFocusOnTab: false
         wheelEnabled: true
-
-        property bool isReady: false
         Component.onCompleted: {
-            isReady = true
-            value = parent.value
+            isReady = true;
+            value = parent.value;
         }
-        onValueChanged: if (isReady) {
-            spinner.value = value / ratio
-            parent.value = value
+        onValueChanged: {
+            if (isReady) {
+                spinner.value = value / ratio;
+                parent.value = value;
+            }
         }
 
         background: Rectangle {
@@ -65,6 +69,9 @@ RowLayout {
             // Hide the right border.
             Rectangle {
                 visible: !label.visible
+                width: 3
+                color: parent.color
+
                 anchors {
                     top: parent.top
                     right: parent.right
@@ -72,29 +79,29 @@ RowLayout {
                     topMargin: 1
                     bottomMargin: 1
                 }
-                width: 3
-                color: parent.color
+
             }
 
             // Indicate percentage full.
             Rectangle {
+                radius: parent.radius
+                width: parent.width * (value - minimumValue) / (maximumValue - minimumValue) - parent.border.width - (label.visible ? parent.border.width : 3)
+                color: enabled ? activePalette.highlight : activePalette.midlight
+
                 anchors {
                     top: parent.top
                     left: parent.left
                     bottom: parent.bottom
                     margins: 1
                 }
-                radius: parent.radius
-                width: parent.width
-                       * (value - minimumValue) / (maximumValue - minimumValue)
-                       - parent.border.width
-                       - (label.visible? parent.border.width : 3)
-                color: enabled? activePalette.highlight : activePalette.midlight
+
             }
+
         }
 
         handle: Rectangle {
         }
+
     }
 
     // Optional label between slider and spinner
@@ -102,10 +109,13 @@ RowLayout {
         width: 4 - parent.spacing * 2
         visible: label.visible
     }
+
     Label {
         id: label
+
         visible: text.length
     }
+
     Rectangle {
         width: 4 - parent.spacing * 2
         visible: label.visible
@@ -113,6 +123,7 @@ RowLayout {
 
     Shotcut.DoubleSpinBox {
         id: spinner
+
         verticalPadding: 2
         Layout.minimumWidth: background.implicitWidth
         from: slider.from / ratio
@@ -132,6 +143,9 @@ RowLayout {
             // Hide the left border.
             Rectangle {
                 visible: !label.visible
+                width: 3
+                color: parent.color
+
                 anchors {
                     top: parent.top
                     left: parent.left
@@ -139,12 +153,17 @@ RowLayout {
                     topMargin: 1
                     bottomMargin: 1
                 }
-                width: 3
-                color: parent.color
+
             }
+
         }
 
-        up.indicator: Rectangle {}
-        down.indicator: Rectangle {}
+        up.indicator: Rectangle {
+        }
+
+        down.indicator: Rectangle {
+        }
+
     }
+
 }

--- a/src/qml/modules/Shotcut/Controls/TextFilterUi.qml
+++ b/src/qml/modules/Shotcut/Controls/TextFilterUi.qml
@@ -22,8 +22,6 @@ import QtQuick.Layouts 1.1
 import Shotcut.Controls 1.0 as Shotcut
 
 GridLayout {
-    columns: 6
-
     property string rectProperty: 'geometry'
     property string valignProperty: 'valign'
     property string halignProperty: 'halign'
@@ -32,194 +30,219 @@ GridLayout {
     property rect filterRect
     property string startValue: '_shotcut:startValue'
     property string middleValue: '_shotcut:middleValue'
-    property string endValue:  '_shotcut:endValue'
+    property string endValue: '_shotcut:endValue'
     property var parameterList: [rectProperty, halignProperty, valignProperty, 'size', 'style', 'fgcolour', 'family', 'weight', 'olcolour', 'outline', 'bgcolour', 'pad', useFontSizeProperty]
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function updateFilter(position) {
         if (position !== null) {
-            filter.blockSignals = true
+            filter.blockSignals = true;
             if (position <= 0 && filter.animateIn > 0)
-                filter.set(startValue, filterRect)
+                filter.set(startValue, filterRect);
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                filter.set(endValue, filterRect)
+                filter.set(endValue, filterRect);
             else
-                filter.set(middleValue, filterRect)
-            filter.blockSignals = false
+                filter.set(middleValue, filterRect);
+            filter.blockSignals = false;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(rectProperty)
-            positionKeyframesButton.checked = false
+            filter.resetProperty(rectProperty);
+            positionKeyframesButton.checked = false;
             if (filter.animateIn > 0) {
-                filter.set(rectProperty, filter.getRect(startValue), 0)
-                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1)
+                filter.set(rectProperty, filter.getRect(startValue), 0);
+                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut)
-                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1)
+                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut);
+                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1);
             }
         } else if (!positionKeyframesButton.checked) {
-            filter.resetProperty(rectProperty)
-            filter.set(rectProperty, filter.getRect(middleValue))
+            filter.resetProperty(rectProperty);
+            filter.set(rectProperty, filter.getRect(middleValue));
         } else if (position !== null) {
-            filter.set(rectProperty, filterRect, position)
+            filter.set(rectProperty, filterRect, position);
         }
     }
 
     function getPointSize() {
-        var pointSize = parseInt(filter.get(pointSizeProperty))
+        var pointSize = parseInt(filter.get(pointSizeProperty));
         if (!pointSize) {
-            var ratio = fontDialog.font.pointSize / fontDialog.font.pixelSize
-            pointSize = filter.get('size') * ratio
+            var ratio = fontDialog.font.pointSize / fontDialog.font.pixelSize;
+            pointSize = filter.get('size') * ratio;
         }
-        return pointSize
+        return pointSize;
     }
 
     function refreshFontButton() {
-        var s = filter.get('family')
+        var s = filter.get('family');
         if (filter.getDouble('weight') > 10 * Font.Medium)
-            s += ' ' + qsTr('Bold')
+            s += ' ' + qsTr('Bold');
+
         if (filter.get('style') === 'italic')
-            s += ' ' + qsTr('Italic')
+            s += ' ' + qsTr('Italic');
+
         if (parseInt(filter.get(useFontSizeProperty)))
-            s += ' ' + getPointSize()
-        fontButton.text = s
+            s += ' ' + getPointSize();
+
+        fontButton.text = s;
     }
 
     function setControls() {
-        fgColor.value = filter.get('fgcolour')
-        fontButton.text = filter.get('family')
-        outlineColor.value = filter.get('olcolour')
-        outlineSpinner.value = filter.getDouble('outline')
-        bgColor.value = filter.get('bgcolour')
-        padSpinner.value = filter.getDouble('pad')
-        var align = filter.get(halignProperty)
+        fgColor.value = filter.get('fgcolour');
+        fontButton.text = filter.get('family');
+        outlineColor.value = filter.get('olcolour');
+        outlineSpinner.value = filter.getDouble('outline');
+        bgColor.value = filter.get('bgcolour');
+        padSpinner.value = filter.getDouble('pad');
+        var align = filter.get(halignProperty);
         if (align === 'left')
-            leftRadioButton.checked = true
+            leftRadioButton.checked = true;
         else if (align === 'center' || align === 'middle')
-            centerRadioButton.checked = true
+            centerRadioButton.checked = true;
         else if (filter.get(halignProperty) === 'right')
-            rightRadioButton.checked = true
-        align = filter.get(valignProperty)
+            rightRadioButton.checked = true;
+        align = filter.get(valignProperty);
         if (align === 'top')
-            topRadioButton.checked = true
+            topRadioButton.checked = true;
         else if (align === 'center' || align === 'middle')
-            middleRadioButton.checked = true
+            middleRadioButton.checked = true;
         else if (align === 'bottom')
-            bottomRadioButton.checked = true
+            bottomRadioButton.checked = true;
         fontDialog.font = Qt.font({
-            family: filter.get('family'),
-            pointSize: getPointSize(),
-            italic: filter.get('style') === 'italic',
-            weight: filter.getDouble('weight') / 10
-        })
-        fontDialog.fontFamily = filter.get('family')
-        fontSizeCheckBox.checked = parseInt(filter.get(useFontSizeProperty))
-        refreshFontButton()
-        setKeyframedControls()
+            "family": filter.get('family'),
+            "pointSize": getPointSize(),
+            "italic": filter.get('style') === 'italic',
+            "weight": filter.getDouble('weight') / 10
+        });
+        fontDialog.fontFamily = filter.get('family');
+        fontSizeCheckBox.checked = parseInt(filter.get(useFontSizeProperty));
+        refreshFontButton();
+        setKeyframedControls();
     }
 
     function setKeyframedControls() {
-        var position = getPosition()
-        var newValue = filter.getRect(rectProperty, position)
+        var position = getPosition();
+        var newValue = filter.getRect(rectProperty, position);
         if (filterRect !== newValue) {
-            filterRect = newValue
-            rectX.value = filterRect.x.toFixed()
-            rectY.value = filterRect.y.toFixed()
-            rectW.value = filterRect.width.toFixed()
-            rectH.value = filterRect.height.toFixed()
+            filterRect = newValue;
+            rectX.value = filterRect.x.toFixed();
+            rectY.value = filterRect.y.toFixed();
+            rectW.value = filterRect.width.toFixed();
+            rectH.value = filterRect.height.toFixed();
         }
-        var enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
-        rectX.enabled = enabled
-        rectY.enabled = enabled
-        rectW.enabled = enabled
-        rectH.enabled = enabled
-        positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
+        var enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
+        rectX.enabled = enabled;
+        rectY.enabled = enabled;
+        rectW.enabled = enabled;
+        rectH.enabled = enabled;
+        positionKeyframesButton.checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
     }
 
-    ButtonGroup { id: halignGroup }
-    ButtonGroup { id: valignGroup }
+    columns: 6
+
+    ButtonGroup {
+        id: halignGroup
+    }
+
+    ButtonGroup {
+        id: valignGroup
+    }
 
     Label {
         text: qsTr('Font')
         Layout.alignment: Qt.AlignRight
     }
+
     Shotcut.ColorPicker {
         id: fgColor
+
         eyedropper: false
         alpha: true
         onValueChanged: filter.set('fgcolour', value)
     }
+
     RowLayout {
         Layout.columnSpan: 4
+
         Shotcut.Button {
             id: fontButton
+
             onClicked: {
-                if (fontSizeCheckBox.checked) {
-                    fontDialog.font.pointSize = getPointSize()
-                } else {
-                    fontDialog.font.pointSize = 48
-                }
-                fontDialog.open()
+                if (fontSizeCheckBox.checked)
+                    fontDialog.font.pointSize = getPointSize();
+                else
+                    fontDialog.font.pointSize = 48;
+                fontDialog.open();
             }
+
             FontDialog {
                 id: fontDialog
-                title: "Please choose a font"
+
                 property string fontFamily: ''
+
+                title: "Please choose a font"
                 modality: application.dialogModality
                 onFontChanged: {
-                    filter.set('family', font.family)
-                    filter.set('weight', 10 * font.weight )
-                    filter.set('style', font.italic? 'italic' : 'normal' )
+                    filter.set('family', font.family);
+                    filter.set('weight', 10 * font.weight);
+                    filter.set('style', font.italic ? 'italic' : 'normal');
                     if (parseInt(filter.get(useFontSizeProperty))) {
-                        filter.set('size', font.pixelSize)
-                        filter.set(pointSizeProperty, font.pointSize)
+                        filter.set('size', font.pixelSize);
+                        filter.set(pointSizeProperty, font.pointSize);
                     }
-                    refreshFontButton()
+                    refreshFontButton();
                 }
                 onAccepted: fontFamily = font.family
                 onRejected: {
-                    filter.set('family', fontFamily)
-                    refreshFontButton()
+                    filter.set('family', fontFamily);
+                    refreshFontButton();
                 }
             }
+
         }
+
         CheckBox {
             id: fontSizeCheckBox
+
             text: qsTr('Use font size')
             onCheckedChanged: {
-                filter.set(useFontSizeProperty, checked)
+                filter.set(useFontSizeProperty, checked);
                 if (checked) {
-                    filter.set('size', fontDialog.font.pixelSize)
-                    filter.set(pointSizeProperty, fontDialog.font.pointSize)
+                    filter.set('size', fontDialog.font.pixelSize);
+                    filter.set(pointSizeProperty, fontDialog.font.pointSize);
                 } else {
-                    filter.set('size', profile.height / text.split('\n').length)
+                    filter.set('size', profile.height / text.split('\n').length);
                 }
-                refreshFontButton()
+                refreshFontButton();
             }
         }
+
     }
 
     Label {
         text: qsTr('Outline')
         Layout.alignment: Qt.AlignRight
     }
+
     Shotcut.ColorPicker {
         id: outlineColor
+
         eyedropper: false
         alpha: true
         onValueChanged: filter.set('olcolour', value)
     }
+
     Label {
         text: qsTr('Thickness')
         Layout.alignment: Qt.AlignRight
     }
+
     Shotcut.DoubleSpinBox {
         id: outlineSpinner
+
         Layout.minimumWidth: 50
         Layout.columnSpan: 3
         from: 0
@@ -231,18 +254,23 @@ GridLayout {
         text: qsTr('Background')
         Layout.alignment: Qt.AlignRight
     }
+
     Shotcut.ColorPicker {
         id: bgColor
+
         eyedropper: false
         alpha: true
         onValueChanged: filter.set('bgcolour', value)
     }
+
     Label {
         text: qsTr('Padding')
         Layout.alignment: Qt.AlignRight
     }
+
     Shotcut.DoubleSpinBox {
         id: padSpinner
+
         Layout.minimumWidth: 50
         Layout.columnSpan: 3
         from: 0
@@ -254,55 +282,73 @@ GridLayout {
         text: qsTr('Position')
         Layout.alignment: Qt.AlignRight
     }
+
     RowLayout {
         Layout.columnSpan: 3
+
         Shotcut.DoubleSpinBox {
             id: rectX
+
             Layout.minimumWidth: 100
             horizontalAlignment: Qt.AlignRight
             decimals: 0
             stepSize: 1
-            from: -999999999
-            to: 999999999
-            onValueModified: if (filterRect.x !== value) {
-                filterRect.x = value
-                updateFilter(getPosition())
+            from: -1e+09
+            to: 1e+09
+            onValueModified: {
+                if (filterRect.x !== value) {
+                    filterRect.x = value;
+                    updateFilter(getPosition());
+                }
             }
         }
-        Label { text: ','; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+        Label {
+            text: ','
+            Layout.minimumWidth: 20
+            horizontalAlignment: Qt.AlignHCenter
+        }
+
         Shotcut.DoubleSpinBox {
             id: rectY
+
             Layout.minimumWidth: 100
             horizontalAlignment: Qt.AlignRight
             decimals: 0
             stepSize: 1
-            from: -999999999
-            to: 999999999
-            onValueModified: if (filterRect.y !== value) {
-                filterRect.y = value
-                updateFilter(getPosition())
+            from: -1e+09
+            to: 1e+09
+            onValueModified: {
+                if (filterRect.y !== value) {
+                    filterRect.y = value;
+                    updateFilter(getPosition());
+                }
             }
         }
+
     }
+
     Shotcut.UndoButton {
         onClicked: {
-            rectX.value = rectY.value = 0
-            filterRect.x = filterRect.y = 0
-            updateFilter(getPosition())
+            rectX.value = rectY.value = 0;
+            filterRect.x = filterRect.y = 0;
+            updateFilter(getPosition());
         }
     }
+
     Shotcut.KeyframesButton {
         id: positionKeyframesButton
+
         Layout.rowSpan: 2
         onToggled: {
             if (checked) {
-                filter.clearSimpleAnimation(rectProperty)
-                filter.set(rectProperty, filterRect, getPosition())
+                filter.clearSimpleAnimation(rectProperty);
+                filter.set(rectProperty, filterRect, getPosition());
             } else {
-                filter.resetProperty(rectProperty)
-                filter.set(rectProperty, filterRect)
+                filter.resetProperty(rectProperty);
+                filter.set(rectProperty, filterRect);
             }
-            checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0
+            checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
         }
     }
 
@@ -310,43 +356,59 @@ GridLayout {
         text: qsTr('Size')
         Layout.alignment: Qt.AlignRight
     }
+
     RowLayout {
         Layout.columnSpan: 3
+
         Shotcut.DoubleSpinBox {
             id: rectW
+
             Layout.minimumWidth: 100
             horizontalAlignment: Qt.AlignRight
             decimals: 0
             stepSize: 1
-            from: -999999999
-            to: 999999999
-            onValueModified: if (filterRect.width !== value) {
-                filterRect.width = value
-                updateFilter(getPosition())
+            from: -1e+09
+            to: 1e+09
+            onValueModified: {
+                if (filterRect.width !== value) {
+                    filterRect.width = value;
+                    updateFilter(getPosition());
+                }
             }
         }
-        Label { text: 'x'; Layout.minimumWidth: 20; horizontalAlignment: Qt.AlignHCenter }
+
+        Label {
+            text: 'x'
+            Layout.minimumWidth: 20
+            horizontalAlignment: Qt.AlignHCenter
+        }
+
         Shotcut.DoubleSpinBox {
             id: rectH
+
             Layout.minimumWidth: 100
             horizontalAlignment: Qt.AlignRight
             decimals: 0
             stepSize: 1
-            from: -999999999
-            to: 999999999
-            onValueModified: if (filterRect.height !== value) {
-                filterRect.height = value
-                updateFilter(getPosition())
+            from: -1e+09
+            to: 1e+09
+            onValueModified: {
+                if (filterRect.height !== value) {
+                    filterRect.height = value;
+                    updateFilter(getPosition());
+                }
             }
         }
+
     }
+
     Shotcut.UndoButton {
         onClicked: {
-            rectW.value = profile.width
-            rectH.value = profile.height
-            filterRect.width = profile.width
-            filterRect.height = profile.height
-            updateFilter(getPosition())
+            rectW.value = profile.width;
+            rectH.value = profile.height;
+            filterRect.width = profile.width;
+            filterRect.height = profile.height;
+            updateFilter(getPosition());
         }
     }
 
@@ -354,74 +416,112 @@ GridLayout {
         text: qsTr('Horizontal fit')
         Layout.alignment: Qt.AlignRight
     }
+
     RadioButton {
         id: leftRadioButton
+
         text: qsTr('Left')
         ButtonGroup.group: halignGroup
         onClicked: filter.set(halignProperty, 'left')
     }
+
     RadioButton {
         id: centerRadioButton
+
         text: qsTr('Center')
         ButtonGroup.group: halignGroup
         onClicked: filter.set(halignProperty, 'center')
     }
+
     RadioButton {
         id: rightRadioButton
+
         text: qsTr('Right')
         ButtonGroup.group: halignGroup
         onClicked: filter.set(halignProperty, 'right')
     }
+
     Shotcut.UndoButton {
         onClicked: {
-            centerRadioButton.checked = true
-            filter.set(halignProperty, 'center')
+            centerRadioButton.checked = true;
+            filter.set(halignProperty, 'center');
         }
     }
-    Item { Layout.fillWidth: true }
+
+    Item {
+        Layout.fillWidth: true
+    }
 
     Label {
         text: qsTr('Vertical fit')
         Layout.alignment: Qt.AlignRight
     }
+
     RadioButton {
         id: topRadioButton
+
         text: qsTr('Top')
         ButtonGroup.group: valignGroup
         onClicked: filter.set(valignProperty, 'top')
     }
+
     RadioButton {
         id: middleRadioButton
+
         text: qsTr('Middle', 'Text video filter')
         ButtonGroup.group: valignGroup
         onClicked: filter.set(valignProperty, 'middle')
     }
+
     RadioButton {
         id: bottomRadioButton
+
         text: qsTr('Bottom')
         ButtonGroup.group: valignGroup
         onClicked: filter.set(valignProperty, 'bottom')
     }
+
     Shotcut.UndoButton {
         onClicked: {
-            bottomRadioButton.checked = true
-            filter.set(valignProperty, 'bottom')
+            bottomRadioButton.checked = true;
+            filter.set(valignProperty, 'bottom');
         }
     }
-    
-    Item { Layout.fillWidth: true }
+
+    Item {
+        Layout.fillWidth: true
+    }
 
     Connections {
+        function onChanged() {
+            setKeyframedControls();
+        }
+
+        function onInChanged() {
+            updateFilter(null);
+        }
+
+        function onOutChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateInChanged() {
+            updateFilter(null);
+        }
+
+        function onAnimateOutChanged() {
+            updateFilter(null);
+        }
+
         target: filter
-        function onChanged() { setKeyframedControls() }
-        function onInChanged() { updateFilter(null) }
-        function onOutChanged() { updateFilter(null) }
-        function onAnimateInChanged() { updateFilter(null) }
-        function onAnimateOutChanged() { updateFilter(null) }
     }
 
     Connections {
+        function onPositionChanged() {
+            setKeyframedControls();
+        }
+
         target: producer
-        function onPositionChanged() { setKeyframedControls() }
     }
+
 }

--- a/src/qml/modules/Shotcut/Controls/TextFilterVui.qml
+++ b/src/qml/modules/Shotcut/Controls/TextFilterVui.qml
@@ -23,69 +23,69 @@ Shotcut.VuiBase {
     property string halignProperty: 'valign'
     property string valignProperty: 'halign'
     property string useFontSizeProperty: 'shotcut:usePointSize'
-    property real zoom: (video.zoom > 0)? video.zoom : 1.0
+    property real zoom: (video.zoom > 0) ? video.zoom : 1
     property rect filterRect: Qt.rect(-1, -1, -1, -1)
     property bool blockUpdate: false
     property string startValue: '_shotcut:startValue'
     property string middleValue: '_shotcut:middleValue'
-    property string endValue:  '_shotcut:endValue'
-
-    Component.onCompleted: {
-        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag'))
-        setRectangleControl()
-    }
+    property string endValue: '_shotcut:endValue'
 
     function getPosition() {
-        return Math.max(producer.position - (filter.in - producer.in), 0)
+        return Math.max(producer.position - (filter.in - producer.in), 0);
     }
 
     function setRectangleControl() {
-        if (blockUpdate) return
-        var position = getPosition()
-        var newValue = filter.getRect(rectProperty, position)
+        if (blockUpdate)
+            return ;
+
+        var position = getPosition();
+        var newValue = filter.getRect(rectProperty, position);
         if (filterRect !== newValue) {
-            filterRect = newValue
-            rectangle.setHandles(filterRect)
+            filterRect = newValue;
+            rectangle.setHandles(filterRect);
         }
-        rectangle.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1)
+        rectangle.enabled = position <= 0 || (position >= (filter.animateIn - 1) && position <= (filter.duration - filter.animateOut)) || position >= (filter.duration - 1);
     }
 
     function updateFilter(position) {
-        blockUpdate = true
-        var rect = rectangle.rectangle
-        filterRect.x = Math.round(rect.x / rectangle.widthScale)
-        filterRect.y = Math.round(rect.y / rectangle.heightScale)
-        filterRect.width = Math.round(rect.width / rectangle.widthScale)
-        filterRect.height = Math.round(rect.height / rectangle.heightScale)
-
+        blockUpdate = true;
+        var rect = rectangle.rectangle;
+        filterRect.x = Math.round(rect.x / rectangle.widthScale);
+        filterRect.y = Math.round(rect.y / rectangle.heightScale);
+        filterRect.width = Math.round(rect.width / rectangle.widthScale);
+        filterRect.height = Math.round(rect.height / rectangle.heightScale);
         if (position !== null) {
-            filter.blockSignals = true
+            filter.blockSignals = true;
             if (position <= 0 && filter.animateIn > 0)
-                filter.set(startValue, filterRect)
+                filter.set(startValue, filterRect);
             else if (position >= filter.duration - 1 && filter.animateOut > 0)
-                filter.set(endValue, filterRect)
+                filter.set(endValue, filterRect);
             else
-                filter.set(middleValue, filterRect)
-            filter.blockSignals = false
+                filter.set(middleValue, filterRect);
+            filter.blockSignals = false;
         }
-
         if (filter.animateIn > 0 || filter.animateOut > 0) {
-            filter.resetProperty(rectProperty)
+            filter.resetProperty(rectProperty);
             if (filter.animateIn > 0) {
-                filter.set(rectProperty, filter.getRect(startValue), 0)
-                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1)
+                filter.set(rectProperty, filter.getRect(startValue), 0);
+                filter.set(rectProperty, filter.getRect(middleValue), filter.animateIn - 1);
             }
             if (filter.animateOut > 0) {
-                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut)
-                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1)
+                filter.set(rectProperty, filter.getRect(middleValue), filter.duration - filter.animateOut);
+                filter.set(rectProperty, filter.getRect(endValue), filter.duration - 1);
             }
         } else if (filter.keyframeCount(rectProperty) <= 0) {
-            filter.resetProperty(rectProperty)
-            filter.set(rectProperty, filter.getRect(middleValue))
+            filter.resetProperty(rectProperty);
+            filter.set(rectProperty, filter.getRect(middleValue));
         } else if (position !== null) {
-            filter.set(rectProperty, filterRect, position)
+            filter.set(rectProperty, filterRect, position);
         }
-        blockUpdate = false
+        blockUpdate = false;
+    }
+
+    Component.onCompleted: {
+        application.showStatusMessage(qsTr('Click in rectangle + hold Shift to drag'));
+        setRectangleControl();
     }
 
     Flickable {
@@ -99,6 +99,7 @@ Shotcut.VuiBase {
 
         Item {
             id: videoItem
+
             x: video.rect.x
             y: video.rect.y
             width: video.rect.width
@@ -107,6 +108,7 @@ Shotcut.VuiBase {
 
             Shotcut.RectangleControl {
                 id: rectangle
+
                 widthScale: video.rect.width / profile.width
                 heightScale: video.rect.height / profile.height
                 handleSize: Math.max(Math.round(8 / zoom), 4)
@@ -115,19 +117,26 @@ Shotcut.VuiBase {
                 onHeightScaleChanged: setHandles(filterRect)
                 onRectChanged: updateFilter(getPosition())
             }
+
         }
+
     }
 
     Connections {
-        target: filter
         function onChanged() {
-            setRectangleControl()
-            videoItem.enabled = filter.get('disable') !== '1'
+            setRectangleControl();
+            videoItem.enabled = filter.get('disable') !== '1';
         }
+
+        target: filter
     }
 
     Connections {
+        function onPositionChanged() {
+            setRectangleControl();
+        }
+
         target: producer
-        function onPositionChanged() { setRectangleControl() }
     }
+
 }

--- a/src/qml/modules/Shotcut/Controls/TimeSpinner.qml
+++ b/src/qml/modules/Shotcut/Controls/TimeSpinner.qml
@@ -22,6 +22,7 @@ import Shotcut.Controls 1.0 as Shotcut
 
 RowLayout {
     id: root
+
     property int minimumValue: 0
     property int maximumValue: 99
     property int value: 0
@@ -31,79 +32,115 @@ RowLayout {
     signal setDefaultClicked()
     signal saveDefaultClicked()
 
+    function clamp(x, min, max) {
+        return Math.max(min, Math.min(max, x));
+    }
+
     spacing: 0
 
     TextField {
         id: timeField
+
         text: filter.timeFromFrames(clamp(value, minimumValue, maximumValue))
         horizontalAlignment: TextInput.AlignRight
         selectByMouse: true
-        validator: RegExpValidator {regExp: /^\s*(\d*:){0,2}(\d*[.;:])?\d*\s*$/}
         onEditingFinished: value = filter.framesFromTime(text)
         Keys.onDownPressed: decrementAction.trigger()
         Keys.onUpPressed: incrementAction.trigger()
-        onFocusChanged: if (focus) selectAll()
+        onFocusChanged: {
+            if (focus)
+                selectAll();
+
+        }
+
+        validator: RegExpValidator {
+            regExp: /^\s*(\d*:){0,2}(\d*[.;:])?\d*\s*$/
+        }
+
     }
+
     Shotcut.Button {
         id: decrementButton
+
         icon.name: 'list-remove'
         icon.source: 'qrc:///icons/oxygen/32x32/actions/list-remove.png'
-        Shotcut.HoverTip { text: qsTr('Decrement') }
         implicitWidth: 20
         implicitHeight: 20
+
+        Shotcut.HoverTip {
+            text: qsTr('Decrement')
+        }
+
         MouseArea {
             anchors.fill: parent
             onPressed: decrementAction.trigger()
             onPressAndHold: decrementTimer.start()
             onReleased: decrementTimer.stop()
         }
+
         Timer {
             id: decrementTimer
+
             repeat: true
             interval: 200
             triggeredOnStart: true
             onTriggered: decrementAction.trigger()
         }
+
     }
+
     Shotcut.Button {
         id: incrementButton
+
         icon.name: 'list-add'
         icon.source: 'qrc:///icons/oxygen/32x32/actions/list-add.png'
-        Shotcut.HoverTip { text: qsTr('Increment') }
         implicitWidth: 20
         implicitHeight: 20
+
+        Shotcut.HoverTip {
+            text: qsTr('Increment')
+        }
+
         MouseArea {
             anchors.fill: parent
             onPressed: incrementAction.trigger()
             onPressAndHold: incrementTimer.start()
             onReleased: incrementTimer.stop()
         }
+
         Timer {
             id: incrementTimer
+
             repeat: true
             interval: 200
             triggeredOnStart: true
             onTriggered: incrementAction.trigger()
         }
+
     }
+
     Shotcut.UndoButton {
         id: undoButton
+
         onClicked: root.setDefaultClicked()
     }
+
     Shotcut.SaveDefaultButton {
         id: saveButton
+
         onClicked: root.saveDefaultClicked()
     }
+
     Action {
         id: decrementAction
+
         onTriggered: value = Math.max(value - 1, minimumValue)
     }
+
     Action {
         id: incrementAction
+
         onTriggered: value = Math.min(value + 1, maximumValue)
     }
 
-    function clamp(x, min, max) {
-        return Math.max(min, Math.min(max, x))
-    }
 }

--- a/src/qml/modules/Shotcut/Controls/TipBox.qml
+++ b/src/qml/modules/Shotcut/Controls/TipBox.qml
@@ -24,14 +24,18 @@ Rectangle {
     radius: 5
     height: Math.ceil(text.length / 80) * label.height + 2 * label.y
 
-    SystemPalette { id: activePalette }
+    SystemPalette {
+        id: activePalette
+    }
 
     Text {
         id: label
+
         x: 10
         y: 10
         width: parent.width - 2 * x
         wrapMode: Text.WordWrap
         color: activePalette.windowText
     }
+
 }

--- a/src/qml/modules/Shotcut/Controls/ToggleButton.qml
+++ b/src/qml/modules/Shotcut/Controls/ToggleButton.qml
@@ -24,9 +24,13 @@ ToolButton {
     checkable: true
     hoverEnabled: true
     display: AbstractButton.TextBesideIcon
-
-    SystemPalette { id: activePalette }
     palette.buttonText: activePalette.buttonText
+    Keys.onReturnPressed: clicked()
+    Keys.onEnterPressed: clicked()
+
+    SystemPalette {
+        id: activePalette
+    }
 
     background: Rectangle {
         radius: 3
@@ -35,6 +39,4 @@ ToolButton {
         border.width: parent.checked ? 0 : 1
     }
 
-    Keys.onReturnPressed: clicked()
-    Keys.onEnterPressed: clicked()
 }

--- a/src/qml/modules/Shotcut/Controls/ToolButton.qml
+++ b/src/qml/modules/Shotcut/Controls/ToolButton.qml
@@ -23,10 +23,13 @@ ToolButton {
     id: control
 
     icon.height: control.height - (verticalPadding * 2)
-    icon.width: control.height -  (horizontalPadding * 2)
+    icon.width: control.height - (horizontalPadding * 2)
     padding: 3
-    opacity: enabled ? 1.0 : 0.5
-
-    SystemPalette { id: activePalette }
+    opacity: enabled ? 1 : 0.5
     palette.button: checked ? activePalette.highlight : activePalette.button
+
+    SystemPalette {
+        id: activePalette
+    }
+
 }

--- a/src/qml/modules/Shotcut/Controls/UndoButton.qml
+++ b/src/qml/modules/Shotcut/Controls/UndoButton.qml
@@ -22,7 +22,11 @@ import Shotcut.Controls 1.0 as Shotcut
 Shotcut.Button {
     icon.name: 'edit-undo'
     icon.source: 'qrc:///icons/oxygen/32x32/actions/edit-undo.png'
-    Shotcut.HoverTip { text: qsTr('Reset to default') }
     implicitWidth: 20
     implicitHeight: 20
+
+    Shotcut.HoverTip {
+        text: qsTr('Reset to default')
+    }
+
 }

--- a/src/qml/modules/Shotcut/Controls/VuiBase.qml
+++ b/src/qml/modules/Shotcut/Controls/VuiBase.qml
@@ -3,104 +3,102 @@ import QtQuick 2.0
 DropArea {
     Canvas {
         id: grid
-        anchors.fill : parent
+
+        anchors.fill: parent
         opacity: 0.5
-
         onPaint: {
-            var ctx = getContext("2d")
-            ctx.reset()
-            if(video.grid > 0)
-            {
-                var zoom = (video.zoom > 0) ? video.zoom : 1.0
-                var rectW = video.rect.width * zoom
-                var rectH = video.rect.height * zoom
-                var zoomOffsetX = ( video.rect.width - rectW ) / 2
-                var zoomOffsetY = ( video.rect.height - rectH ) / 2
-                var rectX = video.rect.x - video.offset.x + zoomOffsetX
-                var rectY = video.rect.y - video.offset.y + zoomOffsetY
-                var gridSizeX = (video.grid > 10000) ? rectW / (profile.width / (video.grid - 10000)) : rectW / video.grid
-                var gridSizeY = (video.grid > 10000) ? rectH / (profile.height / (video.grid - 10000)) : rectH / video.grid
-                var gridOffsetX = rectX % gridSizeX
-                var gridOffsetY = rectY % gridSizeY
-
+            var ctx = getContext("2d");
+            ctx.reset();
+            if (video.grid > 0) {
+                var zoom = (video.zoom > 0) ? video.zoom : 1;
+                var rectW = video.rect.width * zoom;
+                var rectH = video.rect.height * zoom;
+                var zoomOffsetX = (video.rect.width - rectW) / 2;
+                var zoomOffsetY = (video.rect.height - rectH) / 2;
+                var rectX = video.rect.x - video.offset.x + zoomOffsetX;
+                var rectY = video.rect.y - video.offset.y + zoomOffsetY;
+                var gridSizeX = (video.grid > 10000) ? rectW / (profile.width / (video.grid - 10000)) : rectW / video.grid;
+                var gridSizeY = (video.grid > 10000) ? rectH / (profile.height / (video.grid - 10000)) : rectH / video.grid;
+                var gridOffsetX = rectX % gridSizeX;
+                var gridOffsetY = rectY % gridSizeY;
                 if (video.grid <= 10000) {
                     // Black shadow grid (offset by 1)
-                    ctx.lineWidth = 1
-                    ctx.strokeStyle = "#000000"
-                    ctx.beginPath()
+                    ctx.lineWidth = 1;
+                    ctx.strokeStyle = "#000000";
+                    ctx.beginPath();
                     if (video.grid === 8090) {
                         // 80/90% Safe Areas
-                        ctx.rect( 0.1 * rectW + rectX + 2,  0.1 * rectH + rectY + 2, 0.8 * rectW - 1, 0.8 * rectH - 1)
-                        ctx.rect(0.05 * rectW + rectX + 2, 0.05 * rectH + rectY + 2, 0.9 * rectW - 1, 0.9 * rectH - 1)
+                        ctx.rect(0.1 * rectW + rectX + 2, 0.1 * rectH + rectY + 2, 0.8 * rectW - 1, 0.8 * rectH - 1);
+                        ctx.rect(0.05 * rectW + rectX + 2, 0.05 * rectH + rectY + 2, 0.9 * rectW - 1, 0.9 * rectH - 1);
                     } else if (video.grid == 95) {
                         // EBU R95 Safe Areas
-                        ctx.rect( 0.05 * rectW + rectX + 2,  0.05 * rectH + rectY + 2,  0.9 * rectW - 1,  0.9 * rectH - 1)
-                        ctx.rect(0.035 * rectW + rectX + 2, 0.035 * rectH + rectY + 2, 0.93 * rectW - 1, 0.93 * rectH - 1)
+                        ctx.rect(0.05 * rectW + rectX + 2, 0.05 * rectH + rectY + 2, 0.9 * rectW - 1, 0.9 * rectH - 1);
+                        ctx.rect(0.035 * rectW + rectX + 2, 0.035 * rectH + rectY + 2, 0.93 * rectW - 1, 0.93 * rectH - 1);
                     } else {
                         // vertical grid lines
-                        for(var x = 0; x * gridSizeX < parent.width + gridSizeX; x++)
-                        {
-                            context.moveTo(gridOffsetX + x * gridSizeX + 1, 0)
-                            context.lineTo(gridOffsetX + x * gridSizeX + 1, parent.height)
+                        for (var x = 0; x * gridSizeX < parent.width + gridSizeX; x++) {
+                            context.moveTo(gridOffsetX + x * gridSizeX + 1, 0);
+                            context.lineTo(gridOffsetX + x * gridSizeX + 1, parent.height);
                         }
                         // horizontal grid lines
-                        for(var y = 0; y * gridSizeY < parent.height + gridSizeY; y++)
-                        {
-                            context.moveTo(0, gridOffsetY + y * gridSizeY + 1)
-                            context.lineTo(parent.width, gridOffsetY + y * gridSizeY + 1)
+                        for (var y = 0; y * gridSizeY < parent.height + gridSizeY; y++) {
+                            context.moveTo(0, gridOffsetY + y * gridSizeY + 1);
+                            context.lineTo(parent.width, gridOffsetY + y * gridSizeY + 1);
                         }
                     }
                     // draw and close
-                    context.stroke()
-                    context.closePath()
+                    context.stroke();
+                    context.closePath();
                 }
-
                 // White line grid
-                ctx.lineWidth = 1
-                ctx.strokeStyle = "#ffffff"
-                ctx.beginPath()
+                ctx.lineWidth = 1;
+                ctx.strokeStyle = "#ffffff";
+                ctx.beginPath();
                 if (video.grid === 8090) {
                     // 80/90% Safe Areas
-                    ctx.rect( 0.1 * rectW + rectX + 1,  0.1 * rectH + rectY + 1, 0.8 * rectW - 2, 0.8 * rectH - 2)
-                    ctx.rect(0.05 * rectW + rectX + 1, 0.05 * rectH + rectY + 2, 0.9 * rectW - 2, 0.9 * rectH - 2)
+                    ctx.rect(0.1 * rectW + rectX + 1, 0.1 * rectH + rectY + 1, 0.8 * rectW - 2, 0.8 * rectH - 2);
+                    ctx.rect(0.05 * rectW + rectX + 1, 0.05 * rectH + rectY + 2, 0.9 * rectW - 2, 0.9 * rectH - 2);
                 } else if (video.grid == 95) {
                     // EBU R95 Safe Areas
-                    ctx.rect( 0.05 * rectW + rectX + 1,  0.05 * rectH + rectY + 1,  0.9 * rectW - 2,  0.9 * rectH - 2)
-                    ctx.rect(0.035 * rectW + rectX + 1, 0.035 * rectH + rectY + 1, 0.93 * rectW - 2, 0.93 * rectH - 2)
+                    ctx.rect(0.05 * rectW + rectX + 1, 0.05 * rectH + rectY + 1, 0.9 * rectW - 2, 0.9 * rectH - 2);
+                    ctx.rect(0.035 * rectW + rectX + 1, 0.035 * rectH + rectY + 1, 0.93 * rectW - 2, 0.93 * rectH - 2);
                 } else {
                     // vertical grid lines
-                    for(var x = 0; x * gridSizeX < parent.width + gridSizeX; x++)
-                    {
-                        context.moveTo(gridOffsetX + x * gridSizeX, 0)
-                        context.lineTo(gridOffsetX + x * gridSizeX, parent.height)
+                    for (var x = 0; x * gridSizeX < parent.width + gridSizeX; x++) {
+                        context.moveTo(gridOffsetX + x * gridSizeX, 0);
+                        context.lineTo(gridOffsetX + x * gridSizeX, parent.height);
                     }
                     // horizontal grid lines
-                    for(var y = 0; y * gridSizeY < parent.height + gridSizeY; y++)
-                    {
-                        context.moveTo(0, gridOffsetY + y * gridSizeY)
-                        context.lineTo(parent.width, gridOffsetY + y * gridSizeY)
+                    for (var y = 0; y * gridSizeY < parent.height + gridSizeY; y++) {
+                        context.moveTo(0, gridOffsetY + y * gridSizeY);
+                        context.lineTo(parent.width, gridOffsetY + y * gridSizeY);
                     }
                 }
                 // draw and close
-                context.stroke()
-                context.closePath()
+                context.stroke();
+                context.closePath();
             }
         }
     }
 
     Connections {
-        target: video
         function onRectChanged() {
-            grid.requestPaint()
+            grid.requestPaint();
         }
+
         function onGridChanged() {
-            grid.requestPaint()
+            grid.requestPaint();
         }
+
         function onOffsetChanged() {
-            grid.requestPaint()
+            grid.requestPaint();
         }
+
         function onZoomChanged() {
-            grid.requestPaint()
+            grid.requestPaint();
         }
+
+        target: video
     }
+
 }

--- a/src/qml/scopes/audioloudness/audioloudnessscope.qml
+++ b/src/qml/scopes/audioloudness/audioloudnessscope.qml
@@ -15,10 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import QtQml 2.12
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
-import QtQml 2.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Rectangle {
@@ -42,46 +42,180 @@ Rectangle {
 
     color: activePalette.window
     state: orientation == Qt.Horizontal ? "landscape" : "portrait"
-    SystemPalette { id: activePalette }
+    states: [
+        State {
+            name: "landscape"
+
+            PropertyChanges {
+                target: grid
+                flow: GridLayout.LeftToRight
+                columns: 4
+            }
+
+            PropertyChanges {
+                target: momentaryGauge
+                orientation: Qt.Horizontal
+                Layout.fillWidth: true
+                Layout.fillHeight: false
+            }
+
+            PropertyChanges {
+                target: shorttermGauge
+                orientation: Qt.Horizontal
+                Layout.fillWidth: true
+                Layout.fillHeight: false
+            }
+
+            PropertyChanges {
+                target: integratedGauge
+                orientation: Qt.Horizontal
+                Layout.fillWidth: true
+                Layout.fillHeight: false
+            }
+
+            PropertyChanges {
+                target: rangeGauge
+                orientation: Qt.Horizontal
+                Layout.fillWidth: true
+                Layout.fillHeight: false
+            }
+
+            PropertyChanges {
+                target: peakGauge
+                orientation: Qt.Horizontal
+                Layout.fillWidth: true
+                Layout.fillHeight: false
+            }
+
+            PropertyChanges {
+                target: truePeakGauge
+                orientation: Qt.Horizontal
+                Layout.fillWidth: true
+                Layout.fillHeight: false
+            }
+
+            PropertyChanges {
+                target: filler
+                Layout.fillHeight: true
+                Layout.fillWidth: false
+            }
+
+        },
+        State {
+            name: "portrait"
+
+            PropertyChanges {
+                target: grid
+                flow: GridLayout.TopToBottom
+                rows: 4
+            }
+
+            PropertyChanges {
+                target: momentaryGauge
+                orientation: Qt.Vertical
+                Layout.fillWidth: false
+                Layout.fillHeight: true
+            }
+
+            PropertyChanges {
+                target: shorttermGauge
+                orientation: Qt.Vertical
+                Layout.fillWidth: false
+                Layout.fillHeight: true
+            }
+
+            PropertyChanges {
+                target: integratedGauge
+                orientation: Qt.Vertical
+                Layout.fillWidth: false
+                Layout.fillHeight: true
+            }
+
+            PropertyChanges {
+                target: rangeGauge
+                orientation: Qt.Vertical
+                Layout.fillWidth: false
+                Layout.fillHeight: true
+            }
+
+            PropertyChanges {
+                target: peakGauge
+                orientation: Qt.Vertical
+                Layout.fillWidth: false
+                Layout.fillHeight: true
+            }
+
+            PropertyChanges {
+                target: truePeakGauge
+                orientation: Qt.Vertical
+                Layout.fillWidth: false
+                Layout.fillHeight: true
+            }
+
+            PropertyChanges {
+                target: filler
+                Layout.fillHeight: false
+                Layout.fillWidth: true
+            }
+
+        }
+    ]
+
+    SystemPalette {
+        id: activePalette
+    }
 
     TextMetrics {
         id: textMetrics
+
         font: momentaryLabel.font
         text: "-00.0"
     }
 
     GridLayout {
         id: grid
+
         anchors.fill: parent
 
         Label {
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             id: momentaryTitle
+
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             text: 'M'
             color: activePalette.text
-            Shotcut.HoverTip {text: qsTr('Momentary Loudness.')}
             visible: enableMomentary
+
+            Shotcut.HoverTip {
+                text: qsTr('Momentary Loudness.')
+            }
+
         }
+
         Label {
+            id: momentaryLabel
+
             Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             Layout.minimumWidth: textMetrics.width + 5
             Layout.preferredWidth: Layout.minimumWidth
-            id: momentaryLabel
             text: momentary < -99 ? '--' : momentary.toFixed(1)
             color: activePalette.text
             horizontalAlignment: Qt.AlignHCenter
             visible: enableMomentary
         }
+
         Label {
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             id: momentaryUnits
+
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             text: 'LUFS'
             color: activePalette.text
             visible: enableMomentary
         }
+
         Shotcut.Gauge {
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             id: momentaryGauge
+
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             from: -50
             value: momentary
             to: 0
@@ -93,29 +227,39 @@ Rectangle {
             Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             text: 'S'
             color: activePalette.text
-            Shotcut.HoverTip {text: qsTr('Short-term Loudness.')}
             visible: enableShortterm
+
+            Shotcut.HoverTip {
+                text: qsTr('Short-term Loudness.')
+            }
+
         }
+
         Label {
+            id: shorttermLabel
+
             Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             Layout.minimumWidth: textMetrics.width + 5
             Layout.preferredWidth: Layout.minimumWidth
-            id: shorttermLabel
             text: shortterm < -99 ? '--' : shortterm.toFixed(1)
             color: activePalette.text
             horizontalAlignment: Qt.AlignHCenter
             visible: enableShortterm
         }
+
         Label {
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             id: shorttermUnits
+
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             text: 'LUFS'
             color: activePalette.text
             visible: enableShortterm
         }
+
         Shotcut.Gauge {
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             id: shorttermGauge
+
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             from: -50
             value: shortterm
             to: 0
@@ -127,97 +271,127 @@ Rectangle {
             Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             text: 'I'
             color: activePalette.text
-            Shotcut.HoverTip {text: qsTr('Integrated Loudness.')}
             visible: enableIntegrated
+
+            Shotcut.HoverTip {
+                text: qsTr('Integrated Loudness.')
+            }
+
         }
+
         Label {
+            id: integratedLabel
+
             Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             Layout.minimumWidth: textMetrics.width + 5
             Layout.preferredWidth: Layout.minimumWidth
-            id: integratedLabel
             text: integrated < -99 ? '--' : integrated.toFixed(1)
             color: activePalette.text
             horizontalAlignment: Qt.AlignHCenter
             visible: enableIntegrated
         }
+
         Label {
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             id: integratedUnits
+
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             text: 'LUFS'
             color: activePalette.text
             visible: enableIntegrated
         }
+
         Shotcut.Gauge {
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             id: integratedGauge
+
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             from: -50
             value: integrated
             to: 0
             decimals: 0
             visible: enableIntegrated
         }
-        
+
         Label {
             Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             text: 'LRA'
             color: activePalette.text
-            Shotcut.HoverTip {text: qsTr('Loudness Range.')}
             visible: enableRange
+
+            Shotcut.HoverTip {
+                text: qsTr('Loudness Range.')
+            }
+
         }
+
         Label {
+            id: rangeLabel
+
             Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             Layout.minimumWidth: textMetrics.width + 5
             Layout.preferredWidth: Layout.minimumWidth
-            id: rangeLabel
             text: range < 0 ? '--' : range.toFixed(1)
             color: activePalette.text
             horizontalAlignment: Qt.AlignHCenter
             visible: enableRange
         }
+
         Label {
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             id: rangeUnits
+
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             text: 'LU'
             color: activePalette.text
             visible: enableRange
         }
+
         Shotcut.Gauge {
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             id: rangeGauge
+
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             from: 0
             value: range
             to: 30
             decimals: 0
             visible: enableRange
         }
-        
+
         Label {
             Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             text: 'P'
             color: activePalette.text
-            Shotcut.HoverTip {text: qsTr('Peak.')}
             visible: enablePeak
+
+            Shotcut.HoverTip {
+                text: qsTr('Peak.')
+            }
+
         }
+
         Label {
+            id: peakLabel
+
             Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             Layout.minimumWidth: textMetrics.width + 5
             Layout.preferredWidth: Layout.minimumWidth
-            id: peakLabel
             text: peak < -99 ? '--' : peak.toFixed(1)
             color: activePalette.text
             horizontalAlignment: Qt.AlignHCenter
             visible: enablePeak
         }
+
         Label {
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             id: peakUnits
+
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             text: 'dBFS'
             color: activePalette.text
             visible: enablePeak
         }
+
         Shotcut.Gauge {
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             id: peakGauge
+
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             from: -50
             value: peak
             to: 3
@@ -229,29 +403,39 @@ Rectangle {
             Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             text: 'TP'
             color: activePalette.text
-            Shotcut.HoverTip {text: qsTr('True Peak.')}
             visible: enableTruePeak
+
+            Shotcut.HoverTip {
+                text: qsTr('True Peak.')
+            }
+
         }
+
         Label {
+            id: truePeakLabel
+
             Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             Layout.minimumWidth: textMetrics.width + 5
             Layout.preferredWidth: Layout.minimumWidth
-            id: truePeakLabel
             text: truePeak < -99 ? '--' : truePeak.toFixed(1)
             color: activePalette.text
             horizontalAlignment: Qt.AlignHCenter
             visible: enableTruePeak
         }
+
         Label {
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             id: truePeakUnits
+
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             text: 'dBTP'
             color: activePalette.text
             visible: enableTruePeak
         }
+
         Shotcut.Gauge {
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             id: truePeakGauge
+
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             from: -50
             value: truePeak
             to: 3
@@ -262,30 +446,7 @@ Rectangle {
         Item {
             id: filler
         }
+
     }
 
-    states: [
-        State {
-            name: "landscape"
-            PropertyChanges { target: grid; flow: GridLayout.LeftToRight; columns: 4 }
-            PropertyChanges { target: momentaryGauge; orientation: Qt.Horizontal; Layout.fillWidth: true; Layout.fillHeight: false }
-            PropertyChanges { target: shorttermGauge; orientation: Qt.Horizontal; Layout.fillWidth: true; Layout.fillHeight: false }
-            PropertyChanges { target: integratedGauge; orientation: Qt.Horizontal; Layout.fillWidth: true; Layout.fillHeight: false }
-            PropertyChanges { target: rangeGauge; orientation: Qt.Horizontal; Layout.fillWidth: true; Layout.fillHeight: false }
-            PropertyChanges { target: peakGauge; orientation: Qt.Horizontal; Layout.fillWidth: true; Layout.fillHeight: false }
-            PropertyChanges { target: truePeakGauge; orientation: Qt.Horizontal; Layout.fillWidth: true; Layout.fillHeight: false }
-            PropertyChanges { target: filler; Layout.fillHeight: true; Layout.fillWidth: false }
-        },
-        State {
-            name: "portrait"
-            PropertyChanges { target: grid; flow: GridLayout.TopToBottom; rows: 4 }
-            PropertyChanges { target: momentaryGauge; orientation: Qt.Vertical; Layout.fillWidth: false; Layout.fillHeight: true }
-            PropertyChanges { target: shorttermGauge; orientation: Qt.Vertical; Layout.fillWidth: false; Layout.fillHeight: true }
-            PropertyChanges { target: integratedGauge; orientation: Qt.Vertical; Layout.fillWidth: false; Layout.fillHeight: true }
-            PropertyChanges { target: rangeGauge; orientation: Qt.Vertical; Layout.fillWidth: false; Layout.fillHeight: true }
-            PropertyChanges { target: peakGauge; orientation: Qt.Vertical; Layout.fillWidth: false; Layout.fillHeight: true }
-            PropertyChanges { target: truePeakGauge; orientation: Qt.Vertical; Layout.fillWidth: false; Layout.fillHeight: true }
-            PropertyChanges { target: filler; Layout.fillHeight: false; Layout.fillWidth: true }
-        }
-    ]
 }

--- a/src/qml/views/filter/AttachedFilters.qml
+++ b/src/qml/views/filter/AttachedFilters.qml
@@ -15,41 +15,45 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import QtQml.Models 2.12
 import QtQuick 2.12
 import QtQuick.Controls 2.12
-import QtQml.Models 2.12
 import org.shotcut.qml 1.0 as Shotcut
 
 Rectangle {
     id: attachedFilters
-    
+
     signal filterClicked(int index)
-    
+
     function setCurrentFilter(index) {
-        indexDelay.index = index
-        indexDelay.running = true
+        indexDelay.index = index;
+        indexDelay.running = true;
     }
-    
+
+    color: activePalette.base
+
     Timer {
         id: indexDelay
+
         property int index: 0
+
         interval: 1
         onTriggered: {
             // Delay the index setting to allow model updates to complete
-            attachedFiltersView.currentIndex = index
+            attachedFiltersView.currentIndex = index;
         }
     }
-    
-    color: activePalette.base
 
-    SystemPalette { id: activePalette }
+    SystemPalette {
+        id: activePalette
+    }
 
     Component {
         id: filterDelegate
-        
+
         Rectangle {
             id: background
-            
+
             // Trick to make the model item available to the dragItem
             property var modelData: model
             property var viewData: ListView
@@ -64,62 +68,74 @@ Rectangle {
 
             Row {
                 height: parent.height
-                
+
                 Item {
                     width: 4
                     height: parent.height
                 }
-                
+
                 CheckBox {
                     id: filterDelegateCheck
+
                     anchors.verticalCenter: parent.verticalCenter
                     enabled: model.pluginType != Shotcut.Metadata.Link
-                    opacity: enabled ? 1.0 : 0.5
+                    opacity: enabled ? 1 : 0.5
                     checkState: model.checkState
+
                     MouseArea {
                         anchors.fill: parent
                         onClicked: {
-                            model.checkState = !model.checkState
+                            model.checkState = !model.checkState;
                         }
                     }
+
                 }
-                
+
                 Item {
                     width: 4
                     height: parent.height
                 }
-                
-                Label { 
+
+                Label {
                     id: filterDelegateText
+
                     text: model.display
                     color: _currentIndex === model.index ? activePalette.highlightedText : activePalette.windowText
                     width: background.ListView.width - 23
-        
+
                     MouseArea {
                         id: mouseArea
+
                         anchors.fill: parent
                         onDoubleClicked: {
-                            model.checkState = !model.checkState
+                            model.checkState = !model.checkState;
                         }
                         onClicked: filterClicked(model.index)
                     }
+
                 }
+
             }
+
         }
+
     }
-    
+
     Component {
         id: sectionDelegate
 
         Item {
             height: sectionText.implicitHeight + 4
             width: parent ? parent.width : undefined
+
             Rectangle {
                 anchors.fill: parent
                 color: activePalette.alternateBase
             }
+
             Label {
                 id: sectionText
+
                 anchors.fill: parent
                 anchors.topMargin: 2
                 anchors.leftMargin: 4
@@ -127,7 +143,9 @@ Rectangle {
                 color: activePalette.windowText
                 font.bold: true
             }
+
         }
+
     }
 
     ScrollView {
@@ -141,34 +159,8 @@ Rectangle {
 
         ListView {
             id: attachedFiltersView
-            
-            property int dragTarget: -1
-            
-            anchors.fill: parent
-            model: attachedfiltersmodel
-            delegate: filterDelegate
-            boundsBehavior: Flickable.StopAtBounds
-            snapMode: ListView.SnapToItem
-            currentIndex: -1
-            highlight: Rectangle { 
-                color: activePalette.highlight
-                width: parent ? parent.width : undefined
-            }
-            focus: true
-            section.property: "typeDisplay"
-            section.delegate: sectionDelegate
-            spacing: 4
-            highlightMoveVelocity: 1000
 
-            Component.onCompleted: {
-                model.modelReset.connect(positionViewAtBeginning)
-            }
-            
-            onCurrentIndexChanged: {
-                possiblySelectFirstFilter();
-                positionViewAtIndex(currentIndex, ListView.Contain);
-            }
-            onCountChanged: possiblySelectFirstFilter();
+            property int dragTarget: -1
 
             function possiblySelectFirstFilter() {
                 if (count > 0 && currentIndex == -1) {
@@ -177,107 +169,133 @@ Rectangle {
                 }
             }
 
+            anchors.fill: parent
+            model: attachedfiltersmodel
+            delegate: filterDelegate
+            boundsBehavior: Flickable.StopAtBounds
+            snapMode: ListView.SnapToItem
+            currentIndex: -1
+            focus: true
+            section.property: "typeDisplay"
+            section.delegate: sectionDelegate
+            spacing: 4
+            highlightMoveVelocity: 1000
+            Component.onCompleted: {
+                model.modelReset.connect(positionViewAtBeginning);
+            }
+            onCurrentIndexChanged: {
+                possiblySelectFirstFilter();
+                positionViewAtIndex(currentIndex, ListView.Contain);
+            }
+            onCountChanged: possiblySelectFirstFilter()
+
             MouseArea {
                 property int oldIndex: -1
-                property point grabPos: Qt.point(0,0)
+                property point grabPos: Qt.point(0, 0)
                 property string grabSection: ""
-                
+
                 function beginDrag() {
-                    var grabbedItem = attachedFiltersView.itemAt(mouseX, mouseY)
-                    oldIndex = attachedFiltersView.indexAt(mouseX, mouseY)
-                    grabPos = Qt.point(mouseX - grabbedItem.x, mouseY - grabbedItem.y)
-                    grabSection = grabbedItem.viewData.section
-                    dragItem.model = grabbedItem.modelData
-                    dragItem.sourceComponent = filterDelegate
-                    dragItem.x = mouseX - grabPos.x
-                    dragItem.y = mouseY - grabPos.y
-                    filterClicked(oldIndex)
-                    attachedFiltersView.dragTarget = oldIndex
-                    cursorShape = Qt.DragMoveCursor
-                    autoScrollTimer.running = true
+                    var grabbedItem = attachedFiltersView.itemAt(mouseX, mouseY);
+                    oldIndex = attachedFiltersView.indexAt(mouseX, mouseY);
+                    grabPos = Qt.point(mouseX - grabbedItem.x, mouseY - grabbedItem.y);
+                    grabSection = grabbedItem.viewData.section;
+                    dragItem.model = grabbedItem.modelData;
+                    dragItem.sourceComponent = filterDelegate;
+                    dragItem.x = mouseX - grabPos.x;
+                    dragItem.y = mouseY - grabPos.y;
+                    filterClicked(oldIndex);
+                    attachedFiltersView.dragTarget = oldIndex;
+                    cursorShape = Qt.DragMoveCursor;
+                    autoScrollTimer.running = true;
                 }
-                
+
                 function endDrag() {
-                    oldIndex = -1
-                    attachedFiltersView.dragTarget = -1
-                    dragItem.sourceComponent = null
-                    cursorShape = Qt.ArrowCursor
-                    autoScrollTimer.running = false
+                    oldIndex = -1;
+                    attachedFiltersView.dragTarget = -1;
+                    dragItem.sourceComponent = null;
+                    cursorShape = Qt.ArrowCursor;
+                    autoScrollTimer.running = false;
                 }
-                
+
                 function updateDragTarget() {
-                    var mouseItem = attachedFiltersView.itemAt(mouseX, mouseY)
+                    var mouseItem = attachedFiltersView.itemAt(mouseX, mouseY);
                     if (mouseItem && mouseItem.viewData.section === grabSection) {
-                        dragItem.x = mouseX - grabPos.x
-                        dragItem.y = mouseY - grabPos.y - attachedFiltersView.contentY
-                        attachedFiltersView.dragTarget = attachedFiltersView.indexAt(mouseX, mouseY)
-                    } 
+                        dragItem.x = mouseX - grabPos.x;
+                        dragItem.y = mouseY - grabPos.y - attachedFiltersView.contentY;
+                        attachedFiltersView.dragTarget = attachedFiltersView.indexAt(mouseX, mouseY);
+                    }
                 }
-                
+
                 propagateComposedEvents: true
                 anchors.fill: attachedFiltersView.contentItem
                 z: 1
-                
                 onClicked: {
-                    filterClicked(attachedFiltersView.indexAt(mouseX, mouseY))
-                    mouse.accepted = false
+                    filterClicked(attachedFiltersView.indexAt(mouseX, mouseY));
+                    mouse.accepted = false;
                 }
-                
                 onPressAndHold: {
-                    if (oldIndex === -1) {
-                        beginDrag()
-                    }
+                    if (oldIndex === -1)
+                        beginDrag();
+
                 }
                 onReleased: {
-                    if (oldIndex !== -1
-                            && attachedFiltersView.dragTarget !== -1
-                            && oldIndex !== attachedFiltersView.dragTarget) {
-                        attachedfiltersmodel.move(oldIndex, attachedFiltersView.dragTarget)
-                    }
-                    endDrag()
+                    if (oldIndex !== -1 && attachedFiltersView.dragTarget !== -1 && oldIndex !== attachedFiltersView.dragTarget)
+                        attachedfiltersmodel.move(oldIndex, attachedFiltersView.dragTarget);
+
+                    endDrag();
                     mouse.accepted = true;
                 }
                 onPositionChanged: {
-                    if (oldIndex === -1) {
-                        beginDrag()
-                    }
-                    updateDragTarget()
+                    if (oldIndex === -1)
+                        beginDrag();
+
+                    updateDragTarget();
                 }
                 onCanceled: endDrag()
-                
+
                 Timer {
                     id: autoScrollTimer
+
                     interval: 500
                     running: false
                     repeat: true
                     onTriggered: {
                         // Make sure previous and next indices are always visible
-                        var nextIndex = attachedFiltersView.dragTarget + 1
-                        var prevIndex = attachedFiltersView.dragTarget - 1
+                        var nextIndex = attachedFiltersView.dragTarget + 1;
+                        var prevIndex = attachedFiltersView.dragTarget - 1;
                         if (nextIndex < attachedFiltersView.count) {
-                            attachedFiltersView.positionViewAtIndex(nextIndex, ListView.Contain)
-                            parent.updateDragTarget()
+                            attachedFiltersView.positionViewAtIndex(nextIndex, ListView.Contain);
+                            parent.updateDragTarget();
                         }
                         if (prevIndex >= 0) {
-                            attachedFiltersView.positionViewAtIndex(prevIndex, ListView.Contain)
-                            parent.updateDragTarget()
+                            attachedFiltersView.positionViewAtIndex(prevIndex, ListView.Contain);
+                            parent.updateDragTarget();
                         }
                     }
                 }
+
             }
-            
+
             Loader {
                 id: dragItem
-                
+
                 // Emulate the delegate properties added by ListView
-                property var model : Object()
-                
+                property var model: Object()
+
                 onLoaded: {
-                    item.color = activePalette.highlight
-                    item.opacity = 0.5
-                    item.width = attachedFiltersView.width
+                    item.color = activePalette.highlight;
+                    item.opacity = 0.5;
+                    item.width = attachedFiltersView.width;
                 }
             }
+
+            highlight: Rectangle {
+                color: activePalette.highlight
+                width: parent ? parent.width : undefined
+            }
+
         }
+
     }
+
 }

--- a/src/qml/views/filter/FilterMenu.qml
+++ b/src/qml/views/filter/FilterMenu.qml
@@ -14,45 +14,45 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
-import org.shotcut.qml 1.0 as Shotcut
 import Shotcut.Controls 1.0 as Shotcut
+import org.shotcut.qml 1.0 as Shotcut
 
 Rectangle {
     id: filterWindow
-    visible: false
 
     signal filterSelected(int index)
 
     function open() {
-        filterWindow.visible = true
-        searchField.focus = true
+        filterWindow.visible = true;
+        searchField.focus = true;
     }
 
     function close() {
-        filterWindow.visible = false
-        searchField.text = ''
-        searchField.focus = false
+        filterWindow.visible = false;
+        searchField.text = '';
+        searchField.focus = false;
     }
 
+    visible: false
     onVisibleChanged: {
-        if (metadatamodel.filter == Shotcut.MetadataModel.FavoritesFilter) {
-            favButton.checked = true
-        } else if (metadatamodel.filter == Shotcut.MetadataModel.VideoFilter) {
-            vidButton.checked = true
-        } else if (metadatamodel.filter == Shotcut.MetadataModel.AudioFilter) {
-            audButton.checked = true
-        } else if (metadatamodel.filter == Shotcut.MetadataModel.LinkFilter) {
-            lnkButton.checked = true
-        }
+        if (metadatamodel.filter == Shotcut.MetadataModel.FavoritesFilter)
+            favButton.checked = true;
+        else if (metadatamodel.filter == Shotcut.MetadataModel.VideoFilter)
+            vidButton.checked = true;
+        else if (metadatamodel.filter == Shotcut.MetadataModel.AudioFilter)
+            audButton.checked = true;
+        else if (metadatamodel.filter == Shotcut.MetadataModel.LinkFilter)
+            lnkButton.checked = true;
     }
-
     color: activePalette.window
 
-    SystemPalette { id: activePalette }
+    SystemPalette {
+        id: activePalette
+    }
 
     ColumnLayout {
         anchors.left: parent.left
@@ -61,145 +61,192 @@ Rectangle {
 
         RowLayout {
             id: searchBar
-            Layout.fillWidth: true
+
             property var savedFilter
+
+            Layout.fillWidth: true
 
             TextField {
                 id: searchField
+
                 Layout.fillWidth: true
                 focus: true
                 placeholderText: qsTr("search")
                 selectByMouse: true
                 text: metadatamodel.search
                 onTextChanged: {
-                    if (length !== 1 && text !== metadatamodel.search) {
-                        metadatamodel.search = text
-                    }
+                    if (length !== 1 && text !== metadatamodel.search)
+                        metadatamodel.search = text;
+
                     if (length > 0) {
-                        parent.savedFilter = typeGroup.checkedButton
-                        favButton.checked = vidButton.checked = audButton.checked = false
+                        parent.savedFilter = typeGroup.checkedButton;
+                        favButton.checked = vidButton.checked = audButton.checked = false;
                     } else {
-                        parent.savedFilter.checked = true
+                        parent.savedFilter.checked = true;
                     }
                 }
                 Keys.onReturnPressed: {
-                    menuListView.itemSelected(menuListView.currentIndex)
-                    event.accepted = true
+                    menuListView.itemSelected(menuListView.currentIndex);
+                    event.accepted = true;
                 }
                 Keys.onEnterPressed: Keys.onReturnPressed(event)
                 Keys.onEscapePressed: {
                     if (text !== '')
-                        text = ''
+                        text = '';
                     else
-                        filterWindow.close()
+                        filterWindow.close();
                 }
                 Keys.onUpPressed: menuListView.selectPrevious()
                 Keys.onDownPressed: menuListView.selectNext()
             }
+
             ToolButton {
                 id: clearButton
+
                 padding: 2
                 implicitWidth: 20
                 implicitHeight: 20
                 icon.name: 'edit-clear'
                 icon.source: 'qrc:///icons/oxygen/32x32/actions/edit-clear.png'
                 hoverEnabled: true
-                Shotcut.HoverTip { text: qsTr('Clear search') }
                 onClicked: searchField.text = ''
+
+                Shotcut.HoverTip {
+                    text: qsTr('Clear search')
+                }
+
             }
+
         }
 
         RowLayout {
             id: toolBar
+
             Layout.fillWidth: true
 
-            ButtonGroup { id: typeGroup }
+            ButtonGroup {
+                id: typeGroup
+            }
 
             Shotcut.ToggleButton {
                 id: favButton
+
                 checked: true
                 implicitWidth: 82
                 icon.name: 'bookmarks'
                 icon.source: 'qrc:///icons/oxygen/32x32/places/bookmarks.png'
                 text: qsTr('Favorite')
-                Shotcut.HoverTip { text: qsTr('Show favorite filters') }
                 ButtonGroup.group: typeGroup
                 onClicked: {
                     if (checked) {
-                        metadatamodel.filter = Shotcut.MetadataModel.FavoritesFilter
-                        searchField.text = ''
-                        checked = true
+                        metadatamodel.filter = Shotcut.MetadataModel.FavoritesFilter;
+                        searchField.text = '';
+                        checked = true;
                     }
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Show favorite filters')
+                }
+
             }
+
             Shotcut.ToggleButton {
                 id: vidButton
+
                 implicitWidth: 82
                 icon.name: 'video-television'
                 icon.source: 'qrc:///icons/oxygen/32x32/devices/video-television.png'
                 text: qsTr('Video')
-                Shotcut.HoverTip { text: qsTr('Show video filters') }
                 ButtonGroup.group: typeGroup
                 onClicked: {
                     if (checked) {
-                        metadatamodel.filter = Shotcut.MetadataModel.VideoFilter
-                        searchField.text = ''
-                        checked = true
+                        metadatamodel.filter = Shotcut.MetadataModel.VideoFilter;
+                        searchField.text = '';
+                        checked = true;
                     }
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Show video filters')
+                }
+
             }
+
             Shotcut.ToggleButton {
                 id: audButton
+
                 implicitWidth: 82
                 icon.name: 'speaker'
                 icon.source: 'qrc:///icons/oxygen/32x32/actions/speaker.png'
                 text: qsTr('Audio')
-                Shotcut.HoverTip { text: qsTr('Show audio filters') }
                 ButtonGroup.group: typeGroup
                 onClicked: {
                     if (checked) {
-                        metadatamodel.filter = Shotcut.MetadataModel.AudioFilter
-                        searchField.text = ''
-                        checked = true
+                        metadatamodel.filter = Shotcut.MetadataModel.AudioFilter;
+                        searchField.text = '';
+                        checked = true;
                     }
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Show audio filters')
+                }
+
             }
+
             Shotcut.ToggleButton {
                 id: lnkButton
+
                 implicitWidth: 82
                 visible: attachedfiltersmodel.supportsLinks
                 icon.name: 'chronometer'
                 icon.source: 'qrc:///icons/oxygen/32x32/actions/chronometer.png'
                 text: qsTr('Time')
-                Shotcut.HoverTip { text: qsTr('Show time filters') }
                 ButtonGroup.group: typeGroup
                 onClicked: {
                     if (checked) {
-                        metadatamodel.filter = Shotcut.MetadataModel.LinkFilter
-                        searchField.text = ''
-                        checked = true
+                        metadatamodel.filter = Shotcut.MetadataModel.LinkFilter;
+                        searchField.text = '';
+                        checked = true;
                     }
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Show time filters')
+                }
+
             }
-            Button { // separator
+            // separator
+
+            Button {
                 enabled: false
                 implicitWidth: 1
                 implicitHeight: 20
             }
+
             Shotcut.Button {
                 id: closeButton
+
                 icon.name: 'window-close'
                 icon.source: 'qrc:///icons/oxygen/32x32/actions/window-close.png'
                 padding: 2
                 implicitWidth: 20
                 implicitHeight: 20
-                Shotcut.HoverTip { text: qsTr('Close menu') }
                 onClicked: filterWindow.close()
+
+                Shotcut.HoverTip {
+                    text: qsTr('Close menu')
+                }
+
             }
+
             Item {
                 Layout.fillWidth: true
             }
+
         }
+
         ScrollView {
             Layout.fillWidth: true
             Layout.preferredHeight: filterWindow.height - toolBar.height - searchBar.height - parent.anchors.margins * 2
@@ -215,34 +262,39 @@ Rectangle {
 
                 function itemSelected(index) {
                     if (index > -1) {
-                        filterWindow.close()
-                        filterSelected(index)
+                        filterWindow.close();
+                        filterSelected(index);
                     }
                 }
 
                 function selectNext() {
                     do {
-                        currentIndex = Math.min(currentIndex + 1, count - 1)
+                        currentIndex = Math.min(currentIndex + 1, count - 1);
                     } while (currentItem !== null && !currentItem.visible && currentIndex < count - 1)
                 }
 
                 function selectPrevious() {
                     do {
-                        menuListView.currentIndex = Math.max(menuListView.currentIndex - 1, 0)
+                        menuListView.currentIndex = Math.max(menuListView.currentIndex - 1, 0);
                     } while (!menuListView.currentItem.visible && menuListView.currentIndex > 0)
                 }
 
                 anchors.fill: parent
                 model: metadatamodel
-                delegate: FilterMenuDelegate {}
                 boundsBehavior: Flickable.StopAtBounds
                 currentIndex: -1
                 focus: true
-
                 onCountChanged: {
-                    currentIndex = -1
+                    currentIndex = -1;
                 }
+
+                delegate: FilterMenuDelegate {
+                }
+
             }
+
         }
+
     }
+
 }

--- a/src/qml/views/filter/FilterMenuDelegate.qml
+++ b/src/qml/views/filter/FilterMenuDelegate.qml
@@ -15,19 +15,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import "FilterMenu.js" as Logic
 import QtQuick 2.2
 import QtQuick.Controls 2.12
 import org.shotcut.qml 1.0 as Shotcut
-import 'FilterMenu.js' as Logic
 
 Rectangle {
     id: wrapper
-    
+
     visible: isVisible
     height: visible ? Logic.ITEM_HEIGHT : 0
     color: activePalette.base
 
-    SystemPalette { id: activePalette }
+    SystemPalette {
+        id: activePalette
+    }
 
     Row {
         height: Logic.ITEM_HEIGHT
@@ -40,27 +42,31 @@ Rectangle {
 
             ToolButton {
                 id: favButton
+
                 implicitWidth: 20
                 implicitHeight: 18
                 padding: 1
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.verticalCenter: parent.verticalCenter
-                opacity: favorite ? 1.0 : 0.3
+                opacity: favorite ? 1 : 0.3
                 icon.name: 'bookmarks'
                 icon.source: 'qrc:///icons/oxygen/32x32/places/bookmarks.png'
                 onClicked: favorite = !favorite
             }
+
         }
 
         Rectangle {
             id: itemBackground
+
             color: wrapper.ListView.isCurrentItem ? activePalette.highlight : activePalette.base
             width: wrapper.ListView.view.width - favButton.width
             anchors.top: parent.top
             anchors.bottom: parent.bottom
-            
+
             ToolButton {
                 id: itemIcon
+
                 implicitWidth: 20
                 implicitHeight: 18
                 padding: 1
@@ -70,9 +76,10 @@ Rectangle {
                 icon.name: needsGpu ? 'cpu' : isAudio ? 'speaker' : pluginType == Shotcut.Metadata.Link ? 'chronometer' : 'video-television'
                 icon.source: needsGpu ? 'qrc:///icons/oxygen/32x32/devices/cpu.png' : isAudio ? 'qrc:///icons/oxygen/32x32/actions/speaker.png' : pluginType == Shotcut.Metadata.Link ? 'qrc:///icons/oxygen/32x32/actions/chronometer.png' : 'qrc:///icons/oxygen/32x32/devices/video-television.png'
             }
-            
+
             Label {
                 id: itemText
+
                 anchors.left: itemIcon.right
                 anchors.right: itemBackground.right
                 anchors.top: parent.top
@@ -81,18 +88,22 @@ Rectangle {
                 color: wrapper.ListView.isCurrentItem ? activePalette.highlightedText : activePalette.text
                 verticalAlignment: Text.AlignVCenter
             }
-            
+
             MouseArea {
                 id: mouseArea
+
                 anchors.fill: parent
                 hoverEnabled: wrapper.height > 0
                 onClicked: {
-                    wrapper.ListView.view.itemSelected(index)
+                    wrapper.ListView.view.itemSelected(index);
                 }
                 onEntered: {
-                    wrapper.ListView.view.currentIndex = index
+                    wrapper.ListView.view.currentIndex = index;
                 }
             }
+
         }
+
     }
+
 }

--- a/src/qml/views/keyframes/Parameter.qml
+++ b/src/qml/views/keyframes/Parameter.qml
@@ -15,38 +15,39 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.12
 import QtQml.Models 2.12
+import QtQuick 2.12
 import org.shotcut.qml 1.0
 
 Item {
     id: parameterRoot
-    clip: true
+
     property alias rootIndex: keyframeDelegateModel.rootIndex
     property bool isCurve: false
-    property double minimum: 0.0
-    property double maximum: 1.0
+    property double minimum: 0
+    property double maximum: 1
     property bool isLocked: false
 
     signal clicked(var keyframe, var parameter)
     signal rightClicked(var keyframe, var parameter)
 
     function setMinMax(zoomHeight) {
-        minimum = zoomHeight ? model.lowest : model.minimum
-        maximum = zoomHeight ? model.highest : model.maximum
+        minimum = zoomHeight ? model.lowest : model.minimum;
+        maximum = zoomHeight ? model.highest : model.maximum;
     }
 
     function getKeyframeCount() {
-        return keyframesRepeater.count
+        return keyframesRepeater.count;
     }
 
     function getKeyframe(keyframeIndex) {
         if (keyframeIndex < keyframesRepeater.count)
-            return keyframesRepeater.itemAt(keyframeIndex)
+            return keyframesRepeater.itemAt(keyframeIndex);
         else
-            return null
+            return null;
     }
 
+    clip: true
     onMinimumChanged: canvas.requestPaint()
     onMaximumChanged: canvas.requestPaint()
 
@@ -60,6 +61,7 @@ Item {
         color: activePalette.buttonText
         text: Number(maximum).toLocaleString(Qt.locale(), 'f', 1)
     }
+
     Text {
         anchors.left: parent.left
         anchors.verticalCenter: parent.verticalCenter
@@ -69,6 +71,7 @@ Item {
         color: activePalette.buttonText
         text: Number(minimum + ((maximum - minimum) / 2)).toLocaleString(Qt.locale(), 'f', 1)
     }
+
     Text {
         anchors.left: parent.left
         anchors.bottom: parent.bottom
@@ -79,78 +82,89 @@ Item {
         text: Number(minimum).toLocaleString(Qt.locale(), 'f', 1)
     }
 
-    Repeater { id: keyframesRepeater; model: keyframeDelegateModel; onCountChanged: canvas.requestPaint() }
+    Repeater {
+        id: keyframesRepeater
+
+        model: keyframeDelegateModel
+        onCountChanged: canvas.requestPaint()
+    }
 
     Canvas {
         id: canvas
-        visible: isCurve
-        anchors.fill: parent
 
         function catmullRomToBezier(context, i) {
-            var a = 1.0 / 6.0
-            var g = i-2 >= 0 ? i-2 : i
-            var h = i-1 >= 0 ? i-1 : i
-            var j = i+1 < keyframesRepeater.count ? i+1 : i
-            var widthOffset = keyframesRepeater.itemAt(0).width / 2
-            var heightOffset = keyframesRepeater.itemAt(0).height / 2
-            var points = [
-                {x: keyframesRepeater.itemAt(g).x + widthOffset, y: keyframesRepeater.itemAt(g).y + heightOffset},
-                {x: keyframesRepeater.itemAt(h).x + widthOffset, y: keyframesRepeater.itemAt(h).y + heightOffset},
-                {x: keyframesRepeater.itemAt(i).x + widthOffset, y: keyframesRepeater.itemAt(i).y + heightOffset},
-                {x: keyframesRepeater.itemAt(j).x + widthOffset, y: keyframesRepeater.itemAt(j).y + heightOffset},
-            ]
-            context.bezierCurveTo(-a*points[0].x + points[1].x + a*points[2].x,
-                                  -a*points[0].y + points[1].y + a*points[2].y,
-                                   a*points[1].x + points[2].x - a*points[3].x,
-                                   a*points[1].y + points[2].y - a*points[3].y,
-                                     points[2].x, points[2].y)
+            var a = 1 / 6;
+            var g = i - 2 >= 0 ? i - 2 : i;
+            var h = i - 1 >= 0 ? i - 1 : i;
+            var j = i + 1 < keyframesRepeater.count ? i + 1 : i;
+            var widthOffset = keyframesRepeater.itemAt(0).width / 2;
+            var heightOffset = keyframesRepeater.itemAt(0).height / 2;
+            var points = [{
+                "x": keyframesRepeater.itemAt(g).x + widthOffset,
+                "y": keyframesRepeater.itemAt(g).y + heightOffset
+            }, {
+                "x": keyframesRepeater.itemAt(h).x + widthOffset,
+                "y": keyframesRepeater.itemAt(h).y + heightOffset
+            }, {
+                "x": keyframesRepeater.itemAt(i).x + widthOffset,
+                "y": keyframesRepeater.itemAt(i).y + heightOffset
+            }, {
+                "x": keyframesRepeater.itemAt(j).x + widthOffset,
+                "y": keyframesRepeater.itemAt(j).y + heightOffset
+            }];
+            context.bezierCurveTo(-a * points[0].x + points[1].x + a * points[2].x, -a * points[0].y + points[1].y + a * points[2].y, a * points[1].x + points[2].x - a * points[3].x, a * points[1].y + points[2].y - a * points[3].y, points[2].x, points[2].y);
         }
 
+        visible: isCurve
+        anchors.fill: parent
         onPaint: {
-            var ctx = getContext("2d")
-            ctx.strokeStyle = activePalette.buttonText
-            ctx.lineWidth = 1.0
-            ctx.clearRect(0, 0, canvas.width, canvas.height)
-            ctx.beginPath()
+            var ctx = getContext("2d");
+            ctx.strokeStyle = activePalette.buttonText;
+            ctx.lineWidth = 1;
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            ctx.beginPath();
             if (keyframesRepeater.count) {
-                var widthOffset = keyframesRepeater.itemAt(0).width / 2
-                var heightOffset = keyframesRepeater.itemAt(0).height / 2
+                var widthOffset = keyframesRepeater.itemAt(0).width / 2;
+                var heightOffset = keyframesRepeater.itemAt(0).height / 2;
                 // Draw extent before first keyframe.
-                ctx.moveTo(0, keyframesRepeater.itemAt(0).y + heightOffset)
-                ctx.lineTo(keyframesRepeater.itemAt(0).x + widthOffset, keyframesRepeater.itemAt(0).y + heightOffset)
+                ctx.moveTo(0, keyframesRepeater.itemAt(0).y + heightOffset);
+                ctx.lineTo(keyframesRepeater.itemAt(0).x + widthOffset, keyframesRepeater.itemAt(0).y + heightOffset);
                 // Draw lines between keyframes.
                 for (var i = 1; i < keyframesRepeater.count; i++) {
                     switch (keyframesRepeater.itemAt(i - 1).interpolation) {
                     case KeyframesModel.LinearInterpolation:
-                        ctx.lineTo(keyframesRepeater.itemAt(i).x + widthOffset, keyframesRepeater.itemAt(i).y + heightOffset)
-                        break
+                        ctx.lineTo(keyframesRepeater.itemAt(i).x + widthOffset, keyframesRepeater.itemAt(i).y + heightOffset);
+                        break;
                     case KeyframesModel.SmoothInterpolation:
-                        catmullRomToBezier(ctx, i)
-                        ctx.moveTo(keyframesRepeater.itemAt(i).x + widthOffset, keyframesRepeater.itemAt(i).y + heightOffset)
-                        break
-                    default: // KeyframesModel.DiscreteInterpolation
-                        ctx.lineTo(keyframesRepeater.itemAt(i).x + widthOffset, keyframesRepeater.itemAt(i - 1).y + heightOffset)
-                        ctx.moveTo(keyframesRepeater.itemAt(i).x + widthOffset, keyframesRepeater.itemAt(i).y + heightOffset)
-                        break
+                        catmullRomToBezier(ctx, i);
+                        ctx.moveTo(keyframesRepeater.itemAt(i).x + widthOffset, keyframesRepeater.itemAt(i).y + heightOffset);
+                        break; // KeyframesModel.DiscreteInterpolation
+                    default:
+                        ctx.lineTo(keyframesRepeater.itemAt(i).x + widthOffset, keyframesRepeater.itemAt(i - 1).y + heightOffset);
+                        ctx.moveTo(keyframesRepeater.itemAt(i).x + widthOffset, keyframesRepeater.itemAt(i).y + heightOffset);
+                        break;
                     }
                 }
                 // Draw extent after last keyframe.
-                ctx.lineTo(width, keyframesRepeater.itemAt(i - 1).y + heightOffset)
+                ctx.lineTo(width, keyframesRepeater.itemAt(i - 1).y + heightOffset);
             }
-            ctx.stroke()
+            ctx.stroke();
         }
     }
 
     DelegateModel {
         id: keyframeDelegateModel
+
         model: parameters
+
         Keyframe {
             property int frame: model.frame
+
             interpolation: model.interpolation
             name: model.name
             value: model.value
-            minDragX: (filter.in - producer.in + model.minimumFrame) * timeScale - width/2
-            maxDragX: (filter.in - producer.in + model.maximumFrame) * timeScale - width/2
+            minDragX: (filter.in - producer.in + model.minimumFrame) * timeScale - width / 2
+            maxDragX: (filter.in - producer.in + model.maximumFrame) * timeScale - width / 2
             isSelected: root.currentTrack === parameterRoot.DelegateModel.itemsIndex && root.selection.indexOf(index) !== -1
             isCurve: parameterRoot.isCurve
             minimum: parameterRoot.minimum
@@ -160,13 +174,15 @@ Item {
             onRightClicked: parameterRoot.rightClicked(keyframe, parameterRoot)
             onInterpolationChanged: canvas.requestPaint()
             Component.onCompleted: {
-                position = (filter.in - producer.in) + model.frame
+                position = (filter.in - producer.in) + model.frame;
             }
             onFrameChanged: {
-                position = (filter.in - producer.in) + model.frame
+                position = (filter.in - producer.in) + model.frame;
             }
             onPositionChanged: canvas.requestPaint()
             onValueChanged: canvas.requestPaint()
         }
+
     }
+
 }

--- a/src/qml/views/keyframes/ParameterHead.qml
+++ b/src/qml/views/keyframes/ParameterHead.qml
@@ -15,14 +15,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import "Keyframes.js" as Logic
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 import Shotcut.Controls 1.0 as Shotcut
-import 'Keyframes.js' as Logic
 
 Rectangle {
     id: paramHeadRoot
+
     property string trackName: ''
     property bool isLocked: false
     property bool selected: false
@@ -30,73 +31,95 @@ Rectangle {
     property bool isCurve: false
     property bool zoomHeight: false
     property int delegateIndex: -1
+
     signal clicked()
     signal rightClicked()
 
-    SystemPalette { id: activePalette }
-    color: selected ? selectedTrackColor : (delegateIndex % 2)? activePalette.alternateBase : activePalette.base
-    border.color: selected? 'red' : 'transparent'
-    border.width: selected? 1 : 0
+    color: selected ? selectedTrackColor : (delegateIndex % 2) ? activePalette.alternateBase : activePalette.base
+    border.color: selected ? 'red' : 'transparent'
+    border.width: selected ? 1 : 0
     clip: true
     state: 'normal'
     states: [
         State {
             name: 'selected'
             when: paramHeadRoot.selected
+
             PropertyChanges {
                 target: paramHeadRoot
                 color: root.shotcutBlue
             }
+
         },
         State {
             name: 'current'
             when: paramHeadRoot.current
+
             PropertyChanges {
                 target: paramHeadRoot
-                color: Qt.rgba(selectedTrackColor.r * selectedTrackColor.a + activePalette.window.r * (1.0 - selectedTrackColor.a),
-                               selectedTrackColor.g * selectedTrackColor.a + activePalette.window.g * (1.0 - selectedTrackColor.a),
-                               selectedTrackColor.b * selectedTrackColor.a + activePalette.window.b * (1.0 - selectedTrackColor.a),
-                               1.0)
+                color: Qt.rgba(selectedTrackColor.r * selectedTrackColor.a + activePalette.window.r * (1 - selectedTrackColor.a), selectedTrackColor.g * selectedTrackColor.a + activePalette.window.g * (1 - selectedTrackColor.a), selectedTrackColor.b * selectedTrackColor.a + activePalette.window.b * (1 - selectedTrackColor.a), 1)
             }
+
         },
         State {
             name: 'normal'
             when: !paramHeadRoot.selected && !paramHeadRoot.current
+
             PropertyChanges {
                 target: paramHeadRoot
-                color: (delegateIndex % 2)? activePalette.alternateBase : activePalette.base
+                color: (delegateIndex % 2) ? activePalette.alternateBase : activePalette.base
             }
+
         }
     ]
     transitions: [
         Transition {
             to: '*'
-            ColorAnimation { target: paramHeadRoot; duration: 100 }
+
+            ColorAnimation {
+                target: paramHeadRoot
+                duration: 100
+            }
+
         }
     ]
+
+    SystemPalette {
+        id: activePalette
+    }
 
     MouseArea {
         anchors.fill: parent
         acceptedButtons: Qt.LeftButton | Qt.RightButton
         onClicked: {
-            parent.clicked()
+            parent.clicked();
             if (mouse.button == Qt.RightButton)
-                parent.rightClicked()
+                parent.rightClicked();
+
         }
     }
+
     Flow {
         id: trackHeadColumn
-        flow: (paramHeadRoot.height < 30)? Flow.LeftToRight : Flow.TopToBottom
-        spacing: (paramHeadRoot.height < 50)? 0 : 6
+
+        flow: (paramHeadRoot.height < 30) ? Flow.LeftToRight : Flow.TopToBottom
+        spacing: (paramHeadRoot.height < 50) ? 0 : 6
+
         anchors {
             top: parent.top
             left: parent.left
-            margins: (paramHeadRoot.height < 50)? 0 : 4
+            margins: (paramHeadRoot.height < 50) ? 0 : 4
         }
 
         Control {
             id: control
-            width: paramHeadRoot.width - trackHeadColumn.anchors.margins * 2 - 8 - (paramHeadRoot.height < 30? toolButtonsLayout.width : 0)
+
+            width: paramHeadRoot.width - trackHeadColumn.anchors.margins * 2 - 8 - (paramHeadRoot.height < 30 ? toolButtonsLayout.width : 0)
+
+            Shotcut.HoverTip {
+                text: trackName
+            }
+
             contentItem: Label {
                 text: trackName
                 color: activePalette.windowText
@@ -105,13 +128,17 @@ Rectangle {
                 topPadding: 3
                 width: control.width
             }
-            Shotcut.HoverTip { text: trackName }
+
         }
+
         RowLayout {
             id: toolButtonsLayout
-            spacing: (paramHeadRoot.height < 30)? 0 : 6
+
+            spacing: (paramHeadRoot.height < 30) ? 0 : 6
+
             ToolButton {
                 id: previousButton
+
                 icon.name: 'media-skip-backward'
                 icon.source: 'qrc:///icons/oxygen/32x32/actions/media-skip-backward.png'
                 icon.width: 16
@@ -120,30 +147,40 @@ Rectangle {
                 focusPolicy: Qt.NoFocus
                 onClicked: {
                     if (delegateIndex >= 0) {
-                        root.currentTrack = delegateIndex
-                        root.selection = [keyframes.seekPrevious()]
+                        root.currentTrack = delegateIndex;
+                        root.selection = [keyframes.seekPrevious()];
                     } else {
-                        Logic.seekPreviousSimple()
+                        Logic.seekPreviousSimple();
                     }
                 }
-                Shotcut.HoverTip { text: (delegateIndex >= 0) ? qsTr('Seek to previous keyframe') : qsTr('Seek backwards') }
+
+                Shotcut.HoverTip {
+                    text: (delegateIndex >= 0) ? qsTr('Seek to previous keyframe') : qsTr('Seek backwards')
+                }
+
             }
 
             ToolButton {
                 id: addButton
+
                 visible: delegateIndex >= 0
-                icon.name: 'chronometer';
+                icon.name: 'chronometer'
                 icon.source: 'qrc:///icons/oxygen/32x32/actions/chronometer.png'
                 icon.width: 16
                 icon.height: 16
                 padding: 1
                 focusPolicy: Qt.NoFocus
                 onClicked: {
-                    parameters.addKeyframe(delegateIndex, producer.position - (filter.in - producer.in))
-                    root.selection = [parameters.keyframeIndex(delegateIndex, producer.position)]
+                    parameters.addKeyframe(delegateIndex, producer.position - (filter.in - producer.in));
+                    root.selection = [parameters.keyframeIndex(delegateIndex, producer.position)];
                 }
-                Shotcut.HoverTip { text: qsTr('Add a keyframe at play head') }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Add a keyframe at play head')
+                }
+
             }
+
             Item {
                 visible: delegateIndex < 0 && paramHeadRoot.height >= 30
                 width: 18
@@ -152,6 +189,7 @@ Rectangle {
 
             ToolButton {
                 id: deleteButton
+
                 visible: delegateIndex >= 0
                 enabled: delegateIndex === root.currentTrack && root.selection.length > 0
                 icon.width: 16
@@ -159,14 +197,19 @@ Rectangle {
                 padding: 1
                 icon.name: 'edit-delete'
                 icon.source: 'qrc:///icons/oxygen/32x32/actions/edit-delete.png'
-                opacity: enabled? 1.0 : 0.5
+                opacity: enabled ? 1 : 0.5
                 focusPolicy: Qt.NoFocus
                 onClicked: {
-                    parameters.remove(delegateIndex, root.selection[0])
-                    root.selection = []
+                    parameters.remove(delegateIndex, root.selection[0]);
+                    root.selection = [];
                 }
-                Shotcut.HoverTip { text: qsTr('Delete the selected keyframe') }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Delete the selected keyframe')
+                }
+
             }
+
             Item {
                 visible: delegateIndex < 0 && paramHeadRoot.height >= 30
                 width: 18
@@ -175,6 +218,7 @@ Rectangle {
 
             ToolButton {
                 id: nextButton
+
                 icon.name: 'media-skip-forward'
                 icon.source: 'qrc:///icons/oxygen/32x32/actions/media-skip-forward.png'
                 icon.width: 16
@@ -183,17 +227,22 @@ Rectangle {
                 focusPolicy: Qt.NoFocus
                 onClicked: {
                     if (delegateIndex >= 0) {
-                        root.currentTrack = delegateIndex
-                        root.selection = [keyframes.seekNext()]
+                        root.currentTrack = delegateIndex;
+                        root.selection = [keyframes.seekNext()];
                     } else {
-                        Logic.seekNextSimple()
+                        Logic.seekNextSimple();
                     }
                 }
-                Shotcut.HoverTip { text: (delegateIndex >= 0) ? qsTr('Seek to next keyframe') : qsTr('Seek forwards') }
+
+                Shotcut.HoverTip {
+                    text: (delegateIndex >= 0) ? qsTr('Seek to next keyframe') : qsTr('Seek forwards')
+                }
+
             }
 
             ToolButton {
                 id: lockButton
+
                 visible: false && delegateIndex >= 0
                 icon.name: isLocked ? 'object-locked' : 'object-unlocked'
                 icon.source: isLocked ? 'qrc:///icons/oxygen/32x32/status/object-locked.png' : 'qrc:///icons/oxygen/32x32/status/object-unlocked.png'
@@ -201,26 +250,39 @@ Rectangle {
                 icon.height: 16
                 padding: 1
                 focusPolicy: Qt.NoFocus
-//                onClicked: timeline.setTrackLock(index, !isLocked)
-                Shotcut.HoverTip { text: isLocked? qsTr('Unlock track') : qsTr('Lock track') }
+
+                //                onClicked: timeline.setTrackLock(index, !isLocked)
+                Shotcut.HoverTip {
+                    text: isLocked ? qsTr('Unlock track') : qsTr('Lock track')
+                }
+
             }
 
             Shotcut.ToolButton {
-                Shotcut.HoverTip { text: qsTr('Zoom keyframe values') }
                 focusPolicy: Qt.NoFocus
                 visible: delegateIndex >= 0 && paramHeadRoot.isCurve
                 checkable: true
                 checked: zoomHeight
+
+                Shotcut.HoverTip {
+                    text: qsTr('Zoom keyframe values')
+                }
+
                 action: Action {
                     id: zoomFitKeyframeAction
+
                     icon.name: 'zoom-fit-best'
                     icon.source: 'qrc:///icons/oxygen/32x32/actions/zoom-fit-best.png'
                     onTriggered: {
-                        zoomHeight = !zoomHeight
-                        root.paramRepeater.itemAt(delegateIndex).setMinMax(zoomHeight)
+                        zoomHeight = !zoomHeight;
+                        root.paramRepeater.itemAt(delegateIndex).setMinMax(zoomHeight);
                     }
                 }
+
             }
+
         }
+
     }
+
 }

--- a/src/qml/views/keyframes/Ruler.qml
+++ b/src/qml/views/keyframes/Ruler.qml
@@ -19,24 +19,29 @@ import QtQuick 2.12
 import QtQuick.Controls 2.12
 
 Rectangle {
-    property real intervalSeconds: (timeScale > 5)? 1 : (5 * Math.max(1, Math.floor(1.5 / timeScale)))
-
-    SystemPalette { id: activePalette }
-
     id: rulerTop
+
+    property real intervalSeconds: (timeScale > 5) ? 1 : (5 * Math.max(1, Math.floor(1.5 / timeScale)))
+
     height: 28
     color: activePalette.base
 
+    SystemPalette {
+        id: activePalette
+    }
+
     Repeater {
         model: parent.width / (intervalSeconds * profile.fps * timeScale)
+
         Rectangle {
+            // right edge
+
             anchors.bottom: rulerTop.bottom
             height: 18
             width: 1
             color: activePalette.windowText
             x: index * intervalSeconds * profile.fps * timeScale
-            visible: ((x + width)   > tracksFlickable.contentX) && // right edge
-                      (x            < tracksFlickable.contentX + tracksFlickable.width) // left edge
+            visible: ((x + width) > tracksFlickable.contentX) && (x < tracksFlickable.contentX + tracksFlickable.width) // left edge
 
             Label {
                 anchors.left: parent.right
@@ -46,7 +51,9 @@ Rectangle {
                 color: activePalette.windowText
                 text: application.timecode(index * intervalSeconds * profile.fps + 2).substr(0, 8)
             }
+
         }
+
     }
 
     MouseArea {
@@ -55,8 +62,9 @@ Rectangle {
         acceptedButtons: Qt.NoButton
         onExited: bubbleHelp.hide()
         onPositionChanged: {
-            var text = application.timecode(mouse.x / timeScale)
-            bubbleHelp.show(mouse.x + bubbleHelp.width - 8, mouse.y + 65, text)
+            var text = application.timecode(mouse.x / timeScale);
+            bubbleHelp.show(mouse.x + bubbleHelp.width - 8, mouse.y + 65, text);
         }
     }
+
 }

--- a/src/qml/views/keyframes/keyframes.qml
+++ b/src/qml/views/keyframes/keyframes.qml
@@ -15,26 +15,23 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.12
+import "Keyframes.js" as Logic
+import QtGraphicalEffects 1.12
 import QtQml.Models 2.12
+import QtQuick 2.12
 import QtQuick.Controls 2.12
 import Shotcut.Controls 1.0 as Shotcut
-import QtGraphicalEffects 1.12
-import 'Keyframes.js' as Logic
 
 Rectangle {
     id: root
-    width: 400
-    SystemPalette { id: activePalette }
-    color: activePalette.window
 
     property int selectedIndex: -1
     property int headerWidth: 140
     property int currentTrack: 0
     property color selectedTrackColor: Qt.rgba(0.8, 0.8, 0, 0.3)
     property bool stopScrolling: false
-    property color shotcutBlue: Qt.rgba(23/255, 92/255, 118/255, 1.0)
-    property double timeScale: 1.0
+    property color shotcutBlue: Qt.rgba(23 / 255, 92 / 255, 118 / 255, 1)
+    property double timeScale: 1
     property var selection: []
     property alias paramRepeater: parametersRepeater
 
@@ -42,56 +39,66 @@ Rectangle {
     signal keyframeRightClicked()
     signal clipRightClicked()
 
-    onTimeScaleChanged: redrawWaveforms()
-
     function redrawWaveforms() {
-        Logic.scrollIfNeeded()
-        beforeClip.generateWaveform()
-        activeClip.generateWaveform()
-        afterClip.generateWaveform()
+        Logic.scrollIfNeeded();
+        beforeClip.generateWaveform();
+        activeClip.generateWaveform();
+        afterClip.generateWaveform();
     }
 
     function setZoom(value, targetX) {
         if (!targetX)
-            targetX = tracksFlickable.contentX + tracksFlickable.width / 2
-        var offset = targetX - tracksFlickable.contentX
-        var before = timeScale
+            targetX = tracksFlickable.contentX + tracksFlickable.width / 2;
+
+        var offset = targetX - tracksFlickable.contentX;
+        var before = timeScale;
         if (isNaN(value))
-            value = 0.0
-        timeScale = Math.pow(value, 3) + 0.01
-        tracksFlickable.contentX = Logic.clamp((targetX * timeScale / before) - offset, 0, Logic.scrollMax().x)
+            value = 0;
+
+        timeScale = Math.pow(value, 3) + 0.01;
+        tracksFlickable.contentX = Logic.clamp((targetX * timeScale / before) - offset, 0, Logic.scrollMax().x);
+    }
+
+    function adjustZoom(by, targetX) {
+        var value = Math.pow(timeScale - 0.01, 1 / 3);
+        setZoom(value + by, targetX);
+        if (settings.timelineScrollZoom)
+            scrollZoomTimer.restart();
+
+    }
+
+    function zoomIn() {
+        adjustZoom(0.0625);
+    }
+
+    function zoomOut() {
+        adjustZoom(-0.0625);
+    }
+
+    function zoomToFit() {
+        setZoom(Math.pow((tracksFlickable.width - 50) * timeScale / tracksContainer.width - 0.01, 1 / 3));
+        tracksFlickable.contentX = 0;
+    }
+
+    function resetZoom() {
+        setZoom(1);
+    }
+
+    width: 400
+    color: activePalette.window
+    onTimeScaleChanged: redrawWaveforms()
+
+    SystemPalette {
+        id: activePalette
     }
 
     Timer {
         id: scrollZoomTimer
+
         interval: 100
         onTriggered: {
-            Logic.scrollIfNeeded(true)
+            Logic.scrollIfNeeded(true);
         }
-    }
-
-    function adjustZoom(by, targetX) {
-        var value = Math.pow(timeScale - 0.01, 1.0 / 3.0)
-        setZoom(value + by, targetX)
-        if (settings.timelineScrollZoom)
-            scrollZoomTimer.restart()
-    }
-
-    function zoomIn() {
-        adjustZoom(0.0625)
-    }
-
-    function zoomOut() {
-        adjustZoom(-0.0625)
-    }
-
-    function zoomToFit() {
-        setZoom(Math.pow((tracksFlickable.width - 50) * timeScale / tracksContainer.width - 0.01, 1/3))
-        tracksFlickable.contentX = 0
-    }
-
-    function resetZoom() {
-        setZoom(1.0)
     }
 
     MouseArea {
@@ -102,6 +109,7 @@ Rectangle {
 
     Row {
         anchors.fill: parent
+
         Column {
             z: 1
 
@@ -112,6 +120,7 @@ Rectangle {
                 color: activePalette.window
                 z: 1
             }
+
             Flickable {
                 // Non-slider scroll area for the track headers.
                 contentY: tracksFlickable.contentY
@@ -124,15 +133,19 @@ Rectangle {
 
                     ParameterHead {
                         id: clipHead
+
                         visible: metadata !== null
-                        trackName: metadata !== null? metadata.name : ''
+                        trackName: metadata !== null ? metadata.name : ''
                         width: headerWidth
                         height: Logic.trackHeight(true)
                         onRightClicked: root.rightClicked()
                     }
+
                     Repeater {
                         id: trackHeaderRepeater
+
                         model: parameters
+
                         ParameterHead {
                             trackName: model.name
                             delegateIndex: index
@@ -143,8 +156,11 @@ Rectangle {
                             onClicked: currentTrack = index
                             onRightClicked: root.rightClicked()
                         }
+
                     }
+
                 }
+
                 Rectangle {
                     // thin dividing line between headers and tracks
                     visible: metadata !== null
@@ -154,105 +170,108 @@ Rectangle {
                     anchors.top: parent.top
                     anchors.bottom: parent.bottom
                 }
+
             }
+
         }
+
         Item {
             id: tracksArea
+
             width: root.width - headerWidth
             height: root.height
             focus: true
 
             MouseArea {
+                property bool skim: false
+
                 // This provides skimming and continuous scrubbing at the left/right edges.
                 anchors.fill: parent
                 hoverEnabled: true
                 onClicked: {
-                    producer.position = (tracksFlickable.contentX + mouse.x) / timeScale
-                    bubbleHelp.hide()
+                    producer.position = (tracksFlickable.contentX + mouse.x) / timeScale;
+                    bubbleHelp.hide();
                 }
                 onWheel: Logic.onMouseWheel(wheel)
                 onDoubleClicked: {
                     // Figure out which parameter row that is in.
                     for (var i = 0; i < parametersRepeater.count; i++) {
-                        var parameter = parametersRepeater.itemAt(i)
+                        var parameter = parametersRepeater.itemAt(i);
                         // Only for parameters with curves.
                         if (parameter.isCurve) {
-                            var point = tracksArea.mapToItem(parameter, mouse.x, mouse.y)
-                            var position = Math.round(point.x / timeScale) - (filter.in - producer.in)
-                            var trackHeight = parameter.height
-                            var interpolation = 1
+                            var point = tracksArea.mapToItem(parameter, mouse.x, mouse.y);
+                            var position = Math.round(point.x / timeScale) - (filter.in - producer.in);
+                            var trackHeight = parameter.height;
+                            var interpolation = 1;
                             // Get the interpolation from the previous keyframe if any.
                             for (var j = 0; j < parameter.getKeyframeCount(); j++) {
-                                var k = parameter.getKeyframe(j)
+                                var k = parameter.getKeyframe(j);
                                 if (k.position - (filter.in - producer.in) < position)
-                                    interpolation = k.interpolation
+                                    interpolation = k.interpolation;
                                 else
-                                    break
+                                    break;
                             }
                             // If click position is within range.
-                            if (position >= 0 && position < filter.duration
-                                && point.y > 0 && point.y < trackHeight) {
+                            if (position >= 0 && position < filter.duration && point.y > 0 && point.y < trackHeight) {
                                 // Determine the value to set.
-                                var keyframeHeight = 10
-                                var trackValue = Math.min(Math.max(0, 1.0 - (point.y - keyframeHeight/2) / (trackHeight - keyframeHeight)), 1.0)
-                                var value = parameter.minimum + trackValue * (parameter.maximum - parameter.minimum)
+                                var keyframeHeight = 10;
+                                var trackValue = Math.min(Math.max(0, 1 - (point.y - keyframeHeight / 2) / (trackHeight - keyframeHeight)), 1);
+                                var value = parameter.minimum + trackValue * (parameter.maximum - parameter.minimum);
                                 //console.log('clicked parameter ' + i + ' frame ' + position + ' trackValue ' + trackValue + ' value ' + value)
-                                parameters.addKeyframe(i, value, position, interpolation)
-                                break
+                                parameters.addKeyframe(i, value, position, interpolation);
+                                break;
                             }
                         }
                     }
                 }
-
-                property bool skim: false
                 onReleased: skim = false
                 onExited: skim = false
                 onPositionChanged: {
                     if (mouse.modifiers === (Qt.ShiftModifier | Qt.AltModifier) || mouse.buttons === Qt.LeftButton) {
-                        producer.position = (tracksFlickable.contentX + mouse.x) / timeScale
-                        bubbleHelp.hide()
-                        skim = true
+                        producer.position = (tracksFlickable.contentX + mouse.x) / timeScale;
+                        bubbleHelp.hide();
+                        skim = true;
                     } else {
-                        skim = false
+                        skim = false;
                     }
                 }
             }
 
             Timer {
                 id: scrubTimer
+
                 interval: 25
                 repeat: true
-                running: parent.skim && parent.containsMouse
-                         && (parent.mouseX < 50 || parent.mouseX > parent.width - 50)
-                         && (producer.position * timeScale >= 50)
+                running: parent.skim && parent.containsMouse && (parent.mouseX < 50 || parent.mouseX > parent.width - 50) && (producer.position * timeScale >= 50)
                 onTriggered: {
                     if (parent.mouseX < 50)
-                        producer.position -= 10
+                        producer.position -= 10;
                     else
-                        producer.position += 10
+                        producer.position += 10;
                 }
             }
 
             MouseArea {
+                property real startX: mouseX
+                property real startY: mouseY
+
                 // This provides drag-scrolling the timeline with the middle mouse button.
                 anchors.fill: parent
                 acceptedButtons: Qt.MiddleButton
-                cursorShape: drag.active? Qt.ClosedHandCursor : Qt.ArrowCursor
+                cursorShape: drag.active ? Qt.ClosedHandCursor : Qt.ArrowCursor
                 drag.axis: Drag.XAndYAxis
                 drag.filterChildren: true
-                property real startX: mouseX
-                property real startY: mouseY
                 onPressed: {
-                    startX = mouse.x
-                    startY = mouse.y
+                    startX = mouse.x;
+                    startY = mouse.y;
                 }
                 onPositionChanged: {
-                    var n = mouse.x - startX
-                    startX = mouse.x
-                    tracksFlickable.contentX = Logic.clamp(tracksFlickable.contentX - n, 0, Logic.scrollMax().x)
-                    n = mouse.y - startY
-                    startY = mouse.y
-                    tracksFlickable.contentY = Logic.clamp(tracksFlickable.contentY - n, 0, Logic.scrollMax().y)
+                    var n = mouse.x - startX;
+                    startX = mouse.x;
+                    tracksFlickable.contentX = Logic.clamp(tracksFlickable.contentX - n, 0, Logic.scrollMax().x);
+                    n = mouse.y - startY;
+                    startY = mouse.y;
+                    tracksFlickable.contentY = Logic.clamp(tracksFlickable.contentY - n, 0, Logic.scrollMax().y);
                 }
             }
 
@@ -260,20 +279,29 @@ Rectangle {
                 Flickable {
                     // Non-slider scroll area for the Ruler.
                     id: rulerFlickable
+
                     contentX: tracksFlickable.contentX
                     width: root.width - headerWidth
                     height: ruler.height
                     interactive: false
                     // workaround to fix https://github.com/mltframework/shotcut/issues/777
-                    onContentXChanged: if (contentX === 0) contentX = tracksFlickable.contentX
+                    onContentXChanged: {
+                        if (contentX === 0)
+                            contentX = tracksFlickable.contentX;
+
+                    }
 
                     Ruler {
                         id: ruler
+
                         width: producer.duration * timeScale
                     }
+
                 }
+
                 Flickable {
                     id: tracksFlickable
+
                     y: ruler.height
                     width: root.width - headerWidth - 16
                     height: root.height - ruler.height - 16
@@ -283,31 +311,10 @@ Rectangle {
                     interactive: false
                     contentWidth: tracksContainer.width + headerWidth
                     contentHeight: trackHeaders.height + 30 // 30 is padding
-                    ScrollBar.horizontal: ScrollBar {
-                        id: horizontalScrollBar
-                        height: 16
-                        policy: ScrollBar.AlwaysOn
-                        visible: tracksFlickable.contentWidth > tracksFlickable.width
-                        parent: tracksFlickable.parent
-                        anchors.top: tracksFlickable.bottom
-                        anchors.left: tracksFlickable.left
-                        anchors.right: tracksFlickable.right
-                        background: Rectangle { color: parent.palette.alternateBase }
-                    }
-                    ScrollBar.vertical: ScrollBar {
-                        width: 16
-                        policy: ScrollBar.AlwaysOn
-                        visible: tracksFlickable.contentHeight > tracksFlickable.height
-                        parent: tracksFlickable.parent
-                        anchors.top: tracksFlickable.top
-                        anchors.left: tracksFlickable.right
-                        anchors.bottom: tracksFlickable.bottom
-                        anchors.bottomMargin: -16
-                        background: Rectangle { color: parent.palette.alternateBase }
-                    }
 
                     Item {
                         id: tracksLayers
+
                         anchors.fill: parent
 
                         Column {
@@ -317,34 +324,44 @@ Rectangle {
                                 height: clipHead.height
                             }
                             // These make the striped background for the tracks.
+
                             // It is important that these are not part of the track visual hierarchy;
                             // otherwise, the clips will be obscured by the Track's background.
                             Repeater {
                                 model: parameters
+
                                 Rectangle {
                                     width: tracksContainer.width
-                                    color: (index === currentTrack)? selectedTrackColor : (index % 2)? activePalette.alternateBase : activePalette.base
+                                    color: (index === currentTrack) ? selectedTrackColor : (index % 2) ? activePalette.alternateBase : activePalette.base
                                     height: Logic.trackHeight(model.isCurve)
                                 }
+
                             }
+
                         }
+
                         Column {
                             id: tracksContainer
+
                             Rectangle {
                                 id: trackRoot
+
                                 width: clipRow.width
                                 height: Logic.trackHeight(true)
                                 color: 'transparent'
+
                                 Row {
                                     id: clipRow
+
                                     Clip {
                                         id: beforeClip
+
                                         visible: metadata !== null && filter !== null && filter.out > 0 && filter.in > 0
                                         isBlank: true
                                         clipResource: producer.resource
                                         mltService: producer.mlt_service
                                         inPoint: producer.in
-                                        outPoint: filter !== null? filter.in - 1 : 0
+                                        outPoint: filter !== null ? filter.in - 1 : 0
                                         audioLevels: producer.audioLevels
                                         height: trackRoot.height
                                         hash: producer.hash
@@ -352,59 +369,59 @@ Rectangle {
                                         outThumbnailVisible: false
                                         onRightClicked: root.clipRightClicked()
                                     }
+
                                     Clip {
                                         id: activeClip
+
                                         visible: metadata !== null && filter !== null && filter.out > 0
                                         clipName: producer.name
                                         clipResource: producer.resource
                                         mltService: producer.mlt_service
-                                        inPoint: filter !== null? filter.in : 0
-                                        outPoint: filter !== null? filter.out : 0
-                                        animateIn: filter !== null? filter.animateIn : 0
-                                        animateOut: filter !== null? filter.animateOut : 0
+                                        inPoint: filter !== null ? filter.in : 0
+                                        outPoint: filter !== null ? filter.out : 0
+                                        animateIn: filter !== null ? filter.animateIn : 0
+                                        animateOut: filter !== null ? filter.animateOut : 0
                                         audioLevels: producer.audioLevels
                                         height: trackRoot.height
                                         hash: producer.hash
                                         speed: producer.speed
                                         onTrimmingIn: {
-                                            var n = filter.in + delta
+                                            var n = filter.in + delta;
                                             if (delta != 0 && n >= producer.in && n <= filter.out) {
-                                                parameters.trimFilterIn(n)
+                                                parameters.trimFilterIn(n);
                                                 // Show amount trimmed as a time in a "bubble" help.
-                                                var s = application.timecode(Math.abs(clip.originalX))
-                                                s = '%1%2 = %3'.arg((clip.originalX < 0)? '-' : (clip.originalX > 0)? '+' : '')
-                                                               .arg(s.substring(3))
-                                                               .arg(application.timecode(n))
-                                                bubbleHelp.show(clip.x, trackRoot.y + trackRoot.height, s)
+                                                var s = application.timecode(Math.abs(clip.originalX));
+                                                s = '%1%2 = %3'.arg((clip.originalX < 0) ? '-' : (clip.originalX > 0) ? '+' : '').arg(s.substring(3)).arg(application.timecode(n));
+                                                bubbleHelp.show(clip.x, trackRoot.y + trackRoot.height, s);
                                             } else {
-                                                clip.originalX -= delta
+                                                clip.originalX -= delta;
                                             }
                                         }
                                         onTrimmedIn: bubbleHelp.hide()
                                         onTrimmingOut: {
-                                            var n = filter.out - delta
+                                            var n = filter.out - delta;
                                             if (delta != 0 && n >= filter.in && n <= producer.out) {
-                                                parameters.trimFilterOut(n)
+                                                parameters.trimFilterOut(n);
                                                 // Show amount trimmed as a time in a "bubble" help.
-                                                var s = application.timecode(Math.abs(clip.originalX))
-                                                s = '%1%2 = %3'.arg((clip.originalX < 0)? '+' : (clip.originalX > 0)? '-' : '')
-                                                               .arg(s.substring(3))
-                                                               .arg(application.timecode(n))
-                                                bubbleHelp.show(clip.x + clip.width, trackRoot.y + trackRoot.height, s)
+                                                var s = application.timecode(Math.abs(clip.originalX));
+                                                s = '%1%2 = %3'.arg((clip.originalX < 0) ? '+' : (clip.originalX > 0) ? '-' : '').arg(s.substring(3)).arg(application.timecode(n));
+                                                bubbleHelp.show(clip.x + clip.width, trackRoot.y + trackRoot.height, s);
                                             } else {
-                                                clip.originalX -= delta
+                                                clip.originalX -= delta;
                                             }
                                         }
                                         onTrimmedOut: bubbleHelp.hide()
                                         onRightClicked: root.clipRightClicked()
                                     }
+
                                     Clip {
                                         id: afterClip
+
                                         visible: metadata !== null && filter !== null && filter.out > 0
                                         isBlank: true
                                         clipResource: producer.resource
                                         mltService: producer.mlt_service
-                                        inPoint: filter !== null? filter.out + 1 : 0
+                                        inPoint: filter !== null ? filter.out + 1 : 0
                                         outPoint: producer.out
                                         audioLevels: producer.audioLevels
                                         height: trackRoot.height
@@ -413,17 +430,61 @@ Rectangle {
                                         inThumbnailVisible: false
                                         onRightClicked: root.clipRightClicked()
                                     }
+
                                 }
+
                             }
 
-                            Repeater { id: parametersRepeater; model: parameterDelegateModel }
+                            Repeater {
+                                id: parametersRepeater
+
+                                model: parameterDelegateModel
+                            }
+
                         }
+
                     }
+
+                    ScrollBar.horizontal: ScrollBar {
+                        id: horizontalScrollBar
+
+                        height: 16
+                        policy: ScrollBar.AlwaysOn
+                        visible: tracksFlickable.contentWidth > tracksFlickable.width
+                        parent: tracksFlickable.parent
+                        anchors.top: tracksFlickable.bottom
+                        anchors.left: tracksFlickable.left
+                        anchors.right: tracksFlickable.right
+
+                        background: Rectangle {
+                            color: parent.palette.alternateBase
+                        }
+
+                    }
+
+                    ScrollBar.vertical: ScrollBar {
+                        width: 16
+                        policy: ScrollBar.AlwaysOn
+                        visible: tracksFlickable.contentHeight > tracksFlickable.height
+                        parent: tracksFlickable.parent
+                        anchors.top: tracksFlickable.top
+                        anchors.left: tracksFlickable.right
+                        anchors.bottom: tracksFlickable.bottom
+                        anchors.bottomMargin: -16
+
+                        background: Rectangle {
+                            color: parent.palette.alternateBase
+                        }
+
+                    }
+
                 }
+
             }
 
             Rectangle {
                 id: cursor
+
                 visible: producer.position > -1 && metadata !== null
                 color: activePalette.text
                 width: 1
@@ -431,58 +492,99 @@ Rectangle {
                 x: producer.position * timeScale - tracksFlickable.contentX
                 y: 0
             }
+
             Shotcut.TimelinePlayhead {
                 id: playhead
+
                 visible: producer.position > -1 && metadata !== null
-                x: producer.position * timeScale - tracksFlickable.contentX - width/2
+                x: producer.position * timeScale - tracksFlickable.contentX - width / 2
                 y: 0
                 width: 16
                 height: 8
             }
+
         }
+
     }
 
     Rectangle {
         id: bubbleHelp
+
         property alias text: bubbleHelpLabel.text
+
+        function show(x, y, text) {
+            bubbleHelp.x = x + tracksArea.x - tracksFlickable.contentX - bubbleHelpLabel.width;
+            bubbleHelp.y = Math.max(0, y + tracksArea.y - tracksFlickable.contentY - bubbleHelpLabel.height);
+            bubbleHelp.text = text;
+            if (bubbleHelp.state !== 'visible')
+                bubbleHelp.state = 'visible';
+
+        }
+
+        function hide() {
+            bubbleHelp.state = 'invisible';
+            bubbleHelp.opacity = 0;
+        }
+
         color: application.toolTipBaseColor
         width: bubbleHelpLabel.width + 8
         height: bubbleHelpLabel.height + 8
         radius: 4
-        states: [
-            State { name: 'invisible'; PropertyChanges { target: bubbleHelp; opacity: 0} },
-            State { name: 'visible'; PropertyChanges { target: bubbleHelp; opacity: 1} }
-        ]
         state: 'invisible'
+        states: [
+            State {
+                name: 'invisible'
+
+                PropertyChanges {
+                    target: bubbleHelp
+                    opacity: 0
+                }
+
+            },
+            State {
+                name: 'visible'
+
+                PropertyChanges {
+                    target: bubbleHelp
+                    opacity: 1
+                }
+
+            }
+        ]
         transitions: [
             Transition {
                 from: 'invisible'
                 to: 'visible'
-                OpacityAnimator { target: bubbleHelp; duration: 200; easing.type: Easing.InOutQuad }
+
+                OpacityAnimator {
+                    target: bubbleHelp
+                    duration: 200
+                    easing.type: Easing.InOutQuad
+                }
+
             },
             Transition {
                 from: 'visible'
                 to: 'invisible'
-                OpacityAnimator { target: bubbleHelp; duration: 200; easing.type: Easing.InOutQuad }
+
+                OpacityAnimator {
+                    target: bubbleHelp
+                    duration: 200
+                    easing.type: Easing.InOutQuad
+                }
+
             }
         ]
+
         Label {
             id: bubbleHelpLabel
+
             color: application.toolTipTextColor
             anchors.centerIn: parent
         }
-        function show(x, y, text) {
-            bubbleHelp.x = x + tracksArea.x - tracksFlickable.contentX - bubbleHelpLabel.width
-            bubbleHelp.y = Math.max(0, y + tracksArea.y - tracksFlickable.contentY - bubbleHelpLabel.height)
-            bubbleHelp.text = text
-            if (bubbleHelp.state !== 'visible')
-                bubbleHelp.state = 'visible'
-        }
-        function hide() {
-            bubbleHelp.state = 'invisible'
-            bubbleHelp.opacity = 0
-        }
+
     }
+
     DropShadow {
         source: bubbleHelp
         anchors.fill: bubbleHelp
@@ -497,7 +599,9 @@ Rectangle {
 
     DelegateModel {
         id: parameterDelegateModel
+
         model: parameters
+
         Parameter {
             rootIndex: parameterDelegateModel.modelIndex(index)
             width: producer.duration * timeScale
@@ -506,58 +610,91 @@ Rectangle {
             maximum: model.maximum
             height: Logic.trackHeight(model.isCurve)
             onClicked: {
-                currentTrack = parameter.DelegateModel.itemsIndex
-                root.selection = [keyframe.DelegateModel.itemsIndex]
+                currentTrack = parameter.DelegateModel.itemsIndex;
+                root.selection = [keyframe.DelegateModel.itemsIndex];
             }
             onRightClicked: root.keyframeRightClicked()
         }
+
     }
 
     Connections {
-        target: producer
         function onPositionChanged() {
-            if (!stopScrolling) Logic.scrollIfNeeded()
+            if (!stopScrolling)
+                Logic.scrollIfNeeded();
+
         }
+
+        target: producer
     }
 
     Connections {
-        target: filter
         function onChanged(name) {
-            var parameterIndex = parameters.parameterIndex(name)
+            var parameterIndex = parameters.parameterIndex(name);
             if (parameterIndex > -1) {
-                currentTrack = parameterIndex
-                var keyframeIndex = parameters.keyframeIndex(parameterIndex, producer.position + producer.in)
+                currentTrack = parameterIndex;
+                var keyframeIndex = parameters.keyframeIndex(parameterIndex, producer.position + producer.in);
                 if (keyframeIndex > -1)
-                    selection = [keyframeIndex]
+                    selection = [keyframeIndex];
+
             }
         }
+
+        target: filter
     }
 
     Connections {
+        function onSetZoom(value) {
+            setZoom(value);
+        }
+
+        function onZoomIn() {
+            zoomIn();
+        }
+
+        function onZoomOut() {
+            zoomOut();
+        }
+
+        function onZoomToFit() {
+            zoomToFit();
+        }
+
+        function onResetZoom() {
+            resetZoom();
+        }
+
+        function onSeekPreviousSimple() {
+            Logic.seekPreviousSimple();
+        }
+
+        function onSeekNextSimple() {
+            Logic.seekNextSimple();
+        }
+
         target: keyframes
-        function onSetZoom(value) { setZoom(value) }
-        function onZoomIn() { zoomIn() }
-        function onZoomOut() {zoomOut() }
-        function onZoomToFit() { zoomToFit() }
-        function onResetZoom() { resetZoom() }
-        function onSeekPreviousSimple() { Logic.seekPreviousSimple() }
-        function onSeekNextSimple() { Logic.seekNextSimple() }
     }
 
     // This provides continuous scrolling at the left/right edges.
     Timer {
         id: scrollTimer
+
+        property var item
+        property bool backwards
+
         interval: 25
         repeat: true
         triggeredOnStart: true
-        property var item
-        property bool backwards
         onTriggered: {
-            var delta = backwards? -10 : 10
-            if (item) item.x += delta
-            tracksFlickable.contentX += delta
+            var delta = backwards ? -10 : 10;
+            if (item)
+                item.x += delta;
+
+            tracksFlickable.contentX += delta;
             if (tracksFlickable.contentX <= 0)
-                stop()
+                stop();
+
         }
     }
+
 }

--- a/src/qml/views/timeline/Clip.qml
+++ b/src/qml/views/timeline/Clip.qml
@@ -21,6 +21,7 @@ import Shotcut.Controls 1.0 as Shotcut
 
 Rectangle {
     id: clipRoot
+
     property string clipName: ''
     property string clipComment: ''
     property string clipResource: ''
@@ -40,7 +41,7 @@ Rectangle {
     property int originalX: x
     property bool selected: false
     property string hash: ''
-    property double speed: 1.0
+    property double speed: 1
     property string audioIndex: ''
     property bool isTrackMute: false
 
@@ -55,73 +56,104 @@ Rectangle {
     signal trimmingOut(var clip, real delta, var mouse)
     signal trimmedOut(var clip)
 
-    SystemPalette { id: activePalette }
-    gradient: Gradient {
-        GradientStop {
-            id: gradientStop
-            position: 0.00
-            color: Qt.lighter(getColor())
+    function getColor() {
+        return isBlank ? 'transparent' : isTransition ? 'mediumpurple' : isAudio ? 'darkseagreen' : root.shotcutBlue;
+    }
+
+    function reparent(track) {
+        parent = track;
+        isAudio = track.isAudio;
+        height = track.height;
+        generateWaveform(false);
+    }
+
+    function generateWaveform(force) {
+        if (!waveform.visible && !force)
+            return ;
+
+        // This is needed to make the model have the correct count.
+        // Model as a property expression is not working in all cases.
+        waveformRepeater.model = Math.ceil(waveform.innerWidth / waveform.maxWidth);
+        for (var i = 0; i < waveformRepeater.count; i++) waveformRepeater.itemAt(0).update()
+    }
+
+    function updateThumbnails() {
+        var s = inThumbnail.source.toString();
+        if (s.substring(s.length - 1) !== '!') {
+            inThumbnail.source = s + '!';
+            resetThumbnailsSourceTimer.restart();
         }
-        GradientStop {
-            id: gradientStop2
-            position: 1.0
-            color: getColor()
+        s = outThumbnail.source.toString();
+        if (s.substring(s.length - 1) !== '!') {
+            outThumbnail.source = s + '!';
+            resetThumbnailsSourceTimer.restart();
         }
     }
 
-    border.color: (selected || Drag.active || trackIndex != originalTrackIndex)? 'red' : 'black'
+    function imagePath(time) {
+        if (isAudio || isBlank || isTransition)
+            return '';
+        else
+            return 'image://thumbnail/' + hash + '/' + mltService + '/' + clipResource + '#' + time;
+    }
+
+    border.color: (selected || Drag.active || trackIndex != originalTrackIndex) ? 'red' : 'black'
     border.width: isBlank && !selected ? 0 : 1
     clip: true
     Drag.active: mouseArea.drag.active
     Drag.proposedAction: Qt.MoveAction
-    opacity: Drag.active? 0.5 : 1.0
-
-    function getColor() {
-        return isBlank? 'transparent' : isTransition? 'mediumpurple' : isAudio? 'darkseagreen' : root.shotcutBlue
-    }
-
-    function reparent(track) {
-        parent = track
-        isAudio = track.isAudio
-        height = track.height
-        generateWaveform(false)
-    }
-
-    function generateWaveform(force) {
-        if (!waveform.visible && !force) return
-        // This is needed to make the model have the correct count.
-        // Model as a property expression is not working in all cases.
-        waveformRepeater.model = Math.ceil(waveform.innerWidth / waveform.maxWidth)
-        for (var i = 0; i < waveformRepeater.count; i++)
-            waveformRepeater.itemAt(0).update()
-    }
-
-    function updateThumbnails() {
-        var s = inThumbnail.source.toString()
-        if (s.substring(s.length - 1) !== '!') {
-            inThumbnail.source = s + '!'
-            resetThumbnailsSourceTimer.restart()
-        }
-        s = outThumbnail.source.toString()
-        if (s.substring(s.length - 1) !== '!') {
-            outThumbnail.source = s + '!'
-            resetThumbnailsSourceTimer.restart()
-        }
-    }
-
-
-    function imagePath(time) {
-        if (isAudio || isBlank || isTransition) {
-            return ''
-        } else {
-            return 'image://thumbnail/' + hash + '/' + mltService + '/' + clipResource + '#' + time
-        }
-    }
-
+    opacity: Drag.active ? 0.5 : 1
     onAudioLevelsChanged: generateWaveform(false)
+    states: [
+        State {
+            name: 'normal'
+            when: !clipRoot.selected
+
+            PropertyChanges {
+                target: clipRoot
+                z: 0
+            }
+
+        },
+        State {
+            name: 'selectedBlank'
+            when: clipRoot.selected && clipRoot.isBlank
+
+            PropertyChanges {
+                target: gradientStop2
+                color: Qt.lighter(selectedTrackColor)
+            }
+
+            PropertyChanges {
+                target: gradientStop
+                color: Qt.darker(selectedTrackColor)
+            }
+
+        },
+        State {
+            name: 'selected'
+            when: clipRoot.selected
+
+            PropertyChanges {
+                target: clipRoot
+                z: 1
+            }
+
+            PropertyChanges {
+                target: gradientStop
+                color: Qt.darker(getColor())
+            }
+
+        }
+    ]
+
+    SystemPalette {
+        id: activePalette
+    }
 
     Image {
         id: outThumbnail
+
         visible: !isBlank && settings.timelineShowThumbnails && parent.height > 20 && x > inThumbnail.width
         anchors.right: parent.right
         anchors.top: parent.top
@@ -129,13 +161,14 @@ Rectangle {
         anchors.rightMargin: parent.border.width
         anchors.bottom: parent.bottom
         anchors.bottomMargin: parent.height / 2
-        width: height * 16.0/9.0
+        width: height * 16 / 9
         fillMode: Image.PreserveAspectFit
         source: imagePath(outPoint)
     }
 
     Image {
         id: inThumbnail
+
         visible: !isBlank && settings.timelineShowThumbnails && parent.height > 20
         anchors.left: parent.left
         anchors.top: parent.top
@@ -143,47 +176,56 @@ Rectangle {
         anchors.leftMargin: parent.border.width
         anchors.bottom: parent.bottom
         anchors.bottomMargin: parent.height / 2
-        width: height * 16.0/9.0
+        width: height * 16 / 9
         fillMode: Image.PreserveAspectFit
         source: imagePath(inPoint)
     }
 
     Shotcut.TimelineTransition {
+        property var color: isAudio ? 'darkseagreen' : root.shotcutBlue
+
         visible: isTransition
         anchors.fill: parent
-        property var color: isAudio? 'darkseagreen' : root.shotcutBlue
         colorA: color
         colorB: clipRoot.selected ? Qt.darker(color) : Qt.lighter(color)
     }
 
     Row {
         id: waveform
+
+        property int maxWidth: Math.max(application.maxTextureSize / 2, 2048)
+        property int innerWidth: clipRoot.width - clipRoot.border.width * 2
+
         visible: !isBlank && settings.timelineShowWaveforms && (parseInt(audioIndex) > -1 || audioIndex === 'all')
-        height: (isAudio || parent.height <= 20)? parent.height : parent.height / 2
+        height: (isAudio || parent.height <= 20) ? parent.height : parent.height / 2
         anchors.left: parent.left
         anchors.bottom: parent.bottom
         anchors.margins: parent.border.width
         opacity: isTrackMute ? 0.2 : 0.7
-        property int maxWidth: Math.max(application.maxTextureSize / 2, 2048)
-        property int innerWidth: clipRoot.width - clipRoot.border.width * 2
 
         Repeater {
             id: waveformRepeater
+
             model: Math.ceil(waveform.innerWidth / waveform.maxWidth)
+
             Shotcut.TimelineWaveform {
+                // right edge
+                // left edge
+                // bottom edge
+
+                property int channels: 2
+
                 width: Math.min(waveform.innerWidth, waveform.maxWidth)
                 height: waveform.height
                 fillColor: getColor()
-                property int channels: 2
                 inPoint: Math.round((clipRoot.inPoint + index * waveform.maxWidth / timeScale) * speed) * channels
                 outPoint: inPoint + Math.round(width / timeScale * speed) * channels
                 levels: audioLevels
-                active: ((clipRoot.x + x + width)   > tracksFlickable.contentX) && // right edge
-                        ((clipRoot.x + x)           < tracksFlickable.contentX + tracksFlickable.width) && // left edge
-                        ((trackRoot.y + y + height) > tracksFlickable.contentY) && // bottom edge
-                        ((trackRoot.y + y)          < tracksFlickable.contentY + tracksFlickable.height) // top edge
+                active: ((clipRoot.x + x + width) > tracksFlickable.contentX) && ((clipRoot.x + x) < tracksFlickable.contentX + tracksFlickable.width) && ((trackRoot.y + y + height) > tracksFlickable.contentY) && ((trackRoot.y + y) < tracksFlickable.contentY + tracksFlickable.height) // top edge
             }
+
         }
+
     }
 
     Rectangle {
@@ -207,25 +249,26 @@ Rectangle {
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.topMargin: parent.border.width
-        anchors.leftMargin: parent.border.width +
-            ((isAudio || !settings.timelineShowThumbnails) ? 0 : inThumbnail.width)
+        anchors.leftMargin: parent.border.width + ((isAudio || !settings.timelineShowThumbnails) ? 0 : inThumbnail.width)
         width: label.width + 2
         height: label.height
     }
 
     Text {
         id: label
+
         text: clipName
         visible: !isBlank && !isTransition
         font.pointSize: 8
+        color: 'black'
+
         anchors {
             top: parent.top
             left: parent.left
             topMargin: parent.border.width + 1
-            leftMargin: parent.border.width +
-                ((isAudio || !settings.timelineShowThumbnails) ? 0 : inThumbnail.width) + 1
+            leftMargin: parent.border.width + ((isAudio || !settings.timelineShowThumbnails) ? 0 : inThumbnail.width) + 1
         }
-        color: 'black'
+
     }
 
     Rectangle {
@@ -236,102 +279,73 @@ Rectangle {
         anchors.top: parent.top
         anchors.right: parent.right
         anchors.topMargin: parent.border.width
-        anchors.rightMargin: parent.border.width +
-            ((isAudio || !settings.timelineShowThumbnails) ? 0 : outThumbnail.width) + 2
+        anchors.rightMargin: parent.border.width + ((isAudio || !settings.timelineShowThumbnails) ? 0 : outThumbnail.width) + 2
         width: labelRight.width + 2
         height: labelRight.height
     }
 
     Text {
         id: labelRight
+
         text: clipName
-        visible: !isBlank && !isTransition && parent.width > ((settings.timelineShowThumbnails? 2 * outThumbnail.width : 0) + 3 * label.width)
+        visible: !isBlank && !isTransition && parent.width > ((settings.timelineShowThumbnails ? 2 * outThumbnail.width : 0) + 3 * label.width)
         font.pointSize: 8
+        color: 'black'
+
         anchors {
             top: parent.top
             right: parent.right
             topMargin: parent.border.width + 1
-            rightMargin: parent.border.width +
-                ((isAudio || !settings.timelineShowThumbnails) ? 0 : outThumbnail.width) + 3
+            rightMargin: parent.border.width + ((isAudio || !settings.timelineShowThumbnails) ? 0 : outThumbnail.width) + 3
         }
-        color: 'black'
-    }
 
-    states: [
-        State {
-            name: 'normal'
-            when: !clipRoot.selected
-            PropertyChanges {
-                target: clipRoot
-                z: 0
-            }
-        },
-        State {
-            name: 'selectedBlank'
-            when: clipRoot.selected && clipRoot.isBlank
-            PropertyChanges {
-                target: gradientStop2
-                color: Qt.lighter(selectedTrackColor)
-            }
-            PropertyChanges {
-                target: gradientStop
-                color: Qt.darker(selectedTrackColor)
-            }
-        },
-        State {
-            name: 'selected'
-            when: clipRoot.selected
-            PropertyChanges {
-                target: clipRoot
-                z: 1
-            }
-            PropertyChanges {
-                target: gradientStop
-                color: Qt.darker(getColor())
-            }
-        }
-    ]
+    }
 
     MouseArea {
         id: clipNameHover
+
         anchors.fill: parent
         enabled: !isBlank && !mouseArea.drag.active && !trimInMouseArea.drag.active && !trimOutMouseArea.drag.active && !fadeInMouseArea.drag.active && !fadeOutMouseArea.drag.active
         propagateComposedEvents: true
         acceptedButtons: Qt.NoButton
         hoverEnabled: true
+        onEntered: {
+            nameHoverTimer.start();
+        }
+        onPositionChanged: {
+            bubbleHelp.hide();
+            nameHoverTimer.restart();
+        }
+        onExited: {
+            nameHoverTimer.stop();
+            bubbleHelp.hide();
+        }
+
         FontMetrics {
             id: fontMetrics
         }
+
         Timer {
             id: nameHoverTimer
+
             interval: 1000
             onTriggered: {
                 // Limit text to 200 pixels
-                var text = fontMetrics.elidedText(clipName.trim(), Qt.ElideRight, 200)
+                var text = fontMetrics.elidedText(clipName.trim(), Qt.ElideRight, 200);
                 if (text.length > 0) {
-                    var commentLines = clipComment.split('\n')
+                    var commentLines = clipComment.split('\n');
                     if (commentLines.length > 0) {
-                        var comment = fontMetrics.elidedText(commentLines[0].trim(), Qt.ElideRight, 200)
-                        if (comment.length > 0) {
-                            text += '<br>' + comment
-                        }
+                        var comment = fontMetrics.elidedText(commentLines[0].trim(), Qt.ElideRight, 200);
+                        if (comment.length > 0)
+                            text += '<br>' + comment;
+
                     }
-                    text += '<br>' + application.timecode(clipDuration)
-                    bubbleHelp.show(clipRoot.x + clipNameHover.mouseX, trackRoot.y + clipRoot.height, text)
+                    text += '<br>' + application.timecode(clipDuration);
+                    bubbleHelp.show(clipRoot.x + clipNameHover.mouseX, trackRoot.y + clipRoot.height, text);
                 }
             }
         }
-        onEntered: {
-            nameHoverTimer.start()
-        }
-        onPositionChanged: {
-            bubbleHelp.hide()
-            nameHoverTimer.restart()
-        }
-        onExited: {
-            nameHoverTimer.stop()
-            bubbleHelp.hide()
-        }
+
     }
 
     MouseArea {
@@ -339,86 +353,89 @@ Rectangle {
         enabled: isBlank
         acceptedButtons: Qt.RightButton
         onClicked: {
-            timeline.position = timeline.position // pause
-            clipRoot.clicked(clipRoot, mouse)
-            clipRoot.clipRightClicked(clipRoot, mouse)
+            timeline.position = timeline.position; // pause
+            clipRoot.clicked(clipRoot, mouse);
+            clipRoot.clipRightClicked(clipRoot, mouse);
         }
     }
 
     MouseArea {
         id: mouseArea
+
+        property int startX
+
         anchors.fill: parent
         enabled: !isBlank
         acceptedButtons: Qt.LeftButton
         drag.target: parent
         drag.axis: Drag.XAxis
-        property int startX
         onPressed: {
             if (!doubleClickTimer.running) {
-                doubleClickTimer.restart()
-                doubleClickTimer.isFirstRelease = true
+                doubleClickTimer.restart();
+                doubleClickTimer.isFirstRelease = true;
             }
-            root.stopScrolling = true
-            originalX = parent.x
-            originalTrackIndex = trackIndex
-            originalClipIndex = index
-            startX = parent.x
+            root.stopScrolling = true;
+            originalX = parent.x;
+            originalTrackIndex = trackIndex;
+            originalClipIndex = index;
+            startX = parent.x;
             clipRoot.forceActiveFocus();
-            clipRoot.clicked(clipRoot, mouse)
+            clipRoot.clicked(clipRoot, mouse);
         }
         onPositionChanged: {
             if (mouse.y < 0 && trackIndex > 0)
-                parent.draggedToTrack(clipRoot, -1)
+                parent.draggedToTrack(clipRoot, -1);
             else if (mouse.y > height && (trackIndex + 1) < root.trackCount)
-                parent.draggedToTrack(clipRoot, 1)
-            parent.dragged(clipRoot, mouse)
+                parent.draggedToTrack(clipRoot, 1);
+            parent.dragged(clipRoot, mouse);
         }
         onReleased: {
-            root.stopScrolling = false
+            root.stopScrolling = false;
             if (!doubleClickTimer.isFirstRelease && doubleClickTimer.running) {
                 // double click
-                timeline.position = Math.round(clipRoot.x / multitrack.scaleFactor)
-                doubleClickTimer.stop()
+                timeline.position = Math.round(clipRoot.x / multitrack.scaleFactor);
+                doubleClickTimer.stop();
             } else {
                 // single click
-                doubleClickTimer.isFirstRelease = false
-
-                parent.y = 0
-                var delta = parent.x - startX
-                if (Math.abs(delta) >= 1.0 || trackIndex !== originalTrackIndex) {
-                    parent.moved(clipRoot)
-                    originalX = parent.x
-                    originalTrackIndex = trackIndex
+                doubleClickTimer.isFirstRelease = false;
+                parent.y = 0;
+                var delta = parent.x - startX;
+                if (Math.abs(delta) >= 1 || trackIndex !== originalTrackIndex) {
+                    parent.moved(clipRoot);
+                    originalX = parent.x;
+                    originalTrackIndex = trackIndex;
                 } else {
-                    parent.dropped(clipRoot)
+                    parent.dropped(clipRoot);
                 }
             }
         }
+
         Timer {
             id: doubleClickTimer
-            interval: 500 //ms
+
             property bool isFirstRelease
+
+            interval: 500 //ms
         }
 
         MouseArea {
             anchors.fill: parent
             acceptedButtons: Qt.RightButton
             propagateComposedEvents: true
-            cursorShape: (trimInMouseArea.drag.active || trimOutMouseArea.drag.active)? Qt.SizeHorCursor :
-                (fadeInMouseArea.drag.active || fadeOutMouseArea.drag.active)? Qt.PointingHandCursor :
-                mouseArea.drag.active? Qt.ClosedHandCursor :
-                isBlank? Qt.ArrowCursor : Qt.OpenHandCursor
+            cursorShape: (trimInMouseArea.drag.active || trimOutMouseArea.drag.active) ? Qt.SizeHorCursor : (fadeInMouseArea.drag.active || fadeOutMouseArea.drag.active) ? Qt.PointingHandCursor : mouseArea.drag.active ? Qt.ClosedHandCursor : isBlank ? Qt.ArrowCursor : Qt.OpenHandCursor
             onClicked: {
-                timeline.position = timeline.position // pause
+                timeline.position = timeline.position; // pause
                 clipRoot.forceActiveFocus();
-                clipRoot.clicked(clipRoot, mouse)
-                clipRoot.clipRightClicked(clipRoot, mouse)
+                clipRoot.clicked(clipRoot, mouse);
+                clipRoot.clipRightClicked(clipRoot, mouse);
             }
         }
+
     }
 
     Shotcut.TimelineTriangle {
         id: fadeInTriangle
+
         visible: !isBlank && !isTransition
         width: parent.fadeIn * timeScale
         height: parent.height - parent.border.width * 2
@@ -427,8 +444,10 @@ Rectangle {
         anchors.margins: parent.border.width
         opacity: 0.5
     }
+
     Rectangle {
         id: fadeInControl
+
         enabled: !isBlank && !isTransition
         anchors.left: fadeInTriangle.right
         anchors.top: fadeInTriangle.top
@@ -443,8 +462,15 @@ Rectangle {
         border.color: 'white'
         opacity: 0
         Drag.active: fadeInMouseArea.drag.active
+
         MouseArea {
+            // trackRoot.clipSelected(clipRoot, trackRoot) TODO
+
             id: fadeInMouseArea
+
+            property int startX
+            property int startFadeIn
+
             anchors.fill: parent
             hoverEnabled: true
             cursorShape: Qt.PointingHandCursor
@@ -452,56 +478,58 @@ Rectangle {
             drag.axis: Drag.XAxis
             drag.minimumX: 0
             drag.maximumX: clipRoot.width
-            property int startX
-            property int startFadeIn
             onEntered: parent.opacity = 0.7
             onExited: parent.opacity = 0
             onPressed: {
-                root.stopScrolling = true
-                startX = parent.x
-                startFadeIn = fadeIn
-                parent.anchors.left = undefined
-                parent.opacity = 1
-                // trackRoot.clipSelected(clipRoot, trackRoot) TODO
+                root.stopScrolling = true;
+                startX = parent.x;
+                startFadeIn = fadeIn;
+                parent.anchors.left = undefined;
+                parent.opacity = 1;
             }
             onReleased: {
-                root.stopScrolling = false
-                parent.anchors.left = fadeInTriangle.right
-                bubbleHelp.hide()
+                root.stopScrolling = false;
+                parent.anchors.left = fadeInTriangle.right;
+                bubbleHelp.hide();
             }
             onPositionChanged: {
                 if (mouse.buttons === Qt.LeftButton) {
-                    var delta = Math.round((parent.x - startX) / timeScale)
-                    var duration = Math.min(Math.max(0, startFadeIn + delta), clipDuration)
-                    timeline.fadeIn(trackIndex, index, duration)
-
+                    var delta = Math.round((parent.x - startX) / timeScale);
+                    var duration = Math.min(Math.max(0, startFadeIn + delta), clipDuration);
+                    timeline.fadeIn(trackIndex, index, duration);
                     // Show fade duration as time in a "bubble" help.
-                    var s = application.timecode(duration)
-                    bubbleHelp.show(clipRoot.x, trackRoot.y + clipRoot.height, s.substring(6))
+                    var s = application.timecode(duration);
+                    bubbleHelp.show(clipRoot.x, trackRoot.y + clipRoot.height, s.substring(6));
                 }
             }
             onDoubleClicked: timeline.fadeIn(trackIndex, index, (fadeIn > 0) ? 0 : Math.round(profile.fps))
         }
+
         SequentialAnimation on scale {
             loops: Animation.Infinite
             running: fadeInMouseArea.containsMouse
+
             NumberAnimation {
-                from: 1.0
+                from: 1
                 to: 1.5
                 duration: 250
                 easing.type: Easing.InOutQuad
             }
+
             NumberAnimation {
                 from: 1.5
-                to: 1.0
+                to: 1
                 duration: 250
                 easing.type: Easing.InOutQuad
             }
+
         }
+
     }
 
     Shotcut.TimelineTriangle {
         id: fadeOutTriangle
+
         visible: !isBlank && !isTransition
         width: parent.fadeOut * timeScale
         height: parent.height - parent.border.width * 2
@@ -509,10 +537,17 @@ Rectangle {
         anchors.top: parent.top
         anchors.margins: parent.border.width
         opacity: 0.5
-        transform: Scale { xScale: -1; origin.x: fadeOutTriangle.width / 2}
+
+        transform: Scale {
+            xScale: -1
+            origin.x: fadeOutTriangle.width / 2
+        }
+
     }
+
     Rectangle {
         id: fadeOutControl
+
         enabled: !isBlank && !isTransition
         anchors.right: fadeOutTriangle.left
         anchors.top: fadeOutTriangle.top
@@ -526,8 +561,13 @@ Rectangle {
         border.color: 'white'
         opacity: 0
         Drag.active: fadeOutMouseArea.drag.active
+
         MouseArea {
             id: fadeOutMouseArea
+
+            property int startX
+            property int startFadeOut
+
             anchors.fill: parent
             hoverEnabled: true
             cursorShape: Qt.PointingHandCursor
@@ -535,104 +575,111 @@ Rectangle {
             drag.axis: Drag.XAxis
             drag.minimumX: -width - 1
             drag.maximumX: clipRoot.width
-            property int startX
-            property int startFadeOut
             onEntered: parent.opacity = 0.7
             onExited: parent.opacity = 0
             onPressed: {
-                root.stopScrolling = true
-                startX = parent.x
-                startFadeOut = fadeOut
-                parent.anchors.right = undefined
-                parent.opacity = 1
+                root.stopScrolling = true;
+                startX = parent.x;
+                startFadeOut = fadeOut;
+                parent.anchors.right = undefined;
+                parent.opacity = 1;
             }
             onReleased: {
-                root.stopScrolling = false
-                parent.anchors.right = fadeOutTriangle.left
-                bubbleHelp.hide()
+                root.stopScrolling = false;
+                parent.anchors.right = fadeOutTriangle.left;
+                bubbleHelp.hide();
             }
             onPositionChanged: {
                 if (mouse.buttons === Qt.LeftButton) {
-                    var delta = Math.round((startX - parent.x) / timeScale)
-                    var duration = Math.min(Math.max(0, startFadeOut + delta), clipDuration)
-                    timeline.fadeOut(trackIndex, index, duration)
-
+                    var delta = Math.round((startX - parent.x) / timeScale);
+                    var duration = Math.min(Math.max(0, startFadeOut + delta), clipDuration);
+                    timeline.fadeOut(trackIndex, index, duration);
                     // Show fade duration as time in a "bubble" help.
-                    var s = application.timecode(duration)
-                    bubbleHelp.show(clipRoot.x + clipRoot.width, trackRoot.y + clipRoot.height, s.substring(6))
+                    var s = application.timecode(duration);
+                    bubbleHelp.show(clipRoot.x + clipRoot.width, trackRoot.y + clipRoot.height, s.substring(6));
                 }
             }
             onDoubleClicked: timeline.fadeOut(trackIndex, index, (fadeOut > 0) ? 0 : Math.round(profile.fps))
         }
+
         SequentialAnimation on scale {
             loops: Animation.Infinite
             running: fadeOutMouseArea.containsMouse
+
             NumberAnimation {
-                from: 1.0
+                from: 1
                 to: 1.5
                 duration: 250
                 easing.type: Easing.InOutQuad
             }
+
             NumberAnimation {
                 from: 1.5
-                to: 1.0
+                to: 1
                 duration: 250
                 easing.type: Easing.InOutQuad
             }
+
         }
+
     }
 
     Rectangle {
         id: trimIn
+
         enabled: !isBlank && !isTransition
         anchors.left: parent.left
         anchors.leftMargin: 0
         height: parent.height
         width: 5
-        color: isAudio? 'green' : 'lawngreen'
+        color: isAudio ? 'green' : 'lawngreen'
         opacity: 0
         Drag.active: trimInMouseArea.drag.active
         Drag.proposedAction: Qt.MoveAction
 
         MouseArea {
             id: trimInMouseArea
+
+            property double startX
+
             anchors.fill: parent
             hoverEnabled: true
             cursorShape: Qt.SizeHorCursor
             drag.target: parent
             drag.axis: Drag.XAxis
-            property double startX
-
             onPressed: {
-                root.stopScrolling = true
-                startX = mapToItem(null, x, y).x
-                originalX = 0 // reusing originalX to accumulate delta for bubble help
-                parent.anchors.left = undefined
-                originalClipIndex = index
+                root.stopScrolling = true;
+                startX = mapToItem(null, x, y).x;
+                originalX = 0; // reusing originalX to accumulate delta for bubble help
+                parent.anchors.left = undefined;
+                originalClipIndex = index;
             }
             onReleased: {
-                root.stopScrolling = false
-                parent.anchors.left = clipRoot.left
-                clipRoot.trimmedIn(clipRoot)
-                parent.opacity = 0
+                root.stopScrolling = false;
+                parent.anchors.left = clipRoot.left;
+                clipRoot.trimmedIn(clipRoot);
+                parent.opacity = 0;
             }
             onPositionChanged: {
                 if (mouse.buttons === Qt.LeftButton) {
-                    var newX = mapToItem(null, x, y).x
-                    var delta = Math.round((newX - startX) / timeScale)
+                    var newX = mapToItem(null, x, y).x;
+                    var delta = Math.round((newX - startX) / timeScale);
                     if (Math.abs(delta) > 0) {
-                        originalX += delta
-                        clipRoot.trimmingIn(clipRoot, delta, mouse)
-                        startX = newX
+                        originalX += delta;
+                        clipRoot.trimmingIn(clipRoot, delta, mouse);
+                        startX = newX;
                     }
                 }
             }
             onEntered: parent.opacity = 0.5
             onExited: parent.opacity = 0
         }
+
     }
+
     Rectangle {
         id: trimOut
+
         enabled: !isBlank && !isTransition
         anchors.right: parent.right
         anchors.rightMargin: 0
@@ -645,52 +692,73 @@ Rectangle {
 
         MouseArea {
             id: trimOutMouseArea
+
+            property int duration
+
             anchors.fill: parent
             hoverEnabled: true
             cursorShape: Qt.SizeHorCursor
             drag.target: parent
             drag.axis: Drag.XAxis
-            property int duration
-
             onPressed: {
-                root.stopScrolling = true
-                duration = clipDuration
-                originalX = 0 // reusing originalX to accumulate delta for bubble help
-                parent.anchors.right = undefined
+                root.stopScrolling = true;
+                duration = clipDuration;
+                originalX = 0; // reusing originalX to accumulate delta for bubble help
+                parent.anchors.right = undefined;
             }
             onReleased: {
-                root.stopScrolling = false
-                parent.anchors.right = clipRoot.right
-                clipRoot.trimmedOut(clipRoot)
+                root.stopScrolling = false;
+                parent.anchors.right = clipRoot.right;
+                clipRoot.trimmedOut(clipRoot);
             }
             onPositionChanged: {
                 if (mouse.buttons === Qt.LeftButton) {
-                    var newDuration = Math.round((parent.x + parent.width) / timeScale)
-                    var delta = duration - newDuration
+                    var newDuration = Math.round((parent.x + parent.width) / timeScale);
+                    var delta = duration - newDuration;
                     if (Math.abs(delta) > 0) {
-                        originalX += delta
-                        clipRoot.trimmingOut(clipRoot, delta, mouse)
-                        duration = newDuration
+                        originalX += delta;
+                        clipRoot.trimmingOut(clipRoot, delta, mouse);
+                        duration = newDuration;
                     }
                 }
             }
             onEntered: parent.opacity = 0.5
             onExited: parent.opacity = 0
         }
+
     }
 
     Timer {
         id: resetThumbnailsSourceTimer
+
         interval: 5000
         onTriggered: {
-            var s = inThumbnail.source.toString()
-            if (s.substring(s.length - 1) === '!') {
-                inThumbnail.source = s.substring(0, s.length - 1)
-            }
-            s = inThumbnail.source.toString()
-            if (s.substring(s.length - 1) === '!') {
-                inThumbnail.source = s.substring(0, s.length - 1)
-            }
+            var s = inThumbnail.source.toString();
+            if (s.substring(s.length - 1) === '!')
+                inThumbnail.source = s.substring(0, s.length - 1);
+
+            s = inThumbnail.source.toString();
+            if (s.substring(s.length - 1) === '!')
+                inThumbnail.source = s.substring(0, s.length - 1);
+
         }
     }
+
+    gradient: Gradient {
+        GradientStop {
+            id: gradientStop
+
+            position: 0
+            color: Qt.lighter(getColor())
+        }
+
+        GradientStop {
+            id: gradientStop2
+
+            position: 1
+            color: getColor()
+        }
+
+    }
+
 }

--- a/src/qml/views/timeline/CornerSelectionShadow.qml
+++ b/src/qml/views/timeline/CornerSelectionShadow.qml
@@ -25,21 +25,40 @@ Item {
 
     width: 100
     height: clip ? clip.height : 0
-    Behavior on opacity { NumberAnimation { duration: 100 } }
 
     Rectangle {
         id: shadowGradient
+
         width: parent.height
         height: parent.width
         anchors.centerIn: parent
         rotation: mirrorGradient ? -90 : 90
-        gradient: Gradient {
-            GradientStop { position: 0.0; color: "transparent" }
-            GradientStop { position: 1.0; color: "white" }
-        }
+
         PulsingAnimation {
             target: shadowGradient
             running: root.opacity
         }
+
+        gradient: Gradient {
+            GradientStop {
+                position: 0
+                color: "transparent"
+            }
+
+            GradientStop {
+                position: 1
+                color: "white"
+            }
+
+        }
+
     }
+
+    Behavior on opacity {
+        NumberAnimation {
+            duration: 100
+        }
+
+    }
+
 }

--- a/src/qml/views/timeline/PulsingAnimation.qml
+++ b/src/qml/views/timeline/PulsingAnimation.qml
@@ -21,13 +21,16 @@ SequentialAnimation {
     property alias target: firstAnim.target
 
     loops: Animation.Infinite
+
     NumberAnimation {
         id: firstAnim
+
         property: "opacity"
         from: 0.3
         to: 0
         duration: 800
     }
+
     NumberAnimation {
         target: firstAnim.target
         property: "opacity"
@@ -35,6 +38,9 @@ SequentialAnimation {
         to: 0.3
         duration: 800
     }
-    PauseAnimation { duration: 300 }
-}
 
+    PauseAnimation {
+        duration: 300
+    }
+
+}

--- a/src/qml/views/timeline/Ruler.qml
+++ b/src/qml/views/timeline/Ruler.qml
@@ -20,28 +20,34 @@ import QtQuick.Controls 2.12
 import Shotcut.Controls 1.0 as Shotcut
 
 Rectangle {
-    property real timeScale: 1.0
+    id: rulerTop
+
+    property real timeScale: 1
     property int adjustment: 0
-    property real intervalSeconds: ((timeScale > 5)? 1 : (5 * Math.max(1, Math.floor(1.5 / timeScale)))) + adjustment
+    property real intervalSeconds: ((timeScale > 5) ? 1 : (5 * Math.max(1, Math.floor(1.5 / timeScale)))) + adjustment
+
     signal editMarkerRequested(int index)
     signal deleteMarkerRequested(int index)
 
-    SystemPalette { id: activePalette }
-
-    id: rulerTop
     height: 28
     color: activePalette.base
 
+    SystemPalette {
+        id: activePalette
+    }
+
     Repeater {
         model: parent.width / (intervalSeconds * profile.fps * timeScale)
+
         Rectangle {
+            // right edge
+
             anchors.bottom: rulerTop.bottom
             height: 18
             width: 1
             color: activePalette.windowText
             x: index * intervalSeconds * profile.fps * timeScale
-            visible: ((x + width)   > tracksFlickable.contentX) && // right edge
-                      (x            < tracksFlickable.contentX + tracksFlickable.width) // left edge
+            visible: ((x + width) > tracksFlickable.contentX) && (x < tracksFlickable.contentX + tracksFlickable.width) // left edge
 
             Label {
                 anchors.left: parent.right
@@ -51,7 +57,9 @@ Rectangle {
                 color: activePalette.windowText
                 text: application.timecode(index * intervalSeconds * profile.fps + 2).substr(0, 8)
             }
+
         }
+
     }
 
     MouseArea {
@@ -60,8 +68,8 @@ Rectangle {
         acceptedButtons: Qt.NoButton
         onExited: bubbleHelp.hide()
         onPositionChanged: {
-            var text = application.timecode(mouse.x / timeScale)
-            bubbleHelp.show(mouse.x + bubbleHelp.width - 8, mouse.y + 65, text)
+            var text = application.timecode(mouse.x / timeScale);
+            bubbleHelp.show(mouse.x + bubbleHelp.width - 8, mouse.y + 65, text);
         }
     }
 
@@ -69,67 +77,73 @@ Rectangle {
         anchors.top: rulerTop.top
         anchors.left: parent.left
         anchors.right: parent.right
-        timeScale: root.timeScale ? root.timescale : 1.0
+        timeScale: root.timeScale ? root.timescale : 1
         model: markers
         onEditRequested: {
-            parent.editMarkerRequested(index)
+            parent.editMarkerRequested(index);
         }
         onDeleteRequested: {
-            parent.deleteMarkerRequested(index)
+            parent.deleteMarkerRequested(index);
         }
         onExited: bubbleHelp.hide()
         onMouseStatusChanged: {
-            var msg = "<center>" + text
+            var msg = "<center>" + text;
             if (start === end) {
-                msg += "<br>" + application.timecode(start)
+                msg += "<br>" + application.timecode(start);
             } else {
-                msg += "<br>" + application.timecode(start) + " - " + application.timecode(end)
-                msg += "<br>" + application.timecode(end - start + 1)
+                msg += "<br>" + application.timecode(start) + " - " + application.timecode(end);
+                msg += "<br>" + application.timecode(end - start + 1);
             }
-            msg += "</center>"
-            bubbleHelp.show(mouseX + bubbleHelp.width - 8, mouseY + 87, msg)
+            msg += "</center>";
+            bubbleHelp.show(mouseX + bubbleHelp.width - 8, mouseY + 87, msg);
         }
         onSeekRequested: timeline.position = pos
+
         snapper: QtObject {
             function getSnapPosition(position) {
-                if (!settings.timelineSnap) {
-                    return position
-                }
-                var SNAP = 10
+                if (!settings.timelineSnap)
+                    return position;
+
+                var SNAP = 10;
                 // Snap to clips on tracks.
-                var timeline = root
+                var timeline = root;
                 for (var j = 0; j < timeline.trackCount; j++) {
-                    var track = timeline.trackAt(j)
+                    var track = timeline.trackAt(j);
                     for (var i = 0; i < track.clipCount; i++) {
-                        var item = track.clipAt(i)
+                        var item = track.clipAt(i);
                         if (item.isBlank)
-                            continue
-                        var itemLeft = item.x
-                        var itemRight = itemLeft + item.width
+                            continue;
+
+                        var itemLeft = item.x;
+                        var itemRight = itemLeft + item.width;
                         if (position > itemLeft - SNAP && position < itemLeft + SNAP)
-                            return itemLeft
+                            return itemLeft;
                         else if (position > itemRight - SNAP && position < itemRight + SNAP)
-                            return itemRight
+                            return itemRight;
                         else if (itemRight + SNAP > position)
-                            continue
+                            continue;
                     }
                 }
                 // Snap around cursor/playhead.
-                var cursorX = tracksFlickable.contentX + cursor.x
-                if (position > cursorX - SNAP && position < cursorX + SNAP) {
-                    return cursorX
-                }
-                return position
+                var cursorX = tracksFlickable.contentX + cursor.x;
+                if (position > cursorX - SNAP && position < cursorX + SNAP)
+                    return cursorX;
+
+                return position;
             }
+
         }
+
     }
 
     Connections {
-        target: profile
         function onProfileChanged() {
             // Force a repeater model change to update the labels.
-            ++adjustment
-            --adjustment
+            ++adjustment;
+            --adjustment;
         }
+
+        target: profile
     }
+
 }

--- a/src/qml/views/timeline/Track.qml
+++ b/src/qml/views/timeline/Track.qml
@@ -15,16 +15,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.12
 import QtQml.Models 2.12
-import 'Track.js' as Logic
+import QtQuick 2.12
+import "Track.js" as Logic
 
 Rectangle {
     id: trackRoot
+
     property alias model: trackModel.model
     property alias rootIndex: trackModel.rootIndex
     property bool isAudio
-    property real timeScale: 1.0
+    property real timeScale: 1
     property bool placeHolderAdded: false
     property bool isCurrentTrack: false
     property bool isLocked: false
@@ -39,39 +40,42 @@ Rectangle {
     signal checkSnap(var clip)
 
     function redrawWaveforms(force) {
-        for (var i = 0; i < repeater.count; i++)
-            repeater.itemAt(i).generateWaveform(force)
+        for (var i = 0; i < repeater.count; i++) repeater.itemAt(i).generateWaveform(force)
     }
 
     function remakeWaveforms(force) {
-        for (var i = 0; i < repeater.count; i++)
-            timeline.remakeAudioLevels(trackRoot.DelegateModel.itemsIndex, i, force)
+        for (var i = 0; i < repeater.count; i++) timeline.remakeAudioLevels(trackRoot.DelegateModel.itemsIndex, i, force)
     }
 
     function updateThumbnails(clipIndex) {
-        if (clipIndex >= 0 && clipIndex < repeater.count) {
-            repeater.itemAt(clipIndex).updateThumbnails()
-        }
+        if (clipIndex >= 0 && clipIndex < repeater.count)
+            repeater.itemAt(clipIndex).updateThumbnails();
+
     }
 
     function snapClip(clip) {
-        Logic.snapClip(clip, repeater)
+        Logic.snapClip(clip, repeater);
     }
 
     function snapDrop(clip) {
-        Logic.snapDrop(clip, repeater)
+        Logic.snapDrop(clip, repeater);
     }
 
     function clipAt(index) {
-        return repeater.itemAt(index)
+        return repeater.itemAt(index);
     }
 
     color: 'transparent'
     width: clipRow.width
-    onIsMuteChanged: if (!isMute) redrawWaveforms(true)
+    onIsMuteChanged: {
+        if (!isMute)
+            redrawWaveforms(true);
+
+    }
 
     DelegateModel {
         id: trackModel
+
         Clip {
             clipName: typeof model.name !== 'undefined' ? model.name : ""
             clipComment: typeof model.comment !== 'undefined' ? model.comment : ""
@@ -94,159 +98,161 @@ Rectangle {
             audioIndex: typeof model.audioindex !== 'undefined' ? model.audioIndex : 0
             selected: Logic.selectionContains(timeline.selection, trackIndex, index)
             isTrackMute: trackRoot.isMute
-
-            onClicked: trackRoot.clipClicked(clip, trackRoot, mouse);
+            onClicked: trackRoot.clipClicked(clip, trackRoot, mouse)
             onClipRightClicked: trackRoot.clipRightClicked(clip, trackRoot, mouse)
             onMoved: {
-                var fromTrack = clip.originalTrackIndex
-                var toTrack = clip.trackIndex
-                var clipIndex = clip.originalClipIndex
-                var selection = timeline.selection
-                var frame = Math.round(clip.x / timeScale)
-
+                var fromTrack = clip.originalTrackIndex;
+                var toTrack = clip.trackIndex;
+                var clipIndex = clip.originalClipIndex;
+                var selection = timeline.selection;
+                var frame = Math.round(clip.x / timeScale);
                 // Workaround moving multiple clips on the same track with ripple on
                 if (fromTrack === toTrack && settings.timelineRipple && selection.length > 1) {
                     // Use the left-most clip
-                    var clipIndexChanged = false
+                    var clipIndexChanged = false;
                     for (var i = 0; i < selection.length; i++) {
                         if (selection[i].y === fromTrack && selection[i].x < clipIndex) {
-                            clipIndex = selection[i].x
-                            clipIndexChanged = true
+                            clipIndex = selection[i].x;
+                            clipIndexChanged = true;
                         }
                     }
-                    if (clipIndexChanged) {
-                        frame = Math.round((clipAt(clipIndex).x + clip.x - clip.originalX) / timeScale)
-                    }
-                }
+                    if (clipIndexChanged)
+                        frame = Math.round((clipAt(clipIndex).x + clip.x - clip.originalX) / timeScale);
 
+                }
                 // Remove the placeholder inserted in onDraggedToTrack
                 if (placeHolderAdded) {
-                    placeHolderAdded = false
-                    root.resetDrag()
-                    multitrack.reload(true)
+                    placeHolderAdded = false;
+                    root.resetDrag();
+                    multitrack.reload(true);
                 }
                 if (!timeline.moveClip(fromTrack, toTrack, clipIndex, frame, settings.timelineRipple)) {
-                    clip.x = clip.originalX
-                    clip.trackIndex = clip.originalTrackIndex
+                    clip.x = clip.originalX;
+                    clip.trackIndex = clip.originalTrackIndex;
                 }
             }
             onDragged: {
                 if (settings.timelineDragScrub) {
-                    root.stopScrolling = false
-                    timeline.position = Math.round(clip.x / timeScale)
+                    root.stopScrolling = false;
+                    timeline.position = Math.round(clip.x / timeScale);
                 }
                 // Snap if Alt key is not down.
                 if (!(mouse.modifiers & Qt.AltModifier) && settings.timelineSnap)
-                    trackRoot.checkSnap(clip)
+                    trackRoot.checkSnap(clip);
 
                 // Prevent dragging left of multitracks origin.
-                clip.x = Math.max(0, clip.x)
-                var mapped = trackRoot.mapFromItem(clip, mouse.x, mouse.y)
-                trackRoot.clipDragged(clip, mapped.x, mapped.y)
-
+                clip.x = Math.max(0, clip.x);
+                var mapped = trackRoot.mapFromItem(clip, mouse.x, mouse.y);
+                trackRoot.clipDragged(clip, mapped.x, mapped.y);
                 // Show distance moved as time in a "bubble" help.
-                var delta = Math.round(clip.x / timeScale) - model.start
-                var s = application.timecode(Math.abs(delta))
+                var delta = Math.round(clip.x / timeScale) - model.start;
+                var s = application.timecode(Math.abs(delta));
                 // remove leading zeroes
                 if (s.substring(0, 3) === '00:')
-                    s = s.substring(3)
-                s = ((delta < 0)? '-' : (delta > 0)? '+' : '') + s
-                bubbleHelp.show(mapped.x, trackRoot.y + trackRoot.height, s)
+                    s = s.substring(3);
+
+                s = ((delta < 0) ? '-' : (delta > 0) ? '+' : '') + s;
+                bubbleHelp.show(mapped.x, trackRoot.y + trackRoot.height, s);
             }
             onTrimmingIn: {
-                var originalDelta = delta
+                var originalDelta = delta;
                 if (!(mouse.modifiers & Qt.AltModifier) && settings.timelineSnap && !settings.timelineRipple)
-                    delta = Logic.snapTrimIn(clip, delta, root, trackRoot.DelegateModel.itemsIndex)
+                    delta = Logic.snapTrimIn(clip, delta, root, trackRoot.DelegateModel.itemsIndex);
+
                 if (delta != 0) {
-                    if (timeline.trimClipIn(trackRoot.DelegateModel.itemsIndex, clip.DelegateModel.itemsIndex,
-                                            clip.originalClipIndex, delta, settings.timelineRipple)) {
+                    if (timeline.trimClipIn(trackRoot.DelegateModel.itemsIndex, clip.DelegateModel.itemsIndex, clip.originalClipIndex, delta, settings.timelineRipple)) {
                         // Show amount trimmed as a time in a "bubble" help.
-                        var s = application.timecode(Math.abs(clip.originalX))
-                        s = '%1%2 = %3'.arg((clip.originalX < 0)? '-' : (clip.originalX > 0)? '+' : '')
-                                       .arg(s.substring(3))
-                                       .arg(application.timecode(clipDuration))
-                        bubbleHelp.show(clip.x, trackRoot.y + trackRoot.height, s)
+                        var s = application.timecode(Math.abs(clip.originalX));
+                        s = '%1%2 = %3'.arg((clip.originalX < 0) ? '-' : (clip.originalX > 0) ? '+' : '').arg(s.substring(3)).arg(application.timecode(clipDuration));
+                        bubbleHelp.show(clip.x, trackRoot.y + trackRoot.height, s);
                     } else {
-                        clip.originalX -= originalDelta
+                        clip.originalX -= originalDelta;
                     }
                 } else {
-                    clip.originalX -= originalDelta
+                    clip.originalX -= originalDelta;
                 }
             }
             onTrimmedIn: {
-                multitrack.notifyClipIn(trackRoot.DelegateModel.itemsIndex, clip.DelegateModel.itemsIndex)
+                multitrack.notifyClipIn(trackRoot.DelegateModel.itemsIndex, clip.DelegateModel.itemsIndex);
                 // Notify out point of clip A changed when trimming to add a transition.
                 if (clip.DelegateModel.itemsIndex > 1 && repeater.itemAt(clip.DelegateModel.itemsIndex - 1).isTransition)
-                    multitrack.notifyClipOut(trackRoot.DelegateModel.itemsIndex, clip.DelegateModel.itemsIndex - 2)
-                bubbleHelp.hide()
-                timeline.commitTrimCommand()
+                    multitrack.notifyClipOut(trackRoot.DelegateModel.itemsIndex, clip.DelegateModel.itemsIndex - 2);
+
+                bubbleHelp.hide();
+                timeline.commitTrimCommand();
             }
             onTrimmingOut: {
-                var originalDelta = delta
+                var originalDelta = delta;
                 if (!(mouse.modifiers & Qt.AltModifier) && settings.timelineSnap && !settings.timelineRipple)
-                    delta = Logic.snapTrimOut(clip, delta, root, trackRoot.DelegateModel.itemsIndex)
+                    delta = Logic.snapTrimOut(clip, delta, root, trackRoot.DelegateModel.itemsIndex);
+
                 if (delta != 0) {
-                    if (timeline.trimClipOut(trackRoot.DelegateModel.itemsIndex,
-                                             clip.DelegateModel.itemsIndex, delta, settings.timelineRipple)) {
+                    if (timeline.trimClipOut(trackRoot.DelegateModel.itemsIndex, clip.DelegateModel.itemsIndex, delta, settings.timelineRipple)) {
                         // Show amount trimmed as a time in a "bubble" help.
-                        var s = application.timecode(Math.abs(clip.originalX))
-                        s = '%1%2 = %3'.arg((clip.originalX < 0)? '+' : (clip.originalX > 0)? '-' : '')
-                                       .arg(s.substring(3))
-                                       .arg(application.timecode(clipDuration))
-                        bubbleHelp.show(clip.x + clip.width, trackRoot.y + trackRoot.height, s)
+                        var s = application.timecode(Math.abs(clip.originalX));
+                        s = '%1%2 = %3'.arg((clip.originalX < 0) ? '+' : (clip.originalX > 0) ? '-' : '').arg(s.substring(3)).arg(application.timecode(clipDuration));
+                        bubbleHelp.show(clip.x + clip.width, trackRoot.y + trackRoot.height, s);
                     } else {
-                        clip.originalX -= originalDelta
+                        clip.originalX -= originalDelta;
                     }
                 } else {
-                    clip.originalX -= originalDelta
+                    clip.originalX -= originalDelta;
                 }
             }
             onTrimmedOut: {
-                multitrack.notifyClipOut(trackRoot.DelegateModel.itemsIndex, clip.DelegateModel.itemsIndex)
+                multitrack.notifyClipOut(trackRoot.DelegateModel.itemsIndex, clip.DelegateModel.itemsIndex);
                 // Notify in point of clip B changed when trimming to add a transition.
                 if (clip.DelegateModel.itemsIndex + 2 < repeater.count && repeater.itemAt(clip.DelegateModel.itemsIndex + 1).isTransition)
-                    multitrack.notifyClipIn(trackRoot.DelegateModel.itemsIndex, clip.DelegateModel.itemsIndex + 2)
-                bubbleHelp.hide()
-                timeline.commitTrimCommand()
+                    multitrack.notifyClipIn(trackRoot.DelegateModel.itemsIndex, clip.DelegateModel.itemsIndex + 2);
+
+                bubbleHelp.hide();
+                timeline.commitTrimCommand();
             }
             onDraggedToTrack: {
                 if (!placeHolderAdded) {
-                    placeHolderAdded = true
+                    placeHolderAdded = true;
                     trackModel.items.insert(clip.DelegateModel.itemsIndex, {
-                        'name': '',
-                        'resource': '',
-                        'duration': clip.clipDuration,
-                        'mlt_service': '<producer',
-                        'in': 0,
-                        'out': clip.clipDuration - 1,
-                        'blank': true,
-                        'audio': false,
-                        'isTransition': false,
-                        'fadeIn': 0,
-                        'fadeOut': 0,
-                        'hash': '',
-                        'speed': 1.0
-                    })
+                        "name": '',
+                        "resource": '',
+                        "duration": clip.clipDuration,
+                        "mlt_service": '<producer',
+                        "in": 0,
+                        "out": clip.clipDuration - 1,
+                        "blank": true,
+                        "audio": false,
+                        "isTransition": false,
+                        "fadeIn": 0,
+                        "fadeOut": 0,
+                        "hash": '',
+                        "speed": 1
+                    });
                 }
             }
             onDropped: {
                 if (placeHolderAdded) {
-                    timeline.selection = []
-                    multitrack.reload(true)
-                    placeHolderAdded = false
+                    timeline.selection = [];
+                    multitrack.reload(true);
+                    placeHolderAdded = false;
                 }
             }
-
             Component.onCompleted: {
-                moved.connect(trackRoot.clipDropped)
-                dropped.connect(trackRoot.clipDropped)
-                draggedToTrack.connect(trackRoot.clipDraggedToTrack)
+                moved.connect(trackRoot.clipDropped);
+                dropped.connect(trackRoot.clipDropped);
+                draggedToTrack.connect(trackRoot.clipDraggedToTrack);
             }
         }
+
     }
 
     Row {
         id: clipRow
-        Repeater { id: repeater; model: trackModel }
+
+        Repeater {
+            id: repeater
+
+            model: trackModel
+        }
+
     }
+
 }

--- a/src/qml/views/timeline/TrackHead.qml
+++ b/src/qml/views/timeline/TrackHead.qml
@@ -22,6 +22,7 @@ import Shotcut.Controls 1.0 as Shotcut
 
 Rectangle {
     id: trackHeadRoot
+
     property string trackName: ''
     property bool isMute
     property bool isHidden
@@ -35,94 +36,119 @@ Rectangle {
     property bool isBottomAudio
     property bool selected: false
     property bool current: false
+
     signal clicked()
 
     function pulseLockButton() {
         lockButtonAnim.restart();
     }
 
-    SystemPalette { id: activePalette }
-    color: selected ? selectedTrackColor : (index % 2)? activePalette.alternateBase : activePalette.base
-    border.color: selected? 'red' : 'transparent'
-    border.width: selected? 1 : 0
+    color: selected ? selectedTrackColor : (index % 2) ? activePalette.alternateBase : activePalette.base
+    border.color: selected ? 'red' : 'transparent'
+    border.width: selected ? 1 : 0
     clip: true
     state: 'normal'
     states: [
         State {
             name: 'selected'
             when: trackHeadRoot.selected
+
             PropertyChanges {
                 target: trackHeadRoot
-                color: isVideo? root.shotcutBlue : 'darkseagreen'
+                color: isVideo ? root.shotcutBlue : 'darkseagreen'
             }
+
         },
         State {
             name: 'current'
             when: trackHeadRoot.current
+
             PropertyChanges {
                 target: trackHeadRoot
-                color: Qt.rgba(selectedTrackColor.r * selectedTrackColor.a + activePalette.window.r * (1.0 - selectedTrackColor.a),
-                               selectedTrackColor.g * selectedTrackColor.a + activePalette.window.g * (1.0 - selectedTrackColor.a),
-                               selectedTrackColor.b * selectedTrackColor.a + activePalette.window.b * (1.0 - selectedTrackColor.a),
-                               1.0)
+                color: Qt.rgba(selectedTrackColor.r * selectedTrackColor.a + activePalette.window.r * (1 - selectedTrackColor.a), selectedTrackColor.g * selectedTrackColor.a + activePalette.window.g * (1 - selectedTrackColor.a), selectedTrackColor.b * selectedTrackColor.a + activePalette.window.b * (1 - selectedTrackColor.a), 1)
             }
+
         },
         State {
             when: !trackHeadRoot.selected && !trackHeadRoot.current
             name: 'normal'
+
             PropertyChanges {
                 target: trackHeadRoot
-                color: (index % 2)? activePalette.alternateBase : activePalette.base
+                color: (index % 2) ? activePalette.alternateBase : activePalette.base
             }
+
         }
     ]
     transitions: [
         Transition {
             to: '*'
-            ColorAnimation { target: trackHeadRoot; duration: 100 }
+
+            ColorAnimation {
+                target: trackHeadRoot
+                duration: 100
+            }
+
         }
     ]
+
+    SystemPalette {
+        id: activePalette
+    }
 
     MouseArea {
         anchors.fill: parent
         acceptedButtons: Qt.LeftButton | Qt.RightButton
         onClicked: {
-            parent.clicked()
-            nameEdit.focus = false
+            parent.clicked();
+            nameEdit.focus = false;
             if (mouse.button == Qt.RightButton)
-                root.timelineRightClicked()
+                root.timelineRightClicked();
+
         }
     }
+
     Flow {
         id: trackHeadColumn
-        flow: (trackHeadRoot.height < 50)? Flow.LeftToRight : Flow.TopToBottom
-        spacing: (trackHeadRoot.height < 50)? 0 : 6
+
+        flow: (trackHeadRoot.height < 50) ? Flow.LeftToRight : Flow.TopToBottom
+        spacing: (trackHeadRoot.height < 50) ? 0 : 6
+
         anchors {
             top: parent.top
             left: parent.left
             leftMargin: 8
-            rightMargin: (trackHeadRoot.height < 50)? 0 : 4
-            topMargin: (trackHeadRoot.height < 50)? 0 : 4
-            bottomMargin: (trackHeadRoot.height < 50)? 0 : 4
+            rightMargin: (trackHeadRoot.height < 50) ? 0 : 4
+            topMargin: (trackHeadRoot.height < 50) ? 0 : 4
+            bottomMargin: (trackHeadRoot.height < 50) ? 0 : 4
         }
 
         Rectangle {
             color: 'transparent'
-            width: trackHeadRoot.width - trackHeadColumn.anchors.margins * 2 - (trackHeadRoot.height < 50? 110 : 0)
+            width: trackHeadRoot.width - trackHeadColumn.anchors.margins * 2 - (trackHeadRoot.height < 50 ? 110 : 0)
             radius: 2
-            border.color: (!timeline.isFloating() && trackNameMouseArea.containsMouse)? activePalette.shadow : 'transparent'
+            border.color: (!timeline.isFloating() && trackNameMouseArea.containsMouse) ? activePalette.shadow : 'transparent'
             height: nameEdit.height
+
             MouseArea {
                 id: trackNameMouseArea
+
                 height: parent.height
                 width: nameEdit.width
                 hoverEnabled: true
-                onClicked: if (!timeline.isFloating()) {
-                    nameEdit.focus = true
-                    nameEdit.selectAll()
+                onClicked: {
+                    if (!timeline.isFloating()) {
+                        nameEdit.focus = true;
+                        nameEdit.selectAll();
+                    }
                 }
             }
+
             Control {
+                Shotcut.HoverTip {
+                    text: trackName
+                }
+
                 contentItem: Label {
                     text: trackName
                     color: activePalette.windowText
@@ -131,25 +157,31 @@ Rectangle {
                     topPadding: 3
                     width: nameEdit.width
                 }
-                Shotcut.HoverTip{ text: trackName }
+
             }
+
             TextField {
                 id: nameEdit
+
                 visible: focus
                 width: parent.width
                 selectByMouse: true
                 text: trackName
                 onEditingFinished: {
-                    timeline.setTrackName(index, text)
-                    focus = false
+                    timeline.setTrackName(index, text);
+                    focus = false;
                 }
                 Keys.onTabPressed: editingFinished()
             }
+
         }
+
         RowLayout {
             spacing: 8
+
             ToolButton {
                 id: lockButton
+
                 icon.name: isLocked ? 'object-locked' : 'object-unlocked'
                 icon.source: isLocked ? 'qrc:///icons/oxygen/32x32/status/object-locked.png' : 'qrc:///icons/oxygen/32x32/status/object-unlocked.png'
                 icon.width: 16
@@ -157,29 +189,38 @@ Rectangle {
                 padding: 1
                 focusPolicy: Qt.NoFocus
                 onClicked: timeline.setTrackLock(index, !isLocked)
-                Shotcut.HoverTip { text: isLocked? qsTr('Unlock track') : qsTr('Lock track') }
                 transformOrigin: Item.Center
+
+                Shotcut.HoverTip {
+                    text: isLocked ? qsTr('Unlock track') : qsTr('Lock track')
+                }
 
                 SequentialAnimation {
                     id: lockButtonAnim
+
                     loops: 2
+
                     NumberAnimation {
                         target: lockButton
                         property: 'scale'
                         to: 2
                         duration: 200
                     }
+
                     NumberAnimation {
                         target: lockButton
                         property: 'scale'
                         to: 1
                         duration: 200
                     }
+
                 }
+
             }
 
             ToolButton {
                 id: muteButton
+
                 icon.name: isMute ? 'audio-volume-muted' : 'audio-volume-high'
                 icon.source: isMute ? 'qrc:///icons/oxygen/32x32/status/audio-volume-muted.png' : 'qrc:///icons/oxygen/32x32/status/audio-volume-high.png'
                 icon.width: 16
@@ -187,20 +228,29 @@ Rectangle {
                 padding: 1
                 focusPolicy: Qt.NoFocus
                 onClicked: timeline.toggleTrackMute(index)
-                Shotcut.HoverTip { text: isMute? qsTr('Unmute') : qsTr('Mute') }
+
+                Shotcut.HoverTip {
+                    text: isMute ? qsTr('Unmute') : qsTr('Mute')
+                }
+
             }
 
             ToolButton {
                 id: hideButton
+
                 visible: isVideo
                 icon.name: isHidden ? 'layer-visible-off' : 'layer-visible-on'
-                icon.source: isHidden? 'qrc:///icons/oxygen/32x32/actions/layer-visible-off.png' : 'qrc:///icons/oxygen/32x32/actions/layer-visible-on.png'
+                icon.source: isHidden ? 'qrc:///icons/oxygen/32x32/actions/layer-visible-off.png' : 'qrc:///icons/oxygen/32x32/actions/layer-visible-on.png'
                 icon.width: 16
                 icon.height: 16
                 padding: 1
                 focusPolicy: Qt.NoFocus
                 onClicked: timeline.toggleTrackHidden(index)
-                Shotcut.HoverTip { text: isHidden? qsTr('Show') : qsTr('Hide') }
+
+                Shotcut.HoverTip {
+                    text: isHidden ? qsTr('Show') : qsTr('Hide')
+                }
+
             }
 
             ToolButton {
@@ -211,13 +261,20 @@ Rectangle {
                 icon.height: 16
                 padding: 1
                 focusPolicy: Qt.NoFocus
-                Shotcut.HoverTip { text: qsTr('Filters') }
                 onClicked: {
-                    trackHeadRoot.clicked()
-                    nameEdit.focus = false
-                    timeline.filteredClicked()
+                    trackHeadRoot.clicked();
+                    nameEdit.focus = false;
+                    timeline.filteredClicked();
                 }
+
+                Shotcut.HoverTip {
+                    text: qsTr('Filters')
+                }
+
             }
+
         }
+
     }
+
 }


### PR DESCRIPTION
Add a cmake custom target to fix QML formatting
Apply the formatting to all qml files

qmlformat applies the [QT QML Coding Conventions](https://doc-snapshots.qt.io/qt6-dev/qml-codingconventions.html)

In general, I think this makes the code more verbose by expanding many things that are currently on one line line.

I am willing to add a GitHub action job for this if we are interested. I am also OK discarding this PR - I do not feel strongly about it. But I offer this here in case it is interesting to pursue.