### PR TITLE
Fix filters disappear when changing clip properties

### DIFF
--- a/src/commands/timelinecommands.cpp
+++ b/src/commands/timelinecommands.cpp
@@ -1312,12 +1312,10 @@ UpdateCommand::UpdateCommand(TimelineDock &timeline, int trackIndex, int clipInd
     , m_trackIndex(trackIndex)
     , m_clipIndex(clipIndex)
     , m_position(position)
-    , m_isFirstRedo(true)
     , m_undoHelper(*timeline.model())
     , m_ripple(Settings.timelineRipple())
 {
     setText(QObject::tr("Change clip properties"));
-    m_undoHelper.recordBeforeState();
 }
 
 void UpdateCommand::setXmlAfter(const QString &xml)
@@ -1334,15 +1332,13 @@ void UpdateCommand::setPosition(int trackIndex, int clipIndex, int position)
         m_clipIndex = clipIndex;
     if (position >= 0)
         m_position = position;
-    m_undoHelper.recordBeforeState();
 }
 
 void UpdateCommand::redo()
 {
     LOG_DEBUG() << "trackIndex" << m_trackIndex << "clipIndex" << m_clipIndex << "position" <<
                 m_position;
-    if (!m_isFirstRedo)
-        m_undoHelper.recordBeforeState();
+    m_undoHelper.recordBeforeState();
     Mlt::Producer clip(MLT.profile(), "xml-string", m_xmlAfter.toUtf8().constData());
     if (m_ripple) {
         m_timeline.model()->removeClip(m_trackIndex, m_clipIndex, false);
@@ -1360,7 +1356,6 @@ void UpdateCommand::undo()
                 m_position;
     m_undoHelper.undoChanges();
     m_timeline.emitSelectedFromSelection();
-    m_isFirstRedo = false;
 }
 
 DetachAudioCommand::DetachAudioCommand(MultitrackModel &model, int trackIndex, int clipIndex,

--- a/src/commands/timelinecommands.h
+++ b/src/commands/timelinecommands.h
@@ -596,7 +596,6 @@ private:
     int m_clipIndex;
     int m_position;
     QString m_xmlAfter;
-    bool m_isFirstRedo;
     UndoHelper m_undoHelper;
     bool m_ripple;
 };


### PR DESCRIPTION
This happens to clips on the timeline when a clip property is
changed.

As reported here:
https://forum.shotcut.org/t/please-test-the-beta-for-version-22-06/33941/13

However, the problem occurs with any filter, not only Crop:Source

Steps to reproduce:
1) Open a clip and drag to the timeline
2) Add a filter to the clip
3) In the clip properties panel, change the duration or the speed
4) Look at the properties panel and observe that the filter is still applied
5) Click the "Undo" arrow
6) Look at the properties panel and observe that the filter is still missing   <--- BUG

This change fixes this specific test case for me. However, I am posting this as a a review because I do not know why the logic was written that way originally.