### PR TITLE
Add configurable time format

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -889,6 +889,33 @@ void MainWindow::setupSettingsMenu()
     m_previewScaleGroup->addAction(ui->actionPreview720);
 
     group = new QActionGroup(this);
+    group->addAction(ui->actionTimeFrames);
+    ui->actionTimeFrames->setData(mlt_time_frames);
+    group->addAction(ui->actionTimeClock);
+    ui->actionTimeClock->setData(mlt_time_clock);
+    group->addAction(ui->actionTimeDF);
+    ui->actionTimeDF->setData(mlt_time_smpte_df);
+    group->addAction(ui->actionTimeNDF);
+    ui->actionTimeNDF->setData(mlt_time_smpte_ndf);
+    switch (Settings.timeFormat()) {
+    case mlt_time_frames:
+        ui->actionTimeFrames->setChecked(true);
+        break;
+    case mlt_time_clock:
+        ui->actionTimeClock->setChecked(true);
+        break;
+    case mlt_time_smpte_df:
+        ui->actionTimeDF->setChecked(true);
+        break;
+    default:
+        ui->actionTimeNDF->setChecked(true);
+        break;
+    }
+    connect(group, &QActionGroup::triggered, this, [&](QAction * action) {
+        Settings.setTimeFormat(action->data().toInt());
+    });
+
+    group = new QActionGroup(this);
     group->addAction(ui->actionNearest);
     group->addAction(ui->actionBilinear);
     group->addAction(ui->actionBicubic);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -206,10 +206,10 @@
      <property name="title">
       <string>Time Format</string>
      </property>
-     <addaction name="actionTimeFrames"/>
      <addaction name="actionTimeClock"/>
      <addaction name="actionTimeDF"/>
      <addaction name="actionTimeNDF"/>
+     <addaction name="actionTimeFrames"/>
     </widget>
     <widget class="QMenu" name="menuProxy">
      <property name="title">
@@ -283,11 +283,11 @@
     <addaction name="menuBackup"/>
     <addaction name="actionUser_Interface"/>
     <addaction name="menuPreviewScaling"/>
-    <addaction name="menuTimeFormat"/>
     <addaction name="menuProxy"/>
     <addaction name="menuPlayerSettings"/>
     <addaction name="menuPlaylist"/>
     <addaction name="menuTimeline"/>
+    <addaction name="menuTimeFormat"/>
     <addaction name="menuLanguage"/>
     <addaction name="menuTheme"/>
     <addaction name="menuDrawingMethod"/>
@@ -1183,7 +1183,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Drop Frame</string>
+    <string>Timecode (drop Frame)</string>
    </property>
   </action>
   <action name="actionTimeFrames">
@@ -1207,7 +1207,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Non-Drop Frame</string>
+    <string>Timecode (non-drop frame)</string>
    </property>
   </action>
   <action name="actionTopics">

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1183,7 +1183,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Timecode (drop Frame)</string>
+    <string>Timecode (Drop-Frame)</string>
    </property>
   </action>
   <action name="actionTimeFrames">
@@ -1207,7 +1207,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Timecode (non-drop frame)</string>
+    <string>Timecode (Non-Drop Frame)</string>
    </property>
   </action>
   <action name="actionTopics">

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -202,6 +202,15 @@
      <addaction name="actionPreview540"/>
      <addaction name="actionPreview720"/>
     </widget>
+    <widget class="QMenu" name="menuTimeFormat">
+     <property name="title">
+      <string>Time Format</string>
+     </property>
+     <addaction name="actionTimeFrames"/>
+     <addaction name="actionTimeClock"/>
+     <addaction name="actionTimeDF"/>
+     <addaction name="actionTimeNDF"/>
+    </widget>
     <widget class="QMenu" name="menuProxy">
      <property name="title">
       <string>Proxy</string>
@@ -274,6 +283,7 @@
     <addaction name="menuBackup"/>
     <addaction name="actionUser_Interface"/>
     <addaction name="menuPreviewScaling"/>
+    <addaction name="menuTimeFormat"/>
     <addaction name="menuProxy"/>
     <addaction name="menuPlayerSettings"/>
     <addaction name="menuPlaylist"/>
@@ -1166,6 +1176,38 @@
    </property>
    <property name="shortcut">
     <string notr="true">F7</string>
+   </property>
+  </action>
+  <action name="actionTimeDF">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Drop Frame</string>
+   </property>
+  </action>
+  <action name="actionTimeFrames">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Frames</string>
+   </property>
+  </action>
+  <action name="actionTimeClock">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Clock</string>
+   </property>
+  </action>
+  <action name="actionTimeNDF">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Non-Drop Frame</string>
    </property>
   </action>
   <action name="actionTopics">

--- a/src/models/keyframesmodel.cpp
+++ b/src/models/keyframesmodel.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Meltytech, LLC
+ * Copyright (c) 2018-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,6 +16,7 @@
  */
 
 #include "keyframesmodel.h"
+#include "qmltypes/qmlapplication.h"
 #include "qmltypes/qmlmetadata.h"
 #include "qmltypes/qmlfilter.h"
 #include "mltcontroller.h"
@@ -183,8 +184,8 @@ QVariant KeyframesModel::data(const QModelIndex &index, int role) const
                         }
                         double value = m_filter->getDouble(name, position);
                         QString units = m_metadata->keyframes()->parameter(m_metadataIndex[index.internalId()])->units();
-                        return QString("%1 - %2\n%3%4").arg(m_filter->timeFromFrames(position)).arg(type).arg(value).arg(
-                                   units);
+                        return QString("%1 - %2\n%3%4").arg(QmlApplication::singleton().timeFromFrames(position)).arg(
+                                   type).arg(value).arg(units);
                     }
                     case FrameNumberRole:
                         return position;

--- a/src/qml/filters/timer/ClockSpinner.qml
+++ b/src/qml/filters/timer/ClockSpinner.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 Meltytech, LLC
+ * Copyright (c) 2018-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -180,7 +180,7 @@ Item {
                 var frames = filter.framesFromTime(timeStr) - 1;
                 if (frames < 0)
                     frames = 0;
-                var newTime = filter.timeFromFrames(frames, Filter.TIME_CLOCK);
+                var newTime = application.clockFromFrames(frames);
                 var seconds = clamp(timeToSeconds(newTime), minimumValue, maximumValue);
                 timeField.text = secondsToTime(seconds);
             }
@@ -191,7 +191,7 @@ Item {
 
             onTriggered: {
                 var frames = filter.framesFromTime(timeStr) + 1;
-                var newTime = filter.timeFromFrames(frames, Filter.TIME_CLOCK);
+                var newTime = application.clockFromFrames(frames);
                 var seconds = clamp(timeToSeconds(newTime), minimumValue, maximumValue);
                 timeField.text = secondsToTime(seconds);
             }

--- a/src/qml/modules/Shotcut/Controls/TimeSpinner.qml
+++ b/src/qml/modules/Shotcut/Controls/TimeSpinner.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2022 Meltytech, LLC
+ * Copyright (c) 2014-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,12 +35,14 @@ RowLayout {
         return Math.max(min, Math.min(max, x));
     }
 
+    onValueChanged: timeField.text = application.timeFromFrames(clamp(value, minimumValue, maximumValue))
+
     spacing: 0
 
     TextField {
         id: timeField
 
-        text: filter.timeFromFrames(clamp(value, minimumValue, maximumValue))
+        text: application.timeFromFrames(clamp(value, minimumValue, maximumValue))
         horizontalAlignment: TextInput.AlignRight
         selectByMouse: true
         onEditingFinished: value = filter.framesFromTime(text)
@@ -136,5 +138,13 @@ RowLayout {
         id: incrementAction
 
         onTriggered: value = Math.min(value + 1, maximumValue)
+    }
+
+    Connections {
+        function onTimeFormatChanged() {
+            timeField.text = application.timeFromFrames(root.value);
+        }
+
+        target: settings
     }
 }

--- a/src/qml/views/keyframes/KeyframeClip.qml
+++ b/src/qml/views/keyframes/KeyframeClip.qml
@@ -315,7 +315,7 @@ Rectangle {
                     var duration = Math.min(Math.max(0, startFadeIn + delta), clipDuration);
                     filter.animateIn = duration;
                     // Show fade duration as time in a "bubble" help.
-                    var s = application.timecode(Math.max(duration, 0));
+                    var s = application.timeFromFrames(Math.max(duration, 0));
                     bubbleHelp.show(s.substring(6));
                 }
             }
@@ -420,7 +420,7 @@ Rectangle {
                     var duration = Math.min(Math.max(0, startFadeOut + delta), clipDuration);
                     filter.animateOut = duration;
                     // Show fade duration as time in a "bubble" help.
-                    var s = application.timecode(Math.max(duration, 0));
+                    var s = application.timeFromFrames(Math.max(duration, 0));
                     bubbleHelp.show(s.substring(6));
                 }
             }

--- a/src/qml/views/keyframes/KeyframeRuler.qml
+++ b/src/qml/views/keyframes/KeyframeRuler.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2022 Meltytech, LLC
+ * Copyright (c) 2013-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -48,7 +48,7 @@ Rectangle {
                 anchors.bottom: parent.bottom
                 anchors.bottomMargin: 2
                 color: activePalette.windowText
-                text: application.timecode(index * intervalSeconds * profile.fps + 2).substr(0, 8)
+                text: application.clockFromFrames(index * intervalSeconds * profile.fps + 2).substr(0, 8)
             }
         }
     }
@@ -59,7 +59,7 @@ Rectangle {
         acceptedButtons: Qt.NoButton
         onExited: bubbleHelp.hide()
         onPositionChanged: mouse => {
-            var text = application.timecode(mouse.x / timeScale);
+            var text = application.timeFromFrames(mouse.x / timeScale);
             bubbleHelp.show(text);
         }
     }

--- a/src/qml/views/keyframes/keyframes.qml
+++ b/src/qml/views/keyframes/keyframes.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 Meltytech, LLC
+ * Copyright (c) 2017-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -395,8 +395,8 @@ Rectangle {
                                             if (delta !== 0 && n >= producer.in && n <= filter.out) {
                                                 parameters.trimFilterIn(n);
                                                 // Show amount trimmed as a time in a "bubble" help.
-                                                var s = application.timecode(Math.abs(clip.originalX));
-                                                s = '%1%2 = %3'.arg((clip.originalX < 0) ? '-' : (clip.originalX > 0) ? '+' : '').arg(s.substring(3)).arg(application.timecode(n));
+                                                var s = application.timeFromFrames(Math.abs(clip.originalX));
+                                                s = '%1%2 = %3'.arg((clip.originalX < 0) ? '-' : (clip.originalX > 0) ? '+' : '').arg(s.substring(3)).arg(application.timeFromFrames(n));
                                                 bubbleHelp.show(s);
                                             } else {
                                                 clip.originalX -= delta;
@@ -408,8 +408,8 @@ Rectangle {
                                             if (delta !== 0 && n >= filter.in && n <= producer.out) {
                                                 parameters.trimFilterOut(n);
                                                 // Show amount trimmed as a time in a "bubble" help.
-                                                var s = application.timecode(Math.abs(clip.originalX));
-                                                s = '%1%2 = %3'.arg((clip.originalX < 0) ? '+' : (clip.originalX > 0) ? '-' : '').arg(s.substring(3)).arg(application.timecode(n));
+                                                var s = application.timeFromFrames(Math.abs(clip.originalX));
+                                                s = '%1%2 = %3'.arg((clip.originalX < 0) ? '+' : (clip.originalX > 0) ? '-' : '').arg(s.substring(3)).arg(application.timeFromFrames(n));
                                                 bubbleHelp.show(s);
                                             } else {
                                                 clip.originalX -= delta;

--- a/src/qml/views/timeline/Clip.qml
+++ b/src/qml/views/timeline/Clip.qml
@@ -333,7 +333,7 @@ Rectangle {
                         if (comment.length > 0)
                             text += '<br>' + comment;
                     }
-                    text += '<br>' + application.timecode(clipDuration);
+                    text += '<br>' + application.timeFromFrames(clipDuration);
                     bubbleHelp.show(text);
                 }
             }
@@ -488,7 +488,7 @@ Rectangle {
                     var duration = Math.min(Math.max(0, startFadeIn + delta), clipDuration);
                     timeline.fadeIn(trackIndex, index, duration);
                     // Show fade duration as time in a "bubble" help.
-                    var s = application.timecode(duration);
+                    var s = application.timeFromFrames(duration);
                     bubbleHelp.show(s.substring(6));
                 }
             }
@@ -582,7 +582,7 @@ Rectangle {
                     var duration = Math.min(Math.max(0, startFadeOut + delta), clipDuration);
                     timeline.fadeOut(trackIndex, index, duration);
                     // Show fade duration as time in a "bubble" help.
-                    var s = application.timecode(duration);
+                    var s = application.timeFromFrames(duration);
                     bubbleHelp.show(s.substring(6));
                 }
             }

--- a/src/qml/views/timeline/Ruler.qml
+++ b/src/qml/views/timeline/Ruler.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2023 Meltytech, LLC
+ * Copyright (c) 2013-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -59,7 +59,7 @@ Rectangle {
                 anchors.bottom: parent.bottom
                 anchors.bottomMargin: 2
                 color: activePalette.windowText
-                text: application.timecode(index * intervalFrames + 2).substr(0, 8)
+                text: application.clockFromFrames(index * intervalFrames + 2).substr(0, 8)
             }
         }
     }
@@ -72,7 +72,7 @@ Rectangle {
         property double currentPos: timeline.position * timeScale
         cursorShape: (mouseX >= currentPos - 8 && mouseX <= currentPos + 8) ? Qt.SizeHorCursor : Qt.ArrowCursor
         onPositionChanged: mouse => {
-            var text = application.timecode(mouse.x / timeScale);
+            var text = application.timeFromFrames(mouse.x / timeScale);
             bubbleHelp.show(text);
         }
     }
@@ -87,10 +87,10 @@ Rectangle {
         onMouseStatusChanged: (mouseX, mouseY, text, start, end) => {
             var msg = "<center>" + text;
             if (start === end) {
-                msg += "<br>" + application.timecode(start);
+                msg += "<br>" + application.timeFromFrames(start);
             } else {
-                msg += "<br>" + application.timecode(start) + " - " + application.timecode(end);
-                msg += "<br>" + application.timecode(end - start + 1);
+                msg += "<br>" + application.timeFromFrames(start) + " - " + application.timeFromFrames(end);
+                msg += "<br>" + application.timeFromFrames(end - start + 1);
             }
             msg += "</center>";
             bubbleHelp.show(msg);

--- a/src/qml/views/timeline/Track.qml
+++ b/src/qml/views/timeline/Track.qml
@@ -147,7 +147,7 @@ Rectangle {
                 trackRoot.clipDragged(clip, mapped.x, mapped.y);
                 // Show distance moved as time in a "bubble" help.
                 var delta = Math.round(clip.x / timeScale) - model.start;
-                var s = application.timecode(Math.abs(delta));
+                var s = application.timeFromFrames(Math.abs(delta));
                 // remove leading zeroes
                 if (s.substring(0, 3) === '00:')
                     s = s.substring(3);
@@ -161,8 +161,8 @@ Rectangle {
                 if (delta != 0) {
                     if (timeline.trimClipIn(trackRoot.DelegateModel.itemsIndex, clip.DelegateModel.itemsIndex, clip.originalClipIndex, delta, settings.timelineRipple)) {
                         // Show amount trimmed as a time in a "bubble" help.
-                        var s = application.timecode(Math.abs(clip.originalX));
-                        s = '%1%2 = %3'.arg((clip.originalX < 0) ? '-' : (clip.originalX > 0) ? '+' : '').arg(s.substring(3)).arg(application.timecode(clipDuration));
+                        var s = application.timeFromFrames(Math.abs(clip.originalX));
+                        s = '%1%2 = %3'.arg((clip.originalX < 0) ? '-' : (clip.originalX > 0) ? '+' : '').arg(s.substring(3)).arg(application.timeFromFrames(clipDuration));
                         bubbleHelp.show(s);
                     } else {
                         clip.originalX -= originalDelta;
@@ -186,8 +186,8 @@ Rectangle {
                 if (delta != 0) {
                     if (timeline.trimClipOut(trackRoot.DelegateModel.itemsIndex, clip.DelegateModel.itemsIndex, delta, settings.timelineRipple)) {
                         // Show amount trimmed as a time in a "bubble" help.
-                        var s = application.timecode(Math.abs(clip.originalX));
-                        s = '%1%2 = %3'.arg((clip.originalX < 0) ? '+' : (clip.originalX > 0) ? '-' : '').arg(s.substring(3)).arg(application.timecode(clipDuration));
+                        var s = application.timeFromFrames(Math.abs(clip.originalX));
+                        s = '%1%2 = %3'.arg((clip.originalX < 0) ? '+' : (clip.originalX > 0) ? '-' : '').arg(s.substring(3)).arg(application.timeFromFrames(clipDuration));
                         bubbleHelp.show(s);
                     } else {
                         clip.originalX -= originalDelta;

--- a/src/qmltypes/qmlapplication.cpp
+++ b/src/qmltypes/qmlapplication.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2023 Meltytech, LLC
+ * Copyright (c) 2013-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -139,12 +139,20 @@ void QmlApplication::pasteFilters()
     }
 }
 
-QString QmlApplication::timecode(int frames)
+QString QmlApplication::clockFromFrames(int frames)
 {
-    if (MLT.producer() && MLT.producer()->is_valid())
-        return MLT.producer()->frames_to_time(frames, mlt_time_smpte_df);
-    else
-        return QString();
+    if (MLT.producer()) {
+        return MLT.producer()->frames_to_time(frames, mlt_time_clock);
+    }
+    return QString();
+}
+
+QString QmlApplication::timeFromFrames(int frames)
+{
+    if (MLT.producer()) {
+        return MLT.producer()->frames_to_time(frames, Settings.timeFormat());
+    }
+    return QString();
 }
 
 int QmlApplication::audioChannels()

--- a/src/qmltypes/qmlapplication.h
+++ b/src/qmltypes/qmlapplication.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2023 Meltytech, LLC
+ * Copyright (c) 2014-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -53,7 +53,8 @@ public:
     static bool hasFiltersOnClipboard();
     Q_INVOKABLE static void copyFilters();
     Q_INVOKABLE static void pasteFilters();
-    Q_INVOKABLE static QString timecode(int frames);
+    Q_INVOKABLE static QString clockFromFrames(int frames);
+    Q_INVOKABLE static QString timeFromFrames(int frames);
     Q_INVOKABLE static int audioChannels();
     Q_INVOKABLE static QString getNextProjectFile(const QString &filename);
     Q_INVOKABLE static bool isProjectFolder();

--- a/src/qmltypes/qmlfilter.cpp
+++ b/src/qmltypes/qmlfilter.cpp
@@ -527,29 +527,6 @@ int QmlFilter::framesFromTime(const QString &time)
     return 0;
 }
 
-QString QmlFilter::timeFromFrames(int frames, QmlFilter::TimeFormat format)
-{
-    if (MLT.producer()) {
-        mlt_time_format mltFormat = mlt_time_smpte_df;
-        switch ( format ) {
-        case TIME_FRAMES:
-            mltFormat = mlt_time_frames;
-            break;
-        case TIME_CLOCK:
-            mltFormat = mlt_time_clock;
-            break;
-        case TIME_TIMECODE_DF:
-            mltFormat = mlt_time_smpte_df;
-            break;
-        case TIME_TIMECODE_NDF:
-            mltFormat = mlt_time_smpte_ndf;
-            break;
-        }
-        return MLT.producer()->frames_to_time(frames, mltFormat);
-    }
-    return QString();
-}
-
 void QmlFilter::getHash()
 {
     if (m_service.is_valid())

--- a/src/qmltypes/qmlfilter.h
+++ b/src/qmltypes/qmlfilter.h
@@ -53,14 +53,6 @@ class QmlFilter : public QObject
     Q_PROPERTY(bool blockSignals READ signalsBlocked WRITE blockSignals)
 
 public:
-    enum TimeFormat {
-        TIME_FRAMES,
-        TIME_CLOCK,
-        TIME_TIMECODE_DF,
-        TIME_TIMECODE_NDF,
-    };
-    Q_ENUM(TimeFormat)
-
     enum CurrentFilterIndex {
         NoCurrentFilter = -1,
         DeselectCurrentFilter = -2
@@ -116,8 +108,6 @@ public:
     Q_INVOKABLE void deletePreset(const QString &name);
     Q_INVOKABLE void analyze(bool isAudio = false, bool deferJob = true);
     Q_INVOKABLE static int framesFromTime(const QString &time);
-    Q_INVOKABLE static QString timeFromFrames(int frames,
-                                              QmlFilter::TimeFormat format = TIME_TIMECODE_DF);
     Q_INVOKABLE void getHash();
     Mlt::Producer &producer()
     {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1278,3 +1278,14 @@ void ShotcutSettings::setBackupPeriod(int seconds)
 {
     settings.setValue("backupPeriod", seconds);
 }
+
+mlt_time_format ShotcutSettings::timeFormat() const
+{
+    return (mlt_time_format)settings.value("timeFormat", mlt_time_smpte_ndf).toInt();
+}
+
+void ShotcutSettings::setTimeFormat(int format)
+{
+    settings.setValue("timeFormat", format);
+    emit timeFormatChanged();
+}

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1281,7 +1281,7 @@ void ShotcutSettings::setBackupPeriod(int seconds)
 
 mlt_time_format ShotcutSettings::timeFormat() const
 {
-    return (mlt_time_format)settings.value("timeFormat", mlt_time_smpte_ndf).toInt();
+    return (mlt_time_format)settings.value("timeFormat", mlt_time_smpte_df).toInt();
 }
 
 void ShotcutSettings::setTimeFormat(int format)

--- a/src/settings.h
+++ b/src/settings.h
@@ -18,6 +18,8 @@
 #ifndef SETTINGS_H
 #define SETTINGS_H
 
+#include <framework/mlt_types.h>
+
 #include <QKeySequence>
 #include <QObject>
 #include <QSettings>
@@ -283,6 +285,8 @@ public:
     bool warnLowMemory() const;
     int backupPeriod() const;
     void setBackupPeriod(int i);
+    mlt_time_format timeFormat() const;
+    void setTimeFormat(int format);
 
     // proxy
     bool proxyEnabled() const;
@@ -341,6 +345,7 @@ signals:
     void timelineScrollingChanged();
     void timelineAutoAddTracksChanged();
     void timelineRectangleSelectChanged();
+    void timeFormatChanged();
 
 private:
     explicit ShotcutSettings();

--- a/src/widgets/timespinbox.cpp
+++ b/src/widgets/timespinbox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Meltytech, LLC
+ * Copyright (c) 2012-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,6 +17,7 @@
 
 #include "timespinbox.h"
 #include "mltcontroller.h"
+#include "settings.h"
 #include <QRegularExpressionValidator>
 #include <QKeyEvent>
 #include <QFontDatabase>
@@ -35,6 +36,10 @@ TimeSpinBox::TimeSpinBox(QWidget *parent)
     font.setPointSize(QGuiApplication::font().pointSize());
     setFont(font);
     setFixedWidth(fontMetrics().boundingRect("_HHH:MM:SS;FFF_").width());
+
+    connect(&Settings, &ShotcutSettings::timeFormatChanged, this, [&]() {
+        setValue(value());
+    });
 }
 
 QValidator::State TimeSpinBox::validate(QString &input, int &pos) const
@@ -55,9 +60,9 @@ int TimeSpinBox::valueFromText(const QString &text) const
 QString TimeSpinBox::textFromValue(int val) const
 {
     if (MLT.producer() && MLT.producer()->is_valid()) {
-        return MLT.producer()->frames_to_time(val);
+        return MLT.producer()->frames_to_time(val, Settings.timeFormat());
     } else {
-        return Mlt::Producer(MLT.profile(), "color", "").frames_to_time(val);
+        return Mlt::Producer(MLT.profile(), "color", "").frames_to_time(val, Settings.timeFormat());
     }
     return QString();
 }


### PR DESCRIPTION
This pull request is for review and staging until after the next release.

Add a new menu entry for time selection
![image](https://github.com/mltframework/shotcut/assets/821968/45a58cd5-edac-48cc-9be9-006145f44600)

This entry affects everything except for the rulers in the player and timeline
Here is a screenshot with some examples:
![image](https://github.com/mltframework/shotcut/assets/821968/893337f0-d212-4425-8725-0adcc0e41255)

### Notes from the Design Discussion:

 **default to time clock format:**

Not done - currently defaults to SMPTE DF - which was the previous display. I can change it, but I am concerned that some people will be surprised when they upgrade Shotcut and the time display changes.

 **context menu on the time display:**

Not implemented. I made a Settings menu entry. I could also add a context menu on the time entry text field in the play if that is helpful. But people should be aware that it affects the entire application.

 **try to affect everywhere time is displayed:**

Done - with the exception of the Rulers. I can also change the rulers. But I notice that there is some "fudge factor" logic that we would have to overcome. I think that is probably to get around rounding errors.

**input parsing as well based on MLT’s interpretation of string to time:**

Done