### PR TITLE
Fix crash when undo triming transition to a new transition.

### DIFF
--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -2673,6 +2673,20 @@ void TimelineDock::onClipMoved(int fromTrack, int toTrack, int clipIndex, int po
 bool TimelineDock::trimClipIn(int trackIndex, int clipIndex, int oldClipIndex, int delta,
                               bool ripple)
 {
+    if (dynamic_cast<Timeline::RemoveTransitionByTrimInCommand *>(m_trimCommand.get())) {
+        if (delta < 0) {
+            // Do not trim past the removed tansition
+            return false;
+        } else {
+            // Untrimming - Restore the transition
+            dynamic_cast<Timeline::RemoveTransitionByTrimInCommand *>(m_trimCommand.get())->undo();
+            m_trimCommand.release();
+            m_undoHelper.release();
+            delta += m_trimDelta;
+            m_trimDelta = 0;
+            clipIndex += 1;
+        }
+    }
     if (!ripple && m_model.addTransitionByTrimInValid(trackIndex, clipIndex, delta)) {
         clipIndex = m_model.addTransitionByTrimIn(trackIndex, clipIndex, delta);
         m_transitionDelta += delta;
@@ -2734,6 +2748,19 @@ bool TimelineDock::trimClipIn(int trackIndex, int clipIndex, int oldClipIndex, i
 
 bool TimelineDock::trimClipOut(int trackIndex, int clipIndex, int delta, bool ripple)
 {
+    if (dynamic_cast<Timeline::RemoveTransitionByTrimOutCommand *>(m_trimCommand.get())) {
+        if (delta < 0) {
+            // Do not trim past the removed tansition
+            return false;
+        } else {
+            // Untrimming - Restore the transition
+            dynamic_cast<Timeline::RemoveTransitionByTrimOutCommand *>(m_trimCommand.get())->undo();
+            m_trimCommand.release();
+            m_undoHelper.release();
+            delta += m_trimDelta;
+            m_trimDelta = 0;
+        }
+    }
     if (!ripple && m_model.addTransitionByTrimOutValid(trackIndex, clipIndex, delta)) {
         m_model.addTransitionByTrimOut(trackIndex, clipIndex, delta);
         m_transitionDelta += delta;


### PR DESCRIPTION
As reported here:
https://forum.shotcut.org/t/using-undo-after-dragging-transitions-sometimes-cause-crashes/41096

Do not allow the user to trim the transtion past "remove". When they hit the end of the transition, they can either commit, or untrim. Before this change, they could continue to trim and add a new transition. But the new transition command does not know about the removed transition change and that can lead to a crash when undoing.

Also, fix transition diasppearing when it is trimmed out and then back in without releasing the mouse.