### PR TITLE
Port from qAsConst to std::as_const

### DIFF
--- a/src/commands/undohelper.cpp
+++ b/src/commands/undohelper.cpp
@@ -310,7 +310,7 @@ void UndoHelper::debugPrintState()
 void UndoHelper::restoreAffectedTracks()
 {
     // Remove everything in the affected tracks.
-    for (const auto &trackIndex : qAsConst(m_affectedTracks)) {
+    for (const auto &trackIndex : std::as_const(m_affectedTracks)) {
         if (trackIndex >= 0 && trackIndex < m_model.trackList().size()) {
             auto mlt_index = m_model.trackList().at(trackIndex).mlt_index;
             Mlt::Producer producer = m_model.tractor()->multitrack()->track(mlt_index);
@@ -324,7 +324,7 @@ void UndoHelper::restoreAffectedTracks()
         }
     }
 
-    for (const auto &uid : qAsConst(m_insertedOrder)) {
+    for (const auto &uid : std::as_const(m_insertedOrder)) {
         const Info &info = m_state[uid];
         if (m_affectedTracks.contains(info.oldTrackIndex)) {
             UNDOLOG << "Handling uid" << uid << "on track" << info.oldTrackIndex << "index" <<
@@ -359,7 +359,7 @@ void UndoHelper::restoreAffectedTracks()
             AudioLevelsTask::start(clip->parent(), &m_model, modelIndex);
         }
     }
-    for (const auto &trackIndex : qAsConst(m_affectedTracks)) {
+    for (const auto &trackIndex : std::as_const(m_affectedTracks)) {
         if (trackIndex >= 0 && trackIndex < m_model.trackList().size()) {
             auto mlt_index = m_model.trackList().at(trackIndex).mlt_index;
             Mlt::Producer producer = m_model.tractor()->multitrack()->track(mlt_index);

--- a/src/models/actionsmodel.cpp
+++ b/src/models/actionsmodel.cpp
@@ -179,7 +179,7 @@ bool ActionsModel::setData(const QModelIndex &index, const QVariant &value, int 
     QAction *action = m_actions[index.row()];
 
     if (!ks.isEmpty()) {
-        for (const auto a : qAsConst(m_actions)) {
+        for (const auto a : std::as_const(m_actions)) {
             QList<QKeySequence> sequences = a->shortcuts();
             for (int i = 0; i < sequences.size(); i++) {
                 if (sequences[i] == ks) {

--- a/src/models/markersmodel.cpp
+++ b/src/models/markersmodel.cpp
@@ -328,7 +328,7 @@ void MarkersModel::doShift(int shiftPosition, int shiftAmount)
     int maxIndex = -1;
     QScopedPointer<Mlt::Properties> markerList(m_producer->get_props(kShotcutMarkersProperty));
     if (markerList &&  markerList->is_valid()) {
-        for (const auto i : qAsConst(m_keys)) {
+        for (const auto i : std::as_const(m_keys)) {
             QScopedPointer<Mlt::Properties> markerProperties(markerList->get_props(qUtf8Printable(
                                                                                        QString::number(i))));
             if (markerProperties && markerProperties->is_valid()) {
@@ -455,7 +455,7 @@ int MarkersModel::markerIndexForPosition(int position)
 {
     QScopedPointer<Mlt::Properties> markerList(m_producer->get_props(kShotcutMarkersProperty));
     if (markerList &&  markerList->is_valid()) {
-        for (const auto i : qAsConst(m_keys)) {
+        for (const auto i : std::as_const(m_keys)) {
             QScopedPointer<Mlt::Properties> marker(markerList->get_props(qUtf8Printable(QString::number(i))));
             if (marker && marker->is_valid()) {
                 if (position == m_producer->time_to_frames(marker->get("start")) ||
@@ -471,7 +471,7 @@ int MarkersModel::markerIndexForRange(int start, int end)
 {
     QScopedPointer<Mlt::Properties> markerList(m_producer->get_props(kShotcutMarkersProperty));
     if (markerList &&  markerList->is_valid()) {
-        for (const auto i : qAsConst(m_keys)) {
+        for (const auto i : std::as_const(m_keys)) {
             QScopedPointer<Mlt::Properties> marker(markerList->get_props(qUtf8Printable(QString::number(i))));
             if (marker && marker->is_valid()) {
                 if (start == m_producer->time_to_frames(marker->get("start")) &&
@@ -492,7 +492,7 @@ int MarkersModel::nextMarkerPosition(int position)
     }
     QScopedPointer<Mlt::Properties> markerList(m_producer->get_props(kShotcutMarkersProperty));
     if (markerList &&  markerList->is_valid()) {
-        for (const auto i : qAsConst(m_keys)) {
+        for (const auto i : std::as_const(m_keys)) {
             QScopedPointer<Mlt::Properties> marker(markerList->get_props(qUtf8Printable(QString::number(i))));
             if (marker && marker->is_valid()) {
                 int markerPosition = m_producer->time_to_frames(marker->get("start"));
@@ -518,7 +518,7 @@ int MarkersModel::prevMarkerPosition(int position)
     }
     QScopedPointer<Mlt::Properties> markerList(m_producer->get_props(kShotcutMarkersProperty));
     if (markerList &&  markerList->is_valid()) {
-        for (const auto i : qAsConst(m_keys)) {
+        for (const auto i : std::as_const(m_keys)) {
             QScopedPointer<Mlt::Properties> marker(markerList->get_props(qUtf8Printable(QString::number(i))));
             if (marker && marker->is_valid()) {
                 int markerPosition = m_producer->time_to_frames(marker->get("start"));
@@ -545,7 +545,7 @@ QMap<int, QString> MarkersModel::ranges()
     QMap<int, QString> result;
     QScopedPointer<Mlt::Properties> markerList(m_producer->get_props(kShotcutMarkersProperty));
     if (markerList &&  markerList->is_valid()) {
-        for (const auto i : qAsConst(m_keys)) {
+        for (const auto i : std::as_const(m_keys)) {
             QScopedPointer<Mlt::Properties> marker(markerList->get_props(qUtf8Printable(QString::number(i))));
             if (marker && marker->is_valid()) {
                 Markers::Marker m;
@@ -571,7 +571,7 @@ QList<Markers::Marker> MarkersModel::getMarkers() const
         return markers;
     QScopedPointer<Mlt::Properties> markerList(m_producer->get_props(kShotcutMarkersProperty));
     if (markerList &&  markerList->is_valid()) {
-        for (const auto i : qAsConst(m_keys)) {
+        for (const auto i : std::as_const(m_keys)) {
             QScopedPointer<Mlt::Properties> marker(markerList->get_props(qUtf8Printable(QString::number(i))));
             if (marker && marker->is_valid()) {
                 Markers::Marker m;


### PR DESCRIPTION
qAsConst() has been marked deprecated in Qt 6.6.