### PR TITLE
feat: Add quick export frame functionality

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -251,6 +251,7 @@ public slots:
     bool on_actionSave_triggered();
     void onCreateOrEditFilterOnOutput(Mlt::Filter *filter, const QStringList &key_properties);
     void showSettingsMenu() const;
+    void quickExportFrame();
 
 private slots:
     void showUpgradePrompt();


### PR DESCRIPTION
## Description

This PR adds a quick export frame feature that allows users to export the current video frame without opening a save dialog each time.

## Motivation

Currently, exporting a frame requires users to:
1. Click File → Export → Frame
2. Choose a location in the file dialog
3. Enter a filename
4. Click Save

This becomes tedious when exporting multiple frames. The new feature streamlines this workflow.

## Features

- ✅ One-key export (ready for keyboard shortcut binding, e.g., Ctrl+Alt+E)
- ✅ Auto-generate filename based on timecode (format: `Shotcut_HH_MM_SS_FFF.png`)
- ✅ Smart path selection (saves to project folder if available, otherwise default save path)
- ✅ Status message feedback on export success/failure
- ✅ Automatically adds exported file to recent files list
- ✅ PNG format export
- ✅ Proper error handling (no video loaded, unable to capture frame)