### PR TITLE
Fix Full-width spaces replaced by half-width spaces when importing subtitles #1840

### DIFF
--- a/src/docks/subtitlesdock.cpp
+++ b/src/docks/subtitlesdock.cpp
@@ -84,6 +84,11 @@ static QList<Subtitles::SubtitleItem> readSrtFile(const QString &path,
         return items;
     }
 
+    static const QRegularExpression htmlTagPattern(
+        QStringLiteral("</?[A-Za-z][A-Za-z0-9:-]*(?:\\s+[^<>]*)?/?>"));
+    static const QRegularExpression htmlEntityPattern(
+        QStringLiteral("&(?:[A-Za-z][A-Za-z0-9]+|#[0-9]+|#x[0-9A-Fa-f]+);"));
+
     // Convert the items to the return list
     Subtitles::SubtitleItem item;
     for (int i = 0; i < srtItems.size(); i++) {
@@ -91,13 +96,18 @@ static QList<Subtitles::SubtitleItem> readSrtFile(const QString &path,
         QStringList lines = QString::fromStdString(srtItems[i].text).split('\n');
         QString text;
         for (int i = 0; i < lines.size(); i++) {
+            QString line = lines[i];
             // Remove HTML
-            QString line = QTextDocumentFragment::fromHtml(lines[i]).toPlainText();
+            bool hasHtmlSyntax = Qt::mightBeRichText(line) || htmlTagPattern.match(line).hasMatch()
+                                 || htmlEntityPattern.match(line).hasMatch();
+            if (hasHtmlSyntax) {
+                line = QTextDocumentFragment::fromHtml(line).toPlainText();
+            }
             // Remove unnecessary space
-            line = line.simplified();
+            line = line.trimmed();
             // Remove leading "-"
             if (line.startsWith("-")) {
-                line = line.remove(0, 1).simplified();
+                line = line.remove(0, 1).trimmed();
             }
             // Remove unspoken sounds if requested
             if (!includeNonspoken


### PR DESCRIPTION
Some white space characters (like U+3000) were bring removed or converted by the html conversion and simplified()

Simplified was replaced with trimmed(). Html conversion is avoided unless we are certain that the line has HTML.

Fixes https://github.com/mltframework/shotcut/issues/1840

This worked for my tests. The test file provided by the issue reporter now passes U+3000
The few subtitle files that I have with markup still pass with the markup being stripped.
