### PR TITLE
Fix transition properties are not restored when undo trim out

### DIFF
--- a/src/commands/timelinecommands.cpp
+++ b/src/commands/timelinecommands.cpp
@@ -1169,23 +1169,25 @@ void RemoveTransitionByTrimInCommand::undo()
         LOG_DEBUG() << "trackIndex" << m_trackIndex << "clipIndex" << m_clipIndex << "delta" << m_delta;
         m_model.addTransitionByTrimOut(m_trackIndex, m_clipIndex - 1, m_delta);
         // Copy properties from old transition to new transition
-        std::unique_ptr<Mlt::ClipInfo> clipInfo = m_model.getClipInfo(m_trackIndex, m_clipIndex);
-        std::unique_ptr<Mlt::Service> oldService(new Mlt::Producer(MLT.profile(), "xml-string",
-                                                                   m_xml.toUtf8().constData()));
-        while (oldService && oldService->is_valid()) {
-            if (oldService->type() == mlt_service_transition_type) {
-                Mlt::Transition oldTransition(*oldService);
-                std::unique_ptr<Mlt::Service> newService(new Mlt::Producer(clipInfo->producer));
-                while (newService && newService->is_valid()) {
-                    if (newService->type() == mlt_service_transition_type &&
-                            QString(oldService->get("mlt_service")) == QString(newService->get("mlt_service"))) {
-                        newService->inherit(*oldService.get());
+        auto clipInfo = m_model.getClipInfo(m_trackIndex, m_clipIndex);
+        Mlt::Service oldService = Mlt::Producer(MLT.profile(), "xml-string", m_xml.toUtf8().constData());
+        while (oldService.is_valid()) {
+            if (oldService.type() == mlt_service_transition_type) {
+                Mlt::Service newService(clipInfo->producer);
+                while (newService.is_valid()) {
+                    if (newService.type() == mlt_service_transition_type &&
+                            QString(oldService.get("mlt_service")) == QString(newService.get("mlt_service"))) {
+                        newService.inherit(oldService);
                         break;
                     }
-                    newService.reset(newService->producer());
+                    Mlt::Service *tmpNewService = newService.producer();
+                    newService = Mlt::Service(*tmpNewService);
+                    delete tmpNewService;
                 }
             }
-            oldService.reset(oldService->producer());
+            Mlt::Service *tmpOldService = oldService.producer();
+            oldService = Mlt::Service(*tmpOldService);
+            delete tmpOldService;
         }
         m_model.notifyClipIn(m_trackIndex, m_clipIndex + 1);
     } else LOG_WARNING() << "invalid clip index" << m_clipIndex;
@@ -1224,23 +1226,25 @@ void RemoveTransitionByTrimOutCommand::undo()
         LOG_DEBUG() << "trackIndex" << m_trackIndex << "clipIndex" << m_clipIndex << "delta" << m_delta;
         m_model.addTransitionByTrimIn(m_trackIndex, m_clipIndex, m_delta);
         // Copy properties from old transition to new transition
-        std::unique_ptr<Mlt::ClipInfo> clipInfo = m_model.getClipInfo(m_trackIndex, m_clipIndex);
-        std::unique_ptr<Mlt::Service> oldService(new Mlt::Producer(MLT.profile(), "xml-string",
-                                                                   m_xml.toUtf8().constData()));
-        while (oldService && oldService->is_valid()) {
-            if (oldService->type() == mlt_service_transition_type) {
-                Mlt::Transition oldTransition(*oldService);
-                std::unique_ptr<Mlt::Service> newService(new Mlt::Producer(clipInfo->producer));
-                while (newService && newService->is_valid()) {
-                    if (newService->type() == mlt_service_transition_type &&
-                            QString(oldService->get("mlt_service")) == QString(newService->get("mlt_service"))) {
-                        newService->inherit(*oldService.get());
+        auto clipInfo = m_model.getClipInfo(m_trackIndex, m_clipIndex);
+        Mlt::Service oldService = Mlt::Producer(MLT.profile(), "xml-string", m_xml.toUtf8().constData());
+        while (oldService.is_valid()) {
+            if (oldService.type() == mlt_service_transition_type) {
+                Mlt::Service newService(clipInfo->producer);
+                while (newService.is_valid()) {
+                    if (newService.type() == mlt_service_transition_type &&
+                            QString(oldService.get("mlt_service")) == QString(newService.get("mlt_service"))) {
+                        newService.inherit(oldService);
                         break;
                     }
-                    newService.reset(newService->producer());
+                    Mlt::Service *tmpNewService = newService.producer();
+                    newService = Mlt::Service(*tmpNewService);
+                    delete tmpNewService;
                 }
             }
-            oldService.reset(oldService->producer());
+            Mlt::Service *tmpOldService = oldService.producer();
+            oldService = Mlt::Service(*tmpOldService);
+            delete tmpOldService;
         }
         m_model.notifyClipOut(m_trackIndex, m_clipIndex - 1);
     } else LOG_WARNING() << "invalid clip index" << m_clipIndex;

--- a/src/commands/timelinecommands.h
+++ b/src/commands/timelinecommands.h
@@ -467,7 +467,7 @@ class RemoveTransitionByTrimInCommand : public TrimCommand
 {
 public:
     RemoveTransitionByTrimInCommand(MultitrackModel &model, int trackIndex, int clipIndex, int delta,
-                                    bool redo = true, QUndoCommand *parent = 0);
+                                    QString xml, bool redo = true, QUndoCommand *parent = 0);
     void redo();
     void undo();
 private:
@@ -475,6 +475,7 @@ private:
     int m_trackIndex;
     int m_clipIndex;
     int m_delta;
+    QString m_xml;
     bool m_redo;
 };
 
@@ -482,7 +483,7 @@ class RemoveTransitionByTrimOutCommand : public TrimCommand
 {
 public:
     RemoveTransitionByTrimOutCommand(MultitrackModel &model, int trackIndex, int clipIndex, int delta,
-                                     bool redo = true, QUndoCommand *parent = 0);
+                                     QString xml, bool redo = true, QUndoCommand *parent = 0);
     void redo();
     void undo();
 private:
@@ -490,6 +491,7 @@ private:
     int m_trackIndex;
     int m_clipIndex;
     int m_delta;
+    QString m_xml;
     bool m_redo;
 };
 

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -2665,18 +2665,18 @@ bool TimelineDock::trimClipIn(int trackIndex, int clipIndex, int oldClipIndex, i
             m_updateCommand->setPosition(trackIndex, clipIndex, -1);
     } else if (!ripple && m_model.removeTransitionByTrimInValid(trackIndex, clipIndex, delta)) {
         Q_ASSERT(trackIndex >= 0 && clipIndex >= 0);
-        QModelIndex modelIndex = m_model.makeIndex(trackIndex, clipIndex - 1);
-        int n = m_model.data(modelIndex, MultitrackModel::DurationRole).toInt();
+        std::unique_ptr<Mlt::ClipInfo> clipInfo = m_model.getClipInfo(trackIndex, clipIndex - 1);
+        QString xml = MLT.XML(clipInfo->producer);
         m_model.liftClip(trackIndex, clipIndex - 1);
         if (delta < 0 ) {
-            m_model.trimClipIn(trackIndex, clipIndex, -n, false, false);
-            m_trimDelta += -n;
+            m_model.trimClipIn(trackIndex, clipIndex, -clipInfo->length, false, false);
+            m_trimDelta += -clipInfo->length;
         } else if (delta > 0) {
-            m_model.trimClipOut(trackIndex, clipIndex - 2, -n, false, false);
+            m_model.trimClipOut(trackIndex, clipIndex - 2, -clipInfo->length, false, false);
             m_transitionDelta = 0;
         }
         m_trimCommand.reset(new Timeline::RemoveTransitionByTrimInCommand(m_model, trackIndex,
-                                                                          clipIndex - 1, m_trimDelta, false));
+                                                                          clipIndex - 1, m_trimDelta, xml, false));
         if (m_updateCommand && m_updateCommand->trackIndex() == trackIndex
                 && m_updateCommand->clipIndex() == clipIndex)
             m_updateCommand->setPosition(trackIndex, clipIndex - 1, -1);
@@ -2726,18 +2726,18 @@ bool TimelineDock::trimClipOut(int trackIndex, int clipIndex, int delta, bool ri
             m_updateCommand->setPosition(trackIndex, clipIndex, -1);
     } else if (!ripple && m_model.removeTransitionByTrimOutValid(trackIndex, clipIndex, delta)) {
         Q_ASSERT(trackIndex >= 0 && clipIndex >= 0);
-        QModelIndex modelIndex = m_model.makeIndex(trackIndex, clipIndex + 1);
-        int n = m_model.data(modelIndex, MultitrackModel::DurationRole).toInt();
+        std::unique_ptr<Mlt::ClipInfo> clipInfo = m_model.getClipInfo(trackIndex, clipIndex + 1);
+        QString xml = MLT.XML(clipInfo->producer);
         m_model.liftClip(trackIndex, clipIndex + 1);
         if (delta < 0 ) {
-            m_model.trimClipOut(trackIndex, clipIndex, -n, false, false);
-            m_trimDelta += -n;
+            m_model.trimClipOut(trackIndex, clipIndex, -clipInfo->length, false, false);
+            m_trimDelta += -clipInfo->length;
         } else if (delta > 0) {
-            m_model.trimClipIn(trackIndex, clipIndex + 2, -n, false, false);
+            m_model.trimClipIn(trackIndex, clipIndex + 2, -clipInfo->length, false, false);
             m_transitionDelta = 0;
         }
         m_trimCommand.reset(new Timeline::RemoveTransitionByTrimOutCommand(m_model, trackIndex,
-                                                                           clipIndex + 1, m_trimDelta, false));
+                                                                           clipIndex + 1, m_trimDelta, xml, false));
         if (m_updateCommand && m_updateCommand->trackIndex() == trackIndex
                 && m_updateCommand->clipIndex() == clipIndex)
             m_updateCommand->setPosition(trackIndex, clipIndex, -1);


### PR DESCRIPTION
I would love a quick visual sanity check on the approach for this one. Maybe there is a better way.

Steps to reproduce:
1) Put two clips on the timeline - drag one over the other to make a transition
2) Set a property on the transition (e.g. Barn Door Horizontal)
3) Trim the left or right side of the transition until it is removed
4) Edit->undo
5) Observe that the property is not restored (e.g. dissolve instead of Barn Door Horizontal)