### PR TITLE
Add action to cycle color of selected marker

### DIFF
--- a/src/docks/markersdock.h
+++ b/src/docks/markersdock.h
@@ -67,6 +67,7 @@ private slots:
 
 private:
     void enableButtons(bool enable);
+    void setupActions();
 
     MarkersModel *m_model;
     QSortFilterProxyModel *m_proxyModel;


### PR DESCRIPTION
As suggested here:
https://forum.shotcut.org/t/shotcut-marker-qol-thoughts/30510/4

Also intended to fill similar requests to easily/automatically make markers have different colors:
https://forum.shotcut.org/t/could-successive-markers-be-given-different-colours/34703
https://forum.shotcut.org/t/shotcut-marker-qol-thoughts/30510

I suggest "ALT + C" as the shortcut. I also consider that maybe it should not have a shortcut and let users choose to set a shortcut if it is a frequent use feature for them. Open to suggestions.