### PR TITLE
Allow playlist auto change on open multiple files

### DIFF
--- a/src/docks/playlistdock.cpp
+++ b/src/docks/playlistdock.cpp
@@ -1067,8 +1067,7 @@ void PlaylistDock::onPlaylistLoaded()
 
 void PlaylistDock::onPlaylistModified()
 {
-    if (m_model.rowCount() == 1)
-        ui->tableView->resizeColumnsToContents();
+    ui->tableView->resizeColumnsToContents();
 }
 
 void PlaylistDock::onPlaylistCleared()


### PR DESCRIPTION
`if (m_model.rowCount() == 1)` was added 3 years ago. I assumed that some sort of crash would happen if it's changed. But I find nothing bad happening when this is executed.