### PR TITLE
Add clip grouping

### DIFF
--- a/src/commands/timelinecommands.cpp
+++ b/src/commands/timelinecommands.cpp
@@ -685,6 +685,9 @@ void MoveClipCommand::redo()
                 info->producer->set(kClipIndexProperty, clipIndex);
                 info->producer->set(kShotcutInProperty, info->frame_in);
                 info->producer->set(kShotcutOutProperty, info->frame_out);
+                if (info->cut->property_exists(kShotcutGroupProperty)) {
+                    info->producer->set(kGroupProperty, info->cut->get(kShotcutGroupProperty));
+                }
                 newSelection.insert(info->cut->get_int(kPlaylistStartProperty), info->producer);
                 if (m_markerOldStart < 0 || m_markerOldStart > info->start) {
                     // Record the left most clip position being moved
@@ -716,6 +719,13 @@ void MoveClipCommand::redo()
                 m_model.insertClip(toTrack, clip, start, m_rippleAllTracks);
             else
                 m_model.overwrite(toTrack, clip, start, false);
+            if (clip.property_exists(kGroupProperty)) {
+                int clipIndex = m_model.clipIndex(toTrack, start);
+                auto clipInfo = m_model.getClipInfo(toTrack, clipIndex);
+                if (clipInfo && clipInfo->cut) {
+                    clipInfo->cut->set(kShotcutGroupProperty, clip.get(kGroupProperty));
+                }
+            }
         }
     }
 

--- a/src/commands/timelinecommands.h
+++ b/src/commands/timelinecommands.h
@@ -140,8 +140,6 @@ public:
     void redo();
     void undo();
 private:
-    int getUniqueGroupNumber();
-
     MultitrackModel &m_model;
     QList<Mlt::Producer> m_clips;
     QSet<QUuid> m_uuids;

--- a/src/commands/timelinecommands.h
+++ b/src/commands/timelinecommands.h
@@ -132,6 +132,36 @@ private:
     QList<Markers::Marker> m_markers;
 };
 
+class GroupCommand : public QUndoCommand
+{
+public:
+    GroupCommand(MultitrackModel &model, QUndoCommand *parent = 0);
+    void addToGroup(Mlt::Producer &clip);
+    void redo();
+    void undo();
+private:
+    int getUniqueGroupNumber();
+
+    MultitrackModel &m_model;
+    QList<Mlt::Producer> m_clips;
+    QSet<QUuid> m_uuids;
+    QMap<QUuid, int> m_prevGroups;
+};
+
+class UngroupCommand : public QUndoCommand
+{
+public:
+    UngroupCommand(MultitrackModel &model, QUndoCommand *parent = 0);
+    void removeFromGroup(Mlt::Producer &clip);
+    void redo();
+    void undo();
+private:
+    MultitrackModel &m_model;
+    QList<Mlt::Producer> m_clips;
+    QSet<QUuid> m_uuids;
+    QMap<QUuid, int> m_prevGroups;
+};
+
 class NameTrackCommand : public QUndoCommand
 {
 public:

--- a/src/commands/undohelper.cpp
+++ b/src/commands/undohelper.cpp
@@ -62,6 +62,9 @@ void UndoHelper::recordBeforeState()
             info.oldTrackIndex = i;
             info.oldClipIndex = j;
             info.isBlank = playlist.is_blank(j);
+            if (clipInfo.cut && clipInfo.cut->property_exists(kShotcutGroupProperty)) {
+                info.group = clipInfo.cut->get_int(kShotcutGroupProperty);
+            }
         }
     }
 }
@@ -209,6 +212,10 @@ void UndoHelper::undoChanges()
                     fixTransitions(playlist, currentIndex, restoredClip);
                 }
                 playlist.insert(restoredClip, currentIndex, info.frame_in, info.frame_out);
+                if (info.group >= 0) {
+                    QScopedPointer<Mlt::Producer> clip(playlist.get_clip(currentIndex));
+                    clip->set(kShotcutGroupProperty, info.group);
+                }
             }
             m_model.endInsertRows();
 
@@ -348,7 +355,10 @@ void UndoHelper::restoreAffectedTracks()
                     restoredClip.set("mlt_type", "mlt_producer");
                 }
                 playlist.append(restoredClip, info.frame_in, info.frame_out);
-
+                if (info.group >= 0) {
+                    QScopedPointer<Mlt::Producer> clip(playlist.get_clip(currentIndex));
+                    clip->set(kShotcutGroupProperty, info.group);
+                }
             }
             m_model.endInsertRows();
 

--- a/src/commands/undohelper.h
+++ b/src/commands/undohelper.h
@@ -64,6 +64,7 @@ private:
         int frame_out;
         int in_delta;
         int out_delta;
+        int group;
 
         int changes;
         Info()
@@ -77,6 +78,7 @@ private:
             , in_delta(0)
             , out_delta(0)
             , changes(NoChange)
+            , group(-1)
         {}
     };
     QMap<QUuid, Info> m_state;

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -1341,7 +1341,7 @@ void TimelineDock::setupActions()
     });
     Actions.add("timelineRippleTrimClipOutAction", action);
 
-    action = new QAction(tr("Group/UnGroup"), this);
+    action = new QAction(tr("Group/Ungroup"), this);
     action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_G));
     action->setEnabled(false);
     connect(action, &QAction::triggered, this, [&](bool checked) {

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -107,6 +107,7 @@ TimelineDock::TimelineDock(QWidget *parent) :
     selectionMenu->addAction(Actions["timelineSelectClipUnderPlayheadAction"]);
     selectionMenu->addAction(Actions["timelineCurrentTrackAboveAction"]);
     selectionMenu->addAction(Actions["timelineCurrentTrackBelowAction"]);
+    selectionMenu->addAction(Actions["timelineGroupAction"]);
     m_mainMenu->addMenu(selectionMenu);
     QMenu *editMenu = new QMenu(tr("Edit"), this);
     editMenu->addAction(Actions["timelinePasteAction"]);
@@ -146,6 +147,7 @@ TimelineDock::TimelineDock(QWidget *parent) :
     m_clipMenu->addAction(Actions["timelineLiftAction"]);
     m_clipMenu->addAction(Actions["timelineReplaceAction"]);
     m_clipMenu->addAction(Actions["timelineSplitAction"]);
+    m_clipMenu->addAction(Actions["timelineGroupAction"]);
     m_clipMenu->addAction(Actions["timelineNudgeForwardAction"]);
     m_clipMenu->addAction(Actions["timelineNudgeBackwardAction"]);
     m_clipMenu->addAction(Actions["timelineMergeWithNextAction"]);
@@ -1338,6 +1340,43 @@ void TimelineDock::setupActions()
         trimClipAtPlayhead(TimelineDock::TrimOutPoint, true);
     });
     Actions.add("timelineRippleTrimClipOutAction", action);
+
+    action = new QAction(tr("Group/UnGroup"), this);
+    action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_G));
+    action->setEnabled(false);
+    connect(action, &QAction::triggered, this, [&](bool checked) {
+        auto selectedClips = selection();
+        if (selectedClips.size() <= 1) {
+            LOG_ERROR() << "Not enough clips selected" << selectedClips.size();
+            return;
+        }
+        auto firstClip = m_model.getClipInfo(selectedClips[0].y(), selectedClips[0].x());
+        if (firstClip->cut->property_exists(kShotcutGroupProperty)) {
+            // First clip is in a group. Need to ungroup
+            Timeline::UngroupCommand *ungroupCommand = new Timeline::UngroupCommand(m_model);
+            foreach (auto point, selectedClips) {
+                auto clipInfo = m_model.getClipInfo(point.y(), point.x());
+                if (!clipInfo->cut->is_blank()) {
+                    ungroupCommand->removeFromGroup(*clipInfo->cut);
+                }
+            }
+            MAIN.undoStack()->push(ungroupCommand);
+        } else {
+            // First clip is not in a group - ungroup
+            Timeline::GroupCommand *groupCommand = new Timeline::GroupCommand(m_model);
+            foreach (auto point, selectedClips) {
+                auto clipInfo = m_model.getClipInfo(point.y(), point.x());
+                if (!clipInfo->cut->is_blank()) {
+                    groupCommand->addToGroup(*clipInfo->cut);
+                }
+            }
+            MAIN.undoStack()->push(groupCommand);
+        }
+    });
+    connect(this, &TimelineDock::selectionChanged, action, [ = ]() {
+        action->setEnabled(selection().size() > 1);
+    });
+    Actions.add("timelineGroupAction", action);
 }
 
 int TimelineDock::addTrackIfNeeded(TrackType trackType)
@@ -1636,6 +1675,36 @@ void TimelineDock::restoreSelection()
     }
     emit selectionChanged();
     emitSelectedFromSelection();
+}
+
+QVariantList TimelineDock::getGroupForClip(int trackIndex, int clipIndex)
+{
+    QVariantList result;
+
+    auto info = m_model.getClipInfo(trackIndex, clipIndex);
+    if (!info || !info->cut) {
+        return result;
+    }
+    if (!info->cut->property_exists(kShotcutGroupProperty)) {
+        result << QPoint(clipIndex, trackIndex);
+    } else {
+        int group = info->cut->get_int(kShotcutGroupProperty);
+        for (int trackIndex = 0; trackIndex < m_model.trackList().size(); trackIndex++) {
+            int i = m_model.trackList().at(trackIndex).mlt_index;
+            QScopedPointer<Mlt::Producer> track(m_model.tractor()->track(i));
+            if (track) {
+                Mlt::Playlist playlist(*track);
+                for (int clipIndex = 0; clipIndex < playlist.count(); clipIndex++) {
+                    QScopedPointer<Mlt::ClipInfo> info(playlist.clip_info(clipIndex));
+                    if (info && info->cut && info->cut->property_exists(kShotcutGroupProperty)
+                            && info->cut->get_int(kShotcutGroupProperty) == group) {
+                        result << QPoint(clipIndex, trackIndex);
+                    }
+                }
+            }
+        }
+    }
+    return result;
 }
 
 void TimelineDock::selectClipUnderPlayhead()

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -2365,6 +2365,11 @@ void TimelineDock::emitSelectedFromSelection()
         return;
     }
 
+    if (selection().size() > 1) {
+        emit selected(nullptr);
+        return;
+    }
+
     int trackIndex = selection().isEmpty() ? currentTrack() : selection().first().y();
     int clipIndex  = selection().isEmpty() ? 0              : selection().first().x();
     auto info = m_model.getClipInfo(trackIndex, clipIndex);

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -83,6 +83,7 @@ public:
     const QVector<QUuid> selectionUuids();
     void saveAndClearSelection();
     Q_INVOKABLE void restoreSelection();
+    Q_INVOKABLE QVariantList getGroupForClip(int trackIndex, int clipIndex);
     void selectClipUnderPlayhead();
     int centerOfClip(int trackIndex, int clipIndex);
     bool isTrackLocked(int trackIndex) const;

--- a/src/qml/views/filter/filterview.qml
+++ b/src/qml/views/filter/filterview.qml
@@ -169,7 +169,7 @@ Rectangle {
 
             Label {
                 anchors.centerIn: parent
-                text: qsTr("Nothing selected")
+                text: qsTr("Select a clip")
                 color: activePalette.text
                 visible: !attachedfiltersmodel.isProducerSelected
             }

--- a/src/qml/views/timeline/Timeline.js
+++ b/src/qml/views/timeline/Timeline.js
@@ -161,20 +161,32 @@ function onMouseWheel(wheel) {
     }
 }
 
-function toggleSelection(trackIndex, clipIndex) {
-    let result = []
-    let skip = false
-    timeline.selection.forEach(function(el) {
-        if (tracksRepeater.itemAt(el.y).clipAt(el.x).isBlank)
-            // Do not support multiselect for blank clips
-            return
-        if (el.x !== clipIndex || el.y !== trackIndex)
-            result.push(el)
-        else
-            skip = true
+function toggleSelection(trackIndex, clipIndex, group) {
+    let result = timeline.selection
+    let append = true
+    // Check if this clip is already in selection to know if we append or remove
+    result.forEach(function(el) {
+        if (el.x === clipIndex && el.y === trackIndex)
+            append = false
     })
-    if (!skip)
+    if (append && !group) {
+        // Add this one clip to the selection
         result.push(Qt.point(clipIndex, trackIndex))
+    } else if (append && group) {
+        // Add this clip and its group to the selection
+        result = result.concat(timeline.getGroupForClip(trackIndex, clipIndex))
+    } else if (!append && !group) {
+        // Remove this one clip from the selection
+        result = result.filter( function( el ) {
+            return el.x !== clipIndex || el.y !== trackIndex;
+        } );
+    } else if (!append && group) {
+        // Remove this clip and its group from the selection
+        let groupClips = timeline.getGroupForClip(trackIndex, clipIndex)
+        result = result.filter( function( el ) {
+            return groupClips.indexOf( el ) < 0;
+        } );
+    }
     return result
 }
 

--- a/src/qml/views/timeline/timeline.qml
+++ b/src/qml/views/timeline/timeline.qml
@@ -787,12 +787,16 @@ Rectangle {
                 }
                 if (tracksRepeater.itemAt(trackIndex).clipAt(clipIndex).isBlank)
                     timeline.selection = [Qt.point(clipIndex, trackIndex)];
+                else if (mouse && mouse.modifiers & Qt.ControlModifier && mouse.modifiers & Qt.AltModifier)
+                    timeline.selection = Logic.toggleSelection(trackIndex, clipIndex, false);
                 else if (mouse && mouse.modifiers & Qt.ControlModifier)
-                    timeline.selection = Logic.toggleSelection(trackIndex, clipIndex);
+                    timeline.selection = Logic.toggleSelection(trackIndex, clipIndex, true);
                 else if (mouse && mouse.modifiers & Qt.ShiftModifier)
                     timeline.selection = Logic.selectRange(trackIndex, clipIndex);
-                else if (!Logic.selectionContains(trackIndex, clipIndex))
+                else if (mouse && mouse.modifiers & Qt.AltModifier && !Logic.selectionContains(trackIndex, clipIndex))
                     timeline.selection = [Qt.point(clipIndex, trackIndex)];
+                else if (!Logic.selectionContains(trackIndex, clipIndex))
+                    timeline.selection = timeline.getGroupForClip(trackIndex, clipIndex);
                 root.clipClicked();
             }
             onClipRightClicked: root.clipRightClicked()

--- a/src/shotcut_mlt_properties.h
+++ b/src/shotcut_mlt_properties.h
@@ -48,6 +48,7 @@
 #define kShotcutAnimInProperty "shotcut:animIn"
 #define kShotcutAnimOutProperty "shotcut:animOut"
 #define kShotcutMarkersProperty "shotcut:markers"
+#define kShotcutGroupProperty "shotcut:group"
 // Shotcut's VUI (video user interface) components set this so that glwidget can
 // hide the VUI when the play head is not over the clip with the current filter.
 #define kShotcutVuiMetaProperty "meta.shotcut.vui"

--- a/src/shotcut_mlt_properties.h
+++ b/src/shotcut_mlt_properties.h
@@ -96,6 +96,7 @@
 #define kTrackIndexProperty "_shotcut:trackIndex"
 #define kClipIndexProperty "_shotcut:clipIndex"
 #define kFilterIndexProperty "_shotcut:filterIndex"
+#define kGroupProperty "_shotcut:group"
 #define kShotcutInProperty "_shotcut:in"
 #define kShotcutOutProperty "_shotcut:out"
 #define kNewTrackIndexProperty "_shotcut:newTrackIndex"


### PR DESCRIPTION
This implements the proof of concept for clip grouping.

Add a new action to the context menu to group/ungroup with shortcut "CTRL+G"
![image](https://github.com/mltframework/shotcut/assets/821968/3fe94cae-2520-4a88-866b-283f13afc557)

A clip can only be a member of one group.

When selecting in the timeline, I have added a new modifier: hold ALT key to ignore all groups. So for example, click on clip to select the clip and all clips in the group. Hold ALT and click on the clip to only select the clip.

The group parameter is saved in the XML as a property on the playlist clip:

```
    <entry producer="producer0" in="00:00:00.000" out="00:00:03.967">
      <property name="shotcut:group">0</property>
    </entry>
```

Not yet implemented:
* Make the filter and properties panel smarter to not show anything when a group is selected
* Automatically create a group when detaching audio

