### PR TITLE
Fix file save dialog does not open in Ubuntu

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -457,7 +457,7 @@ bool Util::hasDriveLetter(const QString &path)
 QFileDialog::Options Util::getFileDialogOptions()
 {
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
-    if (qEnvironmentVariableIsSet("SNAP")) {
+    if (qEnvironmentVariableIsSet("SNAP") || qEnvironmentVariableIsSet("GNOME_SHELL_SESSION_MODE")) {
         return QFileDialog::DontUseNativeDialog;
     }
 #endif


### PR DESCRIPTION
Using Ubuntu 18.04 and using the transcode dialog. If the dialog is opened using the Convert button, the File Save As dialog works properly. However, if the transcode dialog is triggered by the Time Remap filter (due to using a source with b-frames), the File Save As dialog does not pop up when the user clicks "OK" and Shotcut hangs waiting for the dialog to appear. The dialog is not "under" the application. It does not appear at all.

This behavior exists for both Qt5.15 and Qt6.4.1.

This problem does not occur on Windows.

Posting this here for discussion. I prefer the native File Save As dialog. I tried various workarounds like triggering the dialog with a queued connection. But I can not figure out why it works from the button and not when triggered by the Filter Dock.