### PR TITLE
Add clip nudging to the timeline

### DIFF
--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -632,7 +632,7 @@ void TimelineDock::setupActions()
     Actions.add("timelinePasteAction", action);
 
     action = new QAction(tr("Nudge Forward"), this);
-    action->setShortcut(QKeySequence(Qt::Key_N));
+    action->setShortcut(QKeySequence(Qt::Key_Period));
     action->setEnabled(false);
     connect(action, &QAction::triggered, this, [&]() {
         auto selectedClips = selection();
@@ -655,7 +655,7 @@ void TimelineDock::setupActions()
     Actions.add("timelineNudgeForwardAction", action);
 
     action = new QAction(tr("Nudge Backward"), this);
-    action->setShortcut(QKeySequence(Qt::SHIFT | Qt::Key_N));
+    action->setShortcut(QKeySequence(Qt::Key_Comma));
     action->setEnabled(false);
     connect(action, &QAction::triggered, this, [&]() {
         auto selectedClips = selection();

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -116,6 +116,8 @@ TimelineDock::TimelineDock(QWidget *parent) :
     editMenu->addAction(Actions["timelineRecordAudioAction"]);
     editMenu->addAction(Actions["playerSetInAction"]);
     editMenu->addAction(Actions["playerSetOutAction"]);
+    editMenu->addAction(Actions["timelineNudgeForwardAction"]);
+    editMenu->addAction(Actions["timelineNudgeBackwardAction"]);
     editMenu->addAction(Actions["timelineRippleTrimClipInAction"]);
     editMenu->addAction(Actions["timelineRippleTrimClipOutAction"]);
     editMenu->addAction(Actions["timelineSplitAction"]);
@@ -144,6 +146,8 @@ TimelineDock::TimelineDock(QWidget *parent) :
     m_clipMenu->addAction(Actions["timelineLiftAction"]);
     m_clipMenu->addAction(Actions["timelineReplaceAction"]);
     m_clipMenu->addAction(Actions["timelineSplitAction"]);
+    m_clipMenu->addAction(Actions["timelineNudgeForwardAction"]);
+    m_clipMenu->addAction(Actions["timelineNudgeBackwardAction"]);
     m_clipMenu->addAction(Actions["timelineMergeWithNextAction"]);
     m_clipMenu->addAction(Actions["timelineDetachAudioAction"]);
     m_clipMenu->addAction(Actions["timelineAlignToReferenceAction"]);
@@ -626,6 +630,52 @@ void TimelineDock::setupActions()
         insert(-1);
     });
     Actions.add("timelinePasteAction", action);
+
+    action = new QAction(tr("Nudge Forward"), this);
+    action->setShortcut(QKeySequence(Qt::Key_N));
+    action->setEnabled(false);
+    connect(action, &QAction::triggered, this, [&]() {
+        auto selectedClips = selection();
+        if (!selectedClips.isEmpty()) {
+            int trackIndex = selection().first().y();
+            int clipIndex = selection().first().x();
+            auto clipInfo = m_model.getClipInfo(trackIndex, clipIndex);
+            moveClip(trackIndex, trackIndex, clipIndex, clipInfo->start + 1, Settings.timelineRipple());
+        }
+    });
+    connect(this, &TimelineDock::selectionChanged, action, [ = ]() {
+        bool enabled = m_selection.selectedClips.length() > 0;
+        if (enabled && !selection().isEmpty()) {
+            int trackIndex = selection().first().y();
+            int clipIndex = selection().first().x();
+            enabled = !isBlank(trackIndex, clipIndex);
+        }
+        action->setEnabled(enabled);
+    });
+    Actions.add("timelineNudgeForwardAction", action);
+
+    action = new QAction(tr("Nudge Backward"), this);
+    action->setShortcut(QKeySequence(Qt::SHIFT | Qt::Key_N));
+    action->setEnabled(false);
+    connect(action, &QAction::triggered, this, [&]() {
+        auto selectedClips = selection();
+        if (!selectedClips.isEmpty()) {
+            int trackIndex = selection().first().y();
+            int clipIndex = selection().first().x();
+            auto clipInfo = m_model.getClipInfo(trackIndex, clipIndex);
+            moveClip(trackIndex, trackIndex, clipIndex, clipInfo->start - 1, Settings.timelineRipple());
+        }
+    });
+    connect(this, &TimelineDock::selectionChanged, action, [ = ]() {
+        bool enabled = m_selection.selectedClips.length() > 0;
+        if (enabled && !selection().isEmpty()) {
+            int trackIndex = selection().first().y();
+            int clipIndex = selection().first().x();
+            enabled = !isBlank(trackIndex, clipIndex);
+        }
+        action->setEnabled(enabled);
+    });
+    Actions.add("timelineNudgeBackwardAction", action);
 
     action = new QAction(tr("Append"), this);
     action->setShortcut(QKeySequence(Qt::Key_A));

--- a/src/qml/views/timeline/timeline.qml
+++ b/src/qml/views/timeline/timeline.qml
@@ -780,8 +780,11 @@ Rectangle {
                 let trackIndex = track.DelegateModel.itemsIndex;
                 let clipIndex = clip.DelegateModel.itemsIndex;
                 timeline.currentTrack = trackIndex;
-                if (timeline.selection.length === 1 && tracksRepeater.itemAt(timeline.selection[0].y).clipAt(timeline.selection[0].x).isBlank)
-                    timeline.selection = [];
+                if (timeline.selection.length === 1) {
+                    let clip2 = tracksRepeater.itemAt(timeline.selection[0].y).clipAt(timeline.selection[0].x);
+                    if (clip2 === null || clip2.isBlank)
+                        timeline.selection = [];
+                }
                 if (tracksRepeater.itemAt(trackIndex).clipAt(clipIndex).isBlank)
                     timeline.selection = [Qt.point(clipIndex, trackIndex)];
                 else if (mouse && mouse.modifiers & Qt.ControlModifier)


### PR DESCRIPTION
A nudge moves the clip forward or backward one frame

Looking for some discussion on this idea. Dragging on the timeline does not work well in tiny increments. I know there are some workaround ways to move clips in small increments using snapping. But I do not find those to be intuitive.

I propose these two new nudge commands (forward and backward) that will move the selected clips by one frame. In this proof-of-concept, I added two commands to the hamburger and clip context menus.

![image](https://github.com/mltframework/shotcut/assets/821968/8bfa54b3-7b12-400b-96f1-45010b4a32a7)

I chose shortcuts "N" and "SHIFT+N" for forward and  backward respectively.

One disadvantage to this is that when a move command occurs, the current selection is cleared. This makes it difficult to easily move a clip 3 frames (for example) by typing N+N+N - the user has to reselect the clip between each nudge. I think this might have been done to work around a problem with moving multiple clips across tracks. I am not sure. Maybe I can find a way to improve that.

Maybe users will request a way to specify how many frames should be in a nudge. If we can make quick repetition of nudges work, I do not think that would be worth the effort.