### PR TITLE
Add filter icon on clips

### DIFF
--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -2291,6 +2291,7 @@ void MultitrackModel::filterAddedOrRemoved(Mlt::Producer *producer)
             QVector<int> roles;
             roles << FadeInRole;
             roles << FadeOutRole;
+            roles << IsFilteredRole;
             emit dataChanged(modelIndex, modelIndex, roles);
         }
     } else

--- a/src/qml/views/timeline/Clip.qml
+++ b/src/qml/views/timeline/Clip.qml
@@ -31,6 +31,7 @@ Rectangle {
     property bool isBlank: false
     property bool isAudio: false
     property bool isTransition: false
+    property bool isFiltered: false
     property var audioLevels
     property int fadeIn: 0
     property int fadeOut: 0
@@ -422,6 +423,29 @@ Rectangle {
                 clipRoot.clicked(clipRoot, mouse);
                 clipRoot.clipRightClicked(clipRoot, mouse);
             }
+        }
+    }
+
+    ToolButton {
+        visible: !elided && !isBlank && parent.height > 20 && isFiltered
+        icon.name: 'view-filter'
+        icon.source: 'qrc:///icons/oxygen/32x32/status/view-filter.png'
+        icon.width: 16
+        icon.height: 16
+        anchors.left: parent.left
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: 4
+        anchors.leftMargin: 4
+        width: 20
+        height: 20
+        padding: 1
+        focusPolicy: Qt.NoFocus
+        onClicked: {
+            clipRoot.clicked(clipRoot, null);
+            timeline.filteredClicked();
+        }
+        Shotcut.HoverTip {
+            text: qsTr('Filters')
         }
     }
 

--- a/src/qml/views/timeline/Track.qml
+++ b/src/qml/views/timeline/Track.qml
@@ -86,6 +86,7 @@ Rectangle {
             isBlank: typeof model.blank !== 'undefined' ? model.blank : false
             isAudio: typeof model.audio !== 'undefined' ? model.audio : false
             isTransition: typeof model.isTransition !== 'undefined' ? model.isTransition : false
+            isFiltered:  typeof model.filtered !== 'undefined' ? model.filtered : false
             audioLevels: typeof model.audioLevels !== 'undefined' ? model.audioLevels : ""
             width: typeof model.duration !== 'undefined' ? model.duration * timeScale : 0
             height: trackRoot.height


### PR DESCRIPTION
As suggested here:
https://forum.shotcut.org/t/any-way-to-quickly-see-which-clip-has-filters-on/47468

Posting this for review because I remember a conversation from the past where we expressed concern about adding more features to the timeline and how that could harm UI responsiveness. Not sure how to measure or test that.

This is how it looks:
![image](https://github.com/user-attachments/assets/9df1561f-ee82-475b-b2bf-a88497a67e8b)

I am also open to suggestion about the location.