### PR TITLE
use DJI LRF (MP4) as proxy if available

### DIFF
--- a/src/mltxmlchecker.cpp
+++ b/src/mltxmlchecker.cpp
@@ -690,6 +690,24 @@ void MltXmlChecker::checkForProxy(const QString &mlt_service,
             }
         }
 
+        // Use DJI LRF if available
+        if (QFile::exists(ProxyManager::DJIProxyFilePath(resource))) {
+            for (auto &p : properties) {
+                if (p.first == "resource") {
+                    p.second = ProxyManager::DJIProxyFilePath(resource);
+                    if (isTimewarp) {
+                        p.second = QString("%1:%2").arg(speed, p.second);
+                    }
+                    properties << MltProperty(kIsProxyProperty, "1");
+                    properties << MltProperty(kMetaProxyProperty, "1");
+                    properties << MltProperty(kOriginalResourceProperty, resource);
+                    m_resource.notProxyMeta = !m_resource.isProxy;
+                    m_isUpdated = true;
+                    return;
+                }
+            }
+        }
+
         QDir proxyDir(Settings.proxyFolder());
         QDir projectDir(QFileInfo(m_tempFile->fileName()).dir());
         QString fileName = hash + ProxyManager::videoFilenameExtension();

--- a/src/proxymanager.h
+++ b/src/proxymanager.h
@@ -59,6 +59,7 @@ public:
     static void generateIfNotExistsAll(Mlt::Producer &producer);
     static bool removePending();
     static QString GoProProxyFilePath(const QString &resource);
+    static QString DJIProxyFilePath(const QString &resource);
 };
 
 #endif // PROXYMANAGER_H


### PR DESCRIPTION
DJI cameras create low resolution mp4 files using the same name as the full video file just with the extension replaced to LRF. They can be used as proxy, similar to gopros LRV files.