### PR TITLE
refactor: remove QString::number() in arg() arguments

### DIFF
--- a/src/widgets/scopes/audiowaveformscopewidget.cpp
+++ b/src/widgets/scopes/audiowaveformscopewidget.cpp
@@ -259,15 +259,15 @@ void AudioWaveformScopeWidget::mouseMoveEvent(QMouseEvent *event)
 
     qreal position = (qreal)event->pos().x() / (qreal)width();
     int sample = (qreal)samples * position;
-    QString text = tr("Sample: %1\n").arg(QString::number(sample + 1));
+    QString text = tr("Sample: %1\n").arg(sample + 1);
 
     for (int c = 0; c < channels; c++) {
         const int16_t *q = audio + (channels * sample) + c;
         qreal scaledValue = (qreal) * q / MAX_AMPLITUDE;
         qreal dbValue = 20 * log(fabs(scaledValue));
         if (dbValue < 0.01 && dbValue > -0.01) dbValue = 0.0;
-        text += tr("Ch: %1: %2 (%3 dBFS)").arg(QString::number(c + 1), QString::number(scaledValue, 'f', 2),
-                                               QString::number(dbValue, 'f', 2));
+        text += tr("Ch: %1: %2 (%3 dBFS)").arg(c + 1).arg(scaledValue, 0, 'f', 2)
+                .arg(dbValue, 0, 'f', 2);
         if ( c != channels - 1 ) {
             text += "\n";
         }

--- a/src/widgets/scopes/videohistogramscopewidget.cpp
+++ b/src/widgets/scopes/videohistogramscopewidget.cpp
@@ -148,8 +148,7 @@ void VideoHistogramScopeWidget::drawHistogram(QPainter &p, QString title, QColor
     p.setPen(pen);
     QString text;
     if (maxLevel > minValue)
-        text = QStringLiteral("%1\tMin: %2\tMax: %3").arg(title, QString::number(minValue),
-                                                          QString::number(maxValue));
+        text = QStringLiteral("%1\tMin: %2\tMax: %3").arg(title).arg(minValue).arg(maxValue);
     else
         text = title;
     p.drawText(textpad, rect.y() + fm.height() + textpad, text);
@@ -196,9 +195,9 @@ void VideoHistogramScopeWidget::mouseMoveEvent(QMouseEvent *event)
         qreal ire0x = width() * IRE0 / 256;
         qreal ireStep = (ire0x - ire100x) / 100.0;
         int ire = (ire0x - event->pos().x()) / ireStep;
-        text = tr("Value: %1\nIRE: %2").arg(QString::number(value), QString::number(ire));
+        text = tr("Value: %1\nIRE: %2").arg(value).arg(ire);
     } else {
-        text = tr("Value: %1").arg(QString::number(value));
+        text = tr("Value: %1").arg(value);
     }
 
     QToolTip::showText(event->globalPosition().toPoint(), text);

--- a/src/widgets/scopes/videorgbparadescopewidget.cpp
+++ b/src/widgets/scopes/videorgbparadescopewidget.cpp
@@ -169,10 +169,9 @@ void VideoRgbParadeScopeWidget::mouseMoveEvent(QMouseEvent *event)
 
     if (frameWidth != 0) {
         int pixel = frameWidth * channelX / channelWidth;
-        text =  tr("Channel: %1\nPixel: %2\nValue: %3").arg(channelLabel).arg(QString::number(
-                                                                                  pixel)).arg(QString::number(value));
+        text =  tr("Channel: %1\nPixel: %2\nValue: %3").arg(channelLabel).arg(pixel).arg(value);
     } else {
-        text =  tr("Channel: %1\nValue: %2").arg(channelLabel).arg(QString::number(value));
+        text =  tr("Channel: %1\nValue: %2").arg(channelLabel).arg(value);
     }
     QToolTip::showText(event->globalPosition().toPoint(), text);
 }

--- a/src/widgets/scopes/videorgbwaveformscopewidget.cpp
+++ b/src/widgets/scopes/videorgbwaveformscopewidget.cpp
@@ -155,9 +155,9 @@ void VideoRgbWaveformScopeWidget::mouseMoveEvent(QMouseEvent *event)
 
     if (frameWidth != 0) {
         int pixel = frameWidth * event->pos().x() / width();
-        text =  tr("Pixel: %1\nValue: %2").arg(QString::number(pixel)).arg(QString::number(value));
+        text =  tr("Pixel: %1\nValue: %2").arg(pixel).arg(value);
     } else {
-        text =  tr("Value: %1").arg(QString::number(value));
+        text =  tr("Value: %1").arg(value);
     }
     QToolTip::showText(event->globalPosition().toPoint(), text);
 }

--- a/src/widgets/scopes/videovectorscopewidget.cpp
+++ b/src/widgets/scopes/videovectorscopewidget.cpp
@@ -241,8 +241,7 @@ void VideoVectorScopeWidget::mouseMoveEvent(QMouseEvent *event)
     qreal realY = (qreal)event->pos().y() - ((qreal)height() - squareRect.height()) / 2;
     qreal u = realX * 255.0 / squareRect.width();
     qreal v = (squareRect.height() - realY) * 255.0 / squareRect.height();
-    QString text =  tr("U: %1\nV: %2").arg(QString::number(qRound(u)),
-                                           QString::number(qRound(v)));
+    QString text =  tr("U: %1\nV: %2").arg(qRound(u)).arg(qRound(v));
     QToolTip::showText(event->globalPosition().toPoint(), text);
 }
 

--- a/src/widgets/scopes/videowaveformscopewidget.cpp
+++ b/src/widgets/scopes/videowaveformscopewidget.cpp
@@ -140,9 +140,9 @@ void VideoWaveformScopeWidget::mouseMoveEvent(QMouseEvent *event)
 
     if (frameWidth != 0) {
         int pixel = frameWidth * event->pos().x() / width();
-        text =  tr("Pixel: %1\nIRE: %2").arg(QString::number(pixel), QString::number(ire));
+        text =  tr("Pixel: %1\nIRE: %2").arg(pixel).arg(ire);
     } else {
-        text =  tr("IRE: %1").arg(QString::number(ire));
+        text =  tr("IRE: %1").arg(ire);
     }
     QToolTip::showText(event->globalPosition().toPoint(), text);
 }


### PR DESCRIPTION
- `QString::arg()` has overload for numeric data types, hence it is unnecessary to use `QString::number()` in `QString::arg()` arguments.