### PR TITLE
Fix typo in mainwindow.cpp

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4498,7 +4498,7 @@ bool MainWindow::confirmRestartExternalMonitor()
 {
     QMessageBox dialog(QMessageBox::Information,
                        qApp->applicationName(),
-                       tr("Shotcut must restarto change external monitoring.\n"
+                       tr("Shotcut must restart to change external monitoring.\n"
                           "Do you want to restart now?"),
                        QMessageBox::No | QMessageBox::Yes,
                        this);


### PR DESCRIPTION
Replace "restarto" with "restart to"

All translation updates must go through transifex.com.
Pull requests for those will be rejected.
