### PR TITLE
Fix Keyframes don't get restored after trim in undo

### DIFF
--- a/src/commands/timelinecommands.cpp
+++ b/src/commands/timelinecommands.cpp
@@ -951,8 +951,6 @@ void TrimClipInCommand::redo()
                     << m_delta;
         m_undoHelper.reset(new UndoHelper(m_model));
         if (m_ripple) {
-            m_undoHelper->setHints(UndoHelper::SkipXML);
-        } else {
             m_undoHelper->setHints(UndoHelper::RestoreTracks);
         }
         m_undoHelper->recordBeforeState();

--- a/src/commands/undohelper.cpp
+++ b/src/commands/undohelper.cpp
@@ -270,6 +270,34 @@ void UndoHelper::undoChanges()
                                       info.in_delta,
                                       info.out_delta,
                                       info.in_delta);
+                if (!info.xml.isEmpty() && !info.isBlank) {
+                    // Pass all properties for links and filters to restore keyframes that might have  been affected by a resize.
+                    Mlt::Producer originalClip(clip->parent());
+                    Mlt::Producer restoredClip(MLT.profile(),
+                                               "xml-string",
+                                               info.xml.toUtf8().constData());
+                    if (restoredClip.is_valid()
+                        && restoredClip.filter_count() == originalClip.filter_count()) {
+                        for (int j = 0; j < restoredClip.filter_count(); j++) {
+                            QScopedPointer<Mlt::Filter> filter1(originalClip.filter(j));
+                            QScopedPointer<Mlt::Filter> filter2(restoredClip.filter(j));
+                            filter1->inherit(*filter2);
+                        }
+                        if (originalClip.type() == mlt_service_chain_type
+                            && restoredClip.type() == mlt_service_chain_type) {
+                            Mlt::Chain chain1(originalClip);
+                            Mlt::Chain chain2(restoredClip);
+                            if (chain1.link_count() == chain2.link_count()) {
+                                int link_count = chain1.link_count();
+                                for (int j = 0; j < link_count; j++) {
+                                    QScopedPointer<Mlt::Link> link1(chain1.link(j));
+                                    QScopedPointer<Mlt::Link> link2(chain2.link(j));
+                                    link1->inherit(*link2);
+                                }
+                            }
+                        }
+                    }
+                }
             }
 
             QModelIndex modelIndex = m_model.createIndex(currentIndex, 0, info.oldTrackIndex);

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -3550,9 +3550,7 @@ bool TimelineDock::trimClipIn(
     } else if (m_model.trimClipInValid(trackIndex, clipIndex, delta, ripple || roll)) {
         if (!m_undoHelper) {
             m_undoHelper.reset(new UndoHelper(m_model));
-            if (!ripple) {
-                m_undoHelper->setHints(UndoHelper::SkipXML);
-            } else {
+            if (ripple) {
                 m_undoHelper->setHints(UndoHelper::RestoreTracks);
             }
             m_undoHelper->recordBeforeState();


### PR DESCRIPTION
As reported here:
https://forum.shotcut.org/t/keyframes-dont-get-restored-after-undo/48044
