### PR TITLE
fix: the timeline is not synchronized at the end of playback

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1010,6 +1010,9 @@ void Player::onFrameDisplayed(const SharedFrame &frame)
     }
     int position = frame.get_position();
     bool loop = position >= (m_loopEnd - 1) && Actions["playerLoopAction"]->isChecked();
+    if (position > MLT.producer()->get_length()) {
+        position = MLT.producer()->get_length();
+    }
     if (position <= m_duration) {
         m_position = position;
         m_positionSpinner->blockSignals(true);


### PR DESCRIPTION
The timelinedock timeline is playing to the end, but the videowidget timeline is not positioned to the end
![timelineError](https://github.com/mltframework/shotcut/assets/25766722/7d79566e-a3e2-469f-901f-822cbf28253b)
