### PR TITLE
Add documentation for AndroidAppender class

### DIFF
--- a/CuteLogger/include/AndroidAppender.h
+++ b/CuteLogger/include/AndroidAppender.h
@@ -5,6 +5,22 @@
 #include <AbstractStringAppender.h>
 
 
+/**
+ * @brief A logging appender for Android logcat.
+ *
+ * This class implements a logging appender that sends log messages to the
+ * Android logcat system. It inherits from AbstractStringAppender and provides
+ * Android-specific logging functionality by converting log levels and formatting
+ * messages appropriately for the Android environment.
+ *
+ * The appender maps CuteLogger's log levels to corresponding Android log priorities
+ * and handles the formatting and output of log messages to the Android system log.
+ *
+ * @see AbstractStringAppender for the base class interface
+ * @see Logger::LogLevel for available log levels
+ *
+ * @note This appender is only effective on Android platforms.
+ */
 class AndroidAppender : public AbstractStringAppender
 {
   public:


### PR DESCRIPTION
## Problem
The AndroidAppender class in the CuteLogger module lacked documentation, making it difficult for developers to understand its purpose, usage, and relationship to the base class AbstractStringAppender. This could hinder contribution and maintenance efforts.

## Solution
This PR adds a comprehensive Doxygen docstring to the AndroidAppender class header file (AndroidAppender.h). The documentation covers:
- **Purpose**: Describes the class as a logging appender for Android logcat.
- **Inheritance**: Clarifies the relationship with AbstractStringAppender.
- **Functionality**: Explains log level mapping to Android priorities and message formatting.
- **Usage Notes**: Highlights platform-specific behavior (Android only).

The changes are minimal and focus solely on improving code clarity without altering any functionality or API.

## Verification
- Reviewed the added documentation for accuracy and consistency with repository style.
- Confirmed that no functional changes were made; only documentation was added.
- Ensured the code compiles without errors and maintains backward compatibility.
- Validated that the docstring format aligns with existing documentation practices in the project.