### PR TITLE
GPS text ui: added cadence, temp, grade and units

### DIFF
--- a/src/qml/filters/gpsgraphic/ui.qml
+++ b/src/qml/filters/gpsgraphic/ui.qml
@@ -31,6 +31,7 @@ Item {
     property rect filterRect: filter.getRect(rectProperty)
     property var allParameters: ['time_offset', 'smoothing_value', 'speed_multiplier', 'graph_data_source', 'graph_type', 'trim_start_p', 'trim_end_p', 'crop_mode_h', 'crop_left_p', 'crop_right_p', 'crop_mode_v', 'crop_bot_p', 'crop_top_p', 'color_style', 'color.1', 'color.2', 'color.3', 'color.4', 'color.5', 'color.6', 'color.7', 'color.8', 'color.9', 'color.10', 'show_now_dot', 'now_dot_color', 'show_now_text', 'angle', 'thickness', rectProperty, 'show_grid', 'legend_unit', 'draw_individual_dots', 'bg_img_path', 'bg_scale_w']
     property var default_colors: ["#00aaff", "#00e000", "#ffff00", "#ff8c00", "#ff0000"]
+    property var default_colors_grade: ["#ff00ff", "#00aaff", "#00e000", "#ffff00", "#ff0000"]
     property string color_white: "#ffffff"
     property string default_now_dot: "#00ffffff"
     property string default_rect: '10%/10%:30%x30%'
@@ -365,10 +366,15 @@ Item {
             usedParams = set_graph_style_params(9);
             usedParams.push(set_graph_colors(_, default_colors[0], default_colors[1], default_colors[2], default_colors[3], default_colors[4]));
             filter.savePreset(usedParams, "Map colors: gradient of speed");
+            usedParams = set_graph_style_params(11);
+            usedParams.push(set_graph_colors(_, "#ff00ff", default_colors[0], default_colors[1], default_colors[2], default_colors[4]));
+            filter.savePreset(usedParams, "Map colors: gradient of grade");
             usedParams = set_graph_colors(_, default_colors[0], default_colors[1], default_colors[2], default_colors[3], default_colors[4]);
             filter.savePreset(usedParams, "Colors: default (5)");
             usedParams = set_graph_colors(_, default_colors[4], default_colors[3], default_colors[2], default_colors[1], default_colors[0]);
             filter.savePreset(usedParams, "Colors: inversed default (5)");
+            usedParams = set_graph_colors(_, "#ff00ff", default_colors[0], default_colors[1], default_colors[2], default_colors[4]);
+            filter.savePreset(usedParams, "Colors: green middle (5)");
             usedParams = reset_all_params();
             filter.savePreset(usedParams);
         }
@@ -1263,9 +1269,6 @@ Item {
 
         RowLayout {
             Shotcut.ComboBox {
-                //0
-                //4
-                //6
                 id: combo_color_style
 
                 function get_combo_gradient_nr_colors() {
@@ -1278,7 +1281,12 @@ Item {
                 }
 
                 implicitWidth: 300
-                model: [qsTr('One color'), qsTr('Two colors'), qsTr('Solid past, thin future'), qsTr('Solid future, thin past'), qsTr('Vertical gradient'), qsTr('Horizontal gradient'), qsTr('Color by duration'), qsTr('Color by altitude'), qsTr('Color by heart rate'), qsTr('Color by speed')]
+                //0 to 9
+                property var colorstyle_cbox_strings_v0: [qsTr('One color'), qsTr('Two colors'), qsTr('Solid past, thin future'), qsTr('Solid future, thin past'), qsTr('Vertical gradient'), qsTr('Horizontal gradient'), qsTr('Color by duration'), qsTr('Color by altitude'), qsTr('Color by heart rate'), qsTr('Color by speed')]
+                //10 to 12
+                property var colorstyle_cbox_strings_v2: colorstyle_cbox_strings_v0.concat([qsTr('Color by speed (max 100km/h)'), qsTr('Color by grade (max 90°)'), qsTr('Color by grade (max 20°)')])
+                property var colorstyle_cbox_strings: filter.isAtLeastVersion(2) ? colorstyle_cbox_strings_v2 : colorstyle_cbox_strings_v0
+                model: colorstyle_cbox_strings
                 currentIndex: 1
                 onActivated: {
                     if (_disableUpdate)
@@ -1305,11 +1313,14 @@ Item {
 
                 function set_defcolors_in_gradient_control() {
                     filter.setGradient('color', []);
+                    //saved colors (in .mlt) are reset to default ones on project reopen, not sure how to fix
                     if (combo_color_style.currentIndex === 0) {
                         colGradient.colors = default_colors.slice(0, 1);
                     } else if (combo_color_style.currentIndex <= 3) {
                         colGradient.colors = default_colors.slice(0, 2);
                         colGradient.colors[1] = color_white;
+                    } else if (filter.isAtLeastVersion(2) && (combo_color_style.currentIndex === 11 || combo_color_style.currentIndex === 12)) {
+                        colGradient.colors = default_colors_grade.slice(0, 5);
                     } else {
                         colGradient.colors = default_colors.slice(0, 5);
                     }

--- a/src/qml/filters/gpstext/ui.qml
+++ b/src/qml/filters/gpstext/ui.qml
@@ -783,24 +783,8 @@ Item {
             Layout.bottomMargin: 5
 
             Shotcut.ComboBox {
-
-                //0
-                //1
-                //2
-                //3
-                //4
-                //5
-                //6
-                //7
-                //8
-                //9
-                //10
-                //11
-                //12
-                //13
-                //14
                 implicitWidth: 300
-                model: [qsTr('GPS latitude'), qsTr('GPS longitude'), qsTr('Elevation (m)'), qsTr('Speed (km/h)'), qsTr('Distance (m)'), qsTr('GPS date-time'), qsTr('Video file date-time'), qsTr('Heart-rate (bpm)'), qsTr('Bearing (degrees)'), qsTr('Bearing (compass)'), qsTr('Elevation gain (m)'), qsTr('Elevation loss (m)'), qsTr('Distance uphill (m)'), qsTr('Distance downhill (m)'), qsTr('Distance flat (m)')]
+                model: [qsTr('GPS latitude'), qsTr('GPS longitude'), qsTr('Elevation (m)'), qsTr('Speed (km/h)'), qsTr('Distance (m)'), qsTr('GPS date-time'), qsTr('Video file date-time'), qsTr('Heart-rate (bpm)'), qsTr('Bearing (degrees)'), qsTr('Bearing (compass)'), qsTr('Elevation gain (m)'), qsTr('Elevation loss (m)'), qsTr('Distance uphill (m)'), qsTr('Distance downhill (m)'), qsTr('Distance flat (m)'), qsTr('Cadence'), qsTr('Temperature (C)'), qsTr('Grade (%)'), qsTr('Grade (degrees)')]
                 onActivated: {
                     switch (currentIndex) {
                     case 0:
@@ -810,13 +794,13 @@ Item {
                         onClicked: textArea.insert(textArea.cursorPosition, '#gps_lon#');
                         break;
                     case 2:
-                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_elev m#');
+                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_elev m#m');
                         break;
                     case 3:
-                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_speed kmh#');
+                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_speed kmh#km/h');
                         break;
                     case 4:
-                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_dist m#');
+                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_dist m#m');
                         break;
                     case 5:
                         onClicked: textArea.insert(textArea.cursorPosition, '#gps_datetime_now#');
@@ -825,28 +809,40 @@ Item {
                         onClicked: textArea.insert(textArea.cursorPosition, '#file_datetime_now#');
                         break;
                     case 7:
-                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_hr#');
+                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_hr#bpm');
                         break;
                     case 8:
-                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_bearing#');
+                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_bearing#°');
                         break;
                     case 9:
                         onClicked: textArea.insert(textArea.cursorPosition, '#gps_compass#');
                         break;
                     case 10:
-                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_vdist_up#');
+                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_vdist_up#m');
                         break;
                     case 11:
-                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_vdist_down#');
+                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_vdist_down#m');
                         break;
                     case 12:
-                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_dist_uphill#');
+                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_dist_uphill#m');
                         break;
                     case 13:
-                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_dist_downhill#');
+                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_dist_downhill#m');
                         break;
                     case 14:
-                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_dist_flat#');
+                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_dist_flat#m');
+                        break;
+                    case 15:
+                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_cadence#rpm');
+                        break;
+                    case 16:
+                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_temperature#°C');
+                        break;
+                    case 17:
+                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_grade_percentage#%');
+                        break;
+                    case 18:
+                    	onClicked: textArea.insert(textArea.cursorPosition, '#gps_grade_degrees#°');
                         break;
                     default:
                         console.log('gps_combobox: current index not supported: ' + currentIndex);

--- a/src/qml/filters/gpstext/ui.qml
+++ b/src/qml/filters/gpstext/ui.qml
@@ -781,10 +781,14 @@ Item {
 
         RowLayout {
             Layout.bottomMargin: 5
-
             Shotcut.ComboBox {
                 implicitWidth: 300
-                model: [qsTr('GPS latitude'), qsTr('GPS longitude'), qsTr('Elevation (m)'), qsTr('Speed (km/h)'), qsTr('Distance (m)'), qsTr('GPS date-time'), qsTr('Video file date-time'), qsTr('Heart-rate (bpm)'), qsTr('Bearing (degrees)'), qsTr('Bearing (compass)'), qsTr('Elevation gain (m)'), qsTr('Elevation loss (m)'), qsTr('Distance uphill (m)'), qsTr('Distance downhill (m)'), qsTr('Distance flat (m)'), qsTr('Cadence'), qsTr('Temperature (C)'), qsTr('Grade (%)'), qsTr('Grade (degrees)')]
+                
+                property var gps_cbox_strings_v0: [qsTr('GPS latitude'), qsTr('GPS longitude'), qsTr('Elevation (m)'), qsTr('Speed (km/h)'), qsTr('Distance (m)'), qsTr('GPS date-time'), qsTr('Video file date-time'), qsTr('Heart-rate (bpm)'), qsTr('Bearing (degrees)'), qsTr('Bearing (compass)'), qsTr('Elevation gain (m)'), qsTr('Elevation loss (m)'), qsTr('Distance uphill (m)'), qsTr('Distance downhill (m)'), qsTr('Distance flat (m)')];
+                property var gps_cbox_strings_v3: [qsTr('Cadence'), qsTr('Temperature (C)'), qsTr('Grade (%)'), qsTr('Grade (degrees)')];
+                property var gps_cbox_strings: filter.isAtLeastVersion(3) ? gps_cbox_strings_v0.concat(gps_cbox_strings_v3) : gps_cbox_strings_v0
+
+                model: gps_cbox_strings
                 onActivated: {
                     switch (currentIndex) {
                     case 0:
@@ -812,7 +816,7 @@ Item {
                         onClicked: textArea.insert(textArea.cursorPosition, '#gps_hr#bpm');
                         break;
                     case 8:
-                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_bearing#°');
+                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_bearing#Â°');
                         break;
                     case 9:
                         onClicked: textArea.insert(textArea.cursorPosition, '#gps_compass#');
@@ -836,13 +840,13 @@ Item {
                         onClicked: textArea.insert(textArea.cursorPosition, '#gps_cadence#rpm');
                         break;
                     case 16:
-                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_temperature#°C');
+                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_temperature#Â°C');
                         break;
                     case 17:
                         onClicked: textArea.insert(textArea.cursorPosition, '#gps_grade_percentage#%');
                         break;
                     case 18:
-                    	onClicked: textArea.insert(textArea.cursorPosition, '#gps_grade_degrees#°');
+                    	onClicked: textArea.insert(textArea.cursorPosition, '#gps_grade_degrees#Â°');
                         break;
                     default:
                         console.log('gps_combobox: current index not supported: ' + currentIndex);

--- a/src/qml/filters/gpstext/ui.qml
+++ b/src/qml/filters/gpstext/ui.qml
@@ -783,10 +783,10 @@ Item {
             Layout.bottomMargin: 5
             Shotcut.ComboBox {
                 implicitWidth: 300
-                
+
                 property var gps_cbox_strings_v0: [qsTr('GPS latitude'), qsTr('GPS longitude'), qsTr('Elevation (m)'), qsTr('Speed (km/h)'), qsTr('Distance (m)'), qsTr('GPS date-time'), qsTr('Video file date-time'), qsTr('Heart-rate (bpm)'), qsTr('Bearing (degrees)'), qsTr('Bearing (compass)'), qsTr('Elevation gain (m)'), qsTr('Elevation loss (m)'), qsTr('Distance uphill (m)'), qsTr('Distance downhill (m)'), qsTr('Distance flat (m)')];
-                property var gps_cbox_strings_v3: [qsTr('Cadence'), qsTr('Temperature (C)'), qsTr('Grade (%)'), qsTr('Grade (degrees)')];
-                property var gps_cbox_strings: filter.isAtLeastVersion(3) ? gps_cbox_strings_v0.concat(gps_cbox_strings_v3) : gps_cbox_strings_v0
+                property var gps_cbox_strings_v3: gps_cbox_strings_v0.concat([qsTr('Cadence'), qsTr('Temperature (C)'), qsTr('Grade (%)'), qsTr('Grade (degrees)')]);
+                property var gps_cbox_strings: filter.isAtLeastVersion(3) ? gps_cbox_strings_v3 : gps_cbox_strings_v0
 
                 model: gps_cbox_strings
                 onActivated: {

--- a/src/qml/filters/gpstext/ui.qml
+++ b/src/qml/filters/gpstext/ui.qml
@@ -785,7 +785,7 @@ Item {
                 implicitWidth: 300
 
                 property var gps_cbox_strings_v0: [qsTr('GPS latitude'), qsTr('GPS longitude'), qsTr('Elevation (m)'), qsTr('Speed (km/h)'), qsTr('Distance (m)'), qsTr('GPS date-time'), qsTr('Video file date-time'), qsTr('Heart-rate (bpm)'), qsTr('Bearing (degrees)'), qsTr('Bearing (compass)'), qsTr('Elevation gain (m)'), qsTr('Elevation loss (m)'), qsTr('Distance uphill (m)'), qsTr('Distance downhill (m)'), qsTr('Distance flat (m)')];
-                property var gps_cbox_strings_v3: gps_cbox_strings_v0.concat([qsTr('Cadence'), qsTr('Temperature (C)'), qsTr('Grade (%)'), qsTr('Grade (degrees)')]);
+                property var gps_cbox_strings_v3: gps_cbox_strings_v0.concat([qsTr('Cadence'), qsTr('Temperature (C)'), qsTr('Grade (%)'), qsTr('Grade (degrees)'), qsTr('Vertical speed (m/s)'), qsTr('3D Speed (km/h)')]);
                 property var gps_cbox_strings: filter.isAtLeastVersion(3) ? gps_cbox_strings_v3 : gps_cbox_strings_v0
 
                 model: gps_cbox_strings
@@ -847,6 +847,12 @@ Item {
                         break;
                     case 18:
                     	onClicked: textArea.insert(textArea.cursorPosition, '#gps_grade_degrees#°');
+                        break;
+                    case 19:
+                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_speed vertical m/s#m/s');
+                        break;
+                    case 20:
+                        onClicked: textArea.insert(textArea.cursorPosition, '#gps_speed 3d km/h#km/h');
                         break;
                     default:
                         console.log('gps_combobox: current index not supported: ' + currentIndex);


### PR DESCRIPTION
I've added the degrees symbol in some texts, it's part of extended ascii so I think it's fine in the file.

Btw, the long model list looked a bit more organised one entry per line (with a comment stating it's corresponding case value), not sure if you're willing to update the rules of the formatting tool for this but I think it would be a good change.