### PR TITLE
Fix duplicate after 2 clip moves, 2 undos, and 1 redo

### DIFF
--- a/src/commands/timelinecommands.cpp
+++ b/src/commands/timelinecommands.cpp
@@ -499,7 +499,9 @@ void MoveClipCommand::redo()
             QScopedPointer<Mlt::ClipInfo> info(m_model.findClipByUuid(MLT.uuid(clip), trackIndex, clipIndex));
             if (info && info->producer && info->producer->is_valid() && info->cut) {
                 m_newTrackIndexList << qBound(0, trackIndex + m_trackDelta, m_model.trackList().size() - 1);
+                info->producer->pass_property(*info->cut, kPlaylistStartProperty);
                 m_playlistStartList << info->cut->get_int(kPlaylistStartProperty);
+                info->producer->set(kTrackIndexProperty, trackIndex);
                 m_trackIndexList << trackIndex;
                 m_clipIndexList << clipIndex;
                 m_inList << info->frame_in;

--- a/src/commands/timelinecommands.h
+++ b/src/commands/timelinecommands.h
@@ -226,6 +226,12 @@ private:
     bool m_rippleMarkers;
     UndoHelper m_undoHelper;
     QMultiMap<int, Mlt::Producer> m_selection; // ordered by position
+    QList<int> m_newTrackIndexList;
+    QList<int> m_playlistStartList;
+    QList<int> m_trackIndexList;
+    QList<int> m_clipIndexList;
+    QList<int> m_inList;
+    QList<int> m_outList;
     bool m_redo;
     int m_start;
     int m_trackIndex;

--- a/src/shotcut_mlt_properties.h
+++ b/src/shotcut_mlt_properties.h
@@ -91,10 +91,6 @@
 #define kExportFromProperty "_shotcut:exportFromDefault"
 #define kIsProxyProperty "shotcut:proxy"
 #define kTrackIndexProperty "_shotcut:trackIndex"
-#define kClipIndexProperty "_shotcut:clipIndex"
-#define kShotcutInProperty "_shotcut:in"
-#define kShotcutOutProperty "_shotcut:out"
-#define kNewTrackIndexProperty "_shotcut:newTrackIndex"
 #define kShotcutFiltersClipboard "shotcut:filtersClipboard"
 
 #define kDefaultMltProfile "atsc_1080p_25"


### PR DESCRIPTION
The current redo implementation stores information in producers. This makes difficult to deal with consecutive moves with the same selection.

I made a bunch of `QList` member variables, so that information stays within each undo command object.

This is highly reliant on the assumption that the order the producers are inserted into `newSelection` is the same as all the integers are inserted into the `QList`s.

It's working well on my tests and clears all the reports posted in the forum's v22.01 beta test thread that lead to reverting the initial attempt.