### PR TITLE
Change default track transition to qtblend

### DIFF
--- a/src/controllers/filtercontroller.cpp
+++ b/src/controllers/filtercontroller.cpp
@@ -431,3 +431,17 @@ void FilterController::addOrEditFilter(Mlt::Filter *filter, const QStringList &k
     }
     setCurrentFilter(serviceIndex);
 }
+
+void FilterController::setTrackTransitionService(const QString &service)
+{
+    if (service == QStringLiteral("qtblend")) {
+        m_metadataModel.setHidden("qtBlendMode", false);
+        m_metadataModel.setHidden("blendMode", true);
+    } else if (service == QStringLiteral("frei0r.cairoblend")) {
+        m_metadataModel.setHidden("qtBlendMode", true);
+        m_metadataModel.setHidden("blendMode", false);
+    } else {
+        m_metadataModel.setHidden("qtBlendMode", true);
+        m_metadataModel.setHidden("blendMode", true);
+    }
+}

--- a/src/controllers/filtercontroller.h
+++ b/src/controllers/filtercontroller.h
@@ -47,6 +47,7 @@ public:
     void onUndoOrRedo(Mlt::Service &service);
     int currentIndex() const { return m_currentFilterIndex; }
     void addOrEditFilter(Mlt::Filter *filter, const QStringList &key_properties);
+    void setTrackTransitionService(const QString &service);
 
 protected:
     void timerEvent(QTimerEvent *);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3495,6 +3495,8 @@ void MainWindow::onPlaylistModified()
 void MainWindow::onMultitrackCreated()
 {
     m_player->enableTab(Player::ProjectTabIndex, true);
+    QString trackTransitionService = m_timelineDock->model()->trackTransitionService();
+    m_filterController->setTrackTransitionService(trackTransitionService);
 }
 
 void MainWindow::onMultitrackClosed()

--- a/src/mltxmlchecker.cpp
+++ b/src/mltxmlchecker.cpp
@@ -435,7 +435,8 @@ void MltXmlChecker::checkGpuEffects(const QString &mlt_service)
 
 void MltXmlChecker::checkCpuEffects(const QString &mlt_service)
 {
-    if (mlt_service.startsWith("frei0r.cairoblend") || mlt_service.startsWith("choppy"))
+    if (mlt_service.startsWith("qtblend") || mlt_service.startsWith("frei0r.cairoblend")
+        || mlt_service.startsWith("choppy"))
         m_needsCPU = true;
 }
 

--- a/src/models/metadatamodel.cpp
+++ b/src/models/metadatamodel.cpp
@@ -148,6 +148,24 @@ void InternalMetadataModel::add(QmlMetadata *data)
     data->setParent(this);
 }
 
+void MetadataModel::setHidden(const QString &objectName, bool hidden)
+{
+    static_cast<InternalMetadataModel *>(sourceModel())->setHidden(objectName, hidden);
+}
+
+void InternalMetadataModel::setHidden(const QString &objectName, bool hidden)
+{
+    for (int i = 0; i < m_list.size(); i++) {
+        QmlMetadata *data = m_list[i];
+        if (data->objectName() == objectName) {
+            data->setIsHidden(hidden);
+            data->filterMask = computeFilterMask(data);
+            emit dataChanged(index(i), index(i));
+            break;
+        }
+    }
+}
+
 QmlMetadata *MetadataModel::get(int row) const
 {
     auto sourceIndex = mapToSource(index(row, 0));

--- a/src/models/metadatamodel.h
+++ b/src/models/metadatamodel.h
@@ -70,6 +70,7 @@ public:
     void add(QmlMetadata *data);
     Q_INVOKABLE QmlMetadata *get(int row) const;
     QmlMetadata *getFromSource(int index) const;
+    void setHidden(const QString &objectName, bool hidden);
     Q_INVOKABLE void saveFilterSet(const QString &name);
     Q_INVOKABLE void deleteFilterSet(const QString &name);
     MetadataFilter filter() const { return m_filter; }
@@ -118,6 +119,7 @@ public:
     QmlMetadata *get(int index) const;
     QList<QmlMetadata *> &list() { return m_list; }
     void remove(int index);
+    void setHidden(const QString &objectName, bool hidden);
 
 private:
     typedef QList<QmlMetadata *> MetadataList;

--- a/src/models/multitrackmodel.h
+++ b/src/models/multitrackmodel.h
@@ -130,6 +130,7 @@ public:
     int bottomVideoTrackIndex() const;
     int mltIndexForTrack(int trackIndex) const;
     bool checkForEmptyTracks(int trackIndex);
+    QString trackTransitionService();
 
 signals:
     void created();

--- a/src/qml/filters/blend_mode/meta_cairoblend.qml
+++ b/src/qml/filters/blend_mode/meta_cairoblend.qml
@@ -12,4 +12,5 @@ Metadata {
     isClipOnly: true
     allowMultiple: false
     isGpuCompatible: false
+    isHidden: true
 }

--- a/src/qml/filters/blend_mode/meta_cairoblend.qml
+++ b/src/qml/filters/blend_mode/meta_cairoblend.qml
@@ -1,0 +1,15 @@
+import QtQuick
+import org.shotcut.qml
+
+Metadata {
+    type: Metadata.Filter
+    name: qsTr("Blend Mode")
+    keywords: qsTr('blending composite porter duff', 'search keywords for the Blend Mode video filter') + ' blend mode #rgba'
+    mlt_service: "cairoblend_mode"
+    objectName: 'blendMode'
+    qml: "ui_cairoblend.qml"
+    icon: 'icon.webp'
+    isClipOnly: true
+    allowMultiple: false
+    isGpuCompatible: false
+}

--- a/src/qml/filters/blend_mode/meta_qtblend.qml
+++ b/src/qml/filters/blend_mode/meta_qtblend.qml
@@ -12,4 +12,5 @@ Metadata {
     isClipOnly: true
     allowMultiple: false
     isGpuCompatible: false
+    isHidden: true
 }

--- a/src/qml/filters/blend_mode/meta_qtblend.qml
+++ b/src/qml/filters/blend_mode/meta_qtblend.qml
@@ -5,9 +5,9 @@ Metadata {
     type: Metadata.Filter
     name: qsTr("Blend Mode")
     keywords: qsTr('blending composite porter duff', 'search keywords for the Blend Mode video filter') + ' blend mode #rgba'
-    mlt_service: "cairoblend_mode"
-    objectName: 'blendMode'
-    qml: "ui.qml"
+    mlt_service: "qtblend_mode"
+    objectName: 'qtBlendMode'
+    qml: "ui_qtblend.qml"
     icon: 'icon.webp'
     isClipOnly: true
     allowMultiple: false

--- a/src/qml/filters/blend_mode/ui_cairoblend.qml
+++ b/src/qml/filters/blend_mode/ui_cairoblend.qml
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2019-2025 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Shotcut.Controls as Shotcut
+
+Item {
+    property string propertyName: 'mode'
+
+    width: 100
+    height: 50
+    Component.onCompleted: {
+        if (filter.isNew) {
+            // Set default parameter values
+            combo.currentIndex = 0;
+            filter.set(propertyName, comboItems.get(0).value);
+        } else {
+            // Initialize parameter values
+            var value = filter.get(propertyName);
+            for (var i = 0; i < comboItems.count; i++) {
+                if (value === comboItems.get(i).value) {
+                    combo.currentIndex = i;
+                    break;
+                }
+            }
+        }
+    }
+
+    GridLayout {
+        anchors.fill: parent
+        anchors.margins: 8
+        columns: 4
+
+        Label {
+            text: qsTr('Blend mode')
+        }
+
+        Shotcut.ComboBox {
+            id: combo
+
+            textRole: 'text'
+            onActivated: {
+                filter.set(propertyName, comboItems.get(currentIndex).value);
+            }
+
+            model: ListModel {
+                id: comboItems
+
+                ListElement {
+                    text: qsTr('Over')
+                    value: 'normal'
+                }
+
+                ListElement {
+                    text: qsTr('None')
+                    value: ''
+                }
+
+                ListElement {
+                    text: qsTr('Add')
+                    value: 'add'
+                }
+
+                ListElement {
+                    text: qsTr('Saturate')
+                    value: 'saturate'
+                }
+
+                ListElement {
+                    text: qsTr('Multiply')
+                    value: 'multiply'
+                }
+
+                ListElement {
+                    text: qsTr('Screen')
+                    value: 'screen'
+                }
+
+                ListElement {
+                    text: qsTr('Overlay')
+                    value: 'overlay'
+                }
+
+                ListElement {
+                    text: qsTr('Darken')
+                    value: 'darken'
+                }
+
+                ListElement {
+                    text: qsTr('Dodge')
+                    value: 'colordodge'
+                }
+
+                ListElement {
+                    text: qsTr('Burn')
+                    value: 'colorburn'
+                }
+
+                ListElement {
+                    text: qsTr('Hard Light')
+                    value: 'hardlight'
+                }
+
+                ListElement {
+                    text: qsTr('Soft Light')
+                    value: 'softlight'
+                }
+
+                ListElement {
+                    text: qsTr('Difference')
+                    value: 'difference'
+                }
+
+                ListElement {
+                    text: qsTr('Exclusion')
+                    value: 'exclusion'
+                }
+
+                ListElement {
+                    text: qsTr('HSL Hue')
+                    value: 'hslhue'
+                }
+
+                ListElement {
+                    text: qsTr('HSL Saturation')
+                    value: 'hslsaturatation'
+                }
+
+                ListElement {
+                    text: qsTr('HSL Color')
+                    value: 'hslcolor'
+                }
+
+                ListElement {
+                    text: qsTr('HSL Luminosity')
+                    value: 'hslluminocity'
+                }
+            }
+        }
+
+        Shotcut.UndoButton {
+            onClicked: {
+                filter.set(propertyName, comboItems.get(0).value);
+                combo.currentIndex = 0;
+            }
+        }
+
+        Item {
+            Layout.fillWidth: true
+        }
+
+        Item {
+            Layout.fillHeight: true
+        }
+    }
+}

--- a/src/qml/filters/blend_mode/ui_qtblend.qml
+++ b/src/qml/filters/blend_mode/ui_qtblend.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 Meltytech, LLC
+ * Copyright (c) 2025 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -53,6 +53,7 @@ Item {
         Shotcut.ComboBox {
             id: combo
 
+            implicitContentWidthPolicy: ComboBox.WidestTextWhenCompleted
             textRole: 'text'
             onActivated: {
                 filter.set(propertyName, comboItems.get(currentIndex).value);
@@ -62,93 +63,123 @@ Item {
                 id: comboItems
 
                 ListElement {
-                    text: qsTr('Over')
-                    value: 'normal'
+                    text: qsTr('Source Over')
+                    value: '0'
                 }
 
                 ListElement {
-                    text: qsTr('None')
-                    value: ''
+                    text: qsTr('Destination Over')
+                    value: '1'
                 }
 
                 ListElement {
-                    text: qsTr('Add')
-                    value: 'add'
+                    text: qsTr('Clear')
+                    value: '2'
                 }
 
                 ListElement {
-                    text: qsTr('Saturate')
-                    value: 'saturate'
+                    text: qsTr('Source')
+                    value: '3'
+                }
+
+                ListElement {
+                    text: qsTr('Destination')
+                    value: '4'
+                }
+
+                ListElement {
+                    text: qsTr('Source In')
+                    value: '5'
+                }
+
+                ListElement {
+                    text: qsTr('Destination In')
+                    value: '6'
+                }
+
+                ListElement {
+                    text: qsTr('Source Out')
+                    value: '7'
+                }
+
+                ListElement {
+                    text: qsTr('Destination Out')
+                    value: '8'
+                }
+
+                ListElement {
+                    text: qsTr('Source Atop')
+                    value: '9'
+                }
+
+                ListElement {
+                    text: qsTr('Destination Atop')
+                    value: '10'
+                }
+
+                ListElement {
+                    text: qsTr('XOR')
+                    value: '11'
+                }
+
+                ListElement {
+                    text: qsTr('Plus')
+                    value: '12'
                 }
 
                 ListElement {
                     text: qsTr('Multiply')
-                    value: 'multiply'
+                    value: '13'
                 }
 
                 ListElement {
                     text: qsTr('Screen')
-                    value: 'screen'
+                    value: '14'
                 }
 
                 ListElement {
                     text: qsTr('Overlay')
-                    value: 'overlay'
+                    value: '15'
                 }
 
                 ListElement {
                     text: qsTr('Darken')
-                    value: 'darken'
+                    value: '16'
                 }
 
                 ListElement {
-                    text: qsTr('Dodge')
-                    value: 'colordodge'
+                    text: qsTr('Lighten')
+                    value: '17'
                 }
 
                 ListElement {
-                    text: qsTr('Burn')
-                    value: 'colorburn'
+                    text: qsTr('Color Dodge')
+                    value: '18'
+                }
+
+                ListElement {
+                    text: qsTr('Color Burn')
+                    value: '19'
                 }
 
                 ListElement {
                     text: qsTr('Hard Light')
-                    value: 'hardlight'
+                    value: '20'
                 }
 
                 ListElement {
                     text: qsTr('Soft Light')
-                    value: 'softlight'
+                    value: '21'
                 }
 
                 ListElement {
                     text: qsTr('Difference')
-                    value: 'difference'
+                    value: '22'
                 }
 
                 ListElement {
                     text: qsTr('Exclusion')
-                    value: 'exclusion'
-                }
-
-                ListElement {
-                    text: qsTr('HSL Hue')
-                    value: 'hslhue'
-                }
-
-                ListElement {
-                    text: qsTr('HSL Saturation')
-                    value: 'hslsaturatation'
-                }
-
-                ListElement {
-                    text: qsTr('HSL Color')
-                    value: 'hslcolor'
-                }
-
-                ListElement {
-                    text: qsTr('HSL Luminosity')
-                    value: 'hslluminocity'
+                    value: '23'
                 }
             }
         }

--- a/src/widgets/trackpropertieswidget.cpp
+++ b/src/widgets/trackpropertieswidget.cpp
@@ -67,6 +67,7 @@ TrackPropertiesWidget::TrackPropertiesWidget(Mlt::Producer &track, QWidget *pare
         ui->blendModeCombo->addItem(tr("Soft Light"), "21");
         ui->blendModeCombo->addItem(tr("Difference"), "22");
         ui->blendModeCombo->addItem(tr("Exclusion"), "23");
+        /*
         ui->blendModeCombo->addItem(tr("Source OR Destination"), "24");
         ui->blendModeCombo->addItem(tr("Source AND Destination"), "25");
         ui->blendModeCombo->addItem(tr("Source XOR Destination"), "26");
@@ -79,6 +80,7 @@ TrackPropertiesWidget::TrackPropertiesWidget(Mlt::Producer &track, QWidget *pare
         ui->blendModeCombo->addItem(tr("NOT Source OR Destination"), "33");
         ui->blendModeCombo->addItem(tr("Source OR NOT Destination"), "34");
         ui->blendModeCombo->addItem(tr("NOT Destination"), "37");
+         */
         ui->blendModeCombo->blockSignals(false);
         ui->blendModeLabel->show();
         ui->blendModeCombo->show();

--- a/src/widgets/trackpropertieswidget.cpp
+++ b/src/widgets/trackpropertieswidget.cpp
@@ -27,6 +27,7 @@
 #include <QScopedPointer>
 
 static const char *BLEND_PROPERTY_CAIROBLEND = "1";
+static const char *BLEND_PROPERTY_QTBLEND = "compositing";
 
 TrackPropertiesWidget::TrackPropertiesWidget(Mlt::Producer &track, QWidget *parent)
     : QWidget(parent)
@@ -39,48 +40,99 @@ TrackPropertiesWidget::TrackPropertiesWidget(Mlt::Producer &track, QWidget *pare
     ui->blendModeLabel->hide();
     ui->blendModeCombo->hide();
 
-    QScopedPointer<Mlt::Transition> transition(getTransition("frei0r.cairoblend"));
+    QScopedPointer<Mlt::Transition> transition(getTransition("qtblend"));
     if (transition && transition->is_valid()) {
         ui->blendModeCombo->blockSignals(true);
-        ui->blendModeCombo->addItem(tr("None"), "");
-        ui->blendModeCombo->addItem(tr("Over"), "normal");
-        ui->blendModeCombo->addItem(tr("Add"), "add");
-        ui->blendModeCombo->addItem(tr("Saturate"), "saturate");
-        ui->blendModeCombo->addItem(tr("Multiply"), "multiply");
-        ui->blendModeCombo->addItem(tr("Screen"), "screen");
-        ui->blendModeCombo->addItem(tr("Overlay"), "overlay");
-        ui->blendModeCombo->addItem(tr("Darken"), "darken");
-        ui->blendModeCombo->addItem(tr("Dodge"), "colordodge");
-        ui->blendModeCombo->addItem(tr("Burn"), "colorburn");
-        ui->blendModeCombo->addItem(tr("Hard Light"), "hardlight");
-        ui->blendModeCombo->addItem(tr("Soft Light"), "softlight");
-        ui->blendModeCombo->addItem(tr("Difference"), "difference");
-        ui->blendModeCombo->addItem(tr("Exclusion"), "exclusion");
-        ui->blendModeCombo->addItem(tr("HSL Hue"), "hslhue");
-        ui->blendModeCombo->addItem(tr("HSL Saturation"), "hslsaturatation");
-        ui->blendModeCombo->addItem(tr("HSL Color"), "hslcolor");
-        ui->blendModeCombo->addItem(tr("HSL Luminosity"), "hslluminocity");
+        ui->blendModeCombo->addItem(tr("Source Over"), "0");
+        ui->blendModeCombo->addItem(tr("Destination Over"), "1");
+        ui->blendModeCombo->addItem(tr("Clear"), "2");
+        ui->blendModeCombo->addItem(tr("Source"), "3");
+        ui->blendModeCombo->addItem(tr("Destination"), "4");
+        ui->blendModeCombo->addItem(tr("Source In"), "5");
+        ui->blendModeCombo->addItem(tr("Destination In"), "6");
+        ui->blendModeCombo->addItem(tr("Source Out"), "7");
+        ui->blendModeCombo->addItem(tr("Destination Out"), "8");
+        ui->blendModeCombo->addItem(tr("Source Atop"), "9");
+        ui->blendModeCombo->addItem(tr("Destination Atop"), "10");
+        ui->blendModeCombo->addItem(tr("XOR"), "11");
+        ui->blendModeCombo->addItem(tr("Plus"), "12");
+        ui->blendModeCombo->addItem(tr("Multiply"), "13");
+        ui->blendModeCombo->addItem(tr("Screen"), "14");
+        ui->blendModeCombo->addItem(tr("Overlay"), "15");
+        ui->blendModeCombo->addItem(tr("Darken"), "16");
+        ui->blendModeCombo->addItem(tr("Lighten"), "17");
+        ui->blendModeCombo->addItem(tr("Color Dodge"), "18");
+        ui->blendModeCombo->addItem(tr("Color Burn"), "19");
+        ui->blendModeCombo->addItem(tr("Hard Light"), "20");
+        ui->blendModeCombo->addItem(tr("Soft Light"), "21");
+        ui->blendModeCombo->addItem(tr("Difference"), "22");
+        ui->blendModeCombo->addItem(tr("Exclusion"), "23");
+        ui->blendModeCombo->addItem(tr("Source OR Destination"), "24");
+        ui->blendModeCombo->addItem(tr("Source AND Destination"), "25");
+        ui->blendModeCombo->addItem(tr("Source XOR Destination"), "26");
+        ui->blendModeCombo->addItem(tr("NOT Source AND NOT Destination"), "27");
+        ui->blendModeCombo->addItem(tr("NOT Source OR NOT Destination"), "28");
+        ui->blendModeCombo->addItem(tr("NOT Source XOR Destination"), "29");
+        ui->blendModeCombo->addItem(tr("NOT Source"), "30");
+        ui->blendModeCombo->addItem(tr("NOT Source AND Destination"), "31");
+        ui->blendModeCombo->addItem(tr("Source AND NOT Destination"), "32");
+        ui->blendModeCombo->addItem(tr("NOT Source OR Destination"), "33");
+        ui->blendModeCombo->addItem(tr("Source OR NOT Destination"), "34");
+        ui->blendModeCombo->addItem(tr("NOT Destination"), "37");
         ui->blendModeCombo->blockSignals(false);
         ui->blendModeLabel->show();
         ui->blendModeCombo->show();
 
-        QString blendMode = transition->get(BLEND_PROPERTY_CAIROBLEND);
+        QString blendMode = transition->get(BLEND_PROPERTY_QTBLEND);
         if (transition->get_int("disable"))
             blendMode = QString();
         else if (blendMode.isEmpty()) // A newly added track does not set its mode property.
-            blendMode = "normal";
+            blendMode = "0";
         onModeChanged(blendMode);
     } else {
-        transition.reset(getTransition("movit.overlay"));
+        transition.reset(getTransition("frei0r.cairoblend"));
         if (transition && transition->is_valid()) {
             ui->blendModeCombo->blockSignals(true);
             ui->blendModeCombo->addItem(tr("None"), "");
-            ui->blendModeCombo->addItem(tr("Over"), "over");
+            ui->blendModeCombo->addItem(tr("Over"), "normal");
+            ui->blendModeCombo->addItem(tr("Add"), "add");
+            ui->blendModeCombo->addItem(tr("Saturate"), "saturate");
+            ui->blendModeCombo->addItem(tr("Multiply"), "multiply");
+            ui->blendModeCombo->addItem(tr("Screen"), "screen");
+            ui->blendModeCombo->addItem(tr("Overlay"), "overlay");
+            ui->blendModeCombo->addItem(tr("Darken"), "darken");
+            ui->blendModeCombo->addItem(tr("Dodge"), "colordodge");
+            ui->blendModeCombo->addItem(tr("Burn"), "colorburn");
+            ui->blendModeCombo->addItem(tr("Hard Light"), "hardlight");
+            ui->blendModeCombo->addItem(tr("Soft Light"), "softlight");
+            ui->blendModeCombo->addItem(tr("Difference"), "difference");
+            ui->blendModeCombo->addItem(tr("Exclusion"), "exclusion");
+            ui->blendModeCombo->addItem(tr("HSL Hue"), "hslhue");
+            ui->blendModeCombo->addItem(tr("HSL Saturation"), "hslsaturatation");
+            ui->blendModeCombo->addItem(tr("HSL Color"), "hslcolor");
+            ui->blendModeCombo->addItem(tr("HSL Luminosity"), "hslluminocity");
             ui->blendModeCombo->blockSignals(false);
             ui->blendModeLabel->show();
             ui->blendModeCombo->show();
-            QString blendMode = transition->get_int("disable") ? QString() : "over";
+
+            QString blendMode = transition->get(BLEND_PROPERTY_CAIROBLEND);
+            if (transition->get_int("disable"))
+                blendMode = QString();
+            else if (blendMode.isEmpty()) // A newly added track does not set its mode property.
+                blendMode = "normal";
             onModeChanged(blendMode);
+        } else {
+            transition.reset(getTransition("movit.overlay"));
+            if (transition && transition->is_valid()) {
+                ui->blendModeCombo->blockSignals(true);
+                ui->blendModeCombo->addItem(tr("None"), "");
+                ui->blendModeCombo->addItem(tr("Over"), "over");
+                ui->blendModeCombo->blockSignals(false);
+                ui->blendModeLabel->show();
+                ui->blendModeCombo->show();
+                QString blendMode = transition->get_int("disable") ? QString() : "over";
+                onModeChanged(blendMode);
+            }
         }
     }
 }
@@ -132,6 +184,17 @@ void TrackPropertiesWidget::on_blendModeCombo_currentIndexChanged(int index)
                                                            .toString());
             connect(command, SIGNAL(modeChanged(QString &)), SLOT(onModeChanged(QString &)));
             MAIN.undoStack()->push(command);
+        } else {
+            transition.reset(getTransition("qtblend"));
+            if (transition && transition->is_valid()) {
+                Timeline::ChangeBlendModeCommand *command
+                    = new Timeline::ChangeBlendModeCommand(*transition,
+                                                           BLEND_PROPERTY_QTBLEND,
+                                                           ui->blendModeCombo->itemData(index)
+                                                               .toString());
+                connect(command, SIGNAL(modeChanged(QString &)), SLOT(onModeChanged(QString &)));
+                MAIN.undoStack()->push(command);
+            }
         }
     }
 }


### PR DESCRIPTION
Posting this as a PR to be sure we like the list of blend modes. Do we really want to expose all the OR/XOR/AND operations? Are there any operations from cairoblend that users will miss? I matched the blend names to the QT names. But maybe we want to try to match them to the previous cairoblend modes (like "Source Over" to "Normal")?

I tested backwards compatibility with projects that use cairoblend and it seems fine.

It did not try to convert projects from cairoblend to qt blend.

Code comments are also welcome.
