### PR TITLE
Fix keyframe snapping to cursor doesn't work if a filter start point is set

### DIFF
--- a/src/qml/views/keyframes/Keyframe.qml
+++ b/src/qml/views/keyframes/Keyframe.qml
@@ -127,7 +127,7 @@ Rectangle {
             var keyPosition = newPosition - (filter.in - producer.in)
             // Snap to cursor
             if (keyX > cursorX - 10 && keyX < cursorX + 10) {
-                keyPosition = Math.round((cursorX) / timeScale)
+                keyPosition = Math.round((cursorX) / timeScale) - (filter.in - producer.in)
                 parent.x = cursorX - (parent.width / 2)
             }
             var trackValue = Math.min(Math.max(0, 1.0 - parent.y / (parameterRoot.height - parent.height)), 1.0)


### PR DESCRIPTION
Steps to reproduce:
1. Apply a filter to a clip.
2. In the Filters dock, click the keyframes button.
3. In the Keyframes dock, set a filter start point.
4. Snap a keyframe to the cursor. It appears that snapping succeeded.
5. Change the filter start point.
6. The keyframe will shift exactly the amount of frames the user has set for the filter start point in Step 3.

I made a change to Keyframe.qml, and snapping seems to be working well now.