### PR TITLE
Fix timeline operations failing when clips share a producer

### DIFF
--- a/src/commands/undohelper.cpp
+++ b/src/commands/undohelper.cpp
@@ -53,13 +53,11 @@ void UndoHelper::recordBeforeState()
 
         for (int j = 0; j < playlist.count(); ++j) {
             QScopedPointer<Mlt::Producer> clip(playlist.get_clip(j));
-            QUuid uid = MLT.ensureHasUuid(clip->parent());
-            if (clip->is_blank()) {
-                uid = MLT.ensureHasUuid(*clip);
-            }
+            QUuid uid = MLT.ensureHasUuid(*clip);
             m_insertedOrder << uid;
             Info &info = m_state[uid];
-            if (!(m_hints & SkipXML) || m_xmlClips.contains(uid))
+            if (!(m_hints & SkipXML) || m_xmlClips.contains(uid)
+                || m_xmlClips.contains(MLT.uuid(clip->parent())))
                 info.xml = MLT.XML(&clip->parent());
             Mlt::ClipInfo clipInfo;
             playlist.clip_info(j, &clipInfo);
@@ -89,14 +87,15 @@ void UndoHelper::recordAfterState()
 
         for (int j = 0; j < playlist.count(); ++j) {
             QScopedPointer<Mlt::Producer> clip(playlist.get_clip(j));
-            QUuid uid = MLT.ensureHasUuid(clip->parent());
-            if (clip->is_blank()) {
-                uid = MLT.ensureHasUuid(*clip);
+            QUuid uid = MLT.uuid(*clip);
+            if (uid.isNull()) {
+                uid = MLT.uuid(clip->parent());
             }
 
             /* Clips not previously in m_state are new */
             if (!m_state.contains(uid)) {
                 UNDOLOG << "New clip at" << i << j;
+                uid = MLT.ensureHasUuid(*clip);
                 m_clipsAdded << uid;
                 m_affectedTracks << i;
             } else {
@@ -236,11 +235,7 @@ void UndoHelper::undoChanges()
             QScopedPointer<Mlt::Producer> clip(playlist.get_clip(currentIndex));
             Q_ASSERT(currentIndex < playlist.count());
             Q_ASSERT(!clip.isNull());
-            if (info.isBlank) {
-                MLT.setUuid(*clip, uid);
-            } else {
-                MLT.setUuid(clip->parent(), uid);
-            }
+            MLT.setUuid(*clip, uid);
             if (info.group >= 0) {
                 clip->set(kShotcutGroupProperty, info.group);
             }
@@ -273,8 +268,7 @@ void UndoHelper::undoChanges()
                 // Re-apply timeline-specific properties that are not encoded in the producer XML.
                 QScopedPointer<Mlt::Producer> clip(playlist.get_clip(currentIndex));
                 if (clip && clip->is_valid()) {
-                    // Restore UUID on the parent producer for this non-blank clip.
-                    MLT.setUuid(clip->parent(), uid);
+                    MLT.setUuid(*clip, uid);
                     // Restore grouping metadata on the clip, if any was recorded.
                     if (info.group >= 0) {
                         clip->set(kShotcutGroupProperty, info.group);
@@ -326,10 +320,7 @@ void UndoHelper::undoChanges()
         Mlt::Playlist playlist(*trackProducer);
         for (int i = playlist.count() - 1; i >= 0; --i) {
             QScopedPointer<Mlt::Producer> clip(playlist.get_clip(i));
-            QUuid uid = MLT.uuid(clip->parent());
-            if (clip->is_blank()) {
-                uid = MLT.uuid(*clip);
-            }
+            QUuid uid = MLT.uuid(*clip);
             if (m_clipsAdded.removeOne(uid)) {
                 UNDOLOG << "Removing clip at" << i;
                 m_model.beginRemoveRows(m_model.index(trackIndex), i, i);
@@ -443,11 +434,7 @@ void UndoHelper::restoreAffectedTracks()
             QScopedPointer<Mlt::Producer> clip(playlist.get_clip(currentIndex));
             Q_ASSERT(currentIndex < playlist.count());
             Q_ASSERT(!clip.isNull());
-            if (info.isBlank) {
-                MLT.setUuid(*clip, uid);
-            } else {
-                MLT.setUuid(clip->parent(), uid);
-            }
+            MLT.setUuid(*clip, uid);
             AudioLevelsTask::start(clip->parent(), &m_model, modelIndex);
         }
     }

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -48,6 +48,8 @@
 #include "widgets/textproducerwidget.h"
 #include "widgets/toneproducerwidget.h"
 
+#include <algorithm>
+
 #include <QAction>
 #include <QActionGroup>
 #include <QClipboard>
@@ -2671,10 +2673,14 @@ void TimelineDock::removeSelection(bool withCopy)
         else
             MAIN.undoStack()->beginMacro(tr("Remove %1 from timeline").arg(n));
     }
-    int trackIndex, clipIndex;
-    for (const auto &uuid : selectionUuids()) {
-        m_model.findClipByUuid(uuid, trackIndex, clipIndex);
-        remove(trackIndex, clipIndex, n > 1);
+    auto clips = selection();
+    std::sort(clips.begin(), clips.end(), [](const QPoint &a, const QPoint &b) {
+        if (a.y() != b.y())
+            return a.y() > b.y();
+        return a.x() > b.x();
+    });
+    for (const auto &clip : clips) {
+        remove(clip.y(), clip.x(), n > 1);
     }
     if (n > 1)
         MAIN.undoStack()->endMacro();
@@ -2693,10 +2699,14 @@ void TimelineDock::liftSelection()
     int n = selection().size();
     if (n > 1)
         MAIN.undoStack()->beginMacro(tr("Lift %1 from timeline").arg(n));
-    int trackIndex, clipIndex;
-    for (const auto &uuid : selectionUuids()) {
-        m_model.findClipByUuid(uuid, trackIndex, clipIndex);
-        lift(trackIndex, clipIndex, n > 1);
+    auto clips = selection();
+    std::sort(clips.begin(), clips.end(), [](const QPoint &a, const QPoint &b) {
+        if (a.y() != b.y())
+            return a.y() > b.y();
+        return a.x() > b.x();
+    });
+    for (const auto &clip : clips) {
+        lift(clip.y(), clip.x(), n > 1);
     }
     if (n > 1)
         MAIN.undoStack()->endMacro();


### PR DESCRIPTION
## Summary

- **Fix wrong clip deletion**: When multiple playlist entries reference the same MLT producer (e.g. projects generated by external tools that reuse a single chain element), `removeSelection()` and `liftSelection()` went through a UUID round-trip (`selectionUuids()` → `findClipByUuid()`) that always returned the first matching clip instead of the selected one. Fixed by using direct clip indices from the existing selection, sorted in descending order to avoid index shift during ripple delete.
- **Fix undo corruption**: `UndoHelper::recordBeforeState()` used `clip->parent()` UUID as the dictionary key in `m_state`. When all entries share the same parent producer, all entries had the same UUID, causing state records to overwrite each other — only the last clip's info survived. Undo then restored the entire track as copies of the last clip. Fixed by using the cut UUID (unique per playlist entry) instead of the parent UUID.
- **Preserve trim keyframe restore**: The `m_xmlClips` lookup in `recordBeforeState()` also checks the parent UUID to maintain compatibility with trim commands that register via `storeXmlForClip(parentUuid)` under `SkipXML` hint.

## Test plan

- [ ] Open a project with multiple clips sharing the same producer on a track
- [ ] Select clip N (not the first), press Delete → verify clip N is removed, not clip 0
- [ ] Press Ctrl+Z → verify the correct clip is restored at the correct position with correct in/out
- [ ] Select multiple non-contiguous clips, press Delete → verify all selected clips are removed
- [ ] Select multiple clips, press Lift (Delete without ripple) → verify all selected clips are replaced with blanks
- [ ] Trim a clip with keyframes, undo → verify keyframes are restored correctly
- [ ] Normal workflow: add clips from playlist to timeline, edit, undo/redo → verify no regression