### PR TITLE
Fix uniqueColors comparator strict weak ordering

### DIFF
--- a/src/jobs/encodejob.cpp
+++ b/src/jobs/encodejob.cpp
@@ -181,11 +181,11 @@ void EncodeJob::onEmbedChapters()
     std::sort(uniqueColors.begin(), uniqueColors.end(), [=](const QColor &a, const QColor &b) {
         if (a.hue() == b.hue()) {
             if (a.saturation() == b.saturation()) {
-                return a.value() <= b.value();
+                return a.value() < b.value();
             }
-            return a.saturation() <= b.saturation();
+            return a.saturation() < b.saturation();
         }
-        return a.hue() <= b.hue();
+        return a.hue() < b.hue();
     });
     QStringList colors;
     for (auto &color : uniqueColors) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -6326,11 +6326,11 @@ void MainWindow::on_actionExportChapters_triggered()
     std::sort(uniqueColors.begin(), uniqueColors.end(), [=](const QColor &a, const QColor &b) {
         if (a.hue() == b.hue()) {
             if (a.saturation() == b.saturation()) {
-                return a.value() <= b.value();
+                return a.value() < b.value();
             }
-            return a.saturation() <= b.saturation();
+            return a.saturation() < b.saturation();
         }
-        return a.hue() <= b.hue();
+        return a.hue() < b.hue();
     });
     QStringList colors;
     for (auto &color : uniqueColors) {


### PR DESCRIPTION
Fix an issue in the `uniqueColors` sorting comparator where the use of `<=` violated the requirements of a strict weak ordering. The comparison now uses `<` instead to restore correct comparator behavior and prevent undefined behavior during sorting.

In terms of the algorithm's contract, the comparator used by `std::sort` must induce a strict weak ordering. In particular:

- For all `a`, `comp(a, a) == false`.
- If `comp(a, b) == true` then `comp(b, a) == false`.

Using `<=` violated these rules when two elements were equal. Replacing `<=` with `<` ensures compliance with the standard and improves stability.

Even if equal `QColor` are unlikely or impossible to appear in `uniqueColors`, switching to `<` is still safe and makes the comparator correct by definition. If `QColor` can never be equal, then `<` and `<=` behave the same anyway.

References:

- [C++ reference, C++ named requirements: Compare](https://en.cppreference.com/cpp/named_req/Compare)