### PR TITLE
Fix Zoom Timeline To Fit button and menu item not working if timeline is hours long

### DIFF
--- a/src/qml/views/timeline/timeline.qml
+++ b/src/qml/views/timeline/timeline.qml
@@ -39,6 +39,8 @@ Rectangle {
             targetX = tracksFlickable.contentX + tracksFlickable.width / 2
         var offset = targetX - tracksFlickable.contentX
         var before = multitrack.scaleFactor
+        if (isNaN(value))
+            value = 0.00
         multitrack.scaleFactor = Math.pow(value, 3) + 0.01
         if (!settings.timelineCenterPlayhead && !settings.timelineScrollZoom)
             tracksFlickable.contentX = (targetX * multitrack.scaleFactor / before) - offset


### PR DESCRIPTION
This bug appeared after 783b81120cd872186217ec1176831bb9f8bec0d5.

When the toolbar button is clicked or menu item is selected, this line is executed in `timeline.qml`:
670: `setZoom(Math.pow((tracksFlickable.width - 50) * multitrack.scaleFactor / tracksContainer.width - 0.01, 1/3))`

If the timeline is hours long like 3 hours, `tracksContainer.width` becomes something like 648,000 (60fps * 3600 secs * 3 hours).
`tracksFlickable.width` is typically 1000 - 1800 on a 1920x1080 monitor, so the first argument for `Math.pow` becomes negative, and the value passed to `setZoom` becomes `NaN`.

The fix I came up with is to check if value is `NaN` in `setZoom`, and if it is, set the `value` to `0.00`.