### PR TITLE
Fix clip move duplicated regression

### DIFF
--- a/src/commands/timelinecommands.cpp
+++ b/src/commands/timelinecommands.cpp
@@ -451,7 +451,7 @@ void MoveClipCommand::redo()
 {
     LOG_DEBUG() << "track delta" << m_trackDelta;
     int trackIndex, clipIndex;
-    QMultiMap<int, Mlt::Producer> newSelection;
+    QList<Mlt::Producer> newSelection;
 
     if (!m_redo) {
         if (m_selection.size() > 1)
@@ -506,7 +506,7 @@ void MoveClipCommand::redo()
                 m_clipIndexList << clipIndex;
                 m_inList << info->frame_in;
                 m_outList << info->frame_out;
-                newSelection.insert(info->cut->get_int(kPlaylistStartProperty), info->producer);
+                newSelection << info->producer;
                 if (m_markerOldStart < 0 || m_markerOldStart > info->start) {
                     // Record the left most clip position being moved
                     m_markerOldStart = info->start;

--- a/src/commands/timelinecommands.h
+++ b/src/commands/timelinecommands.h
@@ -211,7 +211,7 @@ public:
                     QUndoCommand *parent = 0);
     void redo();
     void undo();
-    QMultiMap<int, Mlt::Producer> &selection()
+    QList<Mlt::Producer> &selection()
     {
         return m_selection;
     }
@@ -225,7 +225,7 @@ private:
     bool m_rippleAllTracks;
     bool m_rippleMarkers;
     UndoHelper m_undoHelper;
-    QMultiMap<int, Mlt::Producer> m_selection; // ordered by position
+    QList<Mlt::Producer> m_selection; // ordered by whatever order the user has selected clips
     QList<int> m_newTrackIndexList;
     QList<int> m_playlistStartList;
     QList<int> m_trackIndexList;

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -1645,7 +1645,7 @@ void TimelineDock::onProducerChanged(Mlt::Producer *after)
                         new Timeline::LiftCommand(m_model, trackIndex, clipIndex));
                     auto moveCommand = new Timeline::MoveClipCommand(m_model, m_markersModel, 0, true);
                     nextInfo->cut->set(kPlaylistStartProperty, position);
-                    moveCommand->selection().insert(nextInfo->start, *nextInfo->cut);
+                    moveCommand->selection() << *nextInfo->cut;
                     MAIN.undoStack()->push(moveCommand);
                     MAIN.undoStack()->push(
                         new Timeline::OverwriteCommand(m_model, trackIndex, info->start, MLT.XML(after), false));
@@ -2463,7 +2463,7 @@ void TimelineDock::onClipMoved(int fromTrack, int toTrack, int clipIndex, int po
                 LOG_DEBUG() << "moving clip at" << clip << "start" << info->start << "+" << position << "=" <<
                             info->start + position;
                 info->cut->set(kPlaylistStartProperty, info->start + position);
-                command->selection().insert(info->start, *info->cut);
+                command->selection() << *info->cut;
             }
         }
         setSelection();


### PR DESCRIPTION
This converts `QMultiMap` to `QList` in `MoveClipCommand`.

`Poducer`s in `m_selection` is now ordered by how a user has selected clips on the timeline, not by playlist start positions.
