### PR TITLE
Fix The slider in the UI is not updated when a keyframe is deleted

### DIFF
--- a/src/controllers/filtercontroller.cpp
+++ b/src/controllers/filtercontroller.cpp
@@ -179,7 +179,6 @@ void FilterController::setCurrentFilter(int attachedIndex, bool isNew)
         if (!m_mltService) return;
         filter = new QmlFilter(*m_mltService, meta);
         filter->setIsNew(isNew);
-        connect(filter, SIGNAL(changed()), SLOT(onQmlFilterChanged()));
         connect(filter, SIGNAL(changed(QString)), SLOT(onQmlFilterChanged(const QString &)));
     }
 
@@ -250,17 +249,13 @@ void FilterController::handleAttachDuplicateFailed(int index)
     setCurrentFilter(index);
 }
 
-void FilterController::onQmlFilterChanged()
-{
-    emit filterChanged(m_mltService);
-}
-
 void FilterController::onQmlFilterChanged(const QString &name)
 {
     if (name == "disable") {
         QModelIndex index = m_attachedModel.index(m_currentFilterIndex);
         emit m_attachedModel.dataChanged(index, index, QVector<int>() << Qt::CheckStateRole);
     }
+    emit filterChanged(m_mltService);
 }
 
 void FilterController::removeCurrent()

--- a/src/controllers/filtercontroller.h
+++ b/src/controllers/filtercontroller.h
@@ -69,7 +69,6 @@ private slots:
     void handleAttachedRowsRemoved(const QModelIndex &parent, int first, int last);
     void handleAttachedRowsInserted(const QModelIndex &parent, int first, int last);
     void handleAttachDuplicateFailed(int index);
-    void onQmlFilterChanged();
     void onQmlFilterChanged(const QString &name);
 
 private:

--- a/src/docks/filtersdock.cpp
+++ b/src/docks/filtersdock.cpp
@@ -86,7 +86,7 @@ void FiltersDock::setCurrentFilter(QmlFilter *filter, QmlMetadata *meta, int ind
     m_qview.rootContext()->setContextProperty("filter", filter);
     m_qview.rootContext()->setContextProperty("metadata", meta);
     if (filter)
-        connect(filter, SIGNAL(changed()), SIGNAL(changed()));
+        connect(filter, SIGNAL(changed(QString)), SIGNAL(changed()));
     else
         disconnect(this, SIGNAL(changed()));
     QMetaObject::invokeMethod(m_qview.rootObject(), "setCurrentFilter", Q_ARG(QVariant,

--- a/src/docks/keyframesdock.cpp
+++ b/src/docks/keyframesdock.cpp
@@ -419,7 +419,7 @@ void KeyframesDock::setCurrentFilter(QmlFilter *filter, QmlMetadata *meta)
     }
     m_model.load(m_filter, m_metadata);
     disconnect(this, SIGNAL(changed()));
-    connect(m_filter, SIGNAL(changed()), SIGNAL(changed()));
+    connect(m_filter, SIGNAL(changed(QString)), SIGNAL(changed()));
     connect(m_filter, SIGNAL(changed(QString)), &m_model, SLOT(onFilterChanged(QString)));
     connect(m_filter, SIGNAL(animateInChanged()), &m_model, SLOT(reload()));
     connect(m_filter, SIGNAL(animateOutChanged()), &m_model, SLOT(reload()));

--- a/src/models/keyframesmodel.cpp
+++ b/src/models/keyframesmodel.cpp
@@ -286,7 +286,7 @@ bool KeyframesModel::remove(int parameterIndex, int keyframeIndex)
                 }
                 emit dataChanged(index(parameterIndex), index(parameterIndex),
                                  QVector<int>() << LowestValueRole << HighestValueRole);
-                emit m_filter->changed();
+                emit m_filter->changed(name.toUtf8().constData());
             }
         }
     }
@@ -368,7 +368,7 @@ bool KeyframesModel::setInterpolation(int parameterIndex, int keyframeIndex, Int
                 QModelIndex modelIndex = index(keyframeIndex, 0, index(parameterIndex));
                 emit dataChanged(modelIndex, modelIndex, QVector<int>() << KeyframeTypeRole << NameRole);
                 error = false;
-                emit m_filter->changed();
+                emit m_filter->changed(name.toUtf8().constData());
                 emit m_filter->propertyChanged(name.toUtf8().constData());
             }
         }
@@ -428,7 +428,7 @@ void KeyframesModel::setKeyframePosition(int parameterIndex, int keyframeIndex, 
     QModelIndex modelIndex = index(keyframeIndex, 0, index(parameterIndex));
     emit dataChanged(modelIndex, modelIndex, QVector<int>() << FrameNumberRole << NameRole);
     updateNeighborsMinMax(parameterIndex, keyframeIndex);
-    emit m_filter->changed();
+    emit m_filter->changed(name.toUtf8().constData());
     emit m_filter->propertyChanged(name.toUtf8().constData());
 }
 
@@ -525,7 +525,7 @@ void KeyframesModel::setKeyframeValue(int parameterIndex, int keyframeIndex, dou
                  m_metadataIndex[parameterIndex])->gangedProperties())
         m_filter->service().anim_set(name.toUtf8().constData(), value, position, m_filter->duration(),
                                      type);
-    emit m_filter->changed();
+    emit m_filter->changed(name.toUtf8().constData());
     emit m_filter->propertyChanged(name.toUtf8().constData());
     QModelIndex modelIndex = index(keyframeIndex, 0, index(parameterIndex));
     emit dataChanged(modelIndex, modelIndex, QVector<int>() << NumericValueRole << NameRole);
@@ -587,7 +587,7 @@ void KeyframesModel::setKeyframeValuePosition(int parameterIndex, int keyframeIn
                  m_metadataIndex[parameterIndex])->gangedProperties())
         m_filter->service().anim_set(name.toUtf8().constData(), value, position, m_filter->duration(),
                                      type);
-    emit m_filter->changed();
+    emit m_filter->changed(name.toUtf8().constData());
     emit m_filter->propertyChanged(name.toUtf8().constData());
     roles << NumericValueRole << NameRole;
     QModelIndex modelIndex = index(keyframeIndex, 0, index(parameterIndex));

--- a/src/qmltypes/qmlfilter.cpp
+++ b/src/qmltypes/qmlfilter.cpp
@@ -60,8 +60,6 @@ QmlFilter::QmlFilter(Mlt::Service &mltService, const QmlMetadata *metadata, QObj
         // Every attached link has a chain property that points to the chain to which it is attached.
         m_producer = Mlt::Producer(mlt_producer(m_service.is_valid() ? m_service.get_data("chain") : 0));
     }
-
-    connect(this, SIGNAL(changed(QString)), SIGNAL(changed()));
 }
 
 QmlFilter::~QmlFilter()
@@ -279,7 +277,7 @@ void QmlFilter::setGradient(QString name, const QStringList &gradient)
             m_service.clear(qUtf8Printable(colorName));
         }
     }
-    emit changed();
+    emit changed(name.toUtf8().constData());
 }
 
 void QmlFilter::set(QString name, const QRectF &rect, int position, mlt_keyframe_type keyframeType)
@@ -629,7 +627,7 @@ int QmlFilter::keyframeCount(const QString &name)
 void QmlFilter::resetProperty(const QString &name)
 {
     m_service.clear(qUtf8Printable(name));
-    emit changed();
+    emit changed(name.toUtf8().constData());
 }
 
 void QmlFilter::clearSimpleAnimation(const QString &name)

--- a/src/qmltypes/qmlfilter.h
+++ b/src/qmltypes/qmlfilter.h
@@ -145,8 +145,7 @@ public slots:
 signals:
     void presetsChanged();
     void analyzeFinished(bool isSuccess);
-    void changed(); /// Use to let UI and VUI QML signal updates to each other.
-    void changed(QString name);
+    void changed(QString name = QString());
     void inChanged(int delta);
     void outChanged(int delta);
     void animateInChanged();


### PR DESCRIPTION
As reported here:
https://forum.shotcut.org/t/the-slider-in-the-ui-is-not-updated-when-a-keyframe-is-deleted/36150

QmlFilter has two signals with the same name:
 * changed()
 * changed(QString)

The QML Connections item can not bind to a signal when it is overloaded by another signal with the same name but different parameters. As a result, the onChanged() signal never fires in ui.qml.

This change merges the two similar signals into one. If the parameter name is not known, or does not apply, pass an empty string.