### PR TITLE
Add support for XML clips in chains.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,6 +164,7 @@ add_executable(shotcut WIN32 MACOSX_BUNDLE
   widgets/lissajouswidget.ui
   widgets/lumamixtransition.cpp widgets/lumamixtransition.h
   widgets/lumamixtransition.ui
+  widgets/mltclipproducerwidget.cpp widgets/mltclipproducerwidget.h
   widgets/networkproducerwidget.cpp widgets/networkproducerwidget.h
   widgets/networkproducerwidget.ui
   widgets/newprojectfolder.cpp widgets/newprojectfolder.h

--- a/src/controllers/filtercontroller.cpp
+++ b/src/controllers/filtercontroller.cpp
@@ -215,7 +215,8 @@ void FilterController::setProducer(Mlt::Producer *producer)
         m_metadataModel.updateFilterMask(!MLT.isTrackProducer(*producer),
                                          producer->type() == mlt_service_chain_type,
                                          producer->type() == mlt_service_playlist_type,
-                                         producer->type() == mlt_service_tractor_type);
+                                         producer->type() == mlt_service_tractor_type,
+                                         producer->get("mlt_service") != QString("xml-clip"));
     } else {
         setCurrentFilter(QmlFilter::DeselectCurrentFilter);
     }

--- a/src/docks/playlistdock.cpp
+++ b/src/docks/playlistdock.cpp
@@ -992,22 +992,12 @@ void PlaylistDock::addFiles(int row, const QList<QUrl> &urls)
         }
         Mlt::Producer p;
         if (path.endsWith(".mlt") || path.endsWith(".xml")) {
-            if (Settings.playerGPU() && MLT.profile().is_explicit()) {
-                Mlt::Profile testProfile;
-                Mlt::Producer producer(testProfile, path.toUtf8().constData());
-                if (testProfile.width() != MLT.profile().width()
-                        || testProfile.height() != MLT.profile().height()
-                        || Util::isFpsDifferent(MLT.profile().fps(), testProfile.fps())) {
-                    emit showStatusMessage(tr("Failed to open ").append(path));
-                    continue;
-                }
-            }
-            p = Mlt::Producer(MLT.profile(), path.toUtf8().constData());
+            p = Util::openMltVirtualClip(path);
             if (p.is_valid()) {
-                // Convert MLT XML to a virtual clip.
-                p.set(kShotcutVirtualClip, 1);
-                p.set("resource", path.toUtf8().constData());
                 first = false;
+            } else {
+                emit showStatusMessage(tr("Failed to open ").append(path));
+                continue;
             }
         } else {
             p = Mlt::Producer(MLT.profile(), path.toUtf8().constData());

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -2920,20 +2920,10 @@ void TimelineDock::handleDrop(int trackIndex, int position, QString xmlOrUrls)
                 longTask.reportProgress(Util::baseName(path), i++, count);
                 Mlt::Producer p;
                 if (path.endsWith(".mlt") || path.endsWith(".xml")) {
-                    if (Settings.playerGPU() && MLT.profile().is_explicit()) {
-                        Mlt::Profile testProfile;
-                        Mlt::Producer producer(testProfile, path.toUtf8().constData());
-                        if (testProfile.width() != MLT.profile().width()
-                                || testProfile.height() != MLT.profile().height()
-                                || Util::isFpsDifferent(MLT.profile().fps(), testProfile.fps())) {
-                            MAIN.showStatusMessage(QObject::tr("Failed to open ").append(path));
-                            continue;
-                        }
-                    }
-                    p = Mlt::Producer(MLT.profile(), path.toUtf8().constData());
-                    if (p.is_valid()) {
-                        p.set(kShotcutVirtualClip, 1);
-                        p.set("resource", path.toUtf8().constData());
+                    p = Util::openMltVirtualClip(path);
+                    if (!p.is_valid()) {
+                        MAIN.showStatusMessage(tr("Failed to open ").append(path));
+                        continue;
                     }
                 } else {
                     p = Mlt::Producer(MLT.profile(), path.toUtf8().constData());

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -58,6 +58,7 @@
 #include "database.h"
 #include "docks/timelinedock.h"
 #include "widgets/lumamixtransition.h"
+#include "widgets/mltclipproducerwidget.h"
 #include "qmltypes/qmlutilities.h"
 #include "qmltypes/qmlapplication.h"
 #include "autosavefile.h"
@@ -3472,6 +3473,8 @@ QWidget *MainWindow::loadProducerWidget(Mlt::Producer *producer)
         w = new CountProducerWidget(this);
     else if (service == "blipflash")
         w = new BlipProducerWidget(this);
+    else if (service == "xml-clip")
+        w = new MltClipProducerWidget(this);
     else if (producer->parent().get(kShotcutTransitionProperty)) {
         w = new LumaMixTransition(producer->parent(), this);
         scrollArea->setWidget(w);
@@ -3498,7 +3501,13 @@ QWidget *MainWindow::loadProducerWidget(Mlt::Producer *producer)
         return w;
     }
     if (w) {
-        dynamic_cast<AbstractProducerWidget *>(w)->setProducer(producer);
+        AbstractProducerWidget *pw = dynamic_cast<AbstractProducerWidget *>(w);
+        if (pw) {
+            pw->setProducer(producer);
+        } else {
+            LOG_ERROR() << "Widget is not a producer widget.";
+            return w;
+        }
         if (-1 != w->metaObject()->indexOfSignal("producerChanged(Mlt::Producer*)")) {
             connect(w, SIGNAL(producerChanged(Mlt::Producer *)), SLOT(onProducerChanged()));
             connect(w, SIGNAL(producerChanged(Mlt::Producer *)), m_filterController,

--- a/src/mltcontroller.cpp
+++ b/src/mltcontroller.cpp
@@ -184,31 +184,10 @@ bool Controller::openXML(const QString &filename)
 {
     bool error = true;
     close();
-    if (Settings.playerGPU() && profile().is_explicit()) {
-        Profile testProfile;
-        Producer producer(testProfile, filename.toUtf8().constData());
-        if (testProfile.width() != profile().width() || testProfile.height() != profile().height()
-                || Util::isFpsDifferent(profile().fps(), testProfile.fps())) {
-            return error;
-        }
-    }
-    Producer producer(profile(), filename.toUtf8().constData());
-    if (producer.is_valid()) {
-        double fps = profile().fps();
-        if (!profile().is_explicit()) {
-            profile().from_producer(producer);
-            profile().set_width(Util::coerceMultiple(profile().width()));
-            profile().set_height(Util::coerceMultiple(profile().height()));
-        }
-        updatePreviewProfile();
-        setPreviewScale(Settings.playerPreviewScale());
-        if (Util::isFpsDifferent(profile().fps(), fps)) {
-            // reopen with the correct fps
-            producer = Producer(profile(), filename.toUtf8().constData());
-        }
-        producer.set(kShotcutVirtualClip, 1);
-        producer.set("resource", filename.toUtf8().constData());
-        setProducer(new Producer(producer));
+
+    Mlt::Producer xmlProducer = Util::openMltVirtualClip(filename);
+    if (xmlProducer.is_valid()) {
+        setProducer(new Producer(xmlProducer));
         error = false;
     }
     return error;

--- a/src/models/metadatamodel.cpp
+++ b/src/models/metadatamodel.cpp
@@ -227,7 +227,8 @@ bool MetadataModel::filterAcceptsRow(int sourceRow, const QModelIndex &sourcePar
 }
 
 void MetadataModel::updateFilterMask(bool isClipProducer, bool isChainProducer,
-                                     bool isTrackProducer, bool isOutputProducer)
+                                     bool isTrackProducer, bool isOutputProducer,
+                                     bool isReverseSupported)
 {
     beginResetModel();
     m_isClipProducer = isClipProducer;
@@ -254,6 +255,12 @@ void MetadataModel::updateFilterMask(bool isClipProducer, bool isChainProducer,
     } else {
         m_filterMask |= outputOnlyMaskBit;
     }
+    m_isReverseSupported = isReverseSupported;
+    if (m_isReverseSupported) {
+        m_filterMask &= ~reverseMaskBit;
+    } else {
+        m_filterMask |= reverseMaskBit;
+    }
     endResetModel();
 }
 
@@ -267,6 +274,7 @@ unsigned InternalMetadataModel::computeFilterMask(const QmlMetadata *meta)
     if (!meta->isGpuCompatible()) mask |= MetadataModel::gpuIncompatibleMaskBit;
     if (meta->needsGPU()) mask |= MetadataModel::needsGPUMaskBit;
     if (meta->type() == QmlMetadata::Link) mask |= MetadataModel::linkMaskBit;
+    if (meta->seekReverse()) mask |= MetadataModel::reverseMaskBit;
     return mask;
 }
 

--- a/src/models/metadatamodel.h
+++ b/src/models/metadatamodel.h
@@ -61,6 +61,7 @@ public:
         linkMaskBit = 1 << 5,
         trackOnlyMaskBit = 1 << 6,
         outputOnlyMaskBit = 1 << 7,
+        reverseMaskBit = 1 << 8,
     };
 
     explicit MetadataModel(QObject *parent = 0);
@@ -78,7 +79,7 @@ public:
     }
     void setFilter(MetadataFilter);
     void updateFilterMask(bool isClipProducer, bool isChainProducer, bool isTrackProducer,
-                          bool isOutputProducer);
+                          bool isOutputProducer, bool isReverseSupported);
     QString search() const
     {
         return m_search;
@@ -100,6 +101,7 @@ private:
     bool m_isChainProducer;
     bool m_isTrackProducer;
     bool m_isOutputProducer;
+    bool m_isReverseSupported;
 };
 
 class InternalMetadataModel : public QAbstractListModel

--- a/src/util.h
+++ b/src/util.h
@@ -81,6 +81,7 @@ public:
     static void offerSingleFileConversion(QString &message, Mlt::Producer *producer, QWidget *parent);
     static double getAndroidFrameRate(Mlt::Producer *producer);
     static double getSuggestedFrameRate(Mlt::Producer *producer);
+    static Mlt::Producer openMltVirtualClip(const QString &path);
 };
 
 #endif // UTIL_H

--- a/src/widgets/mltclipproducerwidget.cpp
+++ b/src/widgets/mltclipproducerwidget.cpp
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2024 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mltclipproducerwidget.h"
+
+#include "Logger.h"
+#include "mltcontroller.h"
+#include "settings.h"
+#include "util.h"
+
+#include <QGridLayout>
+#include <QLabel>
+#include <QVBoxLayout>
+
+MltClipProducerWidget::MltClipProducerWidget(QWidget *parent) :
+    QWidget(parent)
+{
+    qDebug();
+    QVBoxLayout *vlayout = new QVBoxLayout();
+    m_nameLabel = new QLabel();
+    Util::setColorsToHighlight(m_nameLabel);
+    QFont font = m_nameLabel->font();
+    font.setBold(true);
+    m_nameLabel->setFont(font);
+    m_nameLabel->setAlignment(Qt::AlignCenter);
+    vlayout->addWidget(m_nameLabel);
+
+    int row = 0;
+    QGridLayout *glayout = new QGridLayout();
+    glayout->setHorizontalSpacing(4);
+    glayout->setVerticalSpacing(2);
+
+    glayout->addWidget(new QLabel(tr("Resolution")), row, 0, Qt::AlignRight);
+    glayout->addWidget(new QLabel(":"), row, 1, Qt::AlignLeft);
+    m_resolutionLabel = new QLabel();
+    glayout->addWidget(m_resolutionLabel, row, 2, Qt::AlignLeft);
+    row++;
+
+    glayout->addWidget(new QLabel(tr("Aspect ratio")), row, 0, Qt::AlignRight);
+    glayout->addWidget(new QLabel(":"), row, 1, Qt::AlignLeft);
+    m_aspectRatioLabel = new QLabel();
+    glayout->addWidget(m_aspectRatioLabel, row, 2, Qt::AlignLeft);
+    row++;
+
+    glayout->addWidget(new QLabel(tr("Frame rate")), row, 0, Qt::AlignRight);
+    glayout->addWidget(new QLabel(":"), row, 1, Qt::AlignLeft);
+    m_frameRateLabel = new QLabel();
+    glayout->addWidget(m_frameRateLabel, row, 2, Qt::AlignLeft);
+    row++;
+
+    glayout->addWidget(new QLabel(tr("Scan mode")), row, 0, Qt::AlignRight);
+    glayout->addWidget(new QLabel(":"), row, 1, Qt::AlignLeft);
+    m_scanModeLabel = new QLabel();
+    glayout->addWidget(m_scanModeLabel, row, 2, Qt::AlignLeft);
+    row++;
+
+    glayout->addWidget(new QLabel(tr("Colorspace")), row, 0, Qt::AlignRight);
+    glayout->addWidget(new QLabel(":"), row, 1, Qt::AlignLeft);
+    m_colorspaceLabel = new QLabel();
+    glayout->addWidget(m_colorspaceLabel, row, 2, Qt::AlignLeft);
+    row++;
+
+    glayout->addWidget(new QLabel(tr("Duration")), row, 0, Qt::AlignRight);
+    glayout->addWidget(new QLabel(":"), row, 1, Qt::AlignLeft);
+    m_durationLabel = new QLabel();
+    glayout->addWidget(m_durationLabel, row, 2, Qt::AlignLeft);
+    row++;
+
+    m_errorIcon = new QLabel();
+    glayout->addWidget(m_errorIcon, row, 0, Qt::AlignRight);
+    m_errorText = new QLabel();
+    glayout->addWidget(m_errorText, row, 2, Qt::AlignLeft);
+    row++;
+
+    auto spacer = new QWidget;
+    spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    glayout->addWidget(spacer, row, 2);
+    row++;
+
+    vlayout->addLayout(glayout);
+
+    this->setLayout (vlayout);
+}
+
+MltClipProducerWidget::~MltClipProducerWidget()
+{
+}
+
+Mlt::Producer *MltClipProducerWidget::newProducer(Mlt::Profile &)
+{
+    // Not implemented
+    return nullptr;
+}
+
+void MltClipProducerWidget::setProducer(Mlt::Producer *p)
+{
+    AbstractProducerWidget::setProducer(p);
+    if (!m_producer->is_valid()) {
+        m_nameLabel->setText("");
+        m_nameLabel->setToolTip("");
+        m_resolutionLabel->setText("");
+        m_aspectRatioLabel->setText("");
+        m_frameRateLabel->setText("");
+        m_scanModeLabel->setText("");
+        m_colorspaceLabel->setText("");
+        return;
+    }
+    QString resource = Util::GetFilenameFromProducer(m_producer.data());
+    QString name = Util::baseName(resource, true);
+    m_nameLabel->setText(name);
+    m_nameLabel->setToolTip(resource);
+    int width = m_producer->get_int("meta.media.width");
+    int height = m_producer->get_int("meta.media.height");
+    m_resolutionLabel->setText(QString("%1 x %2").arg(width).arg(height));
+    int sar_num = m_producer->get_int("meta.media.sample_aspect_num");
+    int sar_den = m_producer->get_int("meta.media.sample_aspect_den");
+    int dar_num = width * sar_num;
+    int dar_den = height * sar_den;
+    if (dar_den > 0) {
+        switch (int((double)dar_num / (double)dar_den * 100.0)) {
+        case 133:
+            dar_num = 4;
+            dar_den = 3;
+            break;
+        case 177:
+            dar_num = 16;
+            dar_den = 9;
+            break;
+        case 56:
+            dar_num = 9;
+            dar_den = 16;
+        }
+    }
+    m_aspectRatioLabel->setText(QString("%1 : %2").arg(dar_num).arg(dar_den));
+    int frame_rate_num = m_producer->get_int("meta.media.frame_rate_num");
+    int frame_rate_den = m_producer->get_int("meta.media.frame_rate_den");
+    double fps = (double)frame_rate_num / (double)frame_rate_den;
+    m_frameRateLabel->setText(tr("%L1 fps").arg(fps, 0, 'f', 6));
+    int progressive = m_producer->get_int("meta.media.progressive");
+    if (progressive)
+        m_scanModeLabel->setText(tr("Progressive"));
+    else
+        m_scanModeLabel->setText(tr("Interlaced"));
+    int colorspace = m_producer->get_int("meta.media.colorspace");
+    if (colorspace == 601)
+        m_colorspaceLabel->setText("ITU-R BT.601");
+    else if (colorspace)
+        m_colorspaceLabel->setText("ITU-R BT.709");
+    else
+        m_colorspaceLabel->setText("");
+    m_durationLabel->setText(QString(m_producer->get_length_time(Settings.timeFormat())));
+
+    QPalette standardPalette = palette();
+    QPalette mismatchPalette = standardPalette;
+    bool mismatch = false;
+    mismatchPalette.setColor(this->foregroundRole(), Qt::red);
+
+    QScopedPointer<Mlt::Profile> profile(m_producer->profile());
+    if (profile->width() == width &&
+            profile->height() == height) {
+        m_resolutionLabel->setPalette(standardPalette);
+    } else {
+        mismatch = true;
+        m_resolutionLabel->setPalette(mismatchPalette);
+    }
+    if (!Util::isFpsDifferent(profile->fps(), fps)) {
+        m_frameRateLabel->setPalette(standardPalette);
+    } else {
+        mismatch = true;
+        m_frameRateLabel->setPalette(mismatchPalette);
+    }
+    double darDiff = profile->dar() - ((double)dar_num / (double)dar_den);
+    if (fabs(darDiff) < 0.01) {
+        m_aspectRatioLabel->setPalette(standardPalette);
+    } else {
+        mismatch = true;
+        m_aspectRatioLabel->setPalette(mismatchPalette);
+    }
+    if (profile->progressive() == progressive) {
+        m_scanModeLabel->setPalette(standardPalette);
+    } else {
+        mismatch = true;
+        m_scanModeLabel->setPalette(mismatchPalette);
+    }
+
+    if (mismatch) {
+        QIcon icon = QIcon(":/icons/oxygen/32x32/status/task-attempt.png");
+        m_errorIcon->setPixmap(icon.pixmap(QSize(24, 24)));
+        m_errorText->setText(
+            tr("Subclip profile does not match project profile.\nThis may provide unexpected results"));
+    } else {
+        QIcon icon = QIcon(":/icons/oxygen/32x32/status/task-complete.png");
+        m_errorIcon->setPixmap(icon.pixmap(QSize(24, 24)));
+        m_errorText->setText(tr("Subclip profile matches project profile."));
+    }
+}

--- a/src/widgets/mltclipproducerwidget.h
+++ b/src/widgets/mltclipproducerwidget.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MLTCLIPPRODUCERWIDGET_H
+#define MLTCLIPPRODUCERWIDGET_H
+
+#include "abstractproducerwidget.h"
+
+#include <QWidget>
+#include <MltService.h>
+
+class QLabel;
+
+class MltClipProducerWidget : public QWidget, public AbstractProducerWidget
+{
+    Q_OBJECT
+
+public:
+    explicit MltClipProducerWidget(QWidget *parent = 0);
+    ~MltClipProducerWidget();
+
+    // AbstractProducerWidget overrides
+    Mlt::Producer *newProducer(Mlt::Profile &);
+    void setProducer(Mlt::Producer *);
+
+private:
+    QLabel *m_nameLabel;
+    QLabel *m_resolutionLabel;
+    QLabel *m_aspectRatioLabel;
+    QLabel *m_frameRateLabel;
+    QLabel *m_scanModeLabel;
+    QLabel *m_colorspaceLabel;
+    QLabel *m_durationLabel;
+    QLabel *m_errorIcon;
+    QLabel *m_errorText;
+};
+
+#endif //MLTCLIPPRODUCERWIDGET_H


### PR DESCRIPTION
This allows speed effects to XML clips.
It also adds a properties panel for XML clips.

Also fixes this issue:
https://forum.shotcut.org/t/issues-when-using-mlt-as-a-clip-in-a-timeline/44164

If the XML clip has a filter on the output, the filter will not appear in the project - it is "hidden" inside the chain.

Depends on
https://github.com/mltframework/mlt/pull/1047

This is what the properties panel looks like (similar to the Output properties):
![image](https://github.com/user-attachments/assets/a25bd3aa-260b-4bd5-bdf8-edd66a4b1bd2)

The way this is designed, the embedded XML will always be rendered at the XML clip profile (by the consumer producer). Then it will be converted to the project profile if necessary.

Discussion: Should we show a warning in the properties panel if the XML clip profile does not match the project profile?

Discussion: Do we want to add a button or method to lauch Shotcut from the properties panel so the clip can be edited in another instance of Shotcut? Maybe that would be confusing to have two instances at the same time.