### PR TITLE
Add user configurable jump actions

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -310,6 +310,9 @@ void MainWindow::setupAndConnectPlayerWidget()
     ui->menuPlayer->addAction(Actions["playerBackwardFiveSecondsAction"]);
     ui->menuPlayer->addAction(Actions["playerForwardTenSecondsAction"]);
     ui->menuPlayer->addAction(Actions["playerBackwardTenSecondsAction"]);
+    ui->menuPlayer->addAction(Actions["playerForwardJumpAction"]);
+    ui->menuPlayer->addAction(Actions["playerBackwardJumpAction"]);
+    ui->menuPlayer->addAction(Actions["playerSetJumpAction"]);
     ui->menuPlayer->addAction(Actions["playerSetInAction"]);
     ui->menuPlayer->addAction(Actions["playerSetOutAction"]);
     ui->menuPlayer->addAction(Actions["playerSetPositionAction"]);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -20,6 +20,7 @@
 #include "actions.h"
 #include "scrubbar.h"
 #include "mainwindow.h"
+#include "dialogs/durationdialog.h"
 #include "widgets/statuslabelwidget.h"
 #include "widgets/timespinbox.h"
 #include "widgets/audioscale.h"
@@ -532,6 +533,33 @@ void Player::setupActions()
             seek(position() - 10 * qRound(MLT.profile().fps()));
     });
     Actions.add("playerBackwardTenSecondsAction", action);
+
+    action = new QAction(tr("Forward Jump"), this);
+    action->setShortcut(QKeySequence(Qt::ALT + Qt::Key_PageDown));
+    connect(action, &QAction::triggered, this, [&]() {
+        if (MLT.producer())
+            seek(position() + qRound(MLT.profile().fps() * Settings.playerJumpSeconds()));
+    });
+    Actions.add("playerForwardJumpAction", action);
+
+    action = new QAction(tr("Backward Jump"), this);
+    action->setShortcut(QKeySequence(Qt::ALT + Qt::Key_PageUp));
+    connect(action, &QAction::triggered, this, [&]() {
+        if (MLT.producer())
+            seek(position() - qRound(MLT.profile().fps() * Settings.playerJumpSeconds()));
+    });
+    Actions.add("playerBackwardJumpAction", action);
+
+    action = new QAction(tr("Set Jump Time"), this);
+    action->setShortcut(QKeySequence(Qt::ALT + Qt::Key_J));
+    connect(action, &QAction::triggered, this, [&]() {
+        DurationDialog dialog(this);
+        dialog.setDuration(qRound(MLT.profile().fps() * Settings.playerJumpSeconds()));
+        if (dialog.exec() == QDialog::Accepted) {
+            Settings.setPlayerJumpSeconds((double)dialog.duration() / MLT.profile().fps());
+        }
+    });
+    Actions.add("playerSetJumpAction", action);
 
     action = new QAction(tr("Trim Clip In"), this);
     action->setShortcut(QKeySequence(Qt::Key_I));

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -521,6 +521,16 @@ void ShotcutSettings::setPlayerVideoDelayMs(int i)
     settings.setValue("player/videoDelayMs", i);
 }
 
+double ShotcutSettings::playerJumpSeconds() const
+{
+    return settings.value("player/jumpSeconds", 60.0).toDouble();
+}
+
+void ShotcutSettings::setPlayerJumpSeconds(double i)
+{
+    settings.setValue("player/jumpSeconds", i);
+}
+
 QString ShotcutSettings::playlistThumbnails() const
 {
     return settings.value("playlist/thumbnails", "small").toString();

--- a/src/settings.h
+++ b/src/settings.h
@@ -162,6 +162,8 @@ public:
     void setPlayerPreviewScale(int);
     int playerVideoDelayMs() const;
     void setPlayerVideoDelayMs(int);
+    double playerJumpSeconds() const;
+    void setPlayerJumpSeconds(double);
 
     // playlist
     QString playlistThumbnails() const;


### PR DESCRIPTION
As suggested here:
https://forum.shotcut.org/t/hotkey-to-skip-ahead-at-least-1-minute-at-a-time/34685

This is an attempt to fulfill multiple user requests for user configurable seeking.
Also, some users had implemented a custom patch to the QML based timeline menu that added user configurable seeking which no longer works with the latest release.

I only added these as actions in the player menu. I do not want to add more controls to the player toolbar. And I do not think they belong in the Timeline toolbar as the user patch put them.

Open to discussion on the Shortcut selection
![image](https://user-images.githubusercontent.com/821968/194734552-0c159c96-2283-4a71-8e69-f1bb36ea2fbb.png)
