### PR TITLE
refactor: replace QString(tr()) with tr() to simplify code

### DIFF
--- a/src/docks/encodedock.cpp
+++ b/src/docks/encodedock.cpp
@@ -2266,7 +2266,7 @@ void EncodeDock::on_videoBufferDurationChanged()
     QString vb = ui->videoBitrateCombo->currentText();
     vb.replace('k', "").replace('M', "000");
     double duration = (double)ui->videoBufferSizeSpinner->value() * 8.0 / vb.toDouble();
-    QString label = QString(tr("KiB (%1s)")).arg(duration);
+    QString label = tr("KiB (%1s)").arg(duration);
     ui->videoBufferSizeSuffixLabel->setText(label);
 }
 

--- a/src/models/resourcemodel.cpp
+++ b/src/models/resourcemodel.cpp
@@ -294,7 +294,7 @@ QVariant ResourceModel::data(const QModelIndex &index, int role) const
             QString path = Util::GetFilenameFromProducer(producer, true);
             QFileInfo info(path);
             double size = (double)info.size() / (double)(1024 * 1024);
-            result = QString(tr("%1MB")).arg(QLocale().toString(size, 'f', 2));
+            result = tr("%1MB").arg(QLocale().toString(size, 'f', 2));
             break;
         }
         case COLUMN_VID_DESCRIPTION: {
@@ -309,7 +309,7 @@ QVariant ResourceModel::data(const QModelIndex &index, int role) const
                     QString key = QStringLiteral("meta.media.%1.codec.name").arg(index);
                     QString codec(producer->get(key.toLatin1().constData()));
                     double frame_rate = frame_rate_num / frame_rate_den;
-                    result = QString(tr("%1 %2x%3 %4fps"))
+                    result = tr("%1 %2x%3 %4fps")
                              .arg(codec)
                              .arg(width)
                              .arg(height)

--- a/src/widgets/blipproducerwidget.cpp
+++ b/src/widgets/blipproducerwidget.cpp
@@ -84,5 +84,5 @@ void BlipProducerWidget::on_preset_saveClicked()
 
 QString BlipProducerWidget::detail() const
 {
-    return QString(tr("Period: %1s")).arg(ui->periodSpinBox->value());
+    return tr("Period: %1s").arg(ui->periodSpinBox->value());
 }

--- a/src/widgets/countproducerwidget.cpp
+++ b/src/widgets/countproducerwidget.cpp
@@ -219,6 +219,6 @@ void CountProducerWidget::on_preset_saveClicked()
 
 QString CountProducerWidget::detail() const
 {
-    return QString(tr("Count: %1 %2")).arg(ui->directionCombo->currentText()).arg(
+    return tr("Count: %1 %2").arg(ui->directionCombo->currentText()).arg(
                ui->styleCombo->currentText());
 }

--- a/src/widgets/scopes/videohistogramscopewidget.cpp
+++ b/src/widgets/scopes/videohistogramscopewidget.cpp
@@ -196,9 +196,9 @@ void VideoHistogramScopeWidget::mouseMoveEvent(QMouseEvent *event)
         qreal ire0x = width() * IRE0 / 256;
         qreal ireStep = (ire0x - ire100x) / 100.0;
         int ire = (ire0x - event->pos().x()) / ireStep;
-        text = QString(tr("Value: %1\nIRE: %2")).arg(QString::number(value), QString::number(ire));
+        text = tr("Value: %1\nIRE: %2").arg(QString::number(value), QString::number(ire));
     } else {
-        text = QString(tr("Value: %1")).arg(QString::number(value));
+        text = tr("Value: %1").arg(QString::number(value));
     }
 
     QToolTip::showText(event->globalPosition().toPoint(), text);

--- a/src/widgets/scopes/videorgbparadescopewidget.cpp
+++ b/src/widgets/scopes/videorgbparadescopewidget.cpp
@@ -169,10 +169,10 @@ void VideoRgbParadeScopeWidget::mouseMoveEvent(QMouseEvent *event)
 
     if (frameWidth != 0) {
         int pixel = frameWidth * channelX / channelWidth;
-        text =  QString(tr("Channel: %1\nPixel: %2\nValue: %3")).arg(channelLabel).arg(QString::number(
-                                                                                           pixel)).arg(QString::number(value));
+        text =  tr("Channel: %1\nPixel: %2\nValue: %3").arg(channelLabel).arg(QString::number(
+                                                                                  pixel)).arg(QString::number(value));
     } else {
-        text =  QString(tr("Channel: %1\nValue: %2")).arg(channelLabel).arg(QString::number(value));
+        text =  tr("Channel: %1\nValue: %2").arg(channelLabel).arg(QString::number(value));
     }
     QToolTip::showText(event->globalPosition().toPoint(), text);
 }

--- a/src/widgets/scopes/videorgbwaveformscopewidget.cpp
+++ b/src/widgets/scopes/videorgbwaveformscopewidget.cpp
@@ -155,9 +155,9 @@ void VideoRgbWaveformScopeWidget::mouseMoveEvent(QMouseEvent *event)
 
     if (frameWidth != 0) {
         int pixel = frameWidth * event->pos().x() / width();
-        text =  QString(tr("Pixel: %1\nValue: %2")).arg(QString::number(pixel)).arg(QString::number(value));
+        text =  tr("Pixel: %1\nValue: %2").arg(QString::number(pixel)).arg(QString::number(value));
     } else {
-        text =  QString(tr("Value: %1")).arg(QString::number(value));
+        text =  tr("Value: %1").arg(QString::number(value));
     }
     QToolTip::showText(event->globalPosition().toPoint(), text);
 }

--- a/src/widgets/scopes/videovectorscopewidget.cpp
+++ b/src/widgets/scopes/videovectorscopewidget.cpp
@@ -241,8 +241,8 @@ void VideoVectorScopeWidget::mouseMoveEvent(QMouseEvent *event)
     qreal realY = (qreal)event->pos().y() - ((qreal)height() - squareRect.height()) / 2;
     qreal u = realX * 255.0 / squareRect.width();
     qreal v = (squareRect.height() - realY) * 255.0 / squareRect.height();
-    QString text =  QString(tr("U: %1\nV: %2")).arg(QString::number(qRound(u)),
-                                                    QString::number(qRound(v)));
+    QString text =  tr("U: %1\nV: %2").arg(QString::number(qRound(u)),
+                                           QString::number(qRound(v)));
     QToolTip::showText(event->globalPosition().toPoint(), text);
 }
 

--- a/src/widgets/scopes/videowaveformscopewidget.cpp
+++ b/src/widgets/scopes/videowaveformscopewidget.cpp
@@ -140,9 +140,9 @@ void VideoWaveformScopeWidget::mouseMoveEvent(QMouseEvent *event)
 
     if (frameWidth != 0) {
         int pixel = frameWidth * event->pos().x() / width();
-        text =  QString(tr("Pixel: %1\nIRE: %2")).arg(QString::number(pixel), QString::number(ire));
+        text =  tr("Pixel: %1\nIRE: %2").arg(QString::number(pixel), QString::number(ire));
     } else {
-        text =  QString(tr("IRE: %1")).arg(QString::number(ire));
+        text =  tr("IRE: %1").arg(QString::number(ire));
     }
     QToolTip::showText(event->globalPosition().toPoint(), text);
 }

--- a/src/widgets/scopes/videozoomwidget.cpp
+++ b/src/widgets/scopes/videozoomwidget.cpp
@@ -202,7 +202,7 @@ void VideoZoomWidget::mouseMoveEvent(QMouseEvent *event)
     /*
         // Create a tool tip to display pixel information
         PixelValues values = pixelToValues(currMousePixel);
-        QString text =  QString(tr("Zoom: %1x\nPixel: %2,%3\nRGB: %4 %5 %6\nYUV: %7 %8 %9")).arg(
+        QString text =  tr("Zoom: %1x\nPixel: %2,%3\nRGB: %4 %5 %6\nYUV: %7 %8 %9").arg(
                             QString::number(m_zoom)).arg(
                             QString::number(currMousePixel.x() + 1)).arg(
                             QString::number(currMousePixel.y() + 1)).arg(

--- a/src/widgets/toneproducerwidget.cpp
+++ b/src/widgets/toneproducerwidget.cpp
@@ -93,6 +93,6 @@ void ToneProducerWidget::on_preset_saveClicked()
 
 QString ToneProducerWidget::detail() const
 {
-    return QString(tr("Tone: %1Hz %2dB")).arg(ui->frequencySpinBox->value()).arg(
+    return tr("Tone: %1Hz %2dB").arg(ui->frequencySpinBox->value()).arg(
                ui->levelSpinBox->value());
 }


### PR DESCRIPTION
- `QObject::tr()` returns `QString`, hence it is unnecessary to pass its return value to `QString()` constructor.