### PR TITLE
Append shortcuts to the end of action tooltips

### DIFF
--- a/src/actions.h
+++ b/src/actions.h
@@ -34,6 +34,7 @@ public:
     static const char *displayProperty;
     static const char *defaultKey1Property;
     static const char *defaultKey2Property;
+    static const char *defaultToolTipProperty;
 
     static ShotcutActions &singleton();
     explicit ShotcutActions() : QObject() {}
@@ -43,9 +44,10 @@ public:
     QAction *operator [](const QString &key);
     QList<QString> keys();
     void overrideShortcuts(const QString &key, QList<QKeySequence> shortcuts);
-    void loadSavedShortcuts();
+    void initializeShortcuts();
 
 private:
+    void addShortcutToToolTip(QAction *action);
     QHash<QString, QAction *> m_actions;
 };
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1953,7 +1953,7 @@ void MainWindow::setupActions()
     Actions.loadFromMenu(ui->menuSettings);
     Actions.loadFromMenu(ui->menuHelp);
 
-    Actions.loadSavedShortcuts();
+    Actions.initializeShortcuts();
 }
 
 void MainWindow::writeSettings()


### PR DESCRIPTION
I forgot that we had discussed adding shortcuts to the tooltips. You can choose to merge this before the release, after the release, or not at all.