### PR TITLE
Add support for normalizing links

### DIFF
--- a/src/mltcontroller.cpp
+++ b/src/mltcontroller.cpp
@@ -1053,7 +1053,8 @@ void Controller::copyFilters(Producer &fromProducer, Producer &toProducer, bool 
         count = fromChain.link_count();
         for (int i = 0; i < count; i++) {
             QScopedPointer<Mlt::Link> fromLink(fromChain.link(i));
-            if (fromLink && fromLink->is_valid() && fromLink->get("mlt_service")) {
+            if (fromLink && fromLink->is_valid() && fromLink->get("mlt_service")
+                    && !fromLink->get_int("_loader")) {
                 Mlt::Link toLink(fromLink->get("mlt_service"));
                 if (toLink.is_valid()) {
                     toLink.inherit(*fromLink);

--- a/src/models/attachedfiltersmodel.h
+++ b/src/models/attachedfiltersmodel.h
@@ -85,6 +85,7 @@ private:
     int m_dropRow;
     int m_removeRow;
     int m_normFilterCount;
+    int m_normLinkCount;
     QScopedPointer<Mlt::Producer> m_producer;
     QScopedPointer<Mlt::Event> m_event;
     typedef QList<QmlMetadata *> MetadataList;


### PR DESCRIPTION
Normalizing links should not be displayed just as normalizing filters are not displayed.

This change can go in anytime because it is backwards compatible. But it is needed before https://github.com/mltframework/mlt/pull/844 or the normalize link will be shown in the UI.