### PR TITLE
GPS text: set time_offset to sync start [only once] on file load

### DIFF
--- a/src/qml/filters/gpstext/ui.qml
+++ b/src/qml/filters/gpstext/ui.qml
@@ -198,6 +198,7 @@ Shotcut.KeyframableFilter {
                 gpsFinishParseTimer.stop();
                 calls = 0;
                 filter.set('gps_processing_start_time', filter.get('gps_start_text'));
+                filter.set('time_offset', filter.get('auto_gps_offset_start'));
                 setControls();
             }
         }


### PR DESCRIPTION
This was the obvious place to put the one-time auto sync, not sure why I thought it needed to be in the backend.

This change (+mlt change) should fix these:
https://forum.shotcut.org/t/gps-sync-not-working-after-encoding/41033
https://forum.shotcut.org/t/cant-save-gps-offset/46084