### PR TITLE
Fix local file URL handling when adding files to playlist

### DIFF
--- a/src/docks/playlistdock.cpp
+++ b/src/docks/playlistdock.cpp
@@ -2082,7 +2082,7 @@ void PlaylistDock::onAddFilesActionTriggered()
     if (filenames.length() > 0) {
         Settings.setOpenPath(QFileInfo(filenames.first()).path());
         for (const auto &s : filenames) {
-            urls << s;
+            urls << QUrl::fromLocalFile(s);
         }
         mimeData.setUrls(urls);
         auto index = m_proxyModel->mapToSource(m_view->currentIndex());


### PR DESCRIPTION
Fixes #1582 and #1704 

Problem
This PR fixes an issue where files with special characters or quotes in their names failed to load into the playlist.

Cause
The bug was caused by an implicit conversion from QString to QUrl, leading to malformed encoding.

Fix
I replaced this with an explicit call to QUrl::fromLocalFile()