### PR TITLE
Fix potential crash on remove track

### DIFF
--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -2753,8 +2753,6 @@ void MultitrackModel::removeTrack(int trackIndex)
         beginRemoveRows(QModelIndex(), trackIndex, trackIndex);
         m_tractor->remove_track(track.mlt_index);
         m_trackList.removeAt(trackIndex);
-        endRemoveRows();
-        MLT.updateAvformatCaching(m_tractor->count());
 
 //        foreach (Track t, m_trackList) LOG_DEBUG() << (t.type == VideoTrackType?"Video":"Audio") << "track number" << t.number << "mlt_index" << t.mlt_index;
 
@@ -2787,6 +2785,8 @@ void MultitrackModel::removeTrack(int trackIndex)
             }
             ++row;
         }
+        endRemoveRows();
+        MLT.updateAvformatCaching(m_tractor->count());
 //        foreach (Track t, m_trackList) LOG_DEBUG() << (t.type == VideoTrackType?"Video":"Audio") << "track number" << t.number << "mlt_index" << t.mlt_index;
     }
     emit modified();


### PR DESCRIPTION
This crash is currently prevented by the following line in `timlinedock.cpp`:
```
2077    if (-1 == m_selection.selectedTrack && parent.isValid()) {
```
Ideally, `&& parent.isValid()` should be removed to accommodate track removal and subsequent selection adjustment.

If I remove `&& parent.isValid()`, the following chain of events occurs after a user removes a track:
1. `endRemoveRows` is called in `removeTrack` in `multitrackmodel.cpp`
2. `rowsRemoved` is emitted
3. `onRowsRemoved` is called due to `connect` in `timlinedock.cpp`
4. `setSelection` is called
5. `emitSelectedFromSelection` is called
6. `UpdateCommand::UpdateCommand` constructor is called due to `new` here:
```
1991   m_updateCommand.reset(new Timeline::UpdateCommand(*this, trackIndex, clipIndex, info->start));
```
7. `recordBeforeState` is called in the contructor

`recordBeforeState` refers to `m_trackList` and its `mlt_index` before `mlt_index` is adjusted in `removeTrack`. 
```
455 int mltIndex = m_model.trackList()[i].mlt_index;
```

One solution I found is to change the location of `endRemoveRows`.