### PR TITLE
Fix keyframe positioned at zero is misaligned upon loading of Keyframes dock

### DIFF
--- a/src/qml/views/keyframes/Keyframe.qml
+++ b/src/qml/views/keyframes/Keyframe.qml
@@ -57,6 +57,10 @@ Rectangle {
         }
     }
 
+    Component.onCompleted: {
+        updateX()
+    }
+    
     anchors.verticalCenter: parameterRoot.verticalCenter
     anchors.verticalCenterOffset: isCurve ? minimum != maximum ? trackValue : 0 : 0
     height: 10

--- a/src/qml/views/keyframes/Parameter.qml
+++ b/src/qml/views/keyframes/Parameter.qml
@@ -161,7 +161,6 @@ Item {
             onInterpolationChanged: canvas.requestPaint()
             Component.onCompleted: {
                 position = (filter.in - producer.in) + model.frame
-                updateX()
             }
             onFrameChanged: {
                 position = (filter.in - producer.in) + model.frame

--- a/src/qml/views/keyframes/Parameter.qml
+++ b/src/qml/views/keyframes/Parameter.qml
@@ -161,6 +161,7 @@ Item {
             onInterpolationChanged: canvas.requestPaint()
             Component.onCompleted: {
                 position = (filter.in - producer.in) + model.frame
+                updateX()
             }
             onFrameChanged: {
                 position = (filter.in - producer.in) + model.frame


### PR DESCRIPTION
This bug showed up after 3888b14c9586494c1e6aed027f81b62142c637d3.

Set two filters that have keyframeable parameters to a clip. Set a keyframe at 0 for both filters. Switch between these two filters. Upon refresh of the Keyframes dock, the keyframe at 0 is misaligned by half the width of the keyframe.

If I create another keyframe and move it toward 0, it would look like it crossed over the first one, but only visually. The saved mlt shows the first keyframe is at 00:00:00:00.

Before 3888b14c9586494c1e6aed027f81b62142c637d3, I think `x: position * timeScale - width/2` reacted to a change to `position` in `Component.onCompleted`. For some reason, now `onPositionChanged` don't get triggered after the `position` change in `Component.onCompleted`.