### PR TITLE
Fix crash when selecting track after align to reference

### DIFF
--- a/src/mltcontroller.cpp
+++ b/src/mltcontroller.cpp
@@ -542,6 +542,8 @@ QString Controller::XML(Service *service, bool withProfile, bool withMetadata)
     Service s(service                                  ? service->get_service()
               : (m_producer && m_producer->is_valid()) ? m_producer->get_service()
                                                        : nullptr);
+    // Save the consumer on this service so it can be restored.
+    mlt_service saveConsumer = mlt_service_consumer(s.get_service());
     if (!s.is_valid())
         return "";
     int ignore = s.get_int("ignore_points");
@@ -557,6 +559,8 @@ QString Controller::XML(Service *service, bool withProfile, bool withMetadata)
     c.start();
     if (ignore)
         s.set("ignore_points", ignore);
+    // Restore the consumer that was previously on this service
+    mlt_service_set_consumer(s.get_service(), saveConsumer);
     return QString::fromUtf8(c.get(kMltXmlPropertyName));
 }
 


### PR DESCRIPTION
The align to reference track runs the XML consumer on the reference track. This replaces the previous consumer (which is the multitrack). This change restores the multitrack back on the track service.

As reported here:
https://forum.shotcut.org/t/align-to-reference-track-sometimes-fails-and-makes-my-project-crash/47843
https://forum.shotcut.org/t/crash-after-align-to-reference-track/47684

Depends on this PR: https://github.com/mltframework/mlt/pull/1074

Other ideas I had to fix this:
* Make sure the Shotcut code never uses the consumer() function on a service
* Invent a way to do a deep copy on any service and then run the XML consumer on that copy
* Find a way to modify the XML consumer so that it doesn't get saved on the service. This would require some kind of fundamental change to the way consumers connect to services. Maybe it could be an option for the connect function.
