### PR TITLE
Separate filter undo commands for parameters and keyframes

### DIFF
--- a/src/commands/filtercommands.h
+++ b/src/commands/filtercommands.h
@@ -124,11 +124,11 @@ private:
     bool m_disabled;
 };
 
-class ChangeParameterCommand : public QUndoCommand
+class UndoParameterCommand : public QUndoCommand
 {
 public:
-    ChangeParameterCommand(const QString &name, FilterController *controller, int row,
-                           Mlt::Properties  &before, const QString &desc = QString(), QUndoCommand *parent = 0);
+    UndoParameterCommand(const QString &name, FilterController *controller, int row,
+                         Mlt::Properties  &before, const QString &desc = QString(), QUndoCommand *parent = 0);
     void update(const QString &propertyName);
     void redo();
     void undo();
@@ -147,12 +147,12 @@ private:
     bool m_firstRedo;
 };
 
-class ChangeAddKeyframeCommand : public ChangeParameterCommand
+class UndoAddKeyframeCommand : public UndoParameterCommand
 {
 public:
-    ChangeAddKeyframeCommand(const QString &name, FilterController *controller, int row,
-                             Mlt::Properties &before)
-        : ChangeParameterCommand(name, controller, row, before, QObject::tr("add keyframe"))
+    UndoAddKeyframeCommand(const QString &name, FilterController *controller, int row,
+                           Mlt::Properties &before)
+        : UndoParameterCommand(name, controller, row, before, QObject::tr("add keyframe"))
     {}
 protected:
     int id() const
@@ -165,12 +165,12 @@ protected:
     }
 };
 
-class ChangeRemoveKeyframeCommand : public ChangeParameterCommand
+class UndoRemoveKeyframeCommand : public UndoParameterCommand
 {
 public:
-    ChangeRemoveKeyframeCommand(const QString &name, FilterController *controller, int row,
-                                Mlt::Properties &before)
-        : ChangeParameterCommand(name, controller, row, before, QObject::tr("remove keyframe"))
+    UndoRemoveKeyframeCommand(const QString &name, FilterController *controller, int row,
+                              Mlt::Properties &before)
+        : UndoParameterCommand(name, controller, row, before, QObject::tr("remove keyframe"))
     {}
 protected:
     int id() const
@@ -183,12 +183,12 @@ protected:
     }
 };
 
-class ChangeModifyKeyframeCommand : public ChangeParameterCommand
+class UndoModifyKeyframeCommand : public UndoParameterCommand
 {
 public:
-    ChangeModifyKeyframeCommand(const QString &name, FilterController *controller, int row,
-                                Mlt::Properties &before, int paramIndex, int keyframeIndex)
-        : ChangeParameterCommand(name, controller, row, before, QObject::tr("modify keyframe"))
+    UndoModifyKeyframeCommand(const QString &name, FilterController *controller, int row,
+                              Mlt::Properties &before, int paramIndex, int keyframeIndex)
+        : UndoParameterCommand(name, controller, row, before, QObject::tr("modify keyframe"))
         , m_paramIndex(paramIndex)
         , m_keyframeIndex(keyframeIndex)
     {}
@@ -199,11 +199,11 @@ protected:
     }
     bool mergeWith(const QUndoCommand *other)
     {
-        auto *that = dynamic_cast<const ChangeModifyKeyframeCommand *>(other);
+        auto *that = dynamic_cast<const UndoModifyKeyframeCommand *>(other);
         if (!that || m_paramIndex != that->m_paramIndex || m_keyframeIndex != that->m_keyframeIndex)
             return false;
         else
-            return ChangeParameterCommand::mergeWith(other);
+            return UndoParameterCommand::mergeWith(other);
     }
 
 private:

--- a/src/controllers/filtercontroller.cpp
+++ b/src/controllers/filtercontroller.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2023 Meltytech, LLC
+ * Copyright (c) 2014-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -251,7 +251,7 @@ void FilterController::setCurrentFilter(int attachedIndex)
     emit currentFilterChanged(filter, meta, m_currentFilterIndex);
     m_currentFilter.reset(filter);
     if (filter && !m_attachedModel.isSourceClip()) {
-        filter->startUndoTracking(this, m_currentFilterIndex);
+        filter->startUndoTracking();
     }
 }
 

--- a/src/controllers/filtercontroller.h
+++ b/src/controllers/filtercontroller.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2023 Meltytech, LLC
+ * Copyright (c) 2014-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -51,6 +51,10 @@ public:
     }
     bool isOutputTrackSelected() const;
     void onUndoOrRedo(Mlt::Service &service);
+    int currentIndex() const
+    {
+        return m_currentFilterIndex;
+    }
 
 protected:
     void timerEvent(QTimerEvent *);

--- a/src/qml/filters/audio_fadein/ui.qml
+++ b/src/qml/filters/audio_fadein/ui.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2022 Meltytech, LLC
+ * Copyright (c) 2014-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@ import Shotcut.Controls as Shotcut
 
 Item {
     property alias duration: timeSpinner.value
+    property bool _blockUpdate: false
 
     width: 100
     height: 50
@@ -40,7 +41,9 @@ Item {
 
     Connections {
         function onAnimateInChanged() {
+            _blockUpdate = true;
             duration = filter.animateIn;
+            _blockUpdate = false;
         }
 
         target: filter
@@ -52,6 +55,7 @@ Item {
 
         RowLayout {
             Label {
+                id: durationLabel
                 text: qsTr('Duration')
             }
 
@@ -61,10 +65,14 @@ Item {
                 minimumValue: 2
                 maximumValue: 5000
                 onValueChanged: {
+                    if (_blockUpdate)
+                        return;
+                    filter.startUndoParameterCommand(durationLabel.text);
                     filter.animateIn = duration;
                     filter.resetProperty('level');
                     filter.set('level', -60, 0);
                     filter.set('level', 0, Math.min(duration, filter.duration) - 1);
+                    filter.endUndoCommand();
                 }
                 onSetDefaultClicked: {
                     duration = Math.ceil(settings.audioInDuration * profile.fps);

--- a/src/qml/filters/audio_fadeout/ui.qml
+++ b/src/qml/filters/audio_fadeout/ui.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2022 Meltytech, LLC
+ * Copyright (c) 2014-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@ import Shotcut.Controls as Shotcut
 
 Item {
     property alias duration: timeSpinner.value
+    property bool _blockUpdate: false
 
     function updateFilter() {
         filter.resetProperty('level');
@@ -46,7 +47,9 @@ Item {
 
     Connections {
         function onAnimateOutChanged() {
+            _blockUpdate = true;
             duration = filter.animateOut;
+            _blockUpdate = false;
         }
 
         target: filter
@@ -58,6 +61,7 @@ Item {
 
         RowLayout {
             Label {
+                id: durationLabel
                 text: qsTr('Duration')
             }
 
@@ -67,8 +71,12 @@ Item {
                 minimumValue: 2
                 maximumValue: 5000
                 onValueChanged: {
+                    if (_blockUpdate)
+                        return;
+                    filter.startUndoParameterCommand(durationLabel.text);
                     filter.animateOut = duration;
                     updateFilter();
+                    filter.endUndoCommand();
                 }
                 onSetDefaultClicked: {
                     duration = Math.ceil(settings.audioOutDuration * profile.fps);

--- a/src/qml/filters/audio_gain/ui.qml
+++ b/src/qml/filters/audio_gain/ui.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2023 Meltytech, LLC
+ * Copyright (c) 2013-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -162,6 +162,7 @@ Item {
         }
 
         Label {
+            id: levelLabel
             text: qsTr('Level')
             Layout.alignment: Qt.AlignRight
         }
@@ -173,7 +174,11 @@ Item {
             maximumValue: 24
             suffix: ' dB'
             decimals: 1
-            onValueChanged: updateFilter(getPosition())
+            onValueChanged: {
+                filter.startUndoParameterCommand(levelLabel.text);
+                updateFilter(getPosition());
+                filter.endUndoCommand();
+            }
         }
 
         Shotcut.UndoButton {
@@ -184,6 +189,7 @@ Item {
             id: gainKeyframesButton
 
             onToggled: {
+                filter.startUndoParameterCommand(levelLabel.text);
                 let value = gainSlider.value;
                 if (checked) {
                     blockUpdate = true;
@@ -194,6 +200,7 @@ Item {
                     filter.resetProperty('level');
                     filter.set('level', value);
                 }
+                filter.endUndoCommand();
             }
         }
 

--- a/src/qml/filters/brightness/ui_movit.qml
+++ b/src/qml/filters/brightness/ui_movit.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Meltytech, LLC
+ * Copyright (c) 2016-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -159,6 +159,7 @@ Item {
         }
 
         Label {
+            id: levelLabel
             text: qsTr('Level')
             Layout.alignment: Qt.AlignRight
         }
@@ -170,7 +171,11 @@ Item {
             maximumValue: 200
             decimals: 1
             suffix: ' %'
-            onValueChanged: updateFilter(getPosition())
+            onValueChanged: {
+                filter.startUndoParameterCommand(levelLabel.text);
+                updateFilter(getPosition());
+                filter.endUndoCommand();
+            }
         }
 
         Shotcut.UndoButton {
@@ -181,6 +186,7 @@ Item {
             id: brightnessKeyframesButton
 
             onToggled: {
+                filter.startUndoParameterCommand(levelLabel.text);
                 var value = brightnessSlider.value / 100;
                 if (checked) {
                     blockUpdate = true;
@@ -191,6 +197,7 @@ Item {
                     filter.resetProperty('opacity');
                     filter.set('opacity', value);
                 }
+                filter.endUndoCommand();
             }
         }
 

--- a/src/qml/filters/color/ui.qml
+++ b/src/qml/filters/color/ui.qml
@@ -129,7 +129,7 @@ Item {
             Layout.columnSpan: 8
             parameters: defaultParameters
             onBeforePresetLoaded: {
-                filter.startChangeParameterCommand(presetLabel.text);
+                filter.startUndoParameterCommand(presetLabel.text);
                 filter.resetProperty('lift_r');
                 filter.resetProperty('lift_g');
                 filter.resetProperty('lift_b');
@@ -142,7 +142,7 @@ Item {
             }
             onPresetSelected: {
                 loadValues();
-                filter.endChangeCommand();
+                filter.endUndoCommand();
             }
         }
 
@@ -168,7 +168,7 @@ Item {
 
             Layout.alignment: Qt.AlignLeft
             onToggled: {
-                filter.startChangeParameterCommand(liftLabel.text);
+                filter.startUndoParameterCommand(liftLabel.text);
                 if (checked) {
                     filter.set('lift_r', liftwheel.redF * 2 - 1, getPosition());
                     filter.set('lift_g', liftwheel.greenF * 2 - 1, getPosition());
@@ -181,7 +181,7 @@ Item {
                     filter.set('lift_g', liftwheel.greenF * 2 - 1);
                     filter.set('lift_b', liftwheel.blueF * 2 - 1);
                 }
-                filter.endChangeCommand();
+                filter.endUndoCommand();
             }
         }
 
@@ -206,7 +206,7 @@ Item {
 
             Layout.alignment: Qt.AlignLeft
             onToggled: {
-                filter.startChangeParameterCommand(gammaLabel.text);
+                filter.startUndoParameterCommand(gammaLabel.text);
                 if (checked) {
                     filter.set('gamma_r', scaleWheelToValue(gammawheel.redF, gammaFactor), getPosition());
                     filter.set('gamma_g', scaleWheelToValue(gammawheel.greenF, gammaFactor), getPosition());
@@ -219,7 +219,7 @@ Item {
                     filter.set('gamma_g', scaleWheelToValue(gammawheel.greenF, gammaFactor));
                     filter.set('gamma_b', scaleWheelToValue(gammawheel.blueF, gammaFactor));
                 }
-                filter.endChangeCommand();
+                filter.endUndoCommand();
             }
         }
 
@@ -244,7 +244,7 @@ Item {
 
             Layout.alignment: Qt.AlignLeft
             onToggled: {
-                filter.startChangeParameterCommand(gainLabel.text);
+                filter.startUndoParameterCommand(gainLabel.text);
                 if (checked) {
                     filter.set('gain_r', scaleWheelToValue(gainwheel.redF, gainFactor), getPosition());
                     filter.set('gain_g', scaleWheelToValue(gainwheel.greenF, gainFactor), getPosition());
@@ -257,7 +257,7 @@ Item {
                     filter.set('gain_g', scaleWheelToValue(gainwheel.greenF, gainFactor));
                     filter.set('gain_b', scaleWheelToValue(gainwheel.blueF, gainFactor));
                 }
-                filter.endChangeCommand();
+                filter.endUndoCommand();
             }
         }
 
@@ -280,7 +280,7 @@ Item {
                 if (liftBlueSpinner.value != wheelToSpinner(liftwheel.blueF))
                     liftBlueSpinner.value = wheelToSpinner(liftwheel.blueF);
                 if (!blockUpdate) {
-                    filter.startChangeParameterCommand(liftLabel.text);
+                    filter.startUndoParameterCommand(liftLabel.text);
                     if (!liftKeyframesButton.checked) {
                         filter.resetProperty('lift_r');
                         filter.resetProperty('lift_g');
@@ -294,7 +294,7 @@ Item {
                         filter.set('lift_g', liftwheel.greenF * 2 - 1, position);
                         filter.set('lift_b', liftwheel.blueF * 2 - 1, position);
                     }
-                    filter.endChangeCommand();
+                    filter.endUndoCommand();
                 }
             }
         }
@@ -317,7 +317,7 @@ Item {
                 if (gammaBlueSpinner.value != wheelToSpinner(gammawheel.blueF))
                     gammaBlueSpinner.value = wheelToSpinner(gammawheel.blueF);
                 if (!blockUpdate) {
-                    filter.startChangeParameterCommand(gammaLabel.text);
+                    filter.startUndoParameterCommand(gammaLabel.text);
                     if (!gammaKeyframesButton.checked) {
                         filter.resetProperty('gamma_r');
                         filter.resetProperty('gamma_g');
@@ -331,7 +331,7 @@ Item {
                         filter.set('gamma_g', scaleWheelToValue(gammawheel.greenF, gammaFactor), position);
                         filter.set('gamma_b', scaleWheelToValue(gammawheel.blueF, gammaFactor), position);
                     }
-                    filter.endChangeCommand();
+                    filter.endUndoCommand();
                 }
             }
         }
@@ -354,7 +354,7 @@ Item {
                 if (gainBlueSpinner.value != wheelToSpinner(gainwheel.blueF))
                     gainBlueSpinner.value = wheelToSpinner(gainwheel.blueF);
                 if (!blockUpdate) {
-                    filter.startChangeParameterCommand(gainLabel.text);
+                    filter.startUndoParameterCommand(gainLabel.text);
                     if (!gainKeyframesButton.checked) {
                         filter.resetProperty('gain_r');
                         filter.resetProperty('gain_g');
@@ -368,7 +368,7 @@ Item {
                         filter.set('gain_g', scaleWheelToValue(gainwheel.greenF, gainFactor), position);
                         filter.set('gain_b', scaleWheelToValue(gainwheel.blueF, gainFactor), position);
                     }
-                    filter.endChangeCommand();
+                    filter.endUndoCommand();
                 }
             }
         }

--- a/src/qml/filters/color/ui.qml
+++ b/src/qml/filters/color/ui.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2022 Meltytech, LLC
+ * Copyright (c) 2014-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -120,6 +120,7 @@ Item {
 
         // Row 1
         Label {
+            id: presetLabel
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
@@ -128,6 +129,7 @@ Item {
             Layout.columnSpan: 8
             parameters: defaultParameters
             onBeforePresetLoaded: {
+                filter.startChangeParameterCommand(presetLabel.text);
                 filter.resetProperty('lift_r');
                 filter.resetProperty('lift_g');
                 filter.resetProperty('lift_b');
@@ -140,11 +142,13 @@ Item {
             }
             onPresetSelected: {
                 loadValues();
+                filter.endChangeCommand();
             }
         }
 
         // Row 2
         Label {
+            id: liftLabel
             text: qsTr('Shadows (Lift)')
         }
 
@@ -164,6 +168,7 @@ Item {
 
             Layout.alignment: Qt.AlignLeft
             onToggled: {
+                filter.startChangeParameterCommand(liftLabel.text);
                 if (checked) {
                     filter.set('lift_r', liftwheel.redF * 2 - 1, getPosition());
                     filter.set('lift_g', liftwheel.greenF * 2 - 1, getPosition());
@@ -176,10 +181,12 @@ Item {
                     filter.set('lift_g', liftwheel.greenF * 2 - 1);
                     filter.set('lift_b', liftwheel.blueF * 2 - 1);
                 }
+                filter.endChangeCommand();
             }
         }
 
         Label {
+            id: gammaLabel
             text: qsTr('Midtones (Gamma)')
         }
 
@@ -199,6 +206,7 @@ Item {
 
             Layout.alignment: Qt.AlignLeft
             onToggled: {
+                filter.startChangeParameterCommand(gammaLabel.text);
                 if (checked) {
                     filter.set('gamma_r', scaleWheelToValue(gammawheel.redF, gammaFactor), getPosition());
                     filter.set('gamma_g', scaleWheelToValue(gammawheel.greenF, gammaFactor), getPosition());
@@ -211,10 +219,12 @@ Item {
                     filter.set('gamma_g', scaleWheelToValue(gammawheel.greenF, gammaFactor));
                     filter.set('gamma_b', scaleWheelToValue(gammawheel.blueF, gammaFactor));
                 }
+                filter.endChangeCommand();
             }
         }
 
         Label {
+            id: gainLabel
             text: qsTr('Highlights (Gain)')
         }
 
@@ -234,6 +244,7 @@ Item {
 
             Layout.alignment: Qt.AlignLeft
             onToggled: {
+                filter.startChangeParameterCommand(gainLabel.text);
                 if (checked) {
                     filter.set('gain_r', scaleWheelToValue(gainwheel.redF, gainFactor), getPosition());
                     filter.set('gain_g', scaleWheelToValue(gainwheel.greenF, gainFactor), getPosition());
@@ -246,6 +257,7 @@ Item {
                     filter.set('gain_g', scaleWheelToValue(gainwheel.greenF, gainFactor));
                     filter.set('gain_b', scaleWheelToValue(gainwheel.blueF, gainFactor));
                 }
+                filter.endChangeCommand();
             }
         }
 
@@ -268,6 +280,7 @@ Item {
                 if (liftBlueSpinner.value != wheelToSpinner(liftwheel.blueF))
                     liftBlueSpinner.value = wheelToSpinner(liftwheel.blueF);
                 if (!blockUpdate) {
+                    filter.startChangeParameterCommand(liftLabel.text);
                     if (!liftKeyframesButton.checked) {
                         filter.resetProperty('lift_r');
                         filter.resetProperty('lift_g');
@@ -281,6 +294,7 @@ Item {
                         filter.set('lift_g', liftwheel.greenF * 2 - 1, position);
                         filter.set('lift_b', liftwheel.blueF * 2 - 1, position);
                     }
+                    filter.endChangeCommand();
                 }
             }
         }
@@ -303,6 +317,7 @@ Item {
                 if (gammaBlueSpinner.value != wheelToSpinner(gammawheel.blueF))
                     gammaBlueSpinner.value = wheelToSpinner(gammawheel.blueF);
                 if (!blockUpdate) {
+                    filter.startChangeParameterCommand(gammaLabel.text);
                     if (!gammaKeyframesButton.checked) {
                         filter.resetProperty('gamma_r');
                         filter.resetProperty('gamma_g');
@@ -316,6 +331,7 @@ Item {
                         filter.set('gamma_g', scaleWheelToValue(gammawheel.greenF, gammaFactor), position);
                         filter.set('gamma_b', scaleWheelToValue(gammawheel.blueF, gammaFactor), position);
                     }
+                    filter.endChangeCommand();
                 }
             }
         }
@@ -338,6 +354,7 @@ Item {
                 if (gainBlueSpinner.value != wheelToSpinner(gainwheel.blueF))
                     gainBlueSpinner.value = wheelToSpinner(gainwheel.blueF);
                 if (!blockUpdate) {
+                    filter.startChangeParameterCommand(gainLabel.text);
                     if (!gainKeyframesButton.checked) {
                         filter.resetProperty('gain_r');
                         filter.resetProperty('gain_g');
@@ -351,6 +368,7 @@ Item {
                         filter.set('gain_g', scaleWheelToValue(gainwheel.greenF, gainFactor), position);
                         filter.set('gain_b', scaleWheelToValue(gainwheel.blueF, gainFactor), position);
                     }
+                    filter.endChangeCommand();
                 }
             }
         }

--- a/src/qml/filters/color/ui.qml
+++ b/src/qml/filters/color/ui.qml
@@ -120,7 +120,6 @@ Item {
 
         // Row 1
         Label {
-            id: presetLabel
             text: qsTr('Preset')
             Layout.alignment: Qt.AlignRight
         }
@@ -129,7 +128,6 @@ Item {
             Layout.columnSpan: 8
             parameters: defaultParameters
             onBeforePresetLoaded: {
-                filter.startUndoParameterCommand(presetLabel.text);
                 filter.resetProperty('lift_r');
                 filter.resetProperty('lift_g');
                 filter.resetProperty('lift_b');
@@ -142,7 +140,6 @@ Item {
             }
             onPresetSelected: {
                 loadValues();
-                filter.endUndoCommand();
             }
         }
 

--- a/src/qml/filters/fadein_brightness/ui.qml
+++ b/src/qml/filters/fadein_brightness/ui.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2022 Meltytech, LLC
+ * Copyright (c) 2014-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@ import Shotcut.Controls as Shotcut
 
 Item {
     property alias duration: timeSpinner.value
+    property bool _blockUpdate: false
 
     function updateFilter() {
         var name = (filter.get('alpha') != 1) ? 'alpha' : 'level';
@@ -51,7 +52,9 @@ Item {
 
     Connections {
         function onAnimateInChanged() {
+            _blockUpdate = true;
             duration = filter.animateIn;
+            _blockUpdate = false;
         }
 
         target: filter
@@ -63,6 +66,7 @@ Item {
 
         RowLayout {
             Label {
+                id: durationLabel
                 text: qsTr('Duration')
             }
 
@@ -72,8 +76,12 @@ Item {
                 minimumValue: 2
                 maximumValue: 5000
                 onValueChanged: {
+                    if (_blockUpdate)
+                        return;
+                    filter.startUndoParameterCommand(durationLabel.text);
                     filter.animateIn = duration;
                     updateFilter();
+                    filter.endUndoCommand();
                 }
                 onSetDefaultClicked: {
                     duration = Math.ceil(settings.videoInDuration * profile.fps);

--- a/src/qml/filters/fadein_movit/ui.qml
+++ b/src/qml/filters/fadein_movit/ui.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2022 Meltytech, LLC
+ * Copyright (c) 2014-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,6 +22,7 @@ import org.shotcut.qml
 
 Item {
     property alias duration: timeSpinner.value
+    property bool _blockUpdate: false
 
     width: 100
     height: 50
@@ -43,7 +44,9 @@ Item {
 
     Connections {
         function onAnimateInChanged() {
+            _blockUpdate = true;
             duration = filter.animateIn;
+            _blockUpdate = false;
         }
 
         target: filter
@@ -55,6 +58,7 @@ Item {
 
         RowLayout {
             Label {
+                id: durationLabel
                 text: qsTr('Duration')
             }
 
@@ -64,10 +68,14 @@ Item {
                 minimumValue: 2
                 maximumValue: 5000
                 onValueChanged: {
+                    if (_blockUpdate)
+                        return;
+                    filter.startUndoParameterCommand(durationLabel.text);
                     filter.animateIn = duration;
                     filter.resetProperty('opacity');
                     filter.set('opacity', 0, 0, KeyframesModel.SmoothNaturalInterpolation);
                     filter.set('opacity', 1, Math.min(duration, filter.duration) - 1);
+                    filter.endUndoCommand();
                 }
                 onSetDefaultClicked: {
                     duration = Math.ceil(settings.videoInDuration * profile.fps);

--- a/src/qml/filters/fadeout_brightness/ui.qml
+++ b/src/qml/filters/fadeout_brightness/ui.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2022 Meltytech, LLC
+ * Copyright (c) 2014-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@ import Shotcut.Controls as Shotcut
 
 Item {
     property alias duration: timeSpinner.value
+    property bool _blockUpdate: false
 
     function updateFilter() {
         var name = (filter.get('alpha') != 1) ? 'alpha' : 'level';
@@ -51,7 +52,9 @@ Item {
 
     Connections {
         function onAnimateOutChanged() {
+            _blockUpdate = true;
             duration = filter.animateOut;
+            _blockUpdate = false;
         }
 
         target: filter
@@ -63,6 +66,7 @@ Item {
 
         RowLayout {
             Label {
+                id: durationLabel
                 text: qsTr('Duration')
             }
 
@@ -72,8 +76,12 @@ Item {
                 minimumValue: 2
                 maximumValue: 5000
                 onValueChanged: {
+                    if (_blockUpdate)
+                        return;
+                    filter.startUndoParameterCommand(durationLabel.text);
                     filter.animateOut = duration;
                     updateFilter();
+                    filter.endUndoCommand();
                 }
                 onSetDefaultClicked: {
                     duration = Math.ceil(settings.videoOutDuration * profile.fps);

--- a/src/qml/filters/fadeout_movit/ui.qml
+++ b/src/qml/filters/fadeout_movit/ui.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2023 Meltytech, LLC
+ * Copyright (c) 2014-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,6 +22,7 @@ import org.shotcut.qml
 
 Item {
     property alias duration: timeSpinner.value
+    property bool _blockUpdate: false
 
     function updateFilter() {
         var filterDuration = producer.duration;
@@ -48,7 +49,9 @@ Item {
 
     Connections {
         function onAnimateOutChanged() {
+            _blockUpdate = true;
             duration = filter.animateOut;
+            _blockUpdate = false;
         }
 
         target: filter
@@ -60,6 +63,7 @@ Item {
 
         RowLayout {
             Label {
+                id: durationLabel
                 text: qsTr('Duration')
             }
 
@@ -69,8 +73,12 @@ Item {
                 minimumValue: 2
                 maximumValue: 5000
                 onValueChanged: {
+                    if (_blockUpdate)
+                        return;
+                    filter.startUndoParameterCommand(durationLabel.text);
                     filter.animateOut = duration;
                     updateFilter();
+                    filter.endUndoCommand();
                 }
                 onSetDefaultClicked: {
                     duration = Math.ceil(settings.videoOutDuration * profile.fps);

--- a/src/qml/filters/richtext/ui.qml
+++ b/src/qml/filters/richtext/ui.qml
@@ -306,6 +306,7 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
         }
 
         Label {
+            id: positionLabel
             text: qsTr('Position')
             Layout.alignment: Qt.AlignRight
         }
@@ -324,8 +325,10 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
                 to: 1e+09
                 onValueModified: {
                     if (Math.abs(filterRect.x - value) > 1) {
+                        filter.startUndoParameterCommand(positionLabel.text);
                         filterRect.x = value;
                         updateFilterRect(getPosition());
+                        filter.endUndoCommand();
                     }
                 }
             }
@@ -347,8 +350,10 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
                 to: 1e+09
                 onValueModified: {
                     if (Math.abs(filterRect.y - value) > 1) {
+                        filter.startUndoParameterCommand(positionLabel.text);
                         filterRect.y = value;
                         updateFilterRect(getPosition());
+                        filter.endUndoCommand();
                     }
                 }
             }
@@ -356,9 +361,11 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
 
         Shotcut.UndoButton {
             onClicked: {
+                filter.startUndoParameterCommand(positionLabel.text);
                 filterRect.x = rectX.value = defaultRect.x;
                 filterRect.y = rectY.value = defaultRect.y;
                 updateFilterRect(getPosition());
+                filter.endUndoCommand();
             }
         }
 
@@ -367,6 +374,7 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
 
             Layout.rowSpan: 2
             onToggled: {
+                filter.startUndoParameterCommand(positionLabel.text);
                 if (checked) {
                     filter.blockSignals = true;
                     filter.clearSimpleAnimation(rectProperty);
@@ -379,10 +387,12 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
                     filter.set(rectProperty, filterRect);
                 }
                 checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+                filter.endUndoCommand();
             }
         }
 
         Label {
+            id: backgroundSizeLabel
             text: qsTr('Background size')
             Layout.alignment: Qt.AlignRight
         }
@@ -401,8 +411,10 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
                 to: 1e+09
                 onValueModified: {
                     if (Math.abs(filterRect.width - value) > 1) {
+                        filter.startUndoParameterCommand(backgroundSizeLabel.text);
                         filterRect.width = value;
                         updateFilterRect(getPosition());
+                        filter.endUndoCommand();
                     }
                 }
             }
@@ -424,8 +436,10 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
                 to: 1e+09
                 onValueModified: {
                     if (Math.abs(filterRect.height - value) > 1) {
+                        filter.startUndoParameterCommand(backgroundSizeLabel.text);
                         filterRect.height = value;
                         updateFilterRect(getPosition());
+                        filter.endUndoCommand();
                     }
                 }
             }
@@ -433,9 +447,11 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
 
         Shotcut.UndoButton {
             onClicked: {
+                filter.startUndoParameterCommand(backgroundSizeLabel.text);
                 filterRect.width = rectW.value = defaultRect.width;
                 filterRect.height = rectH.value = defaultRect.height;
                 updateFilterRect(getPosition());
+                filter.endUndoCommand();
             }
         }
 
@@ -504,6 +520,7 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
         }
 
         Label {
+            id: backgroundColorLabel
             text: qsTr('Background color')
             Layout.alignment: Qt.AlignRight
         }
@@ -514,7 +531,11 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
             Layout.columnSpan: 3
             eyedropper: false
             alpha: true
-            onValueChanged: updateFilter('bgcolour', Qt.color(value), bgcolorKeyframesButton, getPosition())
+            onValueChanged: {
+                filter.startUndoParameterCommand(backgroundColorLabel.text);
+                updateFilter('bgcolour', Qt.color(value), bgcolorKeyframesButton, getPosition());
+                filter.endUndoCommand();
+            }
         }
 
         Shotcut.UndoButton {
@@ -523,10 +544,15 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
 
         Shotcut.KeyframesButton {
             id: bgcolorKeyframesButton
-            onToggled: toggleKeyframes(checked, 'bgcolour', Qt.color(bgColor.value))
+            onToggled: {
+                filter.startUndoParameterCommand(backgroundColorLabel.text);
+                toggleKeyframes(checked, 'bgcolour', Qt.color(bgColor.value));
+                filter.endUndoCommand();
+            }
         }
 
         Label {
+            id: overflowLabel
             text: qsTr('Overflow')
             Layout.alignment: Qt.AlignRight
         }
@@ -544,8 +570,10 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
                 text: qsTr('Automatic')
                 ButtonGroup.group: overflowGroup
                 onClicked: {
+                    filter.startUndoParameterCommand(overflowLabel.text);
                     filter.set('overflow-y', '');
                     filter.resetProperty('overflow-y');
+                    filter.endUndoCommand();
                 }
             }
 
@@ -554,7 +582,11 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
 
                 text: qsTr('Visible')
                 ButtonGroup.group: overflowGroup
-                onClicked: filter.set('overflow-y', 1)
+                onClicked: {
+                    filter.startUndoParameterCommand(overflowLabel.text);
+                    filter.set('overflow-y', 1);
+                    filter.endUndoCommand();
+                }
             }
 
             RadioButton {
@@ -562,14 +594,20 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
 
                 text: qsTr('Hidden')
                 ButtonGroup.group: overflowGroup
-                onClicked: filter.set('overflow-y', 0)
+                onClicked: {
+                    filter.startUndoParameterCommand(overflowLabel.text);
+                    filter.set('overflow-y', 0);
+                    filter.endUndoCommand();
+                }
             }
         }
 
         Shotcut.UndoButton {
             onClicked: {
+                filter.startUndoParameterCommand(overflowLabel.text);
                 filter.resetProperty('overflow-y');
                 automaticOverflowRadioButton.checked = true;
+                filter.endUndoCommand();
             }
         }
 
@@ -584,7 +622,9 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
         Shotcut.Button {
             Layout.columnSpan: parent.columns - 1
             text: motionTrackerDialog.title
-            onClicked: motionTrackerDialog.show()
+            onClicked: {
+                motionTrackerDialog.show();
+            }
         }
 
         Item {
@@ -594,15 +634,23 @@ body { font-family:%1; font-size:72pt; font-weight:600; font-style:normal; color
 
     Shotcut.MotionTrackerDialog {
         id: motionTrackerDialog
-        onAccepted: (motionTrackerRow, operation, startFrame) => applyTracking(motionTrackerRow, operation, startFrame)
-        onReset: if (filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0) {
-            motionTrackerModel.undo(filter, rectProperty);
-            filterRect = filter.getRect(rectProperty, getPosition());
-            rectX.value = filterRect.x;
-            rectY.value = filterRect.y;
-            rectW.value = filterRect.width;
-            rectH.value = filterRect.height;
-            updateFilterRect(getPosition());
+        onAccepted: (motionTrackerRow, operation, startFrame) => {
+            filter.startUndoParameterCommand(title);
+            applyTracking(motionTrackerRow, operation, startFrame);
+            filter.endUndoCommand();
+        }
+        onReset: {
+            if (filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0) {
+                filter.startUndoParameterCommand(title);
+                motionTrackerModel.undo(filter, rectProperty);
+                filterRect = filter.getRect(rectProperty, getPosition());
+                rectX.value = filterRect.x;
+                rectY.value = filterRect.y;
+                rectW.value = filterRect.width;
+                rectH.value = filterRect.height;
+                updateFilterRect(getPosition());
+                filter.endUndoCommand();
+            }
         }
     }
 

--- a/src/qml/filters/richtext/vui.qml
+++ b/src/qml/filters/richtext/vui.qml
@@ -498,7 +498,7 @@ Shotcut.VuiBase {
                     }
                 }
 
-                Behavior on width {
+                Behavior on width  {
                     NumberAnimation {
                         duration: 100
                     }

--- a/src/qml/filters/size_position/SizePositionUI.qml
+++ b/src/qml/filters/size_position/SizePositionUI.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2023 Meltytech, LLC
+ * Copyright (c) 2014-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -327,6 +327,9 @@ Item {
         defaultRect.x = Math.round((profile.width - defaultRect.width) / 2);
         defaultRect.y = Math.round((profile.height - defaultRect.height) / 2);
         if (filter.isNew) {
+            if (rotationProperty) {
+                filter.set(rotationProperty, 0);
+            }
             filter.set(fillProperty, 0);
             filter.set(distortProperty, 0);
             filter.set(rectProperty, '0%/50%:50%x50%');
@@ -515,6 +518,7 @@ Item {
         }
 
         Label {
+            id: positionLabel
             text: qsTr('Position')
             Layout.alignment: Qt.AlignRight
         }
@@ -533,8 +537,10 @@ Item {
                 to: 1e+09
                 onValueModified: {
                     if (Math.abs(filterRect.x - value) >= 1) {
+                        filter.startUndoParameterCommand(positionLabel.text);
                         filterRect.x = value;
                         setFilter(getPosition());
+                        filter.endUndoCommand();
                     }
                 }
             }
@@ -556,8 +562,10 @@ Item {
                 to: 1e+09
                 onValueModified: {
                     if (Math.abs(filterRect.y - value) >= 1) {
+                        filter.startUndoParameterCommand(positionLabel.text);
                         filterRect.y = value;
                         setFilter(getPosition());
+                        filter.endUndoCommand();
                     }
                 }
             }
@@ -565,9 +573,11 @@ Item {
 
         Shotcut.UndoButton {
             onClicked: {
+                filter.startUndoParameterCommand(positionLabel.text);
                 filterRect.x = rectX.value = defaultRect.x;
                 filterRect.y = rectY.value = defaultRect.y;
                 setFilter(getPosition());
+                filter.endUndoCommand();
             }
         }
 
@@ -590,6 +600,7 @@ Item {
                 id: positionKeyframesButton
 
                 onToggled: {
+                    filter.startUndoParameterCommand(positionLabel.text);
                     if (checked) {
                         blockUpdate = true;
                         filter.blockSignals = true;
@@ -604,6 +615,7 @@ Item {
                         filter.set(rectProperty, filterRect);
                     }
                     checked = filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0;
+                    filter.endUndoCommand();
                 }
             }
 
@@ -616,6 +628,7 @@ Item {
         }
 
         Label {
+            id: sizeLabel
             text: qsTr('Size')
             Layout.alignment: Qt.AlignRight
         }
@@ -634,12 +647,14 @@ Item {
                 to: 1e+09
                 onValueModified: {
                     if (Math.abs(filterRect.width - value) >= 1) {
+                        filter.startUndoParameterCommand(sizeLabel.text);
                         if (isFillMode()) {
                             scaleByWidth(value);
                         } else {
                             filterRect.width = value;
                             setFilter(getPosition());
                         }
+                        filter.endUndoCommand();
                     }
                 }
             }
@@ -661,12 +676,14 @@ Item {
                 to: 1e+09
                 onValueModified: {
                     if (Math.abs(filterRect.height - value) >= 1) {
+                        filter.startUndoParameterCommand(sizeLabel.text);
                         if (isFillMode()) {
                             scaleByHeight(value);
                         } else {
                             filterRect.height = value;
                             setFilter(getPosition());
                         }
+                        filter.endUndoCommand();
                     }
                 }
             }
@@ -676,14 +693,17 @@ Item {
             id: sizeUndoButton
 
             onClicked: {
+                filter.startUndoParameterCommand(sizeLabel.text);
                 filterRect.width = rectW.value = defaultRect.width;
                 filterRect.height = rectH.value = defaultRect.height;
                 scaleSlider.update();
                 setFilter(getPosition());
+                filter.endUndoCommand();
             }
         }
 
         Label {
+            id: zoomLabel
             text: qsTr('Zoom')
             Layout.alignment: Qt.AlignRight
         }
@@ -704,6 +724,7 @@ Item {
             suffix: ' %'
             onValueChanged: {
                 if (!blockUpdate && Math.abs(value - filterRect.width / defaultRect.width * 100) > 0.1) {
+                    filter.startUndoParameterCommand(zoomLabel.text);
                     var centerX = filterRect.x + filterRect.width / 2;
                     var rightX = filterRect.x + filterRect.width;
                     filterRect.width = rectW.value = defaultRect.width * value / 100;
@@ -719,6 +740,7 @@ Item {
                     else if (bottomRadioButton.checked)
                         filterRect.y = rectY.value = bottomY - filterRect.height;
                     setFilter(getPosition());
+                    filter.endUndoCommand();
                 }
             }
         }
@@ -729,6 +751,7 @@ Item {
         }
 
         Label {
+            id: sizeModeLabel
             text: qsTr('Size mode')
             Layout.alignment: Qt.AlignRight
         }
@@ -739,9 +762,11 @@ Item {
             text: qsTr('Fit')
             ButtonGroup.group: sizeGroup
             onClicked: {
+                filter.startUndoParameterCommand(sizeModeLabel.text);
                 filter.set(fillProperty, 0);
                 filter.set(distortProperty, 0);
                 updateAspectRatio();
+                filter.endUndoCommand();
             }
         }
 
@@ -751,6 +776,7 @@ Item {
             text: qsTr('Fill')
             ButtonGroup.group: sizeGroup
             onClicked: {
+                filter.startUndoParameterCommand(sizeModeLabel.text);
                 filter.set(fillProperty, 1);
                 filter.set(distortProperty, 0);
                 updateAspectRatio();
@@ -760,6 +786,7 @@ Item {
                 else
                     filterRect.width = rectW.value = filterRect.height * producer.displayAspectRatio;
                 setFilter(getPosition());
+                filter.endUndoCommand();
             }
         }
 
@@ -769,18 +796,22 @@ Item {
             text: qsTr('Distort')
             ButtonGroup.group: sizeGroup
             onClicked: {
+                filter.startUndoParameterCommand(sizeModeLabel.text);
                 filter.set(fillProperty, 1);
                 filter.set(distortProperty, 1);
                 updateAspectRatio();
+                filter.endUndoCommand();
             }
         }
 
         Shotcut.UndoButton {
             onClicked: {
+                filter.startUndoParameterCommand(sizeModeLabel.text);
                 fitRadioButton.checked = true;
                 filter.set(fillProperty, 0);
                 filter.set(distortProperty, 0);
                 updateAspectRatio();
+                filter.endUndoCommand();
             }
         }
 
@@ -789,6 +820,7 @@ Item {
         }
 
         Label {
+            id: horizontalFitLabel
             text: qsTr('Horizontal fit')
             Layout.alignment: Qt.AlignRight
         }
@@ -798,7 +830,11 @@ Item {
 
             text: qsTr('Left')
             ButtonGroup.group: halignGroup
-            onClicked: filter.set(halignProperty, 'left')
+            onClicked: {
+                filter.startUndoParameterCommand(horizontalFitLabel.text);
+                filter.set(halignProperty, 'left');
+                filter.endUndoCommand();
+            }
         }
 
         RadioButton {
@@ -806,7 +842,11 @@ Item {
 
             text: qsTr('Center')
             ButtonGroup.group: halignGroup
-            onClicked: filter.set(halignProperty, 'center')
+            onClicked: {
+                filter.startUndoParameterCommand(horizontalFitLabel.text);
+                filter.set(halignProperty, 'center');
+                filter.endUndoCommand();
+            }
         }
 
         RadioButton {
@@ -814,13 +854,19 @@ Item {
 
             text: qsTr('Right')
             ButtonGroup.group: halignGroup
-            onClicked: filter.set(halignProperty, 'right')
+            onClicked: {
+                filter.startUndoParameterCommand(horizontalFitLabel.text);
+                filter.set(halignProperty, 'right');
+                filter.endUndoCommand();
+            }
         }
 
         Shotcut.UndoButton {
             onClicked: {
+                filter.startUndoParameterCommand(horizontalFitLabel.text);
                 leftRadioButton.checked = true;
                 filter.set(halignProperty, 'left');
+                filter.endUndoCommand();
             }
         }
 
@@ -829,6 +875,7 @@ Item {
         }
 
         Label {
+            id: verticalFitLabel
             text: qsTr('Vertical fit')
             Layout.alignment: Qt.AlignRight
         }
@@ -838,7 +885,11 @@ Item {
 
             text: qsTr('Top')
             ButtonGroup.group: valignGroup
-            onClicked: filter.set(valignProperty, 'top')
+            onClicked: {
+                filter.startUndoParameterCommand(verticalFitLabel.text);
+                filter.set(valignProperty, 'top');
+                filter.endUndoCommand();
+            }
         }
 
         RadioButton {
@@ -846,7 +897,11 @@ Item {
 
             text: qsTr('Middle', 'Size and Position video filter')
             ButtonGroup.group: valignGroup
-            onClicked: filter.set(valignProperty, 'middle')
+            onClicked: {
+                filter.startUndoParameterCommand(verticalFitLabel.text);
+                filter.set(valignProperty, 'middle');
+                filter.endUndoCommand();
+            }
         }
 
         RadioButton {
@@ -854,13 +909,19 @@ Item {
 
             text: qsTr('Bottom')
             ButtonGroup.group: valignGroup
-            onClicked: filter.set(valignProperty, 'bottom')
+            onClicked: {
+                filter.startUndoParameterCommand(verticalFitLabel.text);
+                filter.set(valignProperty, 'bottom');
+                filter.endUndoCommand();
+            }
         }
 
         Shotcut.UndoButton {
             onClicked: {
+                filter.startUndoParameterCommand(verticalFitLabel.text);
                 topRadioButton.checked = true;
                 filter.set(valignProperty, 'top');
+                filter.endUndoCommand();
             }
         }
 
@@ -869,6 +930,7 @@ Item {
         }
 
         Label {
+            id: rotationLabel
             text: qsTr('Rotation')
             Layout.alignment: Qt.AlignRight
             visible: !!rotationProperty
@@ -883,7 +945,11 @@ Item {
             maximumValue: 360
             decimals: 1
             suffix: qsTr(' °', 'degrees')
-            onValueChanged: updateRotation(getPosition())
+            onValueChanged: {
+                filter.startUndoParameterCommand(rotationLabel.text);
+                updateRotation(getPosition());
+                filter.endUndoCommand();
+            }
         }
 
         Shotcut.UndoButton {
@@ -896,12 +962,15 @@ Item {
 
             visible: !!rotationProperty
             onToggled: {
+                filter.startUndoParameterCommand(rotationLabel.text);
                 toggleKeyframes(checked, rotationProperty, rotationSlider.value);
                 setControls();
+                filter.endUndoCommand();
             }
         }
 
         Label {
+            id: backgroundColorLabel
             text: qsTr('Background color')
             Layout.alignment: Qt.AlignRight
             visible: bgColor.visible
@@ -914,7 +983,11 @@ Item {
             Layout.columnSpan: 3
             eyedropper: true
             alpha: true
-            onValueChanged: filter.set(backgroundProperty, 'color:' + value)
+            onValueChanged: {
+                filter.startUndoParameterCommand(backgroundColorLabel.text);
+                filter.set(backgroundProperty, 'color:' + value);
+                filter.endUndoCommand();
+            }
         }
 
         Shotcut.UndoButton {
@@ -946,16 +1019,24 @@ Item {
 
     Shotcut.MotionTrackerDialog {
         id: motionTrackerDialog
-        onAccepted: (motionTrackerRow, operation, startFrame) => applyTracking(motionTrackerRow, operation, startFrame)
-        onReset: if (filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0) {
-            motionTrackerModel.undo(filter, rectProperty);
-            filterRect = filter.getRect(rectProperty, getPosition());
-            rectX.value = filterRect.x;
-            rectY.value = filterRect.y;
-            rectW.value = filterRect.width;
-            rectH.value = filterRect.height;
-            scaleSlider.update();
-            setFilter(getPosition());
+        onAccepted: (motionTrackerRow, operation, startFrame) => {
+            filter.startUndoParameterCommand(title);
+            applyTracking(motionTrackerRow, operation, startFrame);
+            filter.endUndoCommand();
+        }
+        onReset: {
+            if (filter.keyframeCount(rectProperty) > 0 && filter.animateIn <= 0 && filter.animateOut <= 0) {
+                filter.startUndoParameterCommand(title);
+                motionTrackerModel.undo(filter, rectProperty);
+                filterRect = filter.getRect(rectProperty, getPosition());
+                rectX.value = filterRect.x;
+                rectY.value = filterRect.y;
+                rectW.value = filterRect.width;
+                rectH.value = filterRect.height;
+                scaleSlider.update();
+                setFilter(getPosition());
+                filter.endUndoCommand();
+            }
         }
     }
 

--- a/src/qml/filters/white/ui.qml
+++ b/src/qml/filters/white/ui.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2022 Meltytech, LLC
+ * Copyright (c) 2014-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -77,6 +77,7 @@ Item {
 
         // Row 1
         Label {
+            id: neutralColorLabel
             text: qsTr('Neutral color')
             Layout.alignment: Qt.AlignRight
         }
@@ -89,8 +90,10 @@ Item {
             Component.onCompleted: isReady = true
             onValueChanged: {
                 if (isReady) {
+                    filter.startUndoParameterCommand(neutralColorLabel.text);
                     filter.set(neutralParam, "" + value);
                     filter.set("disable", 0);
+                    filter.endUndoCommand();
                 }
             }
             onPickStarted: {
@@ -105,6 +108,7 @@ Item {
 
         // Row 2
         Label {
+            id: temperatureLabel
             text: qsTr('Color temperature')
             Layout.alignment: Qt.AlignRight
         }
@@ -123,8 +127,10 @@ Item {
                 Component.onCompleted: isReady = true
                 onValueChanged: {
                     if (isReady) {
+                        filter.startUndoParameterCommand(temperatureLabel.text);
                         tempspinner.value = value;
                         filter.set(tempParam, value / tempScale);
+                        filter.endUndoCommand();
                     }
                 }
 

--- a/src/qml/modules/Shotcut/Controls/Preset.qml
+++ b/src/qml/modules/Shotcut/Controls/Preset.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2023 Meltytech, LLC
+ * Copyright (c) 2013-2024 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -40,6 +40,7 @@ RowLayout {
         model: filter ? filter.presets : 0
         onActivated: {
             if (currentText.length > 0) {
+                filter.startUndoParameterCommand(qsTr('Preset'));
                 // toggling focus works around a weird bug involving sticky
                 // input event focus on the ComboBox
                 enabled = false;
@@ -54,6 +55,7 @@ RowLayout {
                 filter.animateInChanged();
                 filter.animateOutChanged();
                 enabled = true;
+                filter.endUndoCommand();
             }
         }
     }

--- a/src/qml/views/keyframes/KeyframeClip.qml
+++ b/src/qml/views/keyframes/KeyframeClip.qml
@@ -323,7 +323,7 @@ Rectangle {
             onExited: animateInControl.scale = 1
         }
 
-        SequentialAnimation on scale {
+        SequentialAnimation on scale  {
             loops: Animation.Infinite
             running: animateInMouseArea.containsMouse
 
@@ -428,7 +428,7 @@ Rectangle {
             onExited: animateOutControl.scale = 1
         }
 
-        SequentialAnimation on scale {
+        SequentialAnimation on scale  {
             loops: Animation.Infinite
             running: animateOutMouseArea.containsMouse
 

--- a/src/qml/views/timeline/Clip.qml
+++ b/src/qml/views/timeline/Clip.qml
@@ -495,7 +495,7 @@ Rectangle {
             onDoubleClicked: timeline.fadeIn(trackIndex, index, (fadeIn > 0) ? 0 : Math.round(profile.fps))
         }
 
-        SequentialAnimation on scale {
+        SequentialAnimation on scale  {
             loops: Animation.Infinite
             running: fadeInMouseArea.containsMouse
 
@@ -589,7 +589,7 @@ Rectangle {
             onDoubleClicked: timeline.fadeOut(trackIndex, index, (fadeOut > 0) ? 0 : Math.round(profile.fps))
         }
 
-        SequentialAnimation on scale {
+        SequentialAnimation on scale  {
             loops: Animation.Infinite
             running: fadeOutMouseArea.containsMouse
 

--- a/src/qml/views/timeline/CornerSelectionShadow.qml
+++ b/src/qml/views/timeline/CornerSelectionShadow.qml
@@ -51,7 +51,7 @@ Item {
         }
     }
 
-    Behavior on opacity {
+    Behavior on opacity  {
         NumberAnimation {
             duration: 100
         }

--- a/src/qml/views/timeline/timeline.qml
+++ b/src/qml/views/timeline/timeline.qml
@@ -313,13 +313,13 @@ Rectangle {
                                         leftPadding: 10
                                     }
 
-                                    Behavior on opacity {
+                                    Behavior on opacity  {
                                         NumberAnimation {
                                         }
                                     }
                                 }
 
-                                Behavior on width {
+                                Behavior on width  {
                                     PropertyAnimation {
                                         easing.type: Easing.InOutCubic
                                     }
@@ -853,7 +853,7 @@ Rectangle {
                     }
                 }
 
-                Behavior on opacity {
+                Behavior on opacity  {
                     NumberAnimation {
                     }
                 }

--- a/src/qmltypes/qmlfilter.cpp
+++ b/src/qmltypes/qmlfilter.cpp
@@ -180,7 +180,7 @@ void QmlFilter::set(QString name, QString value, int position)
         if (qstrcmp(m_service.get(qUtf8Printable(name)), qUtf8Printable(value)))  {
             m_service.set_string(qUtf8Printable(name), qUtf8Printable(value)) ;
             emit changed(name);
-            updateChangeCommand(name);
+            updateUndoCommand(name);
         }
     } else {
         // Only set an animation keyframe if it does not already exist with the same value.
@@ -189,7 +189,7 @@ void QmlFilter::set(QString name, QString value, int position)
                 || value != m_service.anim_get(qUtf8Printable(name), position, duration())) {
             m_service.anim_set(qUtf8Printable(name), qUtf8Printable(value), position, duration());
             emit changed(name);
-            updateChangeCommand(name);
+            updateUndoCommand(name);
         }
     }
 }
@@ -203,7 +203,7 @@ void QmlFilter::set(QString name, const QColor &value, int position, mlt_keyfram
                 || value != QColor(mltColor.r, mltColor.g, mltColor.b, mltColor.a)) {
             m_service.set(qUtf8Printable(name), Util::mltColorFromQColor(value));
             emit changed(name);
-            updateChangeCommand(name);
+            updateUndoCommand(name);
         }
     } else {
         // Only set an animation keyframe if it does not already exist with the same value.
@@ -213,7 +213,7 @@ void QmlFilter::set(QString name, const QColor &value, int position, mlt_keyfram
                 || value != QColor(mltColor.r, mltColor.g, mltColor.b, mltColor.a)) {
             m_service.anim_set(qUtf8Printable(name), Util::mltColorFromQColor(value), position, duration());
             emit changed(name);
-            updateChangeCommand(name);
+            updateUndoCommand(name);
         }
     }
 }
@@ -232,7 +232,7 @@ void QmlFilter::set(QString name, double value, int position, mlt_keyframe_type 
             } else if (name == "out") {
                 emit outChanged(delta);
             }
-            updateChangeCommand(name);
+            updateUndoCommand(name);
         }
     } else {
         // Only set an animation keyframe if it does not already exist with the same value.
@@ -242,7 +242,7 @@ void QmlFilter::set(QString name, double value, int position, mlt_keyframe_type 
             mlt_keyframe_type type = getKeyframeType(animation, position, keyframeType);
             m_service.anim_set(qUtf8Printable(name), value, position, duration(), type);
             emit changed(name);
-            updateChangeCommand(name);
+            updateUndoCommand(name);
         }
     }
 }
@@ -261,7 +261,7 @@ void QmlFilter::set(QString name, int value, int position, mlt_keyframe_type key
             } else if (name == "out") {
                 emit outChanged(delta);
             }
-            updateChangeCommand(name);
+            updateUndoCommand(name);
         }
     } else {
         // Only set an animation keyframe if it does not already exist with the same value.
@@ -271,7 +271,7 @@ void QmlFilter::set(QString name, int value, int position, mlt_keyframe_type key
             mlt_keyframe_type type = getKeyframeType(animation, position, keyframeType);
             m_service.anim_set(qUtf8Printable(name), value, position, duration(), type);
             emit changed(name);
-            updateChangeCommand(name);
+            updateUndoCommand(name);
         }
     }
 }
@@ -291,7 +291,7 @@ void QmlFilter::set(QString name, double x, double y, double width, double heigh
                 || width != rect.w || height != rect.h || opacity != rect.o) {
             m_service.set(qUtf8Printable(name), x, y, width, height, opacity);
             emit changed(name);
-            updateChangeCommand(name);
+            updateUndoCommand(name);
         }
     } else {
         mlt_rect rect = m_service.anim_get_rect(qUtf8Printable(name), position, duration());
@@ -311,7 +311,7 @@ void QmlFilter::set(QString name, double x, double y, double width, double heigh
             mlt_keyframe_type type = getKeyframeType(animation, position, keyframeType);
             m_service.anim_set(qUtf8Printable(name), rect, position, duration(), type);
             emit changed(name);
-            updateChangeCommand(name);
+            updateUndoCommand(name);
         }
     }
 }
@@ -327,7 +327,7 @@ void QmlFilter::setGradient(QString name, const QStringList &gradient)
         }
     }
     emit changed(name.toUtf8().constData());
-    updateChangeCommand(name);
+    updateUndoCommand(name);
 }
 
 void QmlFilter::set(QString name, const QRectF &rect, int position, mlt_keyframe_type keyframeType)
@@ -601,7 +601,7 @@ void QmlFilter::setAnimateIn(int value)
                 }
             }
         }
-        updateChangeCommand(kShotcutAnimInProperty);
+        updateUndoCommand(kShotcutAnimInProperty);
         emit animateInChanged();
     }
 }
@@ -630,7 +630,7 @@ void QmlFilter::setAnimateOut(int value)
                 }
             }
         }
-        updateChangeCommand(kShotcutAnimOutProperty);
+        updateUndoCommand(kShotcutAnimOutProperty);
         emit animateOutChanged();
     }
 }
@@ -775,7 +775,7 @@ void QmlFilter::startUndoTracking()
     }
 }
 
-void QmlFilter::startChangeParameterCommand(const QString &desc)
+void QmlFilter::startUndoParameterCommand(const QString &desc)
 {
     if (!m_previousState.count()) {
 //        LOG_DEBUG() << "Undo tracking has not started yet";
@@ -786,12 +786,12 @@ void QmlFilter::startChangeParameterCommand(const QString &desc)
 //        LOG_DEBUG() << "Nested change command" << m_changeInProgress;
         return;
     }
-    auto command = new Filter::ChangeParameterCommand(m_metadata->name(),
-                                                      MAIN.filterController(), MAIN.filterController()->currentIndex(), m_previousState, desc);
+    auto command = new Filter::UndoParameterCommand(m_metadata->name(),
+                                                    MAIN.filterController(), MAIN.filterController()->currentIndex(), m_previousState, desc);
     MAIN.undoStack()->push(command);
 }
 
-void QmlFilter::startChangeAddKeyframeCommand()
+void QmlFilter::startUndoAddKeyframeCommand()
 {
     if (!m_previousState.count()) {
 //        LOG_DEBUG() << "Undo tracking has not started yet";
@@ -802,12 +802,12 @@ void QmlFilter::startChangeAddKeyframeCommand()
 //        LOG_DEBUG() << "Nested change command" << m_changeInProgress;
         return;
     }
-    auto command = new Filter::ChangeAddKeyframeCommand(m_metadata->name(),
-                                                        MAIN.filterController(), MAIN.filterController()->currentIndex(), m_previousState);
+    auto command = new Filter::UndoAddKeyframeCommand(m_metadata->name(),
+                                                      MAIN.filterController(), MAIN.filterController()->currentIndex(), m_previousState);
     MAIN.undoStack()->push(command);
 }
 
-void QmlFilter::startChangeRemoveKeyframeCommand()
+void QmlFilter::startUndoRemoveKeyframeCommand()
 {
     if (!m_previousState.count()) {
 //        LOG_DEBUG() << "Undo tracking has not started yet";
@@ -818,13 +818,13 @@ void QmlFilter::startChangeRemoveKeyframeCommand()
 //        LOG_DEBUG() << "Nested change command" << m_changeInProgress;
         return;
     }
-    auto command = new Filter::ChangeRemoveKeyframeCommand(
+    auto command = new Filter::UndoRemoveKeyframeCommand(
         m_metadata->name(), MAIN.filterController(), MAIN.filterController()->currentIndex(),
         m_previousState);
     MAIN.undoStack()->push(command);
 }
 
-void QmlFilter::startChangeModifyKeyframeCommand(int paramIndex, int keyframeIndex)
+void QmlFilter::startUndoModifyKeyframeCommand(int paramIndex, int keyframeIndex)
 {
     if (!m_previousState.count()) {
 //        LOG_DEBUG() << "Undo tracking has not started yet";
@@ -835,13 +835,13 @@ void QmlFilter::startChangeModifyKeyframeCommand(int paramIndex, int keyframeInd
         //        LOG_DEBUG() << "Nested change command" << m_changeInProgress;
         return;
     }
-    auto command = new Filter::ChangeModifyKeyframeCommand(
+    auto command = new Filter::UndoModifyKeyframeCommand(
         m_metadata->name(), MAIN.filterController(), MAIN.filterController()->currentIndex(),
         m_previousState, paramIndex, keyframeIndex);
     MAIN.undoStack()->push(command);
 }
 
-void QmlFilter::updateChangeCommand(const QString &name)
+void QmlFilter::updateUndoCommand(const QString &name)
 {
     if (!m_previousState.count()) {
 //        LOG_DEBUG() << "Undo tracking has not started yet";
@@ -849,8 +849,8 @@ void QmlFilter::updateChangeCommand(const QString &name)
     }
     if (m_changeInProgress) {
         const QUndoCommand *lastCommand = MAIN.undoStack()->command(MAIN.undoStack()->count() - 1);
-        Filter::ChangeParameterCommand *command = dynamic_cast<Filter::ChangeParameterCommand *>
-                                                  (const_cast<QUndoCommand *>(lastCommand));
+        Filter::UndoParameterCommand *command = dynamic_cast<Filter::UndoParameterCommand *>
+                                                (const_cast<QUndoCommand *>(lastCommand));
         if (command) {
             // Update the change that is already in progress
             command->update(name);
@@ -860,14 +860,14 @@ void QmlFilter::updateChangeCommand(const QString &name)
         }
     } else {
         // Nothing in progress... make a generic command for this update
-        auto command = new Filter::ChangeParameterCommand(m_metadata->name(), MAIN.filterController(),
-                                                          MAIN.filterController()->currentIndex(), m_previousState);
+        auto command = new Filter::UndoParameterCommand(m_metadata->name(), MAIN.filterController(),
+                                                        MAIN.filterController()->currentIndex(), m_previousState);
         MAIN.undoStack()->push(command);
     }
     m_previousState.pass_property(m_service, name.toUtf8().constData());
 }
 
-void QmlFilter::endChangeCommand()
+void QmlFilter::endUndoCommand()
 {
     if (!m_previousState.count()) {
 //        LOG_DEBUG() << "Undo tracking has not started yet";

--- a/src/qmltypes/qmlfilter.h
+++ b/src/qmltypes/qmlfilter.h
@@ -35,9 +35,6 @@ class AbstractJob;
 class EncodeJob;
 class QUndoCommand;
 class FilterController;
-namespace Filter {
-class ChangeParameterCommand;
-}
 
 class QmlFilter : public QObject
 {
@@ -139,13 +136,21 @@ public:
     bool allowAnimateIn() const;
     bool allowAnimateOut() const;
     Q_INVOKABLE void crop(const QRectF &rect);
-    void startUndoTracking(FilterController *controller, int row);
+
     Q_INVOKABLE void copyParameters();
     Q_INVOKABLE void pasteParameters(const QStringList &propertyNames);
 
+    // Functions for undo/redo
+    void startUndoTracking();
+    Q_INVOKABLE void startChangeParameterCommand(const QString &desc = QString());
+    void startChangeAddKeyframeCommand();
+    void startChangeRemoveKeyframeCommand();
+    void startChangeModifyKeyframeCommand(int paramIndex, int keyframeIndex);
+    void updateChangeCommand(const QString &name);
+    Q_INVOKABLE void endChangeCommand();
+
 public slots:
     void preset(const QString &name);
-    void updateChangeCommand(const QString &name);
 
 signals:
     void presetsChanged();
@@ -166,8 +171,8 @@ private:
     QString m_path;
     bool m_isNew;
     QStringList m_presets;
-    Filter::ChangeParameterCommand *m_changeCommand;
-    bool m_changeCommandPushed;
+    Mlt::Properties m_previousState;
+    int m_changeInProgress;
 
     QString objectNameOrService();
     int keyframeIndex(Mlt::Animation &animation, int position);

--- a/src/qmltypes/qmlfilter.h
+++ b/src/qmltypes/qmlfilter.h
@@ -142,12 +142,12 @@ public:
 
     // Functions for undo/redo
     void startUndoTracking();
-    Q_INVOKABLE void startChangeParameterCommand(const QString &desc = QString());
-    void startChangeAddKeyframeCommand();
-    void startChangeRemoveKeyframeCommand();
-    void startChangeModifyKeyframeCommand(int paramIndex, int keyframeIndex);
-    void updateChangeCommand(const QString &name);
-    Q_INVOKABLE void endChangeCommand();
+    Q_INVOKABLE void startUndoParameterCommand(const QString &desc = QString());
+    void startUndoAddKeyframeCommand();
+    void startUndoRemoveKeyframeCommand();
+    void startUndoModifyKeyframeCommand(int paramIndex, int keyframeIndex);
+    void updateUndoCommand(const QString &name);
+    Q_INVOKABLE void endUndoCommand();
 
 public slots:
     void preset(const QString &name);


### PR DESCRIPTION
This is currently a work in progress for review and discussion:

Start a new undo command for individual parameters and keyframes in filters. This method works for all keyframs in the keyframe panel.

Tracking of individual parameters is only implemented for the color grading filter for demonstration purpose. We would have to go to every filter qml file and add the start/end function calls to make it work for all filters. I am willing to do this, but want to make sure this method is agreeable, first.

### Parameters in the filter panel
* History text: "Change Color Grading filter: Shadows (Lift)"
* Merging: only merge if it is the same filter and the same parameter (the history text must match)

### Keyframe add and remove
* History text: "Change Brightness filter: add keyframe"
* Merging: never merge

### Modify (move) keyframe in the keyframes panel
* History text: "Change Color Grading filter: modify keyframe"
* Merging: only merge if it is the same filter, the same parameter, and the same keyframe

Here is a demonstration:

https://github.com/mltframework/shotcut/assets/821968/ea6f0ca7-67e9-4157-858f-2f5f81a4f4fd


