### PR TITLE
fix German translation for Rich Text

### DIFF
--- a/translations/shotcut_de.ts
+++ b/translations/shotcut_de.ts
@@ -12362,7 +12362,7 @@ Die meisten Benutzer müssen diese Einstellung nicht verändern.</translation>
     <message>
         <location filename="../src/qml/filters/richtext/meta.qml" line="7"/>
         <source>Text: Rich</source>
-        <translation>Text: fett</translation>
+        <translation>Text: Rich</translation>
     </message>
     <message>
         <location filename="../src/qml/filters/richtext/meta.qml" line="8"/>


### PR DESCRIPTION
In context of fonts "fett" means "bold" and should not be used for translation here because Rich Text is a specific name for a text format. See issue #1555 for more context: it seemed that the filter was only available after a restart (which in this case switched language).