### PR TITLE
Add SVT-AV1 encoder support

### DIFF
--- a/scripts/build-shotcut.sh
+++ b/scripts/build-shotcut.sh
@@ -59,6 +59,7 @@ FFMPEG_SUPPORT_QSV=1
 FFMPEG_SUPPORT_DAV1D=1
 FFMPEG_SUPPORT_AOM=1
 FFMPEG_SUPPORT_WEBP=1
+FFMPEG_SUPPORT_SVTAV1=1
 FFMPEG_SUPPORT_VMAF=1
 FFMPEG_ADDITIONAL_OPTIONS=
 ENABLE_VIDSTAB=1
@@ -83,6 +84,8 @@ DAV1D_HEAD=0
 DAV1D_REVISION="1.4.1"
 AOM_HEAD=0
 AOM_REVISION="v3.8.0"
+SVTAV1_HEAD=0
+SVTAV1_REVISION="v2.0.0"
 VMAF_HEAD=0
 VMAF_REVISION="v3.0.0"
 ENABLE_GLAXNIMATE=1
@@ -261,6 +264,9 @@ function to_key {
     ;;
     libwebp)
       echo 28
+    ;;
+    SVT-AV1)
+      echo 29
     ;;
     *)
       echo UNKNOWN
@@ -487,6 +493,9 @@ function set_globals {
     if test "$FFMPEG_SUPPORT_AOM" = 1 && test "$AOM_HEAD" = 1 -o "$AOM_REVISION" != ""; then
         SUBDIRS="aom $SUBDIRS"
     fi
+    if test "$FFMPEG_SUPPORT_SVTAV1" = 1 && test "$SVTAV1_HEAD" = 1 -o "$SVTAV1_REVISION" != ""; then
+        SUBDIRS="SVT-AV1 $SUBDIRS"
+    fi
     if test "$FFMPEG_SUPPORT_VMAF" = 1 && test "$VMAF_HEAD" = 1 -o "$VMAF_REVISION" != ""; then
         SUBDIRS="vmaf $SUBDIRS"
     fi
@@ -556,6 +565,7 @@ function set_globals {
   REPOLOCS[26]="https://github.com/opencv/opencv.git"
   REPOLOCS[27]="https://github.com/opencv/opencv_contrib.git"
   REPOLOCS[28]="https://github.com/webmproject/libwebp.git"
+  REPOLOCS[29]="https://gitlab.com/AOMediaCodec/SVT-AV1.git"
 
   # REPOTYPE Array holds the repo types. (Yes, this might be redundant, but easy for me)
   REPOTYPES[0]="git"
@@ -585,6 +595,7 @@ function set_globals {
   REPOTYPES[26]="git"
   REPOTYPES[27]="git"
   REPOTYPES[28]="git"
+  REPOTYPES[29]="git"
 
   # And, set up the revisions
   REVISIONS[0]=""
@@ -656,10 +667,6 @@ function set_globals {
   if test 0 = "$AOM_HEAD" -a "$AOM_REVISION" ; then
     REVISIONS[22]="$AOM_REVISION"
   fi
-  REVISIONS[22]=""
-  if test 0 = "$AOM_HEAD" -a "$AOM_REVISION" ; then
-    REVISIONS[22]="$AOM_REVISION"
-  fi
   REVISIONS[23]=""
   if test 0 = "$VMAF_HEAD" -a "$VMAF_REVISION" ; then
     REVISIONS[23]="$VMAF_REVISION"
@@ -679,7 +686,11 @@ function set_globals {
   fi
   REVISIONS[28]=""
   if test 0 = "$LIBWEBP_HEAD" -a "$LIBWEBP_REVISION" ; then
-  REVISIONS[28]="$LIBWEBP_REVISION"
+    REVISIONS[28]="$LIBWEBP_REVISION"
+  fi
+  REVISIONS[29]=""
+  if test 0 = "$SVTAV1_HEAD" -a "$SVTAV1_REVISION" ; then
+    REVISIONS[29]="$SVTAV1_REVISION"
   fi
 
   # Figure out the number of cores in the system. Used both by make and startup script
@@ -769,6 +780,9 @@ function set_globals {
   fi
   if test 1 = "$FFMPEG_SUPPORT_WEBP" ; then
     CONFIG[0]="${CONFIG[0]} --enable-libwebp"
+  fi
+  if test 1 = "$FFMPEG_SUPPORT_SVTAV1" ; then
+    CONFIG[0]="${CONFIG[0]} --enable-libsvtav1"
   fi
   if test 1 = "$FFMPEG_SUPPORT_VMAF" ; then
     CONFIG[0]="${CONFIG[0]} --enable-libvmaf"
@@ -1066,6 +1080,14 @@ function set_globals {
   LDFLAGS_[28]="$LDFLAGS"
   BUILD[28]="ninja -C build -j $MAKEJ"
   INSTALL[28]="ninja -C build install"
+
+  #####
+  # SVT-AV1
+  CONFIG[29]="cmake -B build -G Ninja -D CMAKE_INSTALL_PREFIX=$FINAL_INSTALL_DIR $CMAKE_DEBUG_FLAG -D BUILD_SHARED_LIBS=ON -D BUILD_TESTING=OFF -D BUILD_APPS=OFF -D ENABLE_AVX512=ON"
+  CFLAGS_[29]=$CFLAGS
+  LDFLAGS_[29]=$LDFLAGS
+  BUILD[29]="ninja -C build -j $MAKEJ"
+  INSTALL[29]="ninja -C build install"
 }
 
 function build_ffmpeg_darwin {

--- a/src/docks/encodedock.cpp
+++ b/src/docks/encodedock.cpp
@@ -701,8 +701,6 @@ Mlt::Properties *EncodeDock::collectProperties(int realtime, bool includeProfile
                 setIfNotSet(p, "bf", ui->bFramesSpinner->value());
                 p->set("x265-params", x265params.toUtf8().constData());
             } else if (vcodec == "libsvtav1") {
-                // Most SVT-AV1 parameters must be supplied through svtav1-params.
-                // The preset properties are for UI controls and custom presets.
                 QString bitrate_text = ui->videoBitrateCombo->currentText();
                 int bitrate_kbps = qMax(QString(bitrate_text).replace('k', "").replace('M', "000").toInt(), 1);
                 int buffer_bits = qRound(ui->videoBufferSizeSpinner->value() * 1024.0 * 8.0);
@@ -711,8 +709,6 @@ Mlt::Properties *EncodeDock::collectProperties(int realtime, bool includeProfile
 
                 switch (ui->videoRateControlCombo->currentIndex()) {
                 case RateControlAverage: {
-                    encParams << QString("rc=1");
-                    encParams << QString("tbr=%1").arg(bitrate_text);
                     setIfNotSet(p, "vb", bitrate_text.toLatin1().constData());
                     break;
                 }
@@ -725,13 +721,10 @@ Mlt::Properties *EncodeDock::collectProperties(int realtime, bool includeProfile
                     break;
                 }
                 case RateControlQuality: {
-                    encParams << QString("crf=%1").arg(TO_ABSOLUTE(63, 0, vq));
                     setIfNotSet(p, "crf", TO_ABSOLUTE(63, 0, vq));
                     break;
                 }
                 case RateControlConstrained: {
-                    encParams << QString("crf=%1").arg(TO_ABSOLUTE(63, 0, vq));
-                    encParams << QString("mbr=%1").arg(bitrate_text);
                     setIfNotSet(p, "crf", TO_ABSOLUTE(63, 0, vq));
                     setIfNotSet(p, "vmaxrate", bitrate_text.toLatin1().constData());
                     setIfNotSet(p, "vbufsize", buffer_bits); // For UI only; not used by svtav1-params
@@ -739,7 +732,6 @@ Mlt::Properties *EncodeDock::collectProperties(int realtime, bool includeProfile
                 }
                 }
 
-                encParams << QString("keyint=%1").arg(ui->gopSpinner->value());
                 setIfNotSet(p, "g", ui->gopSpinner->value());
 
                 if (ui->strictGopCheckBox->isChecked()) {

--- a/src/docks/encodedock.h
+++ b/src/docks/encodedock.h
@@ -166,7 +166,7 @@ private:
     void encode(const QString &target);
     void resetOptions();
     Mlt::Producer *fromProducer() const;
-    static void filterX265Params(QStringList &other);
+    static void filterCodecParams(const QString &vcodec, QStringList &other);
     void onVideoCodecComboChanged(int index, bool ignorePreset = false, bool resetBframes = true);
     bool checkForMissingFiles();
     QString &defaultFormatExtension();


### PR DESCRIPTION
Known limitation:
* The new `encodedock.cpp` code is designed to support 2-pass encoding based on the parameters given in the SVT-AV1 documentation. However, 2-pass encoding is not wired up between SVT-AV1 and FFmpeg internally yet. This means Shotcut will signal for 2-pass but it won't actually happen. Given that the SVT-AV1 team specifically changed their multi-pass API/ABI to be compatible with FFmpeg in v2.0.0, I assume this will be fixed sooner than later, hence why I didn't disable 2-pass encoding altogether.

Known quirks:
* When using average bitrate mode (VBR), set B-frames to 1 on the Shotcut export panel. VBR mode requires "random-access mode", which means P/B-frames, and is signaled by `pred-struct=2`.
* When using constant bitrate mode (CBR), set B-frames to 0 on the Shotcut export panel. CBR mode requires "low delay mode", which means P-frames only, and is signaled by `pred-struct=1`.