### PR TITLE
Fix playlist regression

### DIFF
--- a/src/docks/playlistdock.cpp
+++ b/src/docks/playlistdock.cpp
@@ -153,7 +153,8 @@ private:
 
 PlaylistDock::PlaylistDock(QWidget *parent) :
     QDockWidget(parent),
-    ui(new Ui::PlaylistDock)
+    ui(new Ui::PlaylistDock),
+    m_blockResizeColumnsToContents(false)
 {
     LOG_DEBUG() << "begin";
     ui->setupUi(this);
@@ -1067,12 +1068,16 @@ void PlaylistDock::onPlaylistLoaded()
 
 void PlaylistDock::onPlaylistModified()
 {
-    ui->tableView->resizeColumnsToContents();
+    if (!m_blockResizeColumnsToContents) {
+        ui->tableView->resizeColumnsToContents();
+        m_blockResizeColumnsToContents = true;
+    }
 }
 
 void PlaylistDock::onPlaylistCleared()
 {
     enableUpdate(false);
+    m_blockResizeColumnsToContents = false;
 }
 
 void PlaylistDock::onDropped(const QMimeData *data, int row)

--- a/src/docks/playlistdock.h
+++ b/src/docks/playlistdock.h
@@ -116,6 +116,7 @@ private:
     QTimer m_inChangedTimer;
     QTimer m_outChangedTimer;
     QMenu *m_mainMenu;
+    bool m_blockResizeColumnsToContents;
 };
 
 #endif // PLAYLISTDOCK_H


### PR DESCRIPTION
After the commit 973ad1e49374bbf1bded51ab70490a296936e034, the playlist column widths get resized every time there is a slight modification to the playlist model. This means that just changing the order of playlist entries discards user-adjusted column widths.

The purpose of `if (m_model.rowCount() == 1)` was to prevent this.

Now with this pull request, playlist columns get resized only when the playlist is empty. 

