### PR TITLE
Make video codec dropdown option more compact

### DIFF
--- a/src/docks/encodedock.cpp
+++ b/src/docks/encodedock.cpp
@@ -152,6 +152,16 @@ EncodeDock::EncodeDock(QWidget *parent)
     ui->videoCodecCombo->model()->sort(0);
     ui->videoCodecCombo->insertItem(0, tr("Default for format"));
 
+    QListView* listView = new QListView();
+    listView->setFlow(QListView::LeftToRight);
+    listView->setWrapping(true);
+    listView->setResizeMode(QListView::Adjust);
+    listView->setLayoutMode(QListView::SinglePass);
+    listView->setMovement(QListView::Static);
+    listView->setFixedWidth(300);
+    listView->setGridSize(QSize(250, 30)); 
+    ui->videoCodecCombo->setView(listView);
+
     ui->hwencodeCheckBox->setChecked(Settings.encodeUseHardware()
                                      && !Settings.encodeHardware().isEmpty());
 


### PR DESCRIPTION
Made it so that the export section of the codec dropdown menu has a fixed width size of 300. 

So far I've only tested this on 6.14.7-arch2-1. 

![Screenshot_20250526_203034](https://github.com/user-attachments/assets/2961a703-13c6-4ef3-a548-d3f6bf4f0e41)
