### PR TITLE
Fix trimclip regression

### DIFF
--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -2123,7 +2123,8 @@ bool MultitrackModel::removeTransitionByTrimInValid(int trackIndex, int clipInde
         if (clipIndex > 1) {
             // Check if there is a transition and its new length is 0 or less.
             if (isTransition(playlist, clipIndex - 1)
-                    && playlist.clip_length(clipIndex - 1) - qAbs(delta) <= 0) {
+                    && playlist.clip_length(clipIndex - 1) - qAbs(delta) <= 0
+                    && ((delta < 0 && !m_isMakingTransition) || (delta > 0 && m_isMakingTransition))) {
                 result = true;
                 m_isMakingTransition = false;
             }
@@ -2143,7 +2144,8 @@ bool MultitrackModel::removeTransitionByTrimOutValid(int trackIndex, int clipInd
             // Check if there is a transition and its new length is 0 or less.
 //            LOG_DEBUG() << "transition length" << playlist.clip_length(clipIndex + 1) << "delta" << delta << playlist.clip_length(clipIndex + 1) - qAbs(delta);
             if (isTransition(playlist, clipIndex + 1)
-                    && playlist.clip_length(clipIndex + 1) - qAbs(delta) <= 0) {
+                    && playlist.clip_length(clipIndex + 1) - qAbs(delta) <= 0
+                    && ((delta < 0 && !m_isMakingTransition) || (delta > 0 && m_isMakingTransition))) {
                 result = true;
                 m_isMakingTransition = false;
             }


### PR DESCRIPTION
I think this is a pretty serious regression after I made a commit about `trimClipIn` and `trimClipOut` here 5ba3005e450a20789a1e21873cf7bfabc22b6e71.

`removeTransitionByTrimInValid` and `removeTransitionByTrimOutValid` are triggered if `delta` is large enough to exceed the length of the neighboring transition, even if I am enlarging an existing transition through trimming.

If I'm moving my mouse slowly, `trimClipIn` or `trimClipOut` is called with small chunks of `delta`s, so this bug doesn't happen. Only if I move my mouse quickly, `delta` becomes large and the transition gets removed.

The fix makes sure that `removeTransitionByTrimInValid` and `removeTransitionByTrimOutValid` return `true` only if the mouse movement direction and m_isMakingTransition status match.