### PR TITLE
fix export/turn-off proxy if file starts w/ data stream

### DIFF
--- a/src/commands/timelinecommands.cpp
+++ b/src/commands/timelinecommands.cpp
@@ -1517,6 +1517,7 @@ void DetachAudioCommand::redo()
     if (audioClip.is_valid() && videoClip.is_valid()) {
 
         // Disable audio on the video clip.
+        videoClip.set("astream", -1);
         videoClip.set("audio_index", -1);
         // Remove audio filters from the video clip.
         for (int i = 0; i < videoClip.filter_count(); i++) {
@@ -1532,6 +1533,7 @@ void DetachAudioCommand::redo()
         }
 
         // Disable video on the audio clip.
+        audioClip.set("vstream", -1);
         audioClip.set("video_index", -1);
         // Remove video filters from the audio clip.
         for (int i = 0; i < audioClip.filter_count(); i++) {

--- a/src/mltcontroller.h
+++ b/src/mltcontroller.h
@@ -33,6 +33,14 @@ class QQuickView;
 #define MLT_LC_CATEGORY LC_ALL
 #define MLT_LC_NAME     "LC_ALL"
 
+#if LIBMLT_VERSION_INT >= ((7<<16)+(19<<8))
+#define kAudioIndexProperty "astream"
+#define kVideoIndexProperty "vstream"
+#else
+#define kAudioIndexProperty "audio_index"
+#define kVideoIndexProperty "video_index"
+#endif
+
 namespace Mlt {
 
 const int kMaxImageDurationSecs = 3600 * 4;

--- a/src/models/audiolevelstask.cpp
+++ b/src/models/audiolevelstask.cpp
@@ -152,12 +152,9 @@ QString AudioLevelsTask::cacheKey()
         key = hash.result().toHex();
     }
     if (producer->get("audio_index")) {
-        if (m_isForce) {
-            producer->set(kDefaultAudioIndexProperty, -1);
-        }
         // Add the audio index only if different than default to avoid cache miss.
-        if (producer->get(kDefaultAudioIndexProperty) &&
-                producer->get_int("audio_index") != producer->get_int(kDefaultAudioIndexProperty)) {
+        if (m_isForce || (producer->get(kDefaultAudioIndexProperty) &&
+                          producer->get_int("audio_index") != producer->get_int(kDefaultAudioIndexProperty))) {
             key += QString(" %1").arg(producer->get("audio_index"));
         }
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -375,7 +375,8 @@ void Util::applyCustomProperties(Mlt::Producer &destination, Mlt::Producer &sour
     p.clear(kOriginalOutProperty);
     if (!p.get_int(kIsProxyProperty))
         p.clear(kOriginalResourceProperty);
-    destination.pass_list(source, "mlt_service, audio_index, video_index, force_progressive, force_tff,"
+    destination.pass_list(source,
+                          "mlt_service, audio_index, video_index, astream, vstream, force_progressive, force_tff,"
                           "force_aspect_ratio, video_delay, color_range, warp_speed, warp_pitch, rotate,"
                           kAspectRatioNumerator ","
                           kAspectRatioDenominator ","
@@ -685,7 +686,7 @@ QString Util::updateCaption(Mlt::Producer *producer)
 
 void Util::passProducerProperties(Mlt::Producer *src, Mlt::Producer *dst)
 {
-    dst->pass_list(*src, "audio_index, video_index, force_aspect_ratio,"
+    dst->pass_list(*src, "audio_index, video_index, astream, vstream, force_aspect_ratio,"
                    "video_delay, force_progressive, force_tff, force_full_range, color_range, warp_pitch, rotate,"
                    kAspectRatioNumerator ","
                    kAspectRatioDenominator ","


### PR DESCRIPTION
Here are the Shotcut changes. This is a little tricky because I want to maintain backwards compatibility with both MLT latest releases that does not include astream/vstream and existing project files that are using audio_index and video_index. So, we cannot convert to the new property names wholesale even if a new/unreleased MLT version is detected. So, if you search the code, there is still a lot of places where "audio_index" and "video_index" are read, and it depends on the MLT change keeping the relative vs. absolute stream values in sync.