### PR TITLE
Show project profile in title bar

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -252,6 +252,9 @@ void MainWindow::connectUISignals()
     connect(this, &MainWindow::producerOpened, this, &MainWindow::onProducerOpened);
     connect(ui->mainToolBar, SIGNAL(visibilityChanged(bool)), SLOT(onToolbarVisibilityChanged(bool)));
     ui->actionSave->setEnabled(false);
+    connect(this, &MainWindow::audioChannelsChanged, this, &MainWindow::updateWindowTitle);
+    connect(this, &MainWindow::producerOpened, this, &MainWindow::updateWindowTitle);
+    connect(this, &MainWindow::profileChanged, this, &MainWindow::updateWindowTitle);
 }
 
 void MainWindow::setupAndConnectUndoStack()
@@ -2287,19 +2290,31 @@ void MainWindow::configureVideoWidget()
 
 void MainWindow::setCurrentFile(const QString &filename)
 {
-    QString shownName = tr("Untitled");
     if (filename == untitledFileName())
         m_currentFile.clear();
     else
         m_currentFile = filename;
+    updateWindowTitle();
+    ui->actionShowProjectFolder->setDisabled(m_currentFile.isEmpty());
+}
+
+void MainWindow::updateWindowTitle()
+{
+    QString shownName = tr("Untitled");
     if (!m_currentFile.isEmpty())
         shownName = QFileInfo(m_currentFile).fileName();
+    QString profileText = tr("%1x%2 %3fps %4ch").arg(
+                              QString::number(MLT.profile().width(), 'f', 0),
+                              QString::number(MLT.profile().height(), 'f', 0),
+                              QString::number(MLT.profile().fps(), 'g', 2),
+                              QString::number(Settings.playerAudioChannels(), 'f', 0));
 #ifdef Q_OS_MAC
-    setWindowTitle(QStringLiteral("%1 - %2").arg(shownName).arg(qApp->applicationName()));
+    setWindowTitle(QStringLiteral("%1 - %2 - %3").arg(shownName).arg(profileText).arg(
+                       qApp->applicationName()));
 #else
-    setWindowTitle(QStringLiteral("%1[*] - %2").arg(shownName).arg(qApp->applicationName()));
+    setWindowTitle(QStringLiteral("%1[*] - %2 - %3").arg(shownName).arg(profileText).arg(
+                       qApp->applicationName()));
 #endif
-    ui->actionShowProjectFolder->setDisabled(m_currentFile.isEmpty());
 }
 
 void MainWindow::on_actionAbout_Shotcut_triggered()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2301,8 +2301,10 @@ void MainWindow::setCurrentFile(const QString &filename)
 void MainWindow::updateWindowTitle()
 {
     QString shownName = tr("Untitled");
-    if (!m_currentFile.isEmpty())
-        shownName = QFileInfo(m_currentFile).fileName();
+    if (!m_currentFile.isEmpty()) {
+        shownName = QFileInfo(m_currentFile).filePath();
+        shownName = fontMetrics().elidedText(shownName, Qt::ElideLeft, width() / 4);
+    }
     QString profileText = tr("%1x%2 %3fps %4ch").arg(
                               QString::number(MLT.profile().width(), 'f', 0),
                               QString::number(MLT.profile().height(), 'f', 0),

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -179,6 +179,7 @@ private:
     void writeSettings();
     void configureVideoWidget();
     void setCurrentFile(const QString &filename);
+    void updateWindowTitle();
     void changeAudioChannels(bool checked, int channels);
     void changeDeinterlacer(bool checked, const char *method);
     void changeInterpolation(bool checked, const char *method);


### PR DESCRIPTION
As suggested here:
https://forum.shotcut.org/t/settings-video-mode/12790/2

Looking for discussion on this idea.

For me personally, I have had trouble sometimes when it is not perfectly clear what profile is being used. For timeline projects, I  can look at the properties for the "keystone" clip in the timeline. But for playlist and clip projects, I am not sure the  best way to see it. If I do not use Automatic mode, I can look in the settings. But in automatic mode, the best I have found is to go to the Advanced section of the export panel and see what export settings are default.

I would like the profile to be more explicitly visible. At first, I was not excited about the idea of putting it in the title bar. But after trying it, I think it might be OK. I am interested in suggestions for other places it could go. What I like about the title bar is that it is always visible, and every obvious when it changes.

![image](https://github.com/user-attachments/assets/16fa3d49-2147-47c6-b769-9833766a4b88)

I am also interested in discussion about what to show. In this proposed example, I chose to show the resolution, frame rate, and audio channels. But should we add aspect ratio or color space?
