### PR TITLE
Add Settings > Player > Use Old Video Output

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -338,7 +338,9 @@ if(WIN32)
 
   # Windows integration features
   target_sources(shotcut PRIVATE windowstools.cpp windowstools.h)
-  target_link_libraries(shotcut PRIVATE ole32)
+  target_sources(shotcut PRIVATE widgets/d3dvideowidget.h widgets/d3dvideowidget.cpp)
+  target_sources(shotcut PRIVATE widgets/openglvideowidget.h widgets/openglvideowidget.cpp)
+  target_link_libraries(shotcut PRIVATE d3d11 d3dcompiler ole32)
 
   # Runtime exception handler for debug only
   if(CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
@@ -357,10 +359,13 @@ if(WIN32)
   install(DIRECTORY qml DESTINATION ${CMAKE_INSTALL_PREFIX}/share/shotcut/)
   install(DIRECTORY ${CMAKE_SOURCE_DIR}/filter-sets DESTINATION ${CMAKE_INSTALL_PREFIX}/share/shotcut/)
   install(DIRECTORY ${CMAKE_SOURCE_DIR}/voices DESTINATION ${CMAKE_INSTALL_PREFIX}/share/shotcut/)
+else()
+  target_sources(shotcut PRIVATE widgets/openglvideowidget.h widgets/openglvideowidget.cpp)
 endif()
 
 if(APPLE)
-  target_sources(shotcut PRIVATE macos.mm macos.h)
+  target_sources(shotcut PRIVATE macos.mm macos.h
+    widgets/metalvideowidget.h widgets/metalvideowidget.mm)
   set_target_properties(shotcut PROPERTIES
     OUTPUT_NAME "Shotcut"
     MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/packaging/macos/Info.plist.in)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -436,10 +436,15 @@ int main(int argc, char **argv)
 #elif defined(Q_OS_MAC)
         LOG_INFO() << "macOS version" << QSysInfo::productVersion();
 #else
-        if (Settings.drawMethod() == QSGRendererInterface::Vulkan)
-            QQuickWindow::setGraphicsApi(QSGRendererInterface::Vulkan);
-        else if (::qgetenv("QSG_RHI_BACKEND").toLower() != QByteArrayLiteral("vulkan"))
+        if (Settings.playerOldVideoOutput()) {
+            QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
+            QCoreApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
             QCoreApplication::setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
+        } else if (Settings.drawMethod() == QSGRendererInterface::Vulkan) {
+            QQuickWindow::setGraphicsApi(QSGRendererInterface::Vulkan);
+        } else if (::qgetenv("QSG_RHI_BACKEND").toLower() != QByteArrayLiteral("vulkan")) {
+            QCoreApplication::setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
+        }
         LOG_INFO() << "Linux version" << QSysInfo::productVersion();
 #endif
         LOG_INFO() << "number of logical cores =" << QThread::idealThreadCount();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1580,25 +1580,34 @@ void MainWindow::setupSettingsMenu()
     }
 #endif
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
-    // Setup the display method actions.
-    group = new QActionGroup(this);
-    delete ui->actionDrawingAutomatic;
-    delete ui->actionDrawingDirectX;
-    ui->actionDrawingOpenGL->setData(Qt::AA_UseDesktopOpenGL);
-    group->addAction(ui->actionDrawingOpenGL);
-    ui->actionDrawingVulkan->setData(QSGRendererInterface::Vulkan);
-    group->addAction(ui->actionDrawingVulkan);
-    connect(group, SIGNAL(triggered(QAction *)), this, SLOT(onDrawingMethodTriggered(QAction *)));
-    switch (Settings.drawMethod()) {
-    case Qt::AA_UseDesktopOpenGL:
-        ui->actionDrawingOpenGL->setChecked(true);
-        break;
-    case QSGRendererInterface::Vulkan:
-        ui->actionDrawingVulkan->setChecked(true);
-        break;
-    default:
-        ui->actionDrawingOpenGL->setChecked(true);
-        break;
+    if (Settings.playerOldVideoOutput()) {
+        // Old video output requires OpenGL; hide the display method menu.
+        delete ui->menuDrawingMethod;
+        ui->menuDrawingMethod = nullptr;
+    } else {
+        // Setup the display method actions.
+        group = new QActionGroup(this);
+        delete ui->actionDrawingAutomatic;
+        delete ui->actionDrawingDirectX;
+        ui->actionDrawingOpenGL->setData(Qt::AA_UseDesktopOpenGL);
+        group->addAction(ui->actionDrawingOpenGL);
+        ui->actionDrawingVulkan->setData(QSGRendererInterface::Vulkan);
+        group->addAction(ui->actionDrawingVulkan);
+        connect(group,
+                SIGNAL(triggered(QAction *)),
+                this,
+                SLOT(onDrawingMethodTriggered(QAction *)));
+        switch (Settings.drawMethod()) {
+        case Qt::AA_UseDesktopOpenGL:
+            ui->actionDrawingOpenGL->setChecked(true);
+            break;
+        case QSGRendererInterface::Vulkan:
+            ui->actionDrawingVulkan->setChecked(true);
+            break;
+        default:
+            ui->actionDrawingOpenGL->setChecked(true);
+            break;
+        }
     }
 #else
     delete ui->menuDrawingMethod;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -117,7 +117,6 @@
 #include <algorithm>
 
 #define SHOTCUT_THEME
-#define USE_SCREENS_FOR_EXTERNAL_MONITORING
 
 static bool eventDebugCallback(void **data)
 {
@@ -980,6 +979,18 @@ void MainWindow::connectVideoWidgetSignals()
             videoWidget,
             &Mlt::VideoWidget::initialize,
             Qt::DirectConnection);
+    if (Settings.playerOldVideoOutput()) {
+        connect(videoWidget->quickWindow(),
+                &QQuickWindow::beforeRendering,
+                videoWidget,
+                &Mlt::VideoWidget::beforeRendering,
+                Qt::DirectConnection);
+        connect(videoWidget->quickWindow(),
+                &QQuickWindow::beforeRenderPassRecording,
+                videoWidget,
+                &Mlt::VideoWidget::renderVideo,
+                Qt::DirectConnection);
+    }
     connect(videoWidget->quickWindow(),
             &QQuickWindow::sceneGraphInitialized,
             this,
@@ -1261,7 +1272,6 @@ void MainWindow::setupSettingsMenu()
     ui->actionExternalNone->setData(QString());
     m_externalGroup->addAction(ui->actionExternalNone);
 
-#ifdef USE_SCREENS_FOR_EXTERNAL_MONITORING
     QList<QScreen *> screens = QGuiApplication::screens();
     int n = screens.size();
     for (int i = 0; n > 1 && i < n; i++) {
@@ -1294,7 +1304,6 @@ void MainWindow::setupSettingsMenu()
             m_hdrPreviewWindow->requestActivate();
         }
     });
-#endif
 
     Mlt::Profile profile;
     Mlt::Consumer decklink(profile, "decklink:");
@@ -1352,6 +1361,42 @@ void MainWindow::setupSettingsMenu()
             SLOT(onExternalTriggered(QAction *)));
     connect(m_profileGroup, SIGNAL(triggered(QAction *)), this, SLOT(onProfileTriggered(QAction *)));
     updateDecklinkActions();
+
+    // Use Old Video Output
+    auto *oldVideoOutputAction = new QAction(tr("Use Old Video Output"), this);
+    oldVideoOutputAction->setCheckable(true);
+    oldVideoOutputAction->setChecked(Settings.playerOldVideoOutput());
+    ui->menuPlayerSettings->insertAction(ui->menuDeinterlacer->menuAction(), oldVideoOutputAction);
+    connect(oldVideoOutputAction, &QAction::triggered, this, [this, oldVideoOutputAction]() {
+        const bool checked = oldVideoOutputAction->isChecked();
+        if (checked == Settings.playerOldVideoOutput())
+            return;
+        Settings.setPlayerOldVideoOutput(checked);
+        QMessageBox dialog(QMessageBox::Information,
+                           qApp->applicationName(),
+                           tr("Shotcut must restart to change the video output.\n"
+                              "Restart now?"),
+                           QMessageBox::No | QMessageBox::Yes,
+                           this);
+        dialog.setDefaultButton(QMessageBox::Yes);
+        dialog.setEscapeButton(QMessageBox::No);
+        dialog.setWindowModality(QmlApplication::dialogModality());
+        if (dialog.exec() == QMessageBox::Yes) {
+            m_exitCode = EXIT_RESTART;
+            QApplication::closeAllWindows();
+        }
+    });
+    if (Settings.playerOldVideoOutput()) {
+        // Disable screen-based monitoring and HDR preview when using old video output.
+        for (auto *action : m_externalGroup->actions()) {
+            bool isDeckLink = action->data().toString().startsWith(QLatin1String("decklink"));
+            bool isNone = action->data().toString().isEmpty();
+            if (!isDeckLink && !isNone)
+                action->setVisible(false);
+        }
+        if (auto *hdrAction = Actions["hdrPreviewAction"])
+            hdrAction->setVisible(false);
+    }
 
     // Setup the language menu actions
     m_languagesGroup = new QActionGroup(this);
@@ -2508,6 +2553,11 @@ void MainWindow::readPlayerSettings()
     QString external = Settings.playerExternal();
     bool ok = false;
     external.toInt(&ok);
+    if (Settings.playerOldVideoOutput() && ok) {
+        external.clear();
+        Settings.setPlayerExternal(external);
+        ok = false;
+    }
     auto isExternalPeripheral = !external.isEmpty() && !ok;
 
     setAudioChannels(Settings.playerAudioChannels());
@@ -2546,13 +2596,10 @@ void MainWindow::readPlayerSettings()
         ui->actionHyper->setChecked(true);
 
     foreach (QAction *a, m_externalGroup->actions()) {
-#ifndef USE_SCREENS_FOR_EXTERNAL_MONITORING
-        if (isExternalPeripheral)
-#endif
-            if (a->data() == external) {
-                a->setChecked(true);
-                break;
-            }
+        if (a->data() == external) {
+            a->setChecked(true);
+            break;
+        }
     }
     if (m_keyerGroup) {
         auto keyer = Settings.playerKeyerMode();
@@ -2565,7 +2612,7 @@ void MainWindow::readPlayerSettings()
     }
     updateDecklinkActions();
 
-    if (Settings.playerHdrPreview()) {
+    if (Settings.playerHdrPreview() && !Settings.playerOldVideoOutput()) {
         auto hdr = Actions["hdrPreviewAction"];
         if (hdr)
             hdr->setChecked(true);
@@ -5152,7 +5199,6 @@ void MainWindow::onToolbarVisibilityChanged(bool visible)
 void MainWindow::on_menuExternal_aboutToShow()
 {
     updateDecklinkActions();
-#ifdef USE_SCREENS_FOR_EXTERNAL_MONITORING
     foreach (QAction *action, m_externalGroup->actions()) {
         bool ok = false;
         int i = action->data().toInt(&ok);
@@ -5168,7 +5214,6 @@ void MainWindow::on_menuExternal_aboutToShow()
             }
         }
     }
-#endif
 }
 
 void MainWindow::on_actionUpgrade_triggered()

--- a/src/mltcontroller.cpp
+++ b/src/mltcontroller.cpp
@@ -26,6 +26,14 @@
 #include "shotcut_mlt_properties.h"
 #include "util.h"
 #include "videowidget.h"
+#if defined(Q_OS_WIN)
+#include "widgets/d3dvideowidget.h"
+#include "widgets/openglvideowidget.h"
+#elif defined(Q_OS_MAC)
+#include "widgets/metalvideowidget.h"
+#else
+#include "widgets/openglvideowidget.h"
+#endif
 
 #include <Mlt.h>
 #include <QApplication>
@@ -79,7 +87,20 @@ Controller &Controller::singleton(QObject *parent)
     if (!instance) {
         qRegisterMetaType<Mlt::Frame>("Mlt::Frame");
         qRegisterMetaType<SharedFrame>("SharedFrame");
-        instance = new VideoWidget(parent);
+        if (Settings.playerOldVideoOutput()) {
+#if defined(Q_OS_WIN)
+            if (QSGRendererInterface::Direct3D11 == QQuickWindow::graphicsApi())
+                instance = new D3DVideoWidget(parent);
+            else
+                instance = new OpenGLVideoWidget(parent);
+#elif defined(Q_OS_MAC)
+            instance = new MetalVideoWidget(parent);
+#else
+            instance = new OpenGLVideoWidget(parent);
+#endif
+        } else {
+            instance = new VideoWidget(parent);
+        }
     }
     return *instance;
 }

--- a/src/qml/modules/Shotcut/Controls/VuiBase.qml
+++ b/src/qml/modules/Shotcut/Controls/VuiBase.qml
@@ -23,10 +23,14 @@ DropArea {
 
     property real _zoom: (video.zoom > 0) ? video.zoom : 1
 
-    Component.onCompleted: video.setVideoSink(videoOutput.videoSink)
+    Component.onCompleted: {
+        if (!video.oldVideoOutput)
+            video.setVideoSink(videoOutput.videoSink)
+    }
 
     VideoOutput {
         id: videoOutput
+        visible: !video.oldVideoOutput
 
         width: video.rect.width * _zoom
         height: video.rect.height * _zoom

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -895,6 +895,21 @@ void ShotcutSettings::setPlayerPauseAfterSeek(bool b)
     settings.setValue("player/pauseAfterSeek", b);
 }
 
+bool ShotcutSettings::playerOldVideoOutput() const
+{
+#if defined(Q_OS_WIN)
+    bool defaultValue = QSysInfo::currentCpuArchitecture() == QLatin1String("arm64");
+#else
+    bool defaultValue = false;
+#endif
+    return settings.value("player/oldVideoOutput", defaultValue).toBool();
+}
+
+void ShotcutSettings::setPlayerOldVideoOutput(bool b)
+{
+    settings.setValue("player/oldVideoOutput", b);
+}
+
 bool ShotcutSettings::playerHdrPreview() const
 {
     return settings.value("player/hdrPreview", false).toBool();

--- a/src/settings.h
+++ b/src/settings.h
@@ -205,6 +205,8 @@ public:
     void setPlayerAudioDriver(const QString &s);
     bool playerPauseAfterSeek() const;
     void setPlayerPauseAfterSeek(bool);
+    bool playerOldVideoOutput() const;
+    void setPlayerOldVideoOutput(bool);
     bool playerHdrPreview() const;
     void setPlayerHdrPreview(bool);
     QRect playerHdrPreviewGeometry() const;

--- a/src/videowidget.cpp
+++ b/src/videowidget.cpp
@@ -140,7 +140,7 @@ void VideoWidget::initialize()
                 this,
                 &VideoWidget::frameDisplayed,
                 Qt::QueuedConnection);
-        connect(m_frameRenderer, SIGNAL(imageReady()), SIGNAL(imageReady()));
+        connect(m_frameRenderer, &FrameRenderer::imageReady, this, &VideoWidget::imageReady);
     }
     m_initSem.release();
     m_isInitialized = true;

--- a/src/videowidget.cpp
+++ b/src/videowidget.cpp
@@ -75,6 +75,8 @@ VideoWidget::VideoWidget(QObject *parent)
     , m_isInitialized(false)
     , m_frameSemaphore(3)
     , m_imageRequested(false)
+    , m_oldVideoOutput(Settings.playerOldVideoOutput())
+    , m_frameRenderer(nullptr)
     , m_zoom(0.0f)
     , m_offset(QPoint(0, 0))
     , m_snapToGrid(true)
@@ -115,12 +117,31 @@ VideoWidget::~VideoWidget()
 {
     LOG_DEBUG() << "begin";
     stop();
+    if (m_frameRenderer && m_frameRenderer->isRunning()) {
+        m_frameRenderer->quit();
+        m_frameRenderer->wait();
+        m_frameRenderer->deleteLater();
+    }
     LOG_DEBUG() << "end";
 }
 
 void VideoWidget::initialize()
 {
     LOG_DEBUG() << "begin";
+    if (m_oldVideoOutput) {
+        m_frameRenderer = new FrameRenderer();
+        connect(m_frameRenderer,
+                &FrameRenderer::frameDisplayed,
+                this,
+                &VideoWidget::onFrameDisplayed,
+                Qt::QueuedConnection);
+        connect(m_frameRenderer,
+                &FrameRenderer::frameDisplayed,
+                this,
+                &VideoWidget::frameDisplayed,
+                Qt::QueuedConnection);
+        connect(m_frameRenderer, SIGNAL(imageReady()), SIGNAL(imageReady()));
+    }
     m_initSem.release();
     m_isInitialized = true;
     LOG_DEBUG() << "end";
@@ -229,14 +250,38 @@ void VideoWidget::mouseMoveEvent(QMouseEvent *event)
     mimeData->setData(Mlt::XmlMimeType, MLT.XML().toUtf8());
     drag->setMimeData(mimeData);
     mimeData->setText(QString::number(MLT.producer()->get_playtime()));
-    if (m_sharedFrame.is_valid()) {
-        Mlt::Frame displayFrame(m_sharedFrame.clone(false, true));
-        QImage displayImage
-            = MLT.image(&displayFrame, 45 * MLT.profile().dar(), 45).scaledToHeight(45);
+    SharedFrame sourceFrame = m_sharedFrame.is_valid()
+                                  ? m_sharedFrame
+                                  : (m_frameRenderer ? m_frameRenderer->getDisplayFrame()
+                                                     : SharedFrame());
+    if (sourceFrame.is_valid()) {
+        constexpr int kDragThumbnailHeight = 45;
+        Mlt::Frame displayFrame(sourceFrame.clone(false, true));
+        QImage displayImage = MLT.image(&displayFrame,
+                                        kDragThumbnailHeight * MLT.profile().dar(),
+                                        kDragThumbnailHeight)
+                                  .scaledToHeight(kDragThumbnailHeight);
         drag->setPixmap(QPixmap::fromImage(displayImage));
     }
     drag->setHotSpot(QPoint(0, 0));
     drag->exec(Qt::CopyAction);
+}
+
+void VideoWidget::renderVideo() {}
+
+void VideoWidget::onFrameDisplayed(const SharedFrame &frame)
+{
+    m_mutex.lock();
+    m_sharedFrame = frame;
+    m_mutex.unlock();
+    bool isVui = frame.get_int(kShotcutVuiMetaProperty) && !m_hideVui;
+    if (!isVui && source() != QmlUtilities::blankVui()) {
+        m_savedQmlSource = source();
+        setSource(QmlUtilities::blankVui());
+    } else if (isVui && !m_savedQmlSource.isEmpty() && source() != m_savedQmlSource) {
+        setSource(m_savedQmlSource);
+    }
+    quickWindow()->update();
 }
 
 void VideoWidget::wheelEvent(QWheelEvent *event)
@@ -277,8 +322,12 @@ void VideoWidget::keyPressEvent(QKeyEvent *event)
 bool VideoWidget::event(QEvent *event)
 {
     bool result = QQuickWidget::event(event);
-    if (event->type() == QEvent::PaletteChange)
-        setClearColor(palette().window().color());
+    if (event->type() == QEvent::PaletteChange) {
+        if (m_frameRenderer && m_sharedFrame.is_valid())
+            onFrameDisplayed(m_sharedFrame);
+        else
+            setClearColor(palette().window().color());
+    }
     return result;
 }
 
@@ -577,11 +626,12 @@ QPoint VideoWidget::offset() const
 
 QImage VideoWidget::image() const
 {
-    if (m_sharedFrame.is_valid()) {
-        const uint8_t *image = m_sharedFrame.get_image(mlt_image_rgba);
+    SharedFrame frame = m_frameRenderer ? m_frameRenderer->getDisplayFrame() : m_sharedFrame;
+    if (frame.is_valid()) {
+        const uint8_t *image = frame.get_image(mlt_image_rgba);
         if (image) {
-            int width = m_sharedFrame.get_image_width();
-            int height = m_sharedFrame.get_image_height();
+            int width = frame.get_image_width();
+            int height = frame.get_image_height();
             QImage temp(image, width, height, QImage::Format_RGBA8888);
             return temp.copy();
         }
@@ -592,7 +642,7 @@ QImage VideoWidget::image() const
 bool VideoWidget::imageIsProxy() const
 {
     bool isProxy = false;
-    SharedFrame frame = m_sharedFrame;
+    SharedFrame frame = m_frameRenderer ? m_frameRenderer->getDisplayFrame() : m_sharedFrame;
     if (frame.is_valid()) {
         Mlt::Producer *frameProducer = frame.get_original_producer();
         if (frameProducer && frameProducer->is_valid() && frameProducer->get_int(kIsProxyProperty)) {
@@ -603,9 +653,17 @@ bool VideoWidget::imageIsProxy() const
     return isProxy;
 }
 
+bool VideoWidget::oldVideoOutput() const
+{
+    return m_oldVideoOutput;
+}
+
 void VideoWidget::requestImage()
 {
-    m_imageRequested = true;
+    if (m_frameRenderer)
+        m_frameRenderer->requestImage();
+    else
+        m_imageRequested = true;
 }
 
 void VideoWidget::toggleVuiDisplay()
@@ -1014,32 +1072,45 @@ void VideoWidget::on_frame_show(mlt_consumer, VideoWidget *widget, mlt_event_dat
     auto frame = Mlt::EventData(data).to_frame();
     if (frame.is_valid() && frame.get_int("rendered")) {
         int timeout = (widget->consumer()->get_int("real_time") > 0) ? 0 : 1000;
-        if (widget->m_frameSemaphore.tryAcquire(1, timeout)) {
-            QByteArray p016Buffer;
-            if (!qstrcmp(widget->consumer()->get("mlt_image_format"), "yuv420p10")) {
-                mlt_image_format mltFmt = mlt_image_yuv420p10;
-                int width = 0, height = 0;
-                const uint8_t *image = frame.get_image(mltFmt, width, height);
-                if (image && width > 0 && height > 0) {
-                    // Grab a reusable buffer from the pool to avoid per-frame allocation.
-                    {
-                        QMutexLocker lock(&widget->m_p016Pool->mutex);
-                        if (!widget->m_p016Pool->buffers.isEmpty()) {
-                            p016Buffer = std::move(widget->m_p016Pool->buffers.last());
-                            widget->m_p016Pool->buffers.removeLast();
-                        }
-                    }
-                    convertToP016(image, width, height, p016Buffer);
-                }
+        if (widget->m_frameRenderer) {
+            // Old path: dispatch to FrameRenderer thread
+            if (widget->m_frameRenderer->semaphore()->tryAcquire(1, timeout)) {
+                QMetaObject::invokeMethod(widget->m_frameRenderer,
+                                          "showFrame",
+                                          Qt::QueuedConnection,
+                                          Q_ARG(Mlt::Frame, frame));
+            } else if (!Settings.playerRealtime()) {
+                LOG_WARNING() << "VideoWidget dropped frame" << frame.get_position();
             }
-            QMetaObject::invokeMethod(
-                widget,
-                [widget, frame, buf = std::move(p016Buffer)]() mutable {
-                    widget->showFrame(frame, std::move(buf));
-                },
-                Qt::QueuedConnection);
-        } else if (!Settings.playerRealtime()) {
-            LOG_WARNING() << "VideoWidget dropped frame" << frame.get_position();
+        } else {
+            // New QVideoSink path: pre-convert P016 on this thread then hand off to GUI
+            if (widget->m_frameSemaphore.tryAcquire(1, timeout)) {
+                QByteArray p016Buffer;
+                if (!qstrcmp(widget->consumer()->get("mlt_image_format"), "yuv420p10")) {
+                    mlt_image_format mltFmt = mlt_image_yuv420p10;
+                    int width = 0, height = 0;
+                    const uint8_t *image = frame.get_image(mltFmt, width, height);
+                    if (image && width > 0 && height > 0) {
+                        // Grab a reusable buffer from the pool to avoid per-frame allocation.
+                        {
+                            QMutexLocker lock(&widget->m_p016Pool->mutex);
+                            if (!widget->m_p016Pool->buffers.isEmpty()) {
+                                p016Buffer = std::move(widget->m_p016Pool->buffers.last());
+                                widget->m_p016Pool->buffers.removeLast();
+                            }
+                        }
+                        convertToP016(image, width, height, p016Buffer);
+                    }
+                }
+                QMetaObject::invokeMethod(
+                    widget,
+                    [widget, frame, buf = std::move(p016Buffer)]() mutable {
+                        widget->showFrame(frame, std::move(buf));
+                    },
+                    Qt::QueuedConnection);
+            } else if (!Settings.playerRealtime()) {
+                LOG_WARNING() << "VideoWidget dropped frame" << frame.get_position();
+            }
         }
     }
 }
@@ -1075,4 +1146,39 @@ void RenderThread::run()
     m_context->makeCurrent(m_surface.get());
     m_function(m_data);
     m_context->doneCurrent();
+}
+
+FrameRenderer::FrameRenderer()
+    : QThread(nullptr)
+    , m_semaphore(3)
+    , m_imageRequested(false)
+{
+    setObjectName("FrameRenderer");
+    moveToThread(this);
+    start();
+}
+
+FrameRenderer::~FrameRenderer() {}
+
+void FrameRenderer::showFrame(Mlt::Frame frame)
+{
+    m_displayFrame = SharedFrame(frame);
+    emit frameDisplayed(m_displayFrame);
+
+    if (m_imageRequested) {
+        m_imageRequested = false;
+        emit imageReady();
+    }
+
+    m_semaphore.release();
+}
+
+void FrameRenderer::requestImage()
+{
+    m_imageRequested = true;
+}
+
+SharedFrame FrameRenderer::getDisplayFrame()
+{
+    return m_displayFrame;
 }

--- a/src/videowidget.cpp
+++ b/src/videowidget.cpp
@@ -1162,23 +1162,30 @@ FrameRenderer::~FrameRenderer() {}
 
 void FrameRenderer::showFrame(Mlt::Frame frame)
 {
-    m_displayFrame = SharedFrame(frame);
-    emit frameDisplayed(m_displayFrame);
-
-    if (m_imageRequested) {
-        m_imageRequested = false;
-        emit imageReady();
+    SharedFrame newFrame(frame);
+    bool emitImage = false;
+    {
+        QMutexLocker locker(&m_mutex);
+        m_displayFrame = newFrame;
+        if (m_imageRequested) {
+            m_imageRequested = false;
+            emitImage = true;
+        }
     }
-
+    emit frameDisplayed(newFrame);
+    if (emitImage)
+        emit imageReady();
     m_semaphore.release();
 }
 
 void FrameRenderer::requestImage()
 {
+    QMutexLocker locker(&m_mutex);
     m_imageRequested = true;
 }
 
 SharedFrame FrameRenderer::getDisplayFrame()
 {
+    QMutexLocker locker(&m_mutex);
     return m_displayFrame;
 }

--- a/src/videowidget.h
+++ b/src/videowidget.h
@@ -55,6 +55,7 @@ namespace Mlt {
 
 class Filter;
 class RenderThread;
+class FrameRenderer;
 
 typedef void *(*thread_function_t)(void *);
 
@@ -66,6 +67,7 @@ class VideoWidget : public QQuickWidget, public Controller
     Q_PROPERTY(bool snapToGrid READ snapToGrid NOTIFY snapToGridChanged)
     Q_PROPERTY(float zoom READ zoom NOTIFY zoomChanged)
     Q_PROPERTY(QPoint offset READ offset NOTIFY offsetChanged)
+    Q_PROPERTY(bool oldVideoOutput READ oldVideoOutput CONSTANT)
 
 public:
     VideoWidget(QObject *parent = 0);
@@ -113,6 +115,7 @@ public:
     void requestImage();
     bool snapToGrid() const { return m_snapToGrid; }
     int maxTextureSize() const { return m_maxTextureSize; }
+    bool oldVideoOutput() const;
     void toggleVuiDisplay();
     Q_INVOKABLE void setVideoSink(QVideoSink *sink);
 
@@ -125,6 +128,9 @@ public slots:
     void setCurrentFilter(QmlFilter *filter, QmlMetadata *meta);
     void setSnapToGrid(bool snap);
     virtual void initialize();
+    virtual void beforeRendering() {}
+    virtual void renderVideo();
+    virtual void onFrameDisplayed(const SharedFrame &frame);
     void showFrame(Mlt::Frame frame, QByteArray p016Buffer = {});
 
 signals:
@@ -159,6 +165,7 @@ private:
     std::unique_ptr<Event> m_threadJoinEvent;
     QSemaphore m_frameSemaphore;
     bool m_imageRequested;
+    const bool m_oldVideoOutput;
     float m_zoom;
     QPoint m_offset;
     QUrl m_savedQmlSource;
@@ -169,6 +176,7 @@ private:
     QPoint m_mousePosition;
     std::unique_ptr<RenderThread> m_renderThread;
     QPointer<QVideoSink> m_videoSink;
+    FrameRenderer *m_frameRenderer;
 
     static void on_frame_show(mlt_consumer, VideoWidget *widget, mlt_event_data);
     void pushFrameToSink(const SharedFrame &frame, QByteArray p016Buffer = {});
@@ -190,6 +198,7 @@ protected:
     void wheelEvent(QWheelEvent *event) override;
     void keyPressEvent(QKeyEvent *event) override;
     bool event(QEvent *event) override;
+    virtual void createShader() {}
 
     int m_maxTextureSize;
     SharedFrame m_sharedFrame;
@@ -211,6 +220,29 @@ private:
     void *m_data;
     std::unique_ptr<QOpenGLContext> m_context;
     std::unique_ptr<QOffscreenSurface> m_surface;
+};
+
+class FrameRenderer : public QThread
+{
+    Q_OBJECT
+public:
+    FrameRenderer();
+    ~FrameRenderer();
+    QSemaphore *semaphore() { return &m_semaphore; }
+    SharedFrame getDisplayFrame();
+    Q_INVOKABLE void showFrame(Mlt::Frame frame);
+    void requestImage();
+    QImage image() const { return m_image; }
+
+signals:
+    void frameDisplayed(const SharedFrame &frame);
+    void imageReady();
+
+private:
+    QSemaphore m_semaphore;
+    SharedFrame m_displayFrame;
+    bool m_imageRequested;
+    QImage m_image;
 };
 
 } // namespace Mlt

--- a/src/videowidget.h
+++ b/src/videowidget.h
@@ -240,6 +240,7 @@ signals:
 
 private:
     QSemaphore m_semaphore;
+    mutable QMutex m_mutex;
     SharedFrame m_displayFrame;
     bool m_imageRequested;
     QImage m_image;

--- a/src/widgets/d3dvideowidget.cpp
+++ b/src/widgets/d3dvideowidget.cpp
@@ -1,0 +1,403 @@
+/*
+ * Copyright (c) 2023-2026 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "d3dvideowidget.h"
+
+#include "Logger.h"
+
+#include <d3dcompiler.h>
+
+D3DVideoWidget::D3DVideoWidget(QObject *parent)
+    : Mlt::VideoWidget{parent}
+{
+    m_maxTextureSize = D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION;
+    ::memset(&m_constants, 0, sizeof(m_constants));
+}
+
+D3DVideoWidget::~D3DVideoWidget()
+{
+    for (int i = 0; i < 3; i++) {
+        if (m_texture[i])
+            m_texture[i]->Release();
+    }
+    if (m_vs)
+        m_vs->Release();
+    if (m_ps)
+        m_ps->Release();
+    if (m_vbuf)
+        m_vbuf->Release();
+    if (m_cbuf)
+        m_cbuf->Release();
+    if (m_inputLayout)
+        m_inputLayout->Release();
+    if (m_rastState)
+        m_rastState->Release();
+    if (m_dsState)
+        m_dsState->Release();
+}
+
+void D3DVideoWidget::initialize()
+{
+    m_initialized = true;
+    QSGRendererInterface *rif = quickWindow()->rendererInterface();
+
+    // We are not prepared for anything other than running with the RHI and its D3D11 backend.
+    Q_ASSERT(rif->graphicsApi() == QSGRendererInterface::Direct3D11);
+
+    m_device = reinterpret_cast<ID3D11Device *>(
+        rif->getResource(quickWindow(), QSGRendererInterface::DeviceResource));
+    Q_ASSERT(m_device);
+    m_context = reinterpret_cast<ID3D11DeviceContext *>(
+        rif->getResource(quickWindow(), QSGRendererInterface::DeviceContextResource));
+    Q_ASSERT(m_context);
+
+    if (m_vert.isEmpty())
+        prepareShader(VertexStage);
+    if (m_frag.isEmpty())
+        prepareShader(FragmentStage);
+
+    const QByteArray vs = compileShader(VertexStage, m_vert, m_vertEntryPoint);
+    const QByteArray fs = compileShader(FragmentStage, m_frag, m_fragEntryPoint);
+
+    HRESULT hr = m_device->CreateVertexShader(vs.constData(), vs.size(), nullptr, &m_vs);
+    if (FAILED(hr))
+        qFatal("Failed to create vertex shader: 0x%x", uint(hr));
+
+    hr = m_device->CreatePixelShader(fs.constData(), fs.size(), nullptr, &m_ps);
+    if (FAILED(hr))
+        qFatal("Failed to create pixel shader: 0x%x", uint(hr));
+
+    D3D11_BUFFER_DESC bufDesc;
+    memset(&bufDesc, 0, sizeof(bufDesc));
+    bufDesc.ByteWidth = sizeof(float) * 16;
+    bufDesc.Usage = D3D11_USAGE_DEFAULT;
+    bufDesc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
+    hr = m_device->CreateBuffer(&bufDesc, nullptr, &m_vbuf);
+    if (FAILED(hr))
+        qFatal("Failed to create buffer: 0x%x", uint(hr));
+
+    bufDesc.ByteWidth = sizeof(m_constants) + 0xf & 0xfffffff0; // must be a multiple of 16
+    bufDesc.Usage = D3D11_USAGE_DYNAMIC;
+    bufDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+    bufDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+    hr = m_device->CreateBuffer(&bufDesc, nullptr, &m_cbuf);
+    if (FAILED(hr))
+        qFatal("Failed to create buffer: 0x%x", uint(hr));
+
+    const D3D11_INPUT_ELEMENT_DESC inputDesc[] = {
+        {"VERTEX", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0},
+        {"TEXCOORD",
+         0,
+         DXGI_FORMAT_R32G32B32_FLOAT,
+         0,
+         sizeof(DirectX::XMFLOAT2),
+         D3D11_INPUT_PER_VERTEX_DATA,
+         0},
+    };
+    hr = m_device->CreateInputLayout(inputDesc,
+                                     ARRAYSIZE(inputDesc),
+                                     vs.constData(),
+                                     vs.size(),
+                                     &m_inputLayout);
+    if (FAILED(hr))
+        qFatal("Failed to create input layout: 0x%x", uint(hr));
+
+    D3D11_RASTERIZER_DESC rastDesc;
+    memset(&rastDesc, 0, sizeof(rastDesc));
+    rastDesc.FillMode = D3D11_FILL_SOLID;
+    rastDesc.CullMode = D3D11_CULL_NONE;
+    hr = m_device->CreateRasterizerState(&rastDesc, &m_rastState);
+    if (FAILED(hr))
+        qFatal("Failed to create rasterizer state: 0x%x", uint(hr));
+
+    D3D11_DEPTH_STENCIL_DESC dsDesc;
+    memset(&dsDesc, 0, sizeof(dsDesc));
+    hr = m_device->CreateDepthStencilState(&dsDesc, &m_dsState);
+    if (FAILED(hr))
+        qFatal("Failed to create depth/stencil state: 0x%x", uint(hr));
+
+    Mlt::VideoWidget::initialize();
+}
+
+void D3DVideoWidget::beforeRendering()
+{
+    quickWindow()->beginExternalCommands();
+    m_context->ClearState();
+
+    // Provide vertices of triangle strip
+    float width = rect().width() * devicePixelRatioF() / 2.0f;
+    float height = rect().height() * devicePixelRatioF() / 2.0f;
+    float vertexData[] = {
+        // x,y plus u,v texture coordinates
+        width,
+        -height,
+        1.f,
+        1.f, // bottom left
+        -width,
+        -height,
+        0.f,
+        1.f, // bottom right
+        width,
+        height,
+        1.f,
+        0.f, // top left
+        -width,
+        height,
+        0.f,
+        0.f // top right
+    };
+
+    // Setup an orthographic projection
+    QMatrix4x4 modelView;
+    width = this->width() * devicePixelRatioF();
+    height = this->height() * devicePixelRatioF();
+    modelView.scale(2.0f / width, 2.0f / height);
+
+    // Set model-view
+    if (rect().width() > 0.0 && zoom() > 0.0) {
+        if (offset().x() || offset().y())
+            modelView.translate(-offset().x() * devicePixelRatioF(),
+                                offset().y() * devicePixelRatioF());
+        modelView.scale(zoom(), zoom());
+    }
+    for (int i = 0; i < 4; i++) {
+        vertexData[4 * i] *= modelView(0, 0);
+        vertexData[4 * i] += modelView(0, 3);
+        vertexData[4 * i + 1] *= modelView(1, 1);
+        vertexData[4 * i + 1] += modelView(1, 3);
+    }
+    m_context->UpdateSubresource(m_vbuf, 0, nullptr, vertexData, 0, 0);
+
+    // (Re)create the textures
+    m_mutex.lock();
+    if (!m_sharedFrame.is_valid()) {
+        m_mutex.unlock();
+        quickWindow()->endExternalCommands();
+        Mlt::VideoWidget::beforeRendering();
+        return;
+    }
+    int iwidth = m_sharedFrame.get_image_width();
+    int iheight = m_sharedFrame.get_image_height();
+    const uint8_t *image = m_sharedFrame.get_image(mlt_image_yuv420p);
+    for (int i = 0; i < 3; i++) {
+        if (m_texture[i])
+            m_texture[i]->Release();
+    }
+    m_texture[0] = initTexture(image, iwidth, iheight);
+    m_texture[1] = initTexture(image + iwidth * iheight, iwidth / 2, iheight / 2);
+    m_texture[2] = initTexture(image + iwidth * iheight + iwidth / 2 * iheight / 2,
+                               iwidth / 2,
+                               iheight / 2);
+    m_mutex.unlock();
+
+    // Update the constants
+    D3D11_MAPPED_SUBRESOURCE mp;
+    // will copy the entire constant buffer every time -> pass WRITE_DISCARD -> prevent pipeline stalls
+    HRESULT hr = m_context->Map(m_cbuf, 0, D3D11_MAP_WRITE_DISCARD, 0, &mp);
+    if (SUCCEEDED(hr)) {
+        m_constants.colorspace = MLT.profile().colorspace();
+        ::memcpy(mp.pData, &m_constants, sizeof(m_constants));
+        m_context->Unmap(m_cbuf, 0);
+    } else {
+        quickWindow()->endExternalCommands();
+        qFatal("Failed to map constant buffer: 0x%x", uint(hr));
+        return;
+    }
+
+    quickWindow()->endExternalCommands();
+    Mlt::VideoWidget::beforeRendering();
+}
+
+void D3DVideoWidget::renderVideo()
+{
+    if (!m_texture[0]) {
+        Mlt::VideoWidget::renderVideo();
+        return;
+    }
+    quickWindow()->beginExternalCommands();
+
+    D3D11_VIEWPORT v;
+    v.TopLeftX = 0.f;
+    v.TopLeftY = 0.f;
+    v.Width = this->width() * devicePixelRatioF();
+    v.Height = this->height() * devicePixelRatioF();
+    v.MinDepth = 0.f;
+    v.MaxDepth = 1.f;
+
+    m_context->RSSetViewports(1, &v);
+    m_context->VSSetShader(m_vs, nullptr, 0);
+    m_context->PSSetShader(m_ps, nullptr, 0);
+    m_context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+    m_context->IASetInputLayout(m_inputLayout);
+    m_context->OMSetDepthStencilState(m_dsState, 0);
+    m_context->RSSetState(m_rastState);
+    const UINT stride = sizeof(float) * 4;
+    const UINT offset = 0;
+    m_context->IASetVertexBuffers(0, 1, &m_vbuf, &stride, &offset);
+    m_context->PSSetConstantBuffers(0, 1, &m_cbuf);
+    m_context->PSSetShaderResources(0, 3, m_texture);
+    m_context->Draw(4, 0);
+
+    quickWindow()->endExternalCommands();
+    Mlt::VideoWidget::renderVideo();
+}
+
+void D3DVideoWidget::prepareShader(Stage stage)
+{
+    if (stage == VertexStage) {
+        m_vert = "struct VSInput {"
+                 "  float2 vertex : VERTEX;"
+                 "  float2 coords : TEXCOORD;"
+                 "};"
+                 "struct VSOutput {"
+                 "  float2 coords : TEXCOORD0;"
+                 "  float4 position : SV_Position;"
+                 "};"
+                 "VSOutput main(VSInput input) {"
+                 "  VSOutput output;"
+                 "  output.position = float4(input.vertex, 0.0f, 1.0f);"
+                 "  output.coords = input.coords;"
+                 "  return output;"
+                 "}";
+        Q_ASSERT(!m_vert.isEmpty());
+        m_vertEntryPoint = QByteArrayLiteral("main");
+    } else {
+        m_frag = "Texture2D yTex, uTex, vTex;"
+                 "SamplerState yuvSampler;"
+                 "cbuffer buf {"
+                 "    int colorspace;"
+                 "};"
+                 "struct PSInput {"
+                 "  float2 coords : TEXCOORD0;"
+                 "};"
+                 "struct PSOutput {"
+                 "  float4 color : SV_Target0;"
+                 "};"
+                 "PSOutput main(PSInput input) {"
+                 "  float3 yuv;"
+                 "  yuv.x = yTex.Sample(yuvSampler, input.coords).r -  16.0f/255.0f;"
+                 "  yuv.y = uTex.Sample(yuvSampler, input.coords).r - 128.0f/255.0f;"
+                 "  yuv.z = vTex.Sample(yuvSampler, input.coords).r - 128.0f/255.0f;"
+                 "  float3x3 coefficients;"
+                 "  if (colorspace == 601) {"
+                 "    coefficients = float3x3("
+                 "      1.1643f,  0.0f,      1.5958f,"
+                 "      1.1643f, -0.39173f, -0.8129f,"
+                 "      1.1643f,  2.017f,    0.0f);"
+                 "  } else if (colorspace == 2020) {" // ITU-R BT.2020
+                 "    coefficients = float3x3("
+                 "      1.1643f,  0.0f,    1.7167f,"
+                 "      1.1643f, -0.1873f, -0.6504f,"
+                 "      1.1643f,  2.1418f,  0.0f);"
+                 "  } else {" // ITU-R 709
+                 "    coefficients = float3x3("
+                 "      1.1643f,  0.0f,    1.793f,"
+                 "      1.1643f, -0.213f, -0.533f,"
+                 "      1.1643f,  2.112f,  0.0f);"
+                 "  }"
+                 "  PSOutput output;"
+                 "  output.color = float4(mul(coefficients, yuv), 1.0f);"
+                 "  return output;"
+                 "}";
+        m_fragEntryPoint = QByteArrayLiteral("main");
+    }
+}
+
+QByteArray D3DVideoWidget::compileShader(Stage stage,
+                                         const QByteArray &source,
+                                         const QByteArray &entryPoint)
+{
+    const char *target;
+    switch (stage) {
+    case VertexStage:
+        target = "vs_5_0";
+        break;
+    case FragmentStage:
+        target = "ps_5_0";
+        break;
+    default:
+        qFatal("Unknown shader stage %d", stage);
+        return QByteArray();
+    }
+
+    ID3DBlob *bytecode = nullptr;
+    ID3DBlob *errors = nullptr;
+    HRESULT hr = D3DCompile(source.constData(),
+                            source.size(),
+                            nullptr,
+                            nullptr,
+                            nullptr,
+                            entryPoint.constData(),
+                            target,
+                            0,
+                            0,
+                            &bytecode,
+                            &errors);
+    if (FAILED(hr) || !bytecode) {
+        LOG_WARNING("HLSL shader compilation failed: 0x%x", uint(hr));
+        if (errors) {
+            const QByteArray msg(static_cast<const char *>(errors->GetBufferPointer()),
+                                 errors->GetBufferSize());
+            errors->Release();
+            LOG_WARNING("%s", msg.constData());
+        }
+        return QByteArray();
+    }
+
+    QByteArray result;
+    result.resize(bytecode->GetBufferSize());
+    memcpy(result.data(), bytecode->GetBufferPointer(), result.size());
+    bytecode->Release();
+
+    return result;
+}
+
+ID3D11ShaderResourceView *D3DVideoWidget::initTexture(const void *p, int width, int height)
+{
+    ID3D11ShaderResourceView *result;
+    D3D11_TEXTURE2D_DESC desc;
+    desc.Width = width;
+    desc.Height = height;
+    desc.MipLevels = 1;
+    desc.ArraySize = 1;
+    desc.Format = DXGI_FORMAT_R8_UNORM;
+    desc.SampleDesc.Count = 1;
+    desc.SampleDesc.Quality = 0;
+    desc.Usage = D3D11_USAGE_DEFAULT;
+    desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+    desc.CPUAccessFlags = 0;
+    desc.MiscFlags = 0;
+
+    D3D11_SUBRESOURCE_DATA subresourceData;
+    subresourceData.pSysMem = p;
+    subresourceData.SysMemPitch = width;
+    subresourceData.SysMemSlicePitch = 0;
+
+    ID3D11Texture2D *texture;
+    m_device->CreateTexture2D(&desc, &subresourceData, &texture);
+
+    D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc;
+    srvDesc.Format = desc.Format;
+    srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+    srvDesc.Texture2D.MipLevels = 1;
+    srvDesc.Texture2D.MostDetailedMip = 0;
+
+    m_device->CreateShaderResourceView(texture, &srvDesc, &result);
+    texture->Release();
+
+    return result;
+}

--- a/src/widgets/d3dvideowidget.h
+++ b/src/widgets/d3dvideowidget.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023-2026 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef D3DVIDEOWIDGET_H
+#define D3DVIDEOWIDGET_H
+
+#include "videowidget.h"
+
+#include <d3d11.h>
+#include <directxmath.h>
+
+class D3DVideoWidget : public Mlt::VideoWidget
+{
+    Q_OBJECT
+public:
+    explicit D3DVideoWidget(QObject *parent = nullptr);
+    virtual ~D3DVideoWidget();
+
+public slots:
+    virtual void initialize();
+    virtual void beforeRendering();
+    virtual void renderVideo();
+
+private:
+    enum Stage { VertexStage, FragmentStage };
+    void prepareShader(Stage stage);
+    QByteArray compileShader(Stage stage, const QByteArray &source, const QByteArray &entryPoint);
+    ID3D11ShaderResourceView *initTexture(const void *p, int width, int height);
+
+    ID3D11Device *m_device = nullptr;
+    ID3D11DeviceContext *m_context = nullptr;
+    QByteArray m_vert;
+    QByteArray m_vertEntryPoint;
+    QByteArray m_frag;
+    QByteArray m_fragEntryPoint;
+
+    bool m_initialized = false;
+    ID3D11Buffer *m_vbuf = nullptr;
+    ID3D11Buffer *m_cbuf = nullptr;
+    ID3D11VertexShader *m_vs = nullptr;
+    ID3D11PixelShader *m_ps = nullptr;
+    ID3D11InputLayout *m_inputLayout = nullptr;
+    ID3D11RasterizerState *m_rastState = nullptr;
+    ID3D11DepthStencilState *m_dsState = nullptr;
+    ID3D11ShaderResourceView *m_texture[3] = {nullptr, nullptr, nullptr};
+
+    struct ConstantBuffer
+    {
+        int32_t colorspace;
+    };
+
+    ConstantBuffer m_constants;
+};
+
+#endif // D3DVIDEOWIDGET_H

--- a/src/widgets/metalvideowidget.h
+++ b/src/widgets/metalvideowidget.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023-2026 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef METALVIDEOWIDGET_H
+#define METALVIDEOWIDGET_H
+
+#include "videowidget.h"
+
+class MetalVideoRenderer;
+
+class MetalVideoWidget : public Mlt::VideoWidget
+{
+    Q_OBJECT
+public:
+    explicit MetalVideoWidget(QObject *parent);
+    virtual ~MetalVideoWidget();
+
+public slots:
+    virtual void initialize();
+    virtual void renderVideo();
+
+private:
+    std::unique_ptr<MetalVideoRenderer> m_renderer;
+};
+
+#endif // METALVIDEOWIDGET_H

--- a/src/widgets/metalvideowidget.mm
+++ b/src/widgets/metalvideowidget.mm
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2023-2026 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "metalvideowidget.h"
+
+#include "Logger.h"
+
+#include <Metal/Metal.h>
+
+
+class MetalVideoRenderer : public QObject
+{
+    Q_OBJECT
+public:
+    MetalVideoRenderer()
+    {
+        for (int i = 0; i < 3; ++i) {
+            m_ubuf[i] = nil;
+            m_texture[i] = nil;
+        }
+        m_vbuf = nil;
+        m_vs.first = nil;
+        m_vs.second = nil;
+        m_fs.first = nil;
+        m_fs.second = nil;
+    }
+
+    ~MetalVideoRenderer()
+    {
+        LOG_DEBUG() << "cleanup";
+
+        for (int i = 0; i < 3; i++) {
+            [m_texture[i] release];
+            [m_ubuf[i] release];
+        }
+        [m_vbuf release];
+        [m_vs.first release];
+        [m_vs.second release];
+        [m_fs.first release];
+        [m_fs.second release];
+    }
+
+    void initialize(QQuickWindow *window)
+    {
+        LOG_DEBUG() << "init";
+        m_window = window;
+
+        QSGRendererInterface *rif = m_window->rendererInterface();
+
+        // We are not prepared for anything other than running with the RHI and its Metal backend.
+        Q_ASSERT(rif->graphicsApi() == QSGRendererInterface::Metal);
+
+        m_device = (id<MTLDevice>) rif->getResource(m_window, QSGRendererInterface::DeviceResource);
+        Q_ASSERT(m_device);
+
+        if (m_vert.isEmpty())
+            prepareShader(VertexStage);
+        if (m_frag.isEmpty())
+            prepareShader(FragmentStage);
+
+        m_vbuf = [m_device newBufferWithLength: 16*sizeof(float) options: MTLResourceStorageModeShared];
+
+        for (int i = 0; i < m_window->graphicsStateInfo().framesInFlight && i < 3; ++i)
+            m_ubuf[i] = [m_device newBufferWithLength: sizeof(int) options: MTLResourceStorageModeShared];
+
+        MTLVertexDescriptor *inputLayout = [MTLVertexDescriptor vertexDescriptor];
+        inputLayout.attributes[0].format = MTLVertexFormatFloat4;
+        inputLayout.attributes[0].offset = 0;
+        inputLayout.attributes[0].bufferIndex = 1; // ubuf is 0, vbuf is 1
+        inputLayout.layouts[1].stride = 4 * sizeof(float);
+
+        MTLRenderPipelineDescriptor *rpDesc = [[MTLRenderPipelineDescriptor alloc] init];
+        rpDesc.vertexDescriptor = inputLayout;
+
+        m_vs = compileShader(m_vert, m_vertEntryPoint);
+        rpDesc.vertexFunction = m_vs.first;
+        m_fs = compileShader(m_frag, m_fragEntryPoint);
+        rpDesc.fragmentFunction = m_fs.first;
+
+        rpDesc.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
+//        if (m_device.depth24Stencil8PixelFormatSupported) {
+//            rpDesc.depthAttachmentPixelFormat = MTLPixelFormatDepth24Unorm_Stencil8;
+//            rpDesc.stencilAttachmentPixelFormat = MTLPixelFormatDepth24Unorm_Stencil8;
+//        } else {
+//            rpDesc.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
+//            rpDesc.stencilAttachmentPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
+//        }
+
+        NSError *err = nil;
+        m_pipeline = [m_device newRenderPipelineStateWithDescriptor: rpDesc error: &err];
+        if (!m_pipeline) {
+            const QString msg = QString::fromNSString(err.localizedDescription);
+            qFatal("Failed to create render pipeline state: %s", qPrintable(msg));
+        }
+        [rpDesc release];
+    }
+
+    void render(const QSize& viewportSize, const QRectF& videoRect, const double devicePixelRatio,
+                const double zoom, const QPoint& offset, const SharedFrame& sharedFrame)
+    {
+        const QQuickWindow::GraphicsStateInfo &stateInfo(m_window->graphicsStateInfo());
+
+        QSGRendererInterface *rif = m_window->rendererInterface();
+        id<MTLRenderCommandEncoder> encoder = (id<MTLRenderCommandEncoder>) rif->getResource(
+                    m_window, QSGRendererInterface::CommandEncoderResource);
+        Q_ASSERT(encoder);
+
+        // Provide vertices of triangle strip
+        float width = videoRect.width() * devicePixelRatio / 2.0f;
+        float height = videoRect.height() * devicePixelRatio / 2.0f;
+        float vertexData[] = { // x,y plus u,v texture coordinates
+            -width,  height, 0.f, 0.f,
+             width,  height, 1.f, 0.f,
+            -width, -height, 0.f, 1.f,
+             width, -height, 1.f, 1.f
+        };
+
+        // Setup an orthographic projection
+        QMatrix4x4 modelView;
+        width = viewportSize.width() * devicePixelRatio;
+        height = viewportSize.height() * devicePixelRatio;
+        modelView.scale(2.0f / width, 2.0f / height);
+
+        // Set model-view
+        if (videoRect.width() > 0.0 && zoom > 0.0) {
+            if (offset.x() || offset.y())
+                modelView.translate(-offset.x() * devicePixelRatio,
+                                    offset.y() * devicePixelRatio);
+            modelView.scale(zoom, zoom);
+        }
+        for (int i = 0; i < 4; i++) {
+            vertexData[4 * i] *= modelView(0, 0);
+            vertexData[4 * i] += modelView(0, 3);
+            vertexData[4 * i + 1] *= modelView(1, 1);
+            vertexData[4 * i + 1] += modelView(1, 3);
+        }
+
+        m_window->beginExternalCommands();
+
+        void *p = [m_vbuf contents];
+        memcpy(p, vertexData, sizeof(vertexData));
+
+        p = [m_ubuf[stateInfo.currentFrameSlot] contents];
+        int colorspace = MLT.profile().colorspace();
+        memcpy(p, &colorspace, sizeof(colorspace));
+
+        MTLViewport vp;
+        vp.originX = 0;
+        vp.originY = 0;
+        vp.width = width;
+        vp.height = height;
+        vp.znear = 0;
+        vp.zfar = 1;
+        [encoder setViewport: vp];
+
+        // (Re)create the textures
+        int iwidth = sharedFrame.get_image_width();
+        int iheight = sharedFrame.get_image_height();
+        const uint8_t *image = sharedFrame.get_image(mlt_image_yuv420p);
+        for (int i = 0; i < 3; i++) {
+            [m_texture[i] release];
+        }
+        m_texture[0] = initTexture(image, iwidth, iheight);
+        m_texture[1] = initTexture(image + iwidth * iheight, iwidth / 2, iheight / 2);
+        m_texture[2] = initTexture(image + iwidth * iheight + iwidth / 2 * iheight / 2, iwidth / 2,
+                                   iheight / 2);
+        // Set the texture object.  The AAPLTextureIndexBaseColor enum value corresponds
+        ///  to the 'colorMap' argument in the 'samplingShader' function because its
+        //   texture attribute qualifier also uses AAPLTextureIndexBaseColor for its index.
+        for (NSUInteger i = 0; i < 3; i++) {
+            [encoder setFragmentTexture:m_texture[i] atIndex:i];
+        }
+
+
+        [encoder setFragmentBuffer: m_ubuf[stateInfo.currentFrameSlot] offset: 0 atIndex: 0];
+        [encoder setVertexBuffer: m_vbuf offset: 0 atIndex: 1];
+        [encoder setRenderPipelineState: m_pipeline];
+        [encoder drawPrimitives: MTLPrimitiveTypeTriangleStrip vertexStart: 0 vertexCount: 4 instanceCount: 1 baseInstance: 0];
+
+        m_window->endExternalCommands();
+    }
+
+    id<MTLTexture> initTexture(const void *p, NSUInteger width, NSUInteger height)
+    {
+        MTLTextureDescriptor *textureDescriptor = [[MTLTextureDescriptor alloc] init];
+
+        // 8-bit unsigned normalized value (i.e. 0 maps to 0.0 and 255 maps to 1.0)
+        textureDescriptor.pixelFormat = MTLPixelFormatR8Unorm;
+        textureDescriptor.width = width;
+        textureDescriptor.height = height;
+        id<MTLTexture> texture = [m_device newTextureWithDescriptor:textureDescriptor];
+        [textureDescriptor release];
+
+        MTLRegion region = {
+            { 0, 0, 0 },  // MTLOrigin
+            {width, height, 1} // MTLSize
+        };
+
+        // Copy the bytes from the data object into the texture
+        [texture replaceRegion:region mipmapLevel:0 withBytes:p bytesPerRow:width];
+        return texture;
+    }
+
+private:
+    enum Stage {
+        VertexStage,
+        FragmentStage
+    };
+    using FuncAndLib = QPair<id<MTLFunction>, id<MTLLibrary> >;
+    QQuickWindow *m_window = nullptr;
+    QByteArray m_vert;
+    QByteArray m_vertEntryPoint;
+    QByteArray m_frag;
+    QByteArray m_fragEntryPoint;
+    id<MTLDevice> m_device;
+    id<MTLBuffer> m_vbuf;
+    id<MTLBuffer> m_ubuf[3];
+    FuncAndLib m_vs;
+    FuncAndLib m_fs;
+    id<MTLRenderPipelineState> m_pipeline;
+    id<MTLTexture> m_texture[3];
+
+    void prepareShader(Stage stage)
+    {
+        if (stage == VertexStage) {
+            m_vert ="#include <metal_stdlib>\n"
+                    "#include <simd/simd.h>\n"
+                    "using namespace metal;"
+                    "struct main0_out {"
+                    "    float2 coords [[user(locn0)]];"
+                    "    float4 vertices [[position]];"
+                    "};"
+                    "struct main0_in {"
+                    "    float4 vertices [[attribute(0)]];"
+                    "};"
+                    "vertex main0_out main0(main0_in in [[stage_in]]) {"
+                    "    main0_out out = {};"
+                    "    out.vertices = vector_float4(in.vertices.xy, 0.0f, 1.0f);"
+                    "    out.coords = in.vertices.zw;"
+                    "    return out;"
+                    "}";
+            Q_ASSERT(!m_vert.isEmpty());
+            m_vertEntryPoint = QByteArrayLiteral("main0");
+        } else {
+            m_frag ="#include <metal_stdlib>\n"
+                    "#include <simd/simd.h>\n"
+                    "using namespace metal;"
+                    "struct buf {"
+                    "    int colorspace;"
+                    "};"
+                    "struct main0_out {"
+                    "    float4 fragColor [[color(0)]];"
+                    "};"
+                    "struct main0_in {"
+                    "    float2 coords [[user(locn0)]];"
+                    "};"
+                    "fragment main0_out main0(main0_in in [[stage_in]], constant buf& ubuf [[buffer(0)]],"
+                    "      texture2d<half> yTex [[texture(0)]],"
+                    "      texture2d<half> uTex [[texture(1)]],"
+                    "      texture2d<half> vTex [[texture(2)]]"
+                    "      ) {"
+                    "    main0_out out = {};"
+                    "    constexpr sampler yuvSampler (mag_filter::linear, min_filter::linear);"
+                    "    float3 yuv;"
+                    "    yuv.x = yTex.sample(yuvSampler, in.coords).r -  16.0f/255.0f;"
+                    "    yuv.y = uTex.sample(yuvSampler, in.coords).r - 128.0f/255.0f;"
+                    "    yuv.z = vTex.sample(yuvSampler, in.coords).r - 128.0f/255.0f;"
+                    "    float3x3 coefficients;"
+                    "    if (ubuf.colorspace == 601) {"
+                    "      coefficients = float3x3("
+                    "        {1.1643f,  1.1643f,  1.1643f},"
+                    "        {0.0f,    -0.39173f, 2.017f},"
+                    "        {1.5958f, -0.8129f,  0.0f});"
+                    "    } else if (ubuf.colorspace == 2020) {" // ITU-R BT.2020
+                    "      coefficients = float3x3("
+                    "        {1.1643f, 1.1643f, 1.1643f},"
+                    "        {0.0f,   -0.1873f, 2.1418f},"
+                    "        {1.7167f, -0.6504f, 0.0f});"
+                    "    } else {" // ITU-R 709
+                    "      coefficients = float3x3("
+                    "        {1.1643f, 1.1643f, 1.1643f},"
+                    "        {0.0f,   -0.213f,  2.112f},"
+                    "        {1.793f, -0.533f,  0.0f});"
+                    "    }"
+                    "    out.fragColor = float4(coefficients * yuv, 1.0f);"
+                    "    return out;"
+                    "}";
+            m_fragEntryPoint = QByteArrayLiteral("main0");
+        }
+    }
+
+    FuncAndLib compileShader(const QByteArray &source, const QByteArray &entryPoint)
+    {
+        FuncAndLib fl;
+
+        NSString *srcstr = [NSString stringWithUTF8String: source.constData()];
+        MTLCompileOptions *opts = [[MTLCompileOptions alloc] init];
+        opts.languageVersion = MTLLanguageVersion1_2;
+        NSError *err = nil;
+        fl.second = [m_device newLibraryWithSource: srcstr options: opts error: &err];
+        [opts release];
+        // srcstr is autoreleased
+
+        if (err) {
+            const QString msg = QString::fromNSString(err.localizedDescription);
+            qFatal("%s", qPrintable(msg));
+            return fl;
+        }
+
+        NSString *name = [NSString stringWithUTF8String: entryPoint.constData()];
+        fl.first = [fl.second newFunctionWithName: name];
+//        [name release];
+
+        return fl;
+    }
+};
+
+MetalVideoWidget::MetalVideoWidget(QObject *parent)
+    : Mlt::VideoWidget{parent}
+    , m_renderer{new MetalVideoRenderer}
+{
+    m_maxTextureSize = 16384;
+}
+
+MetalVideoWidget::~MetalVideoWidget()
+{
+}
+
+void MetalVideoWidget::initialize()
+{
+    m_renderer->initialize(quickWindow());
+    Mlt::VideoWidget::initialize();
+}
+
+void MetalVideoWidget::renderVideo()
+{
+    m_mutex.lock();
+    if (m_sharedFrame.is_valid()) {
+        m_renderer->render(size(), rect(), devicePixelRatio(), zoom(), offset(), m_sharedFrame);
+    }
+    m_mutex.unlock();
+    Mlt::VideoWidget::renderVideo();
+}
+
+#include "metalvideowidget.moc"

--- a/src/widgets/openglvideowidget.cpp
+++ b/src/widgets/openglvideowidget.cpp
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) 2011-2026 Meltytech, LLC
+ *
+ * Some GL shader based on BSD licensed code from Peter Bengtsson:
+ * http://www.fourcc.org/source/YUV420P-OpenGL-GLSLang.c
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "openglvideowidget.h"
+#include "mainwindow.h"
+
+#include "Logger.h"
+
+#include <utility>
+#include <QOpenGLFunctions_1_1>
+#include <QOpenGLFunctions_3_2_Core>
+#include <QOpenGLVersionFunctionsFactory>
+
+#ifdef QT_NO_DEBUG
+#define check_error(fn) \
+    {}
+#else
+#define check_error(fn) \
+    { \
+        int err = fn->glGetError(); \
+        if (err != GL_NO_ERROR) { \
+            LOG_ERROR() << "GL error" << Qt::hex << err << Qt::dec << "at" << __FILE__ << ":" \
+                        << __LINE__; \
+        } \
+    }
+#endif
+
+OpenGLVideoWidget::OpenGLVideoWidget(QObject *parent)
+    : VideoWidget{parent}
+    , m_quickContext(nullptr)
+    , m_isThreadedOpenGL(false)
+{
+    m_renderTexture[0] = m_renderTexture[1] = m_renderTexture[2] = 0;
+    m_displayTexture[0] = m_displayTexture[1] = m_displayTexture[2] = 0;
+}
+
+OpenGLVideoWidget::~OpenGLVideoWidget()
+{
+    LOG_DEBUG() << "begin";
+    if (m_renderTexture[0] && m_displayTexture[0] && m_context) {
+        m_context->makeCurrent(&m_offscreenSurface);
+        m_context->functions()->glDeleteTextures(3, m_renderTexture);
+        if (m_displayTexture[0] && m_displayTexture[1] && m_displayTexture[2])
+            m_context->functions()->glDeleteTextures(3, m_displayTexture);
+        m_context->doneCurrent();
+    }
+}
+
+void OpenGLVideoWidget::initialize()
+{
+    LOG_DEBUG() << "begin";
+    auto context = static_cast<QOpenGLContext *>(
+        quickWindow()->rendererInterface()->getResource(quickWindow(),
+                                                        QSGRendererInterface::OpenGLContextResource));
+    m_quickContext = context;
+
+    if (!m_offscreenSurface.isValid()) {
+        m_offscreenSurface.setFormat(context->format());
+        m_offscreenSurface.create();
+    }
+    Q_ASSERT(m_offscreenSurface.isValid());
+
+    initializeOpenGLFunctions();
+    LOG_INFO() << "OpenGL vendor" << QString::fromUtf8((const char *) glGetString(GL_VENDOR));
+    LOG_INFO() << "OpenGL renderer" << QString::fromUtf8((const char *) glGetString(GL_RENDERER));
+    LOG_INFO() << "OpenGL threaded?" << context->supportsThreadedOpenGL();
+    LOG_INFO() << "OpenGL ES?" << context->isOpenGLES();
+    glGetIntegerv(GL_MAX_TEXTURE_SIZE, &m_maxTextureSize);
+    LOG_INFO() << "OpenGL maximum texture size =" << m_maxTextureSize;
+    GLint dims[2];
+    glGetIntegerv(GL_MAX_VIEWPORT_DIMS, &dims[0]);
+    LOG_INFO() << "OpenGL maximum viewport size =" << dims[0] << "x" << dims[1];
+
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
+    // Turn off the hardware decoder by default on Linux with NVIDIA
+    const auto nvidia
+        = QString::fromUtf8((const char *) glGetString(GL_RENDERER)).toLower().contains("nv");
+    if (nvidia && !Settings.playerPreviewHardwareDecoderIsSet()) {
+        MAIN.turnOffHardwareDecoder();
+    }
+#endif
+
+    createShader();
+
+    LOG_DEBUG() << "end";
+    Mlt::VideoWidget::initialize();
+}
+
+void OpenGLVideoWidget::createShader()
+{
+    m_shader.reset(new QOpenGLShaderProgram);
+    m_shader->addShaderFromSourceCode(QOpenGLShader::Vertex,
+                                      "uniform highp mat4 projection;"
+                                      "uniform highp mat4 modelView;"
+                                      "attribute highp vec4 vertex;"
+                                      "attribute highp vec2 texCoord;"
+                                      "varying highp vec2 coordinates;"
+                                      "void main(void) {"
+                                      "  gl_Position = projection * modelView * vertex;"
+                                      "  coordinates = texCoord;"
+                                      "}");
+    m_shader
+        ->addShaderFromSourceCode(QOpenGLShader::Fragment,
+                                  "uniform sampler2D Ytex, Utex, Vtex;"
+                                  "uniform lowp int colorspace;"
+                                  "varying highp vec2 coordinates;"
+                                  "void main(void) {"
+                                  "  mediump vec3 texel;"
+                                  "  texel.r = texture2D(Ytex, coordinates).r -  16.0/255.0;" // Y
+                                  "  texel.g = texture2D(Utex, coordinates).r - 128.0/255.0;" // U
+                                  "  texel.b = texture2D(Vtex, coordinates).r - 128.0/255.0;" // V
+                                  "  mediump mat3 coefficients;"
+                                  "  if (colorspace == 601) {"
+                                  "    coefficients = mat3("
+                                  "      1.1643,  1.1643,  1.1643,"    // column 1
+                                  "      0.0,    -0.39173, 2.017,"     // column 2
+                                  "      1.5958, -0.8129,  0.0);"      // column 3
+                                  "  } else if (colorspace == 2020) {" // ITU-R BT.2020
+                                  "    coefficients = mat3("
+                                  "      1.1643, 1.1643, 1.1643," // column 1
+                                  "      0.0,   -0.1873, 2.1418," // column 2
+                                  "      1.7167, -0.6504, 0.0);"  // column 3
+                                  "  } else {"                    // ITU-R 709
+                                  "    coefficients = mat3("
+                                  "      1.1643, 1.1643, 1.1643," // column 1
+                                  "      0.0,   -0.213,  2.112,"  // column 2
+                                  "      1.793, -0.533,  0.0);"   // column 3
+                                  "  }"
+                                  "  gl_FragColor = vec4(coefficients * texel, 1.0);"
+                                  "}");
+    m_shader->link();
+    m_textureLocation[0] = m_shader->uniformLocation("Ytex");
+    m_textureLocation[1] = m_shader->uniformLocation("Utex");
+    m_textureLocation[2] = m_shader->uniformLocation("Vtex");
+    m_colorspaceLocation = m_shader->uniformLocation("colorspace");
+    m_projectionLocation = m_shader->uniformLocation("projection");
+    m_modelViewLocation = m_shader->uniformLocation("modelView");
+    m_vertexLocation = m_shader->attributeLocation("vertex");
+    m_texCoordLocation = m_shader->attributeLocation("texCoord");
+}
+
+static void uploadTextures(QOpenGLContext *context, const SharedFrame &frame, GLuint texture[])
+{
+    int width = frame.get_image_width();
+    int height = frame.get_image_height();
+    const uint8_t *image = frame.get_image(mlt_image_yuv420p);
+    QOpenGLFunctions *f = context->functions();
+
+    // The planes of pixel data may not be a multiple of the default 4 bytes.
+    f->glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
+    // Upload each plane of YUV to a texture.
+    if (texture[0])
+        f->glDeleteTextures(3, texture);
+    check_error(f);
+    f->glGenTextures(3, texture);
+    check_error(f);
+
+    f->glBindTexture(GL_TEXTURE_2D, texture[0]);
+    check_error(f);
+    f->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    check_error(f);
+    f->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    check_error(f);
+    f->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    check_error(f);
+    f->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    check_error(f);
+    f->glTexImage2D(GL_TEXTURE_2D,
+                    0,
+                    GL_LUMINANCE,
+                    width,
+                    height,
+                    0,
+                    GL_LUMINANCE,
+                    GL_UNSIGNED_BYTE,
+                    image);
+    check_error(f);
+
+    f->glBindTexture(GL_TEXTURE_2D, texture[1]);
+    check_error(f);
+    f->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    check_error(f);
+    f->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    check_error(f);
+    f->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    check_error(f);
+    f->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    check_error(f);
+    f->glTexImage2D(GL_TEXTURE_2D,
+                    0,
+                    GL_LUMINANCE,
+                    width / 2,
+                    height / 2,
+                    0,
+                    GL_LUMINANCE,
+                    GL_UNSIGNED_BYTE,
+                    image + width * height);
+    check_error(f);
+
+    f->glBindTexture(GL_TEXTURE_2D, texture[2]);
+    check_error(f);
+    f->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    check_error(f);
+    f->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    check_error(f);
+    f->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    check_error(f);
+    f->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    check_error(f);
+    f->glTexImage2D(GL_TEXTURE_2D,
+                    0,
+                    GL_LUMINANCE,
+                    width / 2,
+                    height / 2,
+                    0,
+                    GL_LUMINANCE,
+                    GL_UNSIGNED_BYTE,
+                    image + width * height + width / 2 * height / 2);
+    check_error(f);
+}
+
+void OpenGLVideoWidget::renderVideo()
+{
+    auto context = static_cast<QOpenGLContext *>(
+        quickWindow()->rendererInterface()->getResource(quickWindow(),
+                                                        QSGRendererInterface::OpenGLContextResource));
+    if (!m_quickContext) {
+        LOG_ERROR() << "No quickContext";
+        return;
+    }
+    if (!context->isValid()) {
+        LOG_ERROR() << "No QSGRendererInterface::OpenGLContextResource";
+        return;
+    }
+
+#ifndef QT_NO_DEBUG
+    QOpenGLFunctions *f = context->functions();
+#endif
+    float width = this->width() * devicePixelRatioF();
+    float height = this->height() * devicePixelRatioF();
+
+    glDisable(GL_BLEND);
+    glDisable(GL_DEPTH_TEST);
+    glDepthMask(GL_FALSE);
+    glViewport(0, 0, width, height);
+    check_error(f);
+
+    if (!m_isThreadedOpenGL) {
+        m_mutex.lock();
+        if (!m_sharedFrame.is_valid()) {
+            m_mutex.unlock();
+            return;
+        }
+        uploadTextures(context, m_sharedFrame, m_displayTexture);
+        m_mutex.unlock();
+    }
+
+    if (!m_displayTexture[0]) {
+        return;
+    }
+
+    quickWindow()->beginExternalCommands();
+
+    // Bind textures.
+    for (int i = 0; i < 3; ++i) {
+        if (m_displayTexture[i]) {
+            glActiveTexture(GL_TEXTURE0 + i);
+            glBindTexture(GL_TEXTURE_2D, m_displayTexture[i]);
+            check_error(f);
+        }
+    }
+
+    // Init shader program.
+    m_shader->bind();
+    m_shader->setUniformValue(m_textureLocation[0], 0);
+    m_shader->setUniformValue(m_textureLocation[1], 1);
+    m_shader->setUniformValue(m_textureLocation[2], 2);
+    m_shader->setUniformValue(m_colorspaceLocation, MLT.profile().colorspace());
+    check_error(f);
+
+    // Setup an orthographic projection.
+    QMatrix4x4 projection;
+    projection.scale(2.0f / width, 2.0f / height);
+    m_shader->setUniformValue(m_projectionLocation, projection);
+    check_error(f);
+
+    // Set model view.
+    QMatrix4x4 modelView;
+    if (rect().width() > 0.0 && zoom() > 0.0) {
+        if (offset().x() || offset().y())
+            modelView.translate(-offset().x() * devicePixelRatioF(),
+                                offset().y() * devicePixelRatioF());
+        modelView.scale(zoom(), zoom());
+    }
+    m_shader->setUniformValue(m_modelViewLocation, modelView);
+    check_error(f);
+
+    // Provide vertices of triangle strip.
+    QVector<QVector2D> vertices;
+    width = rect().width() * devicePixelRatioF();
+    height = rect().height() * devicePixelRatioF();
+    vertices << QVector2D(-width / 2.0f, -height / 2.0f);
+    vertices << QVector2D(-width / 2.0f, height / 2.0f);
+    vertices << QVector2D(width / 2.0f, -height / 2.0f);
+    vertices << QVector2D(width / 2.0f, height / 2.0f);
+    m_shader->enableAttributeArray(m_vertexLocation);
+    check_error(f);
+    m_shader->setAttributeArray(m_vertexLocation, vertices.constData());
+    check_error(f);
+
+    // Provide texture coordinates.
+    QVector<QVector2D> texCoord;
+    texCoord << QVector2D(0.0f, 1.0f);
+    texCoord << QVector2D(0.0f, 0.0f);
+    texCoord << QVector2D(1.0f, 1.0f);
+    texCoord << QVector2D(1.0f, 0.0f);
+    m_shader->enableAttributeArray(m_texCoordLocation);
+    check_error(f);
+    m_shader->setAttributeArray(m_texCoordLocation, texCoord.constData());
+    check_error(f);
+
+    // Render
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, vertices.size());
+    check_error(f);
+
+    // Cleanup
+    m_shader->disableAttributeArray(m_vertexLocation);
+    m_shader->disableAttributeArray(m_texCoordLocation);
+    m_shader->release();
+    for (int i = 0; i < 3; ++i) {
+        if (m_displayTexture[i]) {
+            glActiveTexture(GL_TEXTURE0 + i);
+            glBindTexture(GL_TEXTURE_2D, 0);
+            check_error(f);
+        }
+    }
+    glActiveTexture(GL_TEXTURE0);
+    check_error(f);
+
+    quickWindow()->endExternalCommands();
+    Mlt::VideoWidget::renderVideo();
+}
+
+void OpenGLVideoWidget::onFrameDisplayed(const SharedFrame &frame)
+{
+    if (m_isThreadedOpenGL && !m_context) {
+        m_context.reset(new QOpenGLContext);
+        if (m_context) {
+            m_context->setFormat(m_quickContext->format());
+            m_context->setShareContext(m_quickContext);
+            m_context->create();
+        }
+    }
+    if (m_context && m_context->isValid()) {
+        // Using threaded OpenGL to upload textures.
+        QOpenGLFunctions *f = m_context->functions();
+        m_context->makeCurrent(&m_offscreenSurface);
+        uploadTextures(m_context.get(), frame, m_renderTexture);
+        f->glBindTexture(GL_TEXTURE_2D, 0);
+        check_error(f);
+        f->glFinish();
+        m_context->doneCurrent();
+
+        m_mutex.lock();
+        for (int i = 0; i < 3; ++i)
+            std::swap(m_renderTexture[i], m_displayTexture[i]);
+        m_mutex.unlock();
+    }
+    Mlt::VideoWidget::onFrameDisplayed(frame);
+}

--- a/src/widgets/openglvideowidget.cpp
+++ b/src/widgets/openglvideowidget.cpp
@@ -257,6 +257,8 @@ void OpenGLVideoWidget::renderVideo()
     float width = this->width() * devicePixelRatioF();
     float height = this->height() * devicePixelRatioF();
 
+    quickWindow()->beginExternalCommands();
+
     glDisable(GL_BLEND);
     glDisable(GL_DEPTH_TEST);
     glDepthMask(GL_FALSE);
@@ -267,6 +269,7 @@ void OpenGLVideoWidget::renderVideo()
         m_mutex.lock();
         if (!m_sharedFrame.is_valid()) {
             m_mutex.unlock();
+            quickWindow()->endExternalCommands();
             return;
         }
         uploadTextures(context, m_sharedFrame, m_displayTexture);
@@ -274,10 +277,9 @@ void OpenGLVideoWidget::renderVideo()
     }
 
     if (!m_displayTexture[0]) {
+        quickWindow()->endExternalCommands();
         return;
     }
-
-    quickWindow()->beginExternalCommands();
 
     // Bind textures.
     for (int i = 0; i < 3; ++i) {

--- a/src/widgets/openglvideowidget.h
+++ b/src/widgets/openglvideowidget.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023-2026 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPENGLVIDEOWIDGET_H
+#define OPENGLVIDEOWIDGET_H
+
+#include "videowidget.h"
+
+#include <QOffscreenSurface>
+#include <QOpenGLContext>
+#include <QOpenGLFramebufferObject>
+#include <QOpenGLFunctions>
+#include <QOpenGLShaderProgram>
+
+class OpenGLVideoWidget : public Mlt::VideoWidget, protected QOpenGLFunctions
+{
+    Q_OBJECT
+
+public:
+    explicit OpenGLVideoWidget(QObject *parent = nullptr);
+    virtual ~OpenGLVideoWidget();
+
+public slots:
+    virtual void initialize();
+    virtual void renderVideo();
+    virtual void onFrameDisplayed(const SharedFrame &frame);
+
+private:
+    void createShader();
+
+    QOffscreenSurface m_offscreenSurface;
+    std::unique_ptr<QOpenGLShaderProgram> m_shader;
+    GLint m_projectionLocation;
+    GLint m_modelViewLocation;
+    GLint m_vertexLocation;
+    GLint m_texCoordLocation;
+    GLint m_colorspaceLocation;
+    GLint m_textureLocation[3];
+    QOpenGLContext *m_quickContext;
+    std::unique_ptr<QOpenGLContext> m_context;
+    GLuint m_renderTexture[3];
+    GLuint m_displayTexture[3];
+    bool m_isThreadedOpenGL;
+};
+
+#endif // OPENGLVIDEOWIDGET_H


### PR DESCRIPTION
I have one system (Snapdragon X Windows ARM) that is not working with Quik VideoOutput, and I could not get it working. That raises the risk that it might not be compatible elsewhere, and the old method is proven reliable. So, add a way to go back to the old just in case or until things are fixed everywhere.