### PR TITLE
Fix selection changes after a user removes a track

### DIFF
--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -2074,7 +2074,7 @@ void TimelineDock::onRowsRemoved(const QModelIndex &parent, int first, int last)
 {
     Q_UNUSED(parent)
     // Adjust selected clips for changed indices.
-    if (-1 == m_selection.selectedTrack && parent.isValid()) {
+    if (-1 == m_selection.selectedTrack) {
         QList<QPoint> newSelection;
         int n = last - first + 1;
         if (parent.isValid()) {


### PR DESCRIPTION
Steps to reproduce:
1. Place 1 clip on V1.
2. Place 1 clip on V2. 
3. Select the clip on V2.
4. Choose Add Video Track from the timeline menu.
5. Choose Remove Track while V3 is highlighted green without any clips on it.
6. Selection comes down from V2 to V1.

Prerequisite for merging this pull request is https://github.com/mltframework/shotcut/pull/1326