### PR TITLE
Add multi-split to timeline clips

### DIFF
--- a/src/commands/timelinecommands.cpp
+++ b/src/commands/timelinecommands.cpp
@@ -808,31 +808,37 @@ bool TrimClipOutCommand::mergeWith(const QUndoCommand *other)
     return true;
 }
 
-SplitCommand::SplitCommand(MultitrackModel &model, int trackIndex,
-                           int clipIndex, int position, QUndoCommand *parent)
+SplitCommand::SplitCommand(MultitrackModel &model, const std::vector<int> &trackIndex,
+                           const std::vector<int> &clipIndex, int position, QUndoCommand *parent)
     : QUndoCommand(parent)
     , m_model(model)
-    , m_trackIndex(qBound(0, trackIndex, qMax(model.rowCount() - 1, 0)))
+    , m_trackIndex(trackIndex)
     , m_clipIndex(clipIndex)
     , m_position(position)
     , m_undoHelper(m_model)
 {
-    setText(QObject::tr("Split clip"));
+    if (m_clipIndex.size() == 1) {
+        setText(QObject::tr("Split clip"));
+    } else {
+        setText(QObject::tr("Split clips"));
+    }
     m_undoHelper.setHints(UndoHelper::RestoreTracks);
 }
 
 void SplitCommand::redo()
 {
-    LOG_DEBUG() << "trackIndex" << m_trackIndex << "clipIndex" << m_clipIndex << "position" <<
+    LOG_DEBUG() << "trackIndex" << m_trackIndex[0] << "clipIndex" << m_clipIndex[0] << "position" <<
                 m_position;
     m_undoHelper.recordBeforeState();
-    m_model.splitClip(m_trackIndex, m_clipIndex, m_position);
+    for (int i = 0; i < m_trackIndex.size(); i++) {
+        m_model.splitClip(m_trackIndex[i], m_clipIndex[i], m_position);
+    }
     m_undoHelper.recordAfterState();
 }
 
 void SplitCommand::undo()
 {
-    LOG_DEBUG() << "trackIndex" << m_trackIndex << "clipIndex" << m_clipIndex << "position" <<
+    LOG_DEBUG() << "trackIndex" << m_trackIndex[0] << "clipIndex" << m_clipIndex[0] << "position" <<
                 m_position;
     m_undoHelper.undoChanges();
 }

--- a/src/commands/timelinecommands.h
+++ b/src/commands/timelinecommands.h
@@ -28,6 +28,8 @@
 #include <MltTransition.h>
 #include <MltProducer.h>
 
+#include <vector>
+
 namespace Timeline {
 
 enum {
@@ -314,14 +316,16 @@ private:
 class SplitCommand : public QUndoCommand
 {
 public:
-    SplitCommand(MultitrackModel &model, int trackIndex, int clipIndex, int position,
+    SplitCommand(MultitrackModel &model, const std::vector<int> &trackIndex,
+                 const std::vector<int> &clipIndex,
+                 int position,
                  QUndoCommand *parent = 0);
     void redo();
     void undo();
 private:
     MultitrackModel &m_model;
-    int m_trackIndex;
-    int m_clipIndex;
+    std::vector<int> m_trackIndex;
+    std::vector<int> m_clipIndex;
     int m_position;
     UndoHelper m_undoHelper;
 };

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -167,7 +167,6 @@ public slots:
     void insert(int trackIndex, int position = -1, const QString &xml = QString(), bool seek = true);
     void overwrite(int trackIndex, int position = -1, const QString &xml = QString(), bool seek = true);
     void appendFromPlaylist(Mlt::Playlist *playlist, bool skipProxy);
-    void splitClip(int trackIndex = -1, int clipIndex = -1);
     void fadeIn(int trackIndex, int clipIndex = -1, int duration = -1);
     void fadeOut(int trackIndex, int clipIndex = -1, int duration = -1);
     void seekPreviousEdit();

--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -1245,11 +1245,17 @@ void MultitrackModel::liftClip(int trackIndex, int clipIndex)
 
 void MultitrackModel::splitClip(int trackIndex, int clipIndex, int position)
 {
+    if (trackIndex < 0 || trackIndex >= rowCount()) {
+        LOG_ERROR() << "Invalid track index" << trackIndex;
+    }
     int i = m_trackList.at(trackIndex).mlt_index;
     QScopedPointer<Mlt::Producer> track(m_tractor->track(i));
     if (track) {
         Mlt::Playlist playlist(*track);
         QScopedPointer<Mlt::ClipInfo> info(playlist.clip_info(clipIndex));
+        if (info.isNull()) {
+            LOG_ERROR() << "Invalid clip index" << trackIndex << clipIndex;
+        }
         int in = info->frame_in;
         int out = info->frame_out;
         int filterIn = MLT.filterIn(playlist, clipIndex);


### PR DESCRIPTION
Add a new action (SHIFT + S) to split all clips under the playhead. As requested here:
https://forum.shotcut.org/t/split-across-multiple-tracks/293
https://forum.shotcut.org/t/automating-keyboard-shortcuts-with-autohotkey/12608/10
https://forum.shotcut.org/t/easier-workflow-solution/1456/7
https://forum.shotcut.org/t/propagation-on-tracks/39448/4
https://forum.shotcut.org/t/editing-basics-ripple-multiripple/20488/7

Also, add support for multiple-selection to the existing split command. Now, Shotcut will first look for one or more selected clips under the playhead and split those. If not selected clips on under the playhead, then Shotcut will revert to the current behavior to select a clip based on track selection.

Also added menu entry to the timeline menu
![image](https://github.com/mltframework/shotcut/assets/821968/eae3bd5b-4667-42db-86df-d7bacd4b0436)
