### PR TITLE
Increase non-curve keyframe track height

### DIFF
--- a/src/qml/views/keyframes/Keyframes.js
+++ b/src/qml/views/keyframes/Keyframes.js
@@ -16,7 +16,7 @@
  */
 
 function trackHeight(isCurves) {
-    return isCurves? (multitrack.trackHeight * 2) : (multitrack.trackHeight < 30)? 20 : 36
+    return isCurves? (multitrack.trackHeight * 2) : (multitrack.trackHeight < 30)? 20 : 48
 }
 
 function scrollIfNeeded(center) {


### PR DESCRIPTION
I'm not 100% sure it's not just my issue but I tried my usual scaling (`QT_SCALE_FACTOR=1.2` as I have a 2k 24" monitor), the default 1 and also 2 (too big for my monitor but just to confirm it), it looks the same every time. I use Debian Testing, not sure if it's like that on Windows.

The problem is that non-curve keyframe tracks have fixed height that cuts the low part of the icons. This height can't be increased by the user, it looks bad:
![2022-05-02_16-08-14](https://user-images.githubusercontent.com/184066/166240393-7f525b60-2b8a-4f6f-88f8-6eed58ae5c71.png)
This PR increases the height so it looks better:
![2022-05-02_16-19-20](https://user-images.githubusercontent.com/184066/166240391-2b09f32a-7d12-4140-8d00-77354a493287.png)