### PR TITLE
Patch: introduce proper plural form strings and fix typo

### DIFF
--- a/src/commands/subtitlecommands.cpp
+++ b/src/commands/subtitlecommands.cpp
@@ -102,7 +102,7 @@ OverwriteSubtitlesCommand::OverwriteSubtitlesCommand(SubtitlesModel &model, int 
     if (m_newSubtitles.size() == 1) {
         setText(QObject::tr("Add subtitle"));
     } else {
-        setText(QObject::tr("Add %1 subtitles").arg(m_newSubtitles.size()));
+        setText(QObject::tr("Add %n subtitles", nullptr, m_newSubtitles.size()));
     }
 
     if (m_newSubtitles.size() <= 0) {
@@ -155,7 +155,7 @@ RemoveSubtitlesCommand::RemoveSubtitlesCommand(SubtitlesModel &model, int trackI
     if (m_items.size() == 1) {
         setText(QObject::tr("Remove subtitle"));
     } else {
-        setText(QObject::tr("Remove %1 subtitles").arg(m_items.size()));
+        setText(QObject::tr("Remove %n subtitles", nullptr, m_items.size()));
     }
 }
 
@@ -288,7 +288,7 @@ MoveSubtitlesCommand::MoveSubtitlesCommand(SubtitlesModel &model, int trackIndex
     if (m_oldSubtitles.size() == 1) {
         setText(QObject::tr("Move subtitle"));
     } else {
-        setText(QObject::tr("Move %1 subtitles").arg(m_oldSubtitles.size()));
+        setText(QObject::tr("Move %n subtitles", nullptr, m_oldSubtitles.size()));
     }
     // Create a list of subtitles with the new times
     int64_t delta = msTime - m_oldSubtitles[0].start;

--- a/src/docks/subtitlesdock.cpp
+++ b/src/docks/subtitlesdock.cpp
@@ -494,7 +494,7 @@ void SubtitlesDock::importSrtFromFile(const QString &srtPath, const QString &tra
 
     m_model->importSubtitlesToNewTrack(track, items);
 
-    MAIN.showStatusMessage(QObject::tr("Imported %1 subtitle items").arg(items.size()));
+    MAIN.showStatusMessage(QObject::tr("Imported %1 subtitle item(s)", nullptr, items.size()));
 }
 
 void SubtitlesDock::addSubtitleTrack()
@@ -623,7 +623,7 @@ void SubtitlesDock::importSubtitles()
     }
     ensureTrackExists();
     m_model->importSubtitles(m_trackCombo->currentIndex(), msTime, items);
-    MAIN.showStatusMessage(QObject::tr("Imported %1 subtitle items").arg(items.size()));
+    MAIN.showStatusMessage(QObject::tr("Imported %n subtitle item(s)", nullptr, items.size()));
 }
 
 void SubtitlesDock::exportSubtitles()

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -692,7 +692,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string notr="true">Lanczos (best)</string>
+    <string>Lanczos (best)</string>
    </property>
   </action>
   <action name="actionProfileAutomatic">

--- a/src/qml/filters/fisheye/ui.qml
+++ b/src/qml/filters/fisheye/ui.qml
@@ -854,7 +854,7 @@ Item {
             visible: scaleYShowSlider
 
             Shotcut.HoverTip {
-                text: qsTr('Seperate Y scale')
+                text: qsTr('Separate Y scale')
             }
         }
 

--- a/src/qml/filters/fisheye/ui.qml
+++ b/src/qml/filters/fisheye/ui.qml
@@ -621,7 +621,7 @@ Item {
                     }
 
                     ListElement {
-                        text: qsTr('Ortographic')
+                        text: qsTr('Orthographic')
                         value: 0.333
                     }
 

--- a/src/qml/filters/glow/meta_movit.qml
+++ b/src/qml/filters/glow/meta_movit.qml
@@ -4,7 +4,7 @@ import org.shotcut.qml
 Metadata {
     type: Metadata.Filter
     name: qsTr("Glow")
-    keywords: qsTr('shne blur', 'search keywords for the Glow video filter') + ' glow gpu'
+    keywords: qsTr('shine blur', 'search keywords for the Glow video filter') + ' glow gpu'
     mlt_service: "movit.glow"
     needsGPU: true
     qml: "ui_movit.qml"


### PR DESCRIPTION
This patch consolidates some source string issues found during the translation process.

- fisheye: `ortographic` → `orthographic`, as in [orthographic projection](https://en.wikipedia.org/wiki/Orthographic_projection)
- fisheye: `seperate` → `separate`
- subtitles: fix `QObject::tr` calls with proper plural form support (with the `n` parameter)

Hope this helps! 🚀 