### PR TITLE
Add an option to re-run analysis for all 2-pass filters

### DIFF
--- a/src/docks/findanalysisfilterparser.h
+++ b/src/docks/findanalysisfilterparser.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef FIND_ANALYSIS_FILTER_PARSER_H
+#define FIND_ANALYSIS_FILTER_PARSER_H
+
+#include "qmltypes/qmlapplication.h"
+
+#include <Mlt.h>
+#include <QFile>
+#include <QList>
+#include <QString>
+
+class FindAnalysisFilterParser : public Mlt::Parser
+{
+private:
+    QList<Mlt::Filter> m_filters;
+    bool m_skipAnalyzed;
+
+public:
+    FindAnalysisFilterParser()
+        : Mlt::Parser()
+        , m_skipAnalyzed(true)
+    {}
+
+    QList<Mlt::Filter> &filters() { return m_filters; }
+
+    void skipAnalyzed(bool skip) { m_skipAnalyzed = skip; }
+
+    int on_start_filter(Mlt::Filter *filter)
+    {
+        QString serviceName = filter->get("mlt_service");
+        if (serviceName == "loudness" || serviceName == "vidstab") {
+            // If the results property does not exist, empty, or file does not exist.
+            QString results = filter->get("results");
+            if (results.isEmpty() || !m_skipAnalyzed) {
+                if (serviceName == "vidstab") {
+                    // vidstab requires a filename, which is only available when using a project folder.
+                    QString filename = filter->get("filename");
+                    if (filename.isEmpty() || filename.endsWith("vidstab.trf")) {
+                        filename = QmlApplication::getNextProjectFile("stab");
+                    }
+                    if (!filename.isEmpty()) {
+                        filter->set("filename", filename.toUtf8().constData());
+                        m_filters << Mlt::Filter(*filter);
+
+                        // Touch file to prevent overwriting the same file
+                        QFile file(filename);
+                        file.open(QIODevice::WriteOnly);
+                        file.resize(0);
+                        file.close();
+                    }
+                } else {
+                    m_filters << Mlt::Filter(*filter);
+                }
+            }
+        }
+        return 0;
+    }
+    int on_start_producer(Mlt::Producer *) { return 0; }
+    int on_end_producer(Mlt::Producer *) { return 0; }
+    int on_start_playlist(Mlt::Playlist *) { return 0; }
+    int on_end_playlist(Mlt::Playlist *) { return 0; }
+    int on_start_tractor(Mlt::Tractor *) { return 0; }
+    int on_end_tractor(Mlt::Tractor *) { return 0; }
+    int on_start_multitrack(Mlt::Multitrack *) { return 0; }
+    int on_end_multitrack(Mlt::Multitrack *) { return 0; }
+    int on_start_track() { return 0; }
+    int on_end_track() { return 0; }
+    int on_end_filter(Mlt::Filter *) { return 0; }
+    int on_start_transition(Mlt::Transition *) { return 0; }
+    int on_end_transition(Mlt::Transition *) { return 0; }
+    int on_start_chain(Mlt::Chain *) { return 0; }
+    int on_end_chain(Mlt::Chain *) { return 0; }
+    int on_start_link(Mlt::Link *) { return 0; }
+    int on_end_link(Mlt::Link *) { return 0; }
+};
+
+#endif // FIND_ANALYSIS_FILTER_PARSER_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2393,8 +2393,9 @@ void MainWindow::setupActions()
         if (parser.filters().size() > 0) {
             QMessageBox dialog(QMessageBox::Question,
                                windowTitle(),
-                               tr("This will start %1 analysis jobs. Continue?")
-                                   .arg(parser.filters().size()),
+                               tr("This will start %n analysis job(s). Continue?",
+                                  nullptr,
+                                  parser.filters().size()),
                                QMessageBox::No | QMessageBox::Yes,
                                this);
             dialog.setDefaultButton(QMessageBox::Yes);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -38,6 +38,7 @@
 #include "docks/encodedock.h"
 #include "docks/filesdock.h"
 #include "docks/filtersdock.h"
+#include "docks/findanalysisfilterparser.h"
 #include "docks/jobsdock.h"
 #include "docks/keyframesdock.h"
 #include "docks/markersdock.h"
@@ -2377,6 +2378,43 @@ void MainWindow::setupActions()
     });
     addAction(action);
     Actions.add("timelineReload", action, tr("Timeline"));
+
+    action = new QAction(tr("Rerun Filter Analysis"), this);
+    connect(action, &QAction::triggered, this, [&](bool checked) {
+        FindAnalysisFilterParser parser;
+        parser.skipAnalyzed(false);
+        // Look for two pass filters
+        if (m_timelineDock->model()->tractor() && m_timelineDock->model()->tractor()->is_valid()) {
+            parser.start(*m_timelineDock->model()->tractor());
+        }
+        if (m_playlistDock->model()->playlist() && m_playlistDock->model()->playlist()->is_valid()) {
+            parser.start(*m_playlistDock->model()->playlist());
+        }
+        if (parser.filters().size() > 0) {
+            QMessageBox dialog(QMessageBox::Question,
+                               windowTitle(),
+                               tr("This will start %1 analysis jobs. Continue?")
+                                   .arg(parser.filters().size()),
+                               QMessageBox::No | QMessageBox::Yes,
+                               this);
+            dialog.setDefaultButton(QMessageBox::Yes);
+            dialog.setEscapeButton(QMessageBox::No);
+            dialog.setWindowModality(QmlApplication::dialogModality());
+            if (QMessageBox::Yes == dialog.exec()) {
+                // If dialog accepted enqueue jobs.
+                foreach (Mlt::Filter filter, parser.filters()) {
+                    QScopedPointer<QmlMetadata> meta(new QmlMetadata);
+                    QmlFilter qmlFilter(filter, meta.data());
+                    bool isAudio = !::qstrcmp("loudness", filter.get("mlt_service"));
+                    qmlFilter.analyze(isAudio, false);
+                }
+            }
+        } else {
+            emit showStatusMessage(tr("No filters to analyze."));
+        }
+    });
+    Actions.add("analyzeFilters", action);
+    ui->menuFile->insertAction(ui->actionShowProjectFolder, action);
 
     Actions.loadFromMenu(ui->menuFile);
     Actions.loadFromMenu(ui->menuEdit);


### PR DESCRIPTION
As suggested here:
https://forum.shotcut.org/t/force-stabilization-analysis-for-all-clips/47938

Posting for comment here. Not sure how I feel about the name and putting it in the Timeline->Edit menu. Open to suggestions.

![image](https://github.com/user-attachments/assets/08951cd1-13e4-430c-acfd-be5d64294e82)
