### PR TITLE
Move the marker color cycle action to the timeline dock

### DIFF
--- a/src/docks/markersdock.cpp
+++ b/src/docks/markersdock.cpp
@@ -135,7 +135,6 @@ MarkersDock::MarkersDock(QWidget *parent) :
     QIcon filterIcon = QIcon::fromTheme("marker", QIcon(":/icons/oxygen/32x32/actions/marker.png"));
     setWindowIcon(filterIcon);
     toggleViewAction()->setIcon(windowIcon());
-    setupActions();
 
     QScrollArea *scrollArea = new QScrollArea();
     scrollArea->setFrameShape(QFrame::NoFrame);
@@ -163,7 +162,7 @@ MarkersDock::MarkersDock(QWidget *parent) :
     mainMenu->addAction(Actions["timelineNextMarkerAction"]);
     mainMenu->addAction(Actions["timelineDeleteMarkerAction"]);
     mainMenu->addAction(Actions["timelineMarkSelectedClipAction"]);
-    mainMenu->addAction(Actions["markerCycleColorAction"]);
+    mainMenu->addAction(Actions["timelineCycleMarkerColorAction"]);
     mainMenu->addAction(tr("Remove All Markers"), this, SLOT(onRemoveAllRequested()));
     QAction *action;
     QMenu *columnsMenu = new QMenu(tr("Columns"), this);
@@ -256,36 +255,6 @@ MarkersDock::MarkersDock(QWidget *parent) :
 
 MarkersDock::~MarkersDock()
 {
-}
-
-void MarkersDock::setupActions()
-{
-    QAction *action;
-
-    action = new QAction(tr("Cycle Color On Selected Marker"), this);
-    action->setShortcut(QKeySequence(Qt::CTRL + Qt::ALT + Qt::Key_M));
-    connect(action, &QAction::triggered, this, [&]() {
-        if (m_model && m_proxyModel) {
-            QModelIndexList indices = m_treeView->selectedIndexes();
-            if (indices.size() > 0) {
-                QModelIndex realIndex = m_proxyModel->mapToSource(indices[0]);
-                if (realIndex.isValid()) {
-                    show();
-                    raise();
-                    auto marker = m_model->getMarker(realIndex.row());
-                    auto allColors = m_model->allColors();
-                    int colorIndex = allColors.indexOf(marker.color);
-                    if (colorIndex >= 0) {
-                        show();
-                        raise();
-                        colorIndex = (colorIndex + 1) % allColors.size();
-                        m_model->setColor(realIndex.row(), allColors[colorIndex]);
-                    }
-                }
-            }
-        }
-    });
-    Actions.add("markerCycleColorAction", action);
 }
 
 void MarkersDock::setModel(MarkersModel *model)

--- a/src/docks/markersdock.h
+++ b/src/docks/markersdock.h
@@ -67,7 +67,6 @@ private slots:
 
 private:
     void enableButtons(bool enable);
-    void setupActions();
 
     MarkersModel *m_model;
     QSortFilterProxyModel *m_proxyModel;

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -132,6 +132,7 @@ TimelineDock::TimelineDock(QWidget *parent) :
     markerMenu->addAction(Actions["timelineNextMarkerAction"]);
     markerMenu->addAction(Actions["timelineDeleteMarkerAction"]);
     markerMenu->addAction(Actions["timelineMarkSelectedClipAction"]);
+    markerMenu->addAction(Actions["timelineCycleMarkerColorAction"]);
     m_mainMenu->addMenu(markerMenu);
     Actions.loadFromMenu(m_mainMenu);
 
@@ -752,6 +753,22 @@ void TimelineDock::setupActions()
         deleteMarker();
     });
     Actions.add("timelineDeleteMarkerAction", action);
+
+    action = new QAction(tr("Cycle Marker Color"), this);
+    action->setShortcut(QKeySequence(Qt::CTRL + Qt::ALT + Qt::Key_M));
+    connect(action, &QAction::triggered, this, [&]() {
+        int markerIndex = m_markersModel.markerIndexForPosition(m_position);
+        if (markerIndex >= 0) {
+            auto marker = m_markersModel.getMarker(markerIndex);
+            auto allColors = m_markersModel.allColors();
+            int colorIndex = allColors.indexOf(marker.color);
+            if (colorIndex >= 0) {
+                colorIndex = (colorIndex + 1) % allColors.size();
+                m_markersModel.setColor(markerIndex, allColors[colorIndex]);
+            }
+        }
+    });
+    Actions.add("timelineCycleMarkerColorAction", action);
 
     action = new QAction(tr("Create Marker Around Selected Clip"), this);
     action->setShortcut(QKeySequence(Qt::ALT + Qt::Key_M));


### PR DESCRIPTION
This allows the action to work even when the markers dock is not visible. Also, the action is applied to the marker under the cursor instead of the selected marker.

As observed here:
https://forum.shotcut.org/t/please-test-the-beta-for-version-22-12/36806/5