### PR TITLE
Fix keyframes can have the same frame position and cross over one another after snapped to cursor

### DIFF
--- a/src/qml/views/keyframes/Keyframe.qml
+++ b/src/qml/views/keyframes/Keyframe.qml
@@ -129,6 +129,10 @@ Rectangle {
             // Snap to cursor
             if (keyX > cursorX - 10 && keyX < cursorX + 10) {
                 keyPosition = Math.round((cursorX) / timeScale) - (filter.in - producer.in)
+                if (keyPosition < model.minimumFrame)
+                    keyPosition = model.minimumFrame
+                else if (keyPosition > model.maximumFrame)
+                    keyPosition = model.maximumFrame
                 parent.x = cursorX - (parent.width / 2)
             }
             var trackValue = Math.min(Math.max(0, 1.0 - parent.y / (parameterRoot.height - parent.height)), 1.0)

--- a/src/qml/views/keyframes/Keyframe.qml
+++ b/src/qml/views/keyframes/Keyframe.qml
@@ -127,12 +127,8 @@ Rectangle {
             var newPosition = Math.round((keyX) / timeScale)
             var keyPosition = newPosition - (filter.in - producer.in)
             // Snap to cursor
-            if (keyX > cursorX - 10 && keyX < cursorX + 10) {
+            if (keyX > cursorX - 10 && keyX < cursorX + 10 && cursorX > minDragX + parent.width/2 && cursorX < maxDragX + parent.width/2) {
                 keyPosition = Math.round((cursorX) / timeScale) - (filter.in - producer.in)
-                if (keyPosition < model.minimumFrame)
-                    keyPosition = model.minimumFrame
-                else if (keyPosition > model.maximumFrame)
-                    keyPosition = model.maximumFrame
                 parent.x = cursorX - (parent.width / 2)
             }
             var trackValue = Math.min(Math.max(0, 1.0 - parent.y / (parameterRoot.height - parent.height)), 1.0)


### PR DESCRIPTION
Steps to reproduce:
1. Apply a filter to a clip.
2. Snap two neighboring keyframes to the cursor.
3. These keyframes can move passed each other afterward.

The fix I came up with is to check if the position is less than `model.minimumFrame` or greater than `model.maximumFrame` and adjust the position accordingly.