### PR TITLE
Add timeline looping on markers

### DIFF
--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -39,6 +39,9 @@ class TimelineDock : public QDockWidget
 {
     Q_OBJECT
     Q_PROPERTY(int position READ position WRITE setPosition NOTIFY positionChanged)
+    Q_PROPERTY(int loopStart READ loopStart NOTIFY loopChanged)
+    Q_PROPERTY(int loopEnd READ loopEnd NOTIFY loopChanged)
+    Q_PROPERTY(QColor loopColor READ loopColor NOTIFY loopChanged)
     Q_PROPERTY(int currentTrack READ currentTrack WRITE setCurrentTrack NOTIFY currentTrackChanged)
     Q_PROPERTY(QVariantList selection READ selectionForJS WRITE setSelectionFromJS NOTIFY
                selectionChanged)
@@ -66,6 +69,18 @@ public:
         return m_position;
     }
     void setPosition(int position);
+    int loopStart() const
+    {
+        return m_loopStart;
+    }
+    int loopEnd() const
+    {
+        return m_loopEnd;
+    }
+    QColor loopColor() const
+    {
+        return m_loopColor;
+    }
     Mlt::Producer producerForClip(int trackIndex, int clipIndex);
     int clipIndexAtPlayhead(int trackIndex = -1);
     int clipIndexAtPosition(int trackIndex, int position);
@@ -113,6 +128,7 @@ signals:
     void selectionChanged();
     void seeked(int position);
     void positionChanged();
+    void loopChanged();
     void clipOpened(Mlt::Producer *producer);
     void dragging(const QPointF &pos, int duration);
     void dropped();
@@ -202,6 +218,7 @@ public slots:
     void deleteMarker(int markerIndex = -1);
     void seekNextMarker();
     void seekPrevMarker();
+    void toggleLoopMarker(int index);
     void onFilterModelChanged();
     void trimClipIn(bool ripple = false);
     void trimClipOut(bool ripple = false);
@@ -259,6 +276,10 @@ private:
     int m_currentTrack {0};
     QMenu *m_mainMenu;
     QMenu *m_clipMenu;
+    int m_loopMarker;
+    int m_loopStart;
+    int m_loopEnd;
+    QColor m_loopColor;
 
 private slots:
     void load(bool force);
@@ -274,6 +295,7 @@ private slots:
     void onTimelineRightClicked();
     void onClipRightClicked();
     void onNoMoreEmptyTracks(bool isAudio);
+    void updateLoop();
 };
 
 class TimelineSelectionBlocker

--- a/src/models/markersmodel.cpp
+++ b/src/models/markersmodel.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Meltytech, LLC
+ * Copyright (c) 2021-2023 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -460,6 +460,23 @@ int MarkersModel::markerIndexForPosition(int position)
             if (marker && marker->is_valid()) {
                 if (position == m_producer->time_to_frames(marker->get("start")) ||
                         position == m_producer->time_to_frames(marker->get("end")))
+                    return keyIndex(i);
+            }
+        }
+    }
+    return -1;
+}
+
+int MarkersModel::rangeMarkerIndexForPosition(int position)
+{
+    QScopedPointer<Mlt::Properties> markerList(m_producer->get_props(kShotcutMarkersProperty));
+    if (markerList &&  markerList->is_valid()) {
+        for (const auto i : qAsConst(m_keys)) {
+            QScopedPointer<Mlt::Properties> marker(markerList->get_props(qUtf8Printable(QString::number(i))));
+            if (marker && marker->is_valid()) {
+                int start = m_producer->time_to_frames(marker->get("start"));
+                int end = m_producer->time_to_frames(marker->get("end"));
+                if (position >= start && position <= end && start != end)
                     return keyIndex(i);
             }
         }

--- a/src/models/markersmodel.h
+++ b/src/models/markersmodel.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Meltytech, LLC
+ * Copyright (c) 2021-2023 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -55,9 +55,11 @@ public:
     virtual ~MarkersModel();
 
     void load(Mlt::Producer *producer);
+    int markerCount() const;
     Markers::Marker getMarker(int markerIndex);
     int uniqueKey() const;
     int markerIndexForPosition(int position);
+    int rangeMarkerIndexForPosition(int position);
     int markerIndexForRange(int start, int end);
     Q_INVOKABLE int nextMarkerPosition(int position);
     Q_INVOKABLE int prevMarkerPosition(int position);
@@ -100,7 +102,6 @@ protected:
     QHash<int, QByteArray> roleNames() const;
 
 private:
-    int markerCount() const;
     int keyIndex(int key) const;
     Mlt::Properties *getMarkerProperties(int markerIndex);
     void updateRecentColors(const QColor &color);

--- a/src/qml/views/timeline/timeline.qml
+++ b/src/qml/views/timeline/timeline.qml
@@ -632,6 +632,18 @@ Rectangle {
             }
 
             Rectangle {
+                id: loopIndicator
+
+                visible: timeline.loopStart != timeline.loopEnd
+                color: timeline.loopColor
+                opacity: 0.5
+                width: (timeline.loopEnd - timeline.loopStart) * multitrack.scaleFactor
+                height: root.height - horizontalScrollBar.height
+                x: timeline.loopStart * multitrack.scaleFactor - tracksFlickable.contentX
+                y: 0
+            }
+
+            Rectangle {
                 id: cursor
 
                 visible: timeline.position > -1

--- a/src/qmltypes/qmlmarkermenu.cpp
+++ b/src/qmltypes/qmlmarkermenu.cpp
@@ -59,6 +59,7 @@ void QmlMarkerMenu::popup()
         return;
 
     QMenu menu;
+    Markers::Marker marker = m_timeline->markersModel()->getMarker(m_index);
 
     QAction editAction(tr("Edit..."));
     editAction.setShortcut(Actions["timelineMarkerAction"]->shortcut());
@@ -123,6 +124,7 @@ void QmlMarkerMenu::popup()
 
     QAction loopAction(tr("Loop/Unloop Marker"));
     loopAction.setShortcut(Actions["timelineToggleLoopMarkerAction"]->shortcut());
+    loopAction.setEnabled(marker.start != marker.end);
     connect(&loopAction, &QAction::triggered, this, [&]() {
         m_timeline->toggleLoopMarker(m_index);
     });

--- a/src/qmltypes/qmlmarkermenu.cpp
+++ b/src/qmltypes/qmlmarkermenu.cpp
@@ -121,5 +121,12 @@ void QmlMarkerMenu::popup()
         recentColorMenu->addAction(widgetAction);
     }
 
+    QAction loopAction(tr("Loop/Unloop Marker"));
+    loopAction.setShortcut(Actions["timelineToggleLoopMarkerAction"]->shortcut());
+    connect(&loopAction, &QAction::triggered, this, [&]() {
+        m_timeline->toggleLoopMarker(m_index);
+    });
+    menu.addAction(&loopAction);
+
     menu.exec(QCursor::pos());
 }


### PR DESCRIPTION
As requested here:
https://forum.shotcut.org/t/loop-region-for-playback/32123/16

Add an option to the context menu to loop/unloop around a range marker.
![image](https://github.com/mltframework/shotcut/assets/821968/2ce15bb0-7a08-4dfe-a2f5-7f6b4db8c9ac)

When range marker looping is enabled, the timeline is highlighted around that region and the cursor can not seek outside of that region.
![image](https://github.com/mltframework/shotcut/assets/821968/22ab8a7b-15ad-4e7c-860c-20db9317df9c)

Depends on https://github.com/mltframework/mlt/pull/964