### PR TITLE
Add curve option for audio fade in/out filters

### DIFF
--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -1497,6 +1497,7 @@ void MultitrackModel::fadeIn(int trackIndex, int clipIndex, int duration)
                 filter.reset(getFilter("fadeInVolume", info->producer));
 
                 if (duration > 0) {
+                    mlt_keyframe_type type = (mlt_keyframe_type)Settings.audioInCurve();
                     // Add audio filter if needed.
                     if (!filter) {
                         Mlt::Filter f(MLT.profile(), "volume");
@@ -1504,12 +1505,19 @@ void MultitrackModel::fadeIn(int trackIndex, int clipIndex, int duration)
                         info->producer->attach(f);
                         filter.reset(new Mlt::Filter(f));
                         filter->set_in_and_out(info->frame_in, info->frame_out);
+                    } else {
+                        Mlt::Animation animation(filter->get_animation("level"));
+                        if (animation.is_valid()) {
+                            type = animation.key_get_type(0);
+                        }
                     }
 
                     // Adjust audio filter.
                     filter->clear("level");
                     filter->anim_set("level", -60, 0);
                     filter->anim_set("level", 0, duration - 1);
+                    Mlt::Animation animation(filter->get_animation("level"));
+                    animation.key_set_type(0, type);
                     filter->set(kShotcutAnimInProperty, duration);
                     isChanged = true;
                 } else if (filter) {
@@ -1614,6 +1622,7 @@ void MultitrackModel::fadeOut(int trackIndex, int clipIndex, int duration)
                 filter.reset(getFilter("fadeOutVolume", info->producer));
 
                 if (duration > 0) {
+                    mlt_keyframe_type type = (mlt_keyframe_type)Settings.audioOutCurve();
                     // Add audio filter if needed.
                     if (!filter) {
                         Mlt::Filter f(MLT.profile(), "volume");
@@ -1621,12 +1630,19 @@ void MultitrackModel::fadeOut(int trackIndex, int clipIndex, int duration)
                         info->producer->attach(f);
                         filter.reset(new Mlt::Filter(f));
                         filter->set_in_and_out(info->frame_in, info->frame_out);
+                    } else {
+                        Mlt::Animation animation(filter->get_animation("level"));
+                        if (animation.is_valid()) {
+                            type = animation.key_get_type(0);
+                        }
                     }
 
                     // Adjust audio filter.
                     filter->clear("level");
                     filter->anim_set("level", 0, info->frame_count - duration);
                     filter->anim_set("level", -60, info->frame_count - 1);
+                    Mlt::Animation animation(filter->get_animation("level"));
+                    animation.key_set_type(0, type);
                     filter->set(kShotcutAnimOutProperty, duration);
                     isChanged = true;
                 } else if (filter) {

--- a/src/qml/filters/audio_fadein/ui.qml
+++ b/src/qml/filters/audio_fadein/ui.qml
@@ -102,7 +102,7 @@ Item {
         Label {
             id: curveLabel
 
-            text: qsTr('Curve')
+            text: qsTr('Type')
             Layout.alignment: Qt.AlignRight
         }
 

--- a/src/qml/filters/audio_fadein/ui.qml
+++ b/src/qml/filters/audio_fadein/ui.qml
@@ -27,8 +27,14 @@ Item {
     height: 50
     objectName: 'fadeIn'
     Component.onCompleted: {
+        _blockUpdate = true;
         if (filter.isNew) {
             duration = Math.ceil(settings.audioInDuration * profile.fps);
+            filter.animateIn = duration;
+            filter.resetProperty('level');
+            filter.set('level', -60, 0);
+            filter.set('level', 0, Math.min(duration, filter.duration) - 1);
+            filter.setKeyFrameType('level', 0, settings.audioInCurve);
         } else if (filter.animateIn === 0) {
             // Convert legacy filter.
             duration = filter.duration;
@@ -37,6 +43,8 @@ Item {
         } else {
             duration = filter.animateIn;
         }
+        curveCombo.setCurrentValue(filter.getKeyFrameType('level', 0));
+        _blockUpdate = false;
     }
 
     Connections {
@@ -49,38 +57,78 @@ Item {
         target: filter
     }
 
-    ColumnLayout {
+    GridLayout {
         anchors.fill: parent
-        anchors.margins: 8
+        columns: 5
 
-        RowLayout {
-            Label {
-                id: durationLabel
-                text: qsTr('Duration')
+        Label {
+            id: durationLabel
+
+            text: qsTr('Duration')
+            Layout.alignment: Qt.AlignRight
+        }
+
+        Shotcut.TimeSpinner {
+            id: timeSpinner
+
+            undoButtonVisible: false
+            saveButtonVisible: false
+            minimumValue: 2
+            maximumValue: 5000
+            onValueChanged: {
+                if (_blockUpdate)
+                    return;
+                filter.startUndoParameterCommand(durationLabel.text);
+                filter.animateIn = duration;
+                filter.resetProperty('level');
+                filter.set('level', -60, 0, curveCombo.currentValue);
+                filter.set('level', 0, Math.min(duration, filter.duration) - 1);
+                filter.endUndoCommand();
             }
+        }
 
-            Shotcut.TimeSpinner {
-                id: timeSpinner
+        Shotcut.UndoButton {
+            onClicked: duration = Math.ceil(settings.audioInDuration * profile.fps)
+        }
 
-                minimumValue: 2
-                maximumValue: 5000
-                onValueChanged: {
-                    if (_blockUpdate)
-                        return;
-                    filter.startUndoParameterCommand(durationLabel.text);
-                    filter.animateIn = duration;
-                    filter.resetProperty('level');
-                    filter.set('level', -60, 0);
-                    filter.set('level', 0, Math.min(duration, filter.duration) - 1);
-                    filter.endUndoCommand();
-                }
-                onSetDefaultClicked: {
-                    duration = Math.ceil(settings.audioInDuration * profile.fps);
-                }
-                onSaveDefaultClicked: {
-                    settings.audioInDuration = duration / profile.fps;
-                }
+        Shotcut.SaveDefaultButton {
+            onClicked: settings.audioInDuration = duration / profile.fps
+        }
+
+        Item {
+            Layout.fillWidth: true
+        }
+
+        Label {
+            id: curveLabel
+
+            text: qsTr('Curve')
+            Layout.alignment: Qt.AlignRight
+        }
+
+        Shotcut.CurveComboBox {
+            id: curveCombo
+
+            implicitContentWidthPolicy: ComboBox.WidestText
+            onActivated: {
+                if (_blockUpdate)
+                    return;
+                filter.startUndoParameterCommand(curveLabel.text);
+                filter.setKeyFrameType('level', 0, curveCombo.currentValue);
+                filter.endUndoCommand();
             }
+        }
+
+        Shotcut.UndoButton {
+            onClicked: curveCombo.setCurrentValue(settings.audioInCurve)
+        }
+
+        Shotcut.SaveDefaultButton {
+            onClicked: settings.audioInCurve = curveCombo.currentValue
+        }
+
+        Item {
+            Layout.fillWidth: true
         }
 
         Item {

--- a/src/qml/filters/audio_fadeout/ui.qml
+++ b/src/qml/filters/audio_fadeout/ui.qml
@@ -105,7 +105,7 @@ Item {
         Label {
             id: curveLabel
 
-            text: qsTr('Curve')
+            text: qsTr('Type')
             Layout.alignment: Qt.AlignRight
         }
 

--- a/src/qml/modules/Shotcut/Controls/CurveComboBox.qml
+++ b/src/qml/modules/Shotcut/Controls/CurveComboBox.qml
@@ -33,84 +33,20 @@ Shotcut.ComboBox {
     model: ListModel {
         id: curveModel
         ListElement {
-            text: qsTr('Linear')
+            text: qsTr('Natural')
             value: 1
         }
         ListElement {
-            text: qsTr('Smooth')
-            value: 4
-        }
-        ListElement {
-            text: qsTr('Ease In Sinusoidal')
-            value: 5
-        }
-        ListElement {
-            text: qsTr('Ease Out Sinusoidal')
-            value: 6
-        }
-        ListElement {
-            text: qsTr('Ease In/Out Sinusoidal')
-            value: 7
-        }
-        ListElement {
-            text: qsTr('Ease In Quadratic')
-            value: 8
-        }
-        ListElement {
-            text: qsTr('Ease Out Quadratic')
-            value: 9
-        }
-        ListElement {
-            text: qsTr('Ease In/Out Quadratic')
-            value: 10
-        }
-        ListElement {
-            text: qsTr('Ease In Cubic')
-            value: 11
-        }
-        ListElement {
-            text: qsTr('Ease Out Cubic')
-            value: 12
-        }
-        ListElement {
-            text: qsTr('Ease In/Out Cubic')
-            value: 13
-        }
-        ListElement {
-            text: qsTr('Ease In Quartic')
-            value: 14
-        }
-        ListElement {
-            text: qsTr('Ease Out Quartic')
-            value: 15
-        }
-        ListElement {
-            text: qsTr('Ease In/Out Quartic')
+            text: qsTr('S-Curve')
             value: 16
         }
         ListElement {
-            text: qsTr('Ease In Exponential')
-            value: 17
+            text: qsTr('Fast-Slow')
+            value: 15
         }
         ListElement {
-            text: qsTr('Ease Out Exponential')
-            value: 18
-        }
-        ListElement {
-            text: qsTr('Ease In/Out Exponential')
-            value: 19
-        }
-        ListElement {
-            text: qsTr('Ease In Circular')
-            value: 20
-        }
-        ListElement {
-            text: qsTr('Ease Out Circular')
-            value: 21
-        }
-        ListElement {
-            text: qsTr('Ease In/Out Circular')
-            value: 22
+            text: qsTr('Slow-Fast')
+            value: 14
         }
     }
 

--- a/src/qml/modules/Shotcut/Controls/CurveComboBox.qml
+++ b/src/qml/modules/Shotcut/Controls/CurveComboBox.qml
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2024 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import QtQml.Models
+import Shotcut.Controls as Shotcut
+
+Shotcut.ComboBox {
+    id: curveCombo
+
+    function setCurrentValue(value) {
+        var modelIndex = indexOfValue(value);
+        if (modelIndex >= 0) {
+            currentIndex = modelIndex;
+        } else {
+            console.log("Invalid value for curve", value);
+            currentIndex = 0;
+        }
+    }
+
+    model: ListModel {
+        id: curveModel
+        ListElement {
+            text: qsTr('Linear')
+            value: 1
+        }
+        ListElement {
+            text: qsTr('Smooth')
+            value: 4
+        }
+        ListElement {
+            text: qsTr('Ease In Sinusoidal')
+            value: 5
+        }
+        ListElement {
+            text: qsTr('Ease Out Sinusoidal')
+            value: 6
+        }
+        ListElement {
+            text: qsTr('Ease In/Out Sinusoidal')
+            value: 7
+        }
+        ListElement {
+            text: qsTr('Ease In Quadratic')
+            value: 8
+        }
+        ListElement {
+            text: qsTr('Ease Out Quadratic')
+            value: 9
+        }
+        ListElement {
+            text: qsTr('Ease In/Out Quadratic')
+            value: 10
+        }
+        ListElement {
+            text: qsTr('Ease In Cubic')
+            value: 11
+        }
+        ListElement {
+            text: qsTr('Ease Out Cubic')
+            value: 12
+        }
+        ListElement {
+            text: qsTr('Ease In/Out Cubic')
+            value: 13
+        }
+        ListElement {
+            text: qsTr('Ease In Quartic')
+            value: 14
+        }
+        ListElement {
+            text: qsTr('Ease Out Quartic')
+            value: 15
+        }
+        ListElement {
+            text: qsTr('Ease In/Out Quartic')
+            value: 16
+        }
+        ListElement {
+            text: qsTr('Ease In Exponential')
+            value: 17
+        }
+        ListElement {
+            text: qsTr('Ease Out Exponential')
+            value: 18
+        }
+        ListElement {
+            text: qsTr('Ease In/Out Exponential')
+            value: 19
+        }
+        ListElement {
+            text: qsTr('Ease In Circular')
+            value: 20
+        }
+        ListElement {
+            text: qsTr('Ease Out Circular')
+            value: 21
+        }
+        ListElement {
+            text: qsTr('Ease In/Out Circular')
+            value: 22
+        }
+    }
+
+    textRole: "text"
+    valueRole: "value"
+}

--- a/src/qml/modules/Shotcut/Controls/qmldir
+++ b/src/qml/modules/Shotcut/Controls/qmldir
@@ -20,6 +20,7 @@ KeyframableFilter 1.0 KeyframableFilter.qml
 ToolButton 1.0 ToolButton.qml
 HoverTip 1.0 HoverTip.qml
 ComboBox 1.0 ComboBox.qml
+CurveComboBox 1.0 CurveComboBox.qml
 EditMenu 1.0 EditMenu.qml
 TipBox 1.0 TipBox.qml
 Marker 1.0 Marker.qml

--- a/src/qmltypes/qmlfilter.cpp
+++ b/src/qmltypes/qmlfilter.cpp
@@ -900,6 +900,18 @@ mlt_keyframe_type QmlFilter::getKeyframeType(Mlt::Animation &animation, int posi
     return result;
 }
 
+int QmlFilter::getKeyFrameType(const QString &name, int keyIndex)
+{
+    Mlt::Animation animation = getAnimation(name);
+    return (int)animation.key_get_type(keyIndex);
+}
+
+void QmlFilter::setKeyFrameType(const QString &name, int keyIndex, int type)
+{
+    Mlt::Animation animation = getAnimation(name);
+    animation.key_set_type(keyIndex, (mlt_keyframe_type)type);
+}
+
 int QmlFilter::getNextKeyframePosition(const QString &name, int position)
 {
     int result = -1;

--- a/src/qmltypes/qmlfilter.h
+++ b/src/qmltypes/qmlfilter.h
@@ -128,6 +128,8 @@ public:
     Q_INVOKABLE int keyframeCount(const QString &name);
     mlt_keyframe_type getKeyframeType(Mlt::Animation &animation, int position,
                                       mlt_keyframe_type defaultType);
+    Q_INVOKABLE int getKeyFrameType(const QString &name, int keyIndex);
+    Q_INVOKABLE void setKeyFrameType(const QString &name, int keyIndex, int type);
     Q_INVOKABLE int getNextKeyframePosition(const QString &name, int position);
     Q_INVOKABLE int getPrevKeyframePosition(const QString &name, int position);
     Q_INVOKABLE bool isAtLeastVersion(const QString &version);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -976,6 +976,28 @@ void ShotcutSettings::setVideoOutDuration(double d)
     emit videoOutDurationChanged();
 }
 
+int ShotcutSettings::audioInCurve() const
+{
+    return settings.value("filter/audioInCurve", mlt_keyframe_linear).toInt();
+}
+
+void ShotcutSettings::setAudioInCurve(int c)
+{
+    settings.setValue("filter/audioInCurve", c);
+    emit audioInCurveChanged();
+}
+
+int ShotcutSettings::audioOutCurve() const
+{
+    return settings.value("filter/audioOutCurve", mlt_keyframe_linear).toInt();
+}
+
+void ShotcutSettings::setAudioOutCurve(int c)
+{
+    settings.setValue("filter/audioOutCurve", c);
+    emit audioOutCurveChanged();
+}
+
 bool ShotcutSettings::askOutputFilter() const
 {
     return settings.value("filter/askOutput", true).toBool();

--- a/src/settings.h
+++ b/src/settings.h
@@ -62,6 +62,10 @@ class ShotcutSettings : public QObject
                videoInDurationChanged)
     Q_PROPERTY(double videoOutDuration READ videoOutDuration WRITE setVideoOutDuration NOTIFY
                videoOutDurationChanged)
+    Q_PROPERTY(double audioInCurve READ audioInCurve WRITE setAudioInCurve NOTIFY
+               audioInCurveChanged)
+    Q_PROPERTY(double audioOutCurve READ audioOutCurve WRITE setAudioOutCurve NOTIFY
+               audioOutCurveChanged)
     Q_PROPERTY(bool smallIcons READ smallIcons WRITE setSmallIcons NOTIFY smallIconsChanged)
     Q_PROPERTY(bool askOutputFilter READ askOutputFilter WRITE setAskOutputFilter NOTIFY
                askOutputFilterChanged)
@@ -236,6 +240,10 @@ public:
     void setVideoInDuration(double);
     double videoOutDuration() const;
     void setVideoOutDuration(double);
+    int audioInCurve() const;
+    void setAudioInCurve(int);
+    int audioOutCurve() const;
+    void setAudioOutCurve(int);
     bool askOutputFilter() const;
     void setAskOutputFilter(bool);
 
@@ -379,6 +387,8 @@ signals:
     void audioOutDurationChanged();
     void videoInDurationChanged();
     void videoOutDurationChanged();
+    void audioInCurveChanged();
+    void audioOutCurveChanged();
     void playlistThumbnailsChanged();
     void viewModeChanged();
     void filesViewModeChanged();


### PR DESCRIPTION
As suggested here:
https://forum.shotcut.org/t/add-perceptually-linear-option-to-audio-fade-in-out/43680

In that suggestion, the poster requests a "perceptually linear" curve. The current keyframe type is linear, but it is operating on dB. So I would argue that it is already perceptually linear. Nonetheless, it is not that hard to expose the existing keyframe interpolation types. So this PR provides a drop-down box in the filter panels for fade in/out to allow the user to select the curve type. 

![image](https://github.com/user-attachments/assets/18665d1f-b09e-49cd-85b9-d2689ce46dd5)

![image](https://github.com/user-attachments/assets/3d45fb1b-4058-424f-9107-5130e178adad)

Here is the original (linear) fade waveform:
![image](https://github.com/user-attachments/assets/6058f20f-2e37-48b9-8f16-5b88775b0594)

Here is an example using Ease Out Exponential:
![image](https://github.com/user-attachments/assets/d58ce1ae-5b49-45d3-9053-b0fc839acff6)

Here is an example using Ease In/Out Circular:
![image](https://github.com/user-attachments/assets/bbb465b1-611c-4635-86e9-739cb4c50f5d)

Note 1: it is not possible to provide a linear VALUE option since that would require the inverse of "20 log" which we do not offer.

Note 2: I did not try to render the fade line in the timeline to represent the curve type

Note 3: I did not provide options for the "bouncy" interpolation types

Discussion topic 1: would it be worthwhile to also offer this for the video fade filters?

Discussion topic 2: is "Curve" the best label for this? We don't really expose that it is using keyframes under the hood. So I did not want to use "Keyframe Type". Other ideas?

Discussion topic 3: Should I try to add some kind of graphical representation of the interpolation type (like we do in the keyframe type menu)? I could change the combobox do a menu with icons.
