### PR TITLE
Fix text area context menu > Delete doesn't work

### DIFF
--- a/src/qml/modules/Shotcut/Controls/EditMenu.qml
+++ b/src/qml/modules/Shotcut/Controls/EditMenu.qml
@@ -77,7 +77,7 @@ Menu {
 
         action: Action {
             text: qsTr('Delete')
-            onTriggered: parent.control(control.selectionStart, control.selectionEnd)
+            onTriggered: control.remove(control.selectionStart, control.selectionEnd)
         }
 
     }


### PR DESCRIPTION
Mainly affects Text: Simple, but also DoubleSpinBox, SliderSpinner, and GradientControl. 