### PR TITLE
Add speed range option for audio alignment adjustment

### DIFF
--- a/src/dialogs/alignaudiodialog.h
+++ b/src/dialogs/alignaudiodialog.h
@@ -23,7 +23,6 @@
 #include <QDialog>
 #include <QUuid>
 
-class QCheckBox;
 class QComboBox;
 class QDialogButtonBox;
 class QLabel;
@@ -59,7 +58,7 @@ private:
     AlignClipsModel m_alignClipsModel;
     QVector<QUuid> m_uuids;
     QComboBox *m_trackCombo;
-    QCheckBox *m_speedCheckBox;
+    QComboBox *m_speedCombo;
     QTreeView *m_table;
     QDialogButtonBox *m_buttonBox;
     QPushButton *m_applyButton;

--- a/src/dialogs/alignmentarray.cpp
+++ b/src/dialogs/alignmentarray.cpp
@@ -126,7 +126,8 @@ double AlignmentArray::calculateOffset(AlignmentArray &from, int *offset)
     return max / correlationCoefficient;
 }
 
-double AlignmentArray::calculateOffsetAndSpeed(AlignmentArray &from, double *speed, int *offset)
+double AlignmentArray::calculateOffsetAndSpeed(AlignmentArray &from, double *speed, int *offset,
+                                               double speedRange)
 {
     // The minimum speed step results in one frame of stretch.
     // Do not try to compensate for more than 1 frame of speed difference.
@@ -136,8 +137,8 @@ double AlignmentArray::calculateOffsetAndSpeed(AlignmentArray &from, double *spe
     int bestOffset = 0;
     double bestScore = calculateOffset(from, &bestOffset);
     AlignmentArray stretched(m_minimumSize);
-    double speedMin = bestSpeed - 0.005;
-    double speedMax = bestSpeed + 0.005;
+    double speedMin = bestSpeed - speedRange;
+    double speedMax = bestSpeed + speedRange;
 
     while (speedStep > (minimumSpeedStep / 10)) {
         for (double s = speedMin; s <= speedMax; s += speedStep) {

--- a/src/dialogs/alignmentarray.h
+++ b/src/dialogs/alignmentarray.h
@@ -36,7 +36,7 @@ public:
     void init(size_t minimum_size);
     void setValues(const std::vector<double> &values);
     double calculateOffset(AlignmentArray &from, int *offset);
-    double calculateOffsetAndSpeed(AlignmentArray &from, double *speed_about, int *offset);
+    double calculateOffsetAndSpeed(AlignmentArray &from, double *speed, int *offset, double speedRange);
 
 private:
     void transform();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -671,13 +671,13 @@ void ShotcutSettings::setAudioReferenceTrack(int track)
     settings.setValue("timeline/audioReferenceTrack", track);
 }
 
-bool ShotcutSettings::audioReferenceCalcSpeed() const
+double ShotcutSettings::audioReferenceSpeedRange() const
 {
-    return settings.value("timeline/audioReferenceCalcSpeed", false).toBool();
+    return settings.value("timeline/audioReferenceSpeedRange", 0).toDouble();
 }
-void ShotcutSettings::setAudioReferenceCalcSpeed(bool enable)
+void ShotcutSettings::setAudioReferenceSpeedRange(double range)
 {
-    settings.setValue("timeline/audioReferenceCalcSpeed", enable);
+    settings.setValue("timeline/audioReferenceSpeedRange", range);
 }
 
 QString ShotcutSettings::filterFavorite(const QString &filterName)

--- a/src/settings.h
+++ b/src/settings.h
@@ -193,8 +193,8 @@ public:
     void setTimelineFramebufferWaveform(bool);
     int audioReferenceTrack() const;
     void setAudioReferenceTrack(int);
-    bool audioReferenceCalcSpeed() const;
-    void setAudioReferenceCalcSpeed(bool);
+    double audioReferenceSpeedRange() const;
+    void setAudioReferenceSpeedRange(double);
 
     // filter
     QString filterFavorite(const QString &filterName);


### PR DESCRIPTION
Is it too late to add this before the release candidate? A forum user made a good case for this additional user configuration (Speed adjustment range). It adds two translation strings.

![image](https://user-images.githubusercontent.com/821968/172020168-82dcd741-633b-4220-94a9-a7252a2af97a.png)
