### PR TITLE
Fix timeline zoom slider doesn't update after opening of a timeline project file

### DIFF
--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -3295,6 +3295,7 @@ void MultitrackModel::load()
     }
     emit loaded();
     emit filteredChanged();
+    emit scaleFactorChanged();
 }
 
 void MultitrackModel::reload(bool asynchronous)


### PR DESCRIPTION
This bug appeared after 783b81120cd872186217ec1176831bb9f8bec0d5.

Create a timeline project, change the zoom level, and save the project. Close Shotcut and Relanuch Shotcut. Open the project through Open File. The zoom slider remains the same at 1.01. 