### PR TITLE
Fix selection changes on add or erase transition on a different track

### DIFF
--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -2047,6 +2047,10 @@ void TimelineDock::onRowsInserted(const QModelIndex &parent, int first, int last
         int n = last - first + 1;
         if (parent.isValid()) {
             foreach (auto i, m_selection.selectedClips) {
+                if (parent.row() != i.y()) {
+                    newSelection << QPoint(i.x(), i.y());
+                    continue;
+                }
                 if (i.x() < first)
                     newSelection << QPoint(i.x(), parent.row());
                 else
@@ -2075,6 +2079,10 @@ void TimelineDock::onRowsRemoved(const QModelIndex &parent, int first, int last)
         int n = last - first + 1;
         if (parent.isValid()) {
             foreach (auto i, m_selection.selectedClips) {
+                if (parent.row() != i.y()) {
+                    newSelection << QPoint(i.x(), i.y());
+                    continue;
+                }
                 if (i.x() < first)
                     newSelection << QPoint(i.x(), parent.row());
                 else if (i.x() > last)


### PR DESCRIPTION
Steps to reproduce:
1. Place 4 clips on V1
2. Place 4 clips on V2.
3. Select all 4 clips on V2.
4. Make a transition by trimming between any two clip on V1.
5. Selection comes down from V2 to V1.

I don't think this is intended, especially now Shotcut has the ability to select multiple timeline clips.

The solution I came up with is to copy selection if tracks are different. Only if they are the same, `i.x()` adjustment with `n` is made.