### PR TITLE
Improve ripple for speed change

### DIFF
--- a/src/commands/timelinecommands.cpp
+++ b/src/commands/timelinecommands.cpp
@@ -1668,6 +1668,7 @@ UpdateCommand::UpdateCommand(TimelineDock &timeline, int trackIndex, int clipInd
     , m_isFirstRedo(true)
     , m_undoHelper(*timeline.model())
     , m_ripple(Settings.timelineRipple())
+    , m_rippleAllTracks(Settings.timelineRippleAllTracks())
 {
     setText(QObject::tr("Change clip properties"));
     m_undoHelper.recordBeforeState();
@@ -1677,6 +1678,7 @@ void UpdateCommand::setXmlAfter(const QString &xml)
 {
     m_xmlAfter = xml;
     m_ripple = Settings.timelineRipple();
+    m_rippleAllTracks = Settings.timelineRippleAllTracks();
 }
 
 void UpdateCommand::setPosition(int trackIndex, int clipIndex, int position)
@@ -1698,8 +1700,8 @@ void UpdateCommand::redo()
         m_undoHelper.recordBeforeState();
     Mlt::Producer clip(MLT.profile(), "xml-string", m_xmlAfter.toUtf8().constData());
     if (m_ripple) {
-        m_timeline.model()->removeClip(m_trackIndex, m_clipIndex, false);
-        m_timeline.model()->insertClip(m_trackIndex, clip, m_position, false, false);
+        m_timeline.model()->removeClip(m_trackIndex, m_clipIndex, m_rippleAllTracks);
+        m_timeline.model()->insertClip(m_trackIndex, clip, m_position, m_rippleAllTracks, false);
     } else {
         m_timeline.model()->liftClip(m_trackIndex, m_clipIndex);
         m_timeline.model()->overwrite(m_trackIndex, clip, m_position, false);

--- a/src/commands/timelinecommands.h
+++ b/src/commands/timelinecommands.h
@@ -687,6 +687,7 @@ private:
     bool m_isFirstRedo;
     UndoHelper m_undoHelper;
     bool m_ripple;
+    bool m_rippleAllTracks;
 };
 
 class DetachAudioCommand: public QUndoCommand

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -1995,28 +1995,6 @@ void TimelineDock::onProducerChanged(Mlt::Producer *after)
                     //TODO: keyframes
                 }
             }
-
-            if (speedRatio != 1.0 && Settings.timelineRipple() && Settings.timelineRippleAllTracks()
-                    && (clipIndex + 1) < playlist.count()) {
-                auto position = info->start + out - in + 1;
-                QScopedPointer<Mlt::ClipInfo> nextInfo(playlist.clip_info(clipIndex + 1));
-                if (playlist.is_blank(clipIndex + 1)) {
-                    position += nextInfo->frame_count;
-                    nextInfo.reset(playlist.clip_info(clipIndex + 2));
-                }
-                if (nextInfo && nextInfo->cut) {
-                    MAIN.undoStack()->beginMacro(tr("Change clip properties"));
-                    MAIN.undoStack()->push(
-                        new Timeline::LiftCommand(m_model, trackIndex, clipIndex));
-                    auto moveCommand = new Timeline::MoveClipCommand(*this, 0, position - nextInfo->start, true);
-                    moveCommand->addClip(trackIndex, clipIndex + 1);
-                    MAIN.undoStack()->push(moveCommand);
-                    MAIN.undoStack()->push(
-                        new Timeline::OverwriteCommand(m_model, trackIndex, info->start, MLT.XML(after), false));
-                    MAIN.undoStack()->endMacro();
-                    return;
-                }
-            }
         }
     }
     QString xmlAfter = MLT.XML(after);


### PR DESCRIPTION
Move all clips immediately following the clip to be changed

As suggested here:
https://forum.shotcut.org/t/clip-speed-change-multiple-tracks-ripple-bug/42852

On the forum we suggested that we would remove ripple support for speed change. I am still willing to implement that. But I think this change produces more predictable results.

