### PR TITLE
Increase maximum resolution in UI to 8640.

### DIFF
--- a/src/dialogs/customprofiledialog.ui
+++ b/src/dialogs/customprofiledialog.ui
@@ -99,7 +99,7 @@
            <number>1</number>
           </property>
           <property name="maximum">
-           <number>8192</number>
+           <number>8640</number>
           </property>
           <property name="value">
            <number>16</number>
@@ -119,7 +119,7 @@
            <number>1</number>
           </property>
           <property name="maximum">
-           <number>8192</number>
+           <number>8640</number>
           </property>
           <property name="value">
            <number>9</number>
@@ -244,7 +244,7 @@
            <number>16</number>
           </property>
           <property name="maximum">
-           <number>8192</number>
+           <number>8640</number>
           </property>
           <property name="singleStep">
            <number>2</number>
@@ -267,7 +267,7 @@
            <number>1</number>
           </property>
           <property name="maximum">
-           <number>8192</number>
+           <number>8640</number>
           </property>
           <property name="singleStep">
            <number>2</number>

--- a/src/docks/encodedock.ui
+++ b/src/docks/encodedock.ui
@@ -707,7 +707,7 @@ with parallel processing enabled.</string>
                       <number>16</number>
                      </property>
                      <property name="maximum">
-                      <number>8192</number>
+                      <number>8640</number>
                      </property>
                      <property name="singleStep">
                       <number>2</number>
@@ -730,7 +730,7 @@ with parallel processing enabled.</string>
                       <number>1</number>
                      </property>
                      <property name="maximum">
-                      <number>8192</number>
+                      <number>8640</number>
                      </property>
                      <property name="singleStep">
                       <number>2</number>
@@ -903,7 +903,7 @@ with parallel processing enabled.</string>
                       <number>1</number>
                      </property>
                      <property name="maximum">
-                      <number>8192</number>
+                      <number>8640</number>
                      </property>
                      <property name="value">
                       <number>16</number>
@@ -923,7 +923,7 @@ with parallel processing enabled.</string>
                       <number>1</number>
                      </property>
                      <property name="maximum">
-                      <number>8192</number>
+                      <number>8640</number>
                      </property>
                      <property name="value">
                       <number>9</number>

--- a/src/widgets/avformatproducerwidget.ui
+++ b/src/widgets/avformatproducerwidget.ui
@@ -512,7 +512,7 @@
                 <number>1</number>
                </property>
                <property name="maximum">
-                <number>8192</number>
+                <number>8640</number>
                </property>
                <property name="value">
                 <number>16</number>
@@ -538,7 +538,7 @@
                 <number>1</number>
                </property>
                <property name="maximum">
-                <number>8192</number>
+                <number>8640</number>
                </property>
                <property name="value">
                 <number>9</number>


### PR DESCRIPTION
A valid resolution for 8k Youtube Videos (in VR 180 format) is 8640 x 4320. Making Shotcut support up to 8640 pixels maximum resolution allows such videos to be edited and rendered in Shotcut.

All translation updates must go through transifex.com.
Pull requests for those will be rejected.
