### PR TITLE
Allow the user to override sample rate when transcoding

### DIFF
--- a/src/dialogs/transcodedialog.cpp
+++ b/src/dialogs/transcodedialog.cpp
@@ -106,6 +106,17 @@ void TranscodeDialog::set709Convert(bool enable)
     ui->convert709CheckBox->setChecked(enable);
 }
 
+QString TranscodeDialog::sampleRate() const
+{
+    QString sampleRate;
+    if ( ui->sampleRateComboBox->currentIndex() == 1 ) {
+        sampleRate = "44100";
+    } else if ( ui->sampleRateComboBox->currentIndex() == 2 ) {
+        sampleRate = "48000";
+    }
+    return sampleRate;
+}
+
 void TranscodeDialog::showSubClipCheckBox()
 {
     ui->subclipCheckBox->show();

--- a/src/dialogs/transcodedialog.h
+++ b/src/dialogs/transcodedialog.h
@@ -46,6 +46,7 @@ public:
     QString frc() const;
     bool get709Convert();
     void set709Convert(bool enable);
+    QString sampleRate() const;
     void showSubClipCheckBox();
     bool isSubClip() const;
     void setSubClipChecked(bool checked);

--- a/src/dialogs/transcodedialog.ui
+++ b/src/dialogs/transcodedialog.ui
@@ -144,11 +144,55 @@
     <widget class="QWidget" name="advancedWidget" native="true">
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
+       <layout class="QGridLayout" name="gridLayout" columnstretch="0,0">
         <item row="4" column="1">
          <widget class="FrameRateWidget" name="fpsWidget" native="true">
           <property name="toolTip">
            <string>Override the frame rate to a specific value.</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <widget class="QCheckBox" name="convert709CheckBox">
+          <property name="toolTip">
+           <string>This is useful when the source video is HDR (High Dynamic Range), which requires tone-mapping to the old, standard range.</string>
+          </property>
+          <property name="text">
+           <string>Convert to BT.709 colorspace</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QCheckBox" name="subclipCheckBox">
+          <property name="toolTip">
+           <string>This option converts only the trimmed portion of the source
+clip plus a little instead of the entire clip. When this option is
+used not all of the matching source clips are replaced, instead
+only the currently selected one.</string>
+          </property>
+          <property name="text">
+           <string>Use sub-clip</string>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="1">
+         <widget class="QCheckBox" name="advancedCheckBox">
+          <property name="toolTip">
+           <string>Enable this to keep the Advanced section open for the next time this dialog appears.</string>
+          </property>
+          <property name="text">
+           <string>Keep Advanced open</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QComboBox" name="frcComboBox">
+          <property name="toolTip">
+           <string>Frame rate conversion method
+
+Duplicate: Duplicate frames.
+Blend: Blend frames.
+Motion Compensation: Interpolate new frames using motion compensation. This method is very slow and may result in artifacts.</string>
           </property>
          </widget>
         </item>
@@ -169,44 +213,13 @@
           </property>
          </widget>
         </item>
-        <item row="6" column="1">
-         <widget class="QCheckBox" name="convert709CheckBox">
-          <property name="toolTip">
-           <string>This is useful when the source video is HDR (High Dynamic Range), which requires tone-mapping to the old, standard range.</string>
+        <item row="7" column="0">
+         <widget class="QLabel" name="sampleRateLabel">
+          <property name="enabled">
+           <bool>true</bool>
           </property>
           <property name="text">
-           <string>Convert to BT.709 colorspace</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="frcLabel">
-          <property name="text">
-           <string>Frame rate conversion</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="QComboBox" name="frcComboBox">
-          <property name="toolTip">
-           <string>Frame rate conversion method
-
-Duplicate: Duplicate frames.
-Blend: Blend frames.
-Motion Compensation: Interpolate new frames using motion compensation. This method is very slow and may result in artifacts.</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QCheckBox" name="subclipCheckBox">
-          <property name="toolTip">
-           <string>This option converts only the trimmed portion of the source
-clip plus a little instead of the entire clip. When this option is
-used not all of the matching source clips are replaced, instead
-only the currently selected one.</string>
-          </property>
-          <property name="text">
-           <string>Use sub-clip</string>
+           <string>Sample rate</string>
           </property>
          </widget>
         </item>
@@ -227,14 +240,36 @@ only the currently selected one.</string>
           </property>
          </widget>
         </item>
-        <item row="7" column="1">
-         <widget class="QCheckBox" name="advancedCheckBox">
-          <property name="toolTip">
-           <string>Enable this to keep the Advanced section open for the next time this dialog appears.</string>
-          </property>
+        <item row="5" column="0">
+         <widget class="QLabel" name="frcLabel">
           <property name="text">
-           <string>Keep Advanced open</string>
+           <string>Frame rate conversion</string>
           </property>
+         </widget>
+        </item>
+        <item row="7" column="1">
+         <widget class="QComboBox" name="sampleRateComboBox">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="currentText">
+           <string>Same as original</string>
+          </property>
+          <item>
+           <property name="text">
+            <string>Same as original</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>44100</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>48000</string>
+           </property>
+          </item>
          </widget>
         </item>
        </layout>

--- a/src/widgets/avformatproducerwidget.cpp
+++ b/src/widgets/avformatproducerwidget.cpp
@@ -861,6 +861,11 @@ void AvformatProducerWidget::convert(TranscodeDialog &dialog)
         }
         args << "-map_metadata" << "0" << "-ignore_unknown";
 
+        // Set Sample rate if different than source
+        if ( !dialog.sampleRate().isEmpty() ) {
+            args << "-ar" << dialog.sampleRate();
+        }
+
         // Set video filters
         args << "-vf";
         QString filterString;


### PR DESCRIPTION
We tend to call the file converter "edit friendly". In Shotcut, 48kHz is the most friendly audio sample rate.

See past issues which do not have a good solution:
https://forum.shotcut.org/t/splitting-audio-adds-pops-clicks/24903
https://forum.shotcut.org/t/audio-crackling-in-exported-media-frankenbited-audio/35876/9

Looking for discussion on this...
One risk/disadvantage of this is that the user can still set the sample rate to something other than 48000 in the export settings. In that case, they might get unexpected results. But in that case, we can tell them to change the export settings to 48000.