### PR TITLE
Add Shotcut QML documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ scripts/build-shotcut.conf
 .vscode
 MinimalMediaBackend/
 CuteLogger/libCuteLogger.dll
+docs/qml-api/
+shotcut.code-workspace

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ if(WIN32)
   option(WINDOWS_DEPLOY "Install exes/libs directly to prefix (no subdir /bin)" ON)
 endif()
 option(CLANG_FORMAT "Enable Clang Format" ON)
+option(BUILD_DOCS "Build QDoc API documentation" OFF)
 option(EXTERNAL_LAUNCHERS "Whether include features to launch external programs; for example, this should be off for Flatpak due to sandbox." ON)
 option(USE_VULKAN "Whether to use Vulkan for hardware video decoding" OFF)
 if (UNIX AND NOT APPLE)
@@ -111,3 +112,22 @@ file(GLOB_RECURSE QML_SRC "src/qml/*.qml")
 add_custom_target(qmlformat COMMAND
   ${CMAKE_PREFIX_PATH}/bin/qmlformat -i ${QML_SRC}
 )
+
+if(BUILD_DOCS)
+  find_program(QDOC_EXECUTABLE qdoc
+    HINTS
+      "${Qt6_DIR}/../../../bin"
+      "$ENV{HOME}/Qt/6.10.3/gcc_64/bin"
+      "${CMAKE_PREFIX_PATH}/bin"
+  )
+  if(NOT QDOC_EXECUTABLE)
+    message(FATAL_ERROR "qdoc not found. Install Qt documentation tools or set Qt6_DIR correctly.")
+  endif()
+  add_custom_target(docs
+    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_SOURCE_DIR}/docs/qml-api
+    COMMAND ${QDOC_EXECUTABLE} ${CMAKE_SOURCE_DIR}/docs/qml-api.qdocconf
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMENT "Generating QDoc API documentation"
+    VERBATIM
+  )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,10 +115,10 @@ add_custom_target(qmlformat COMMAND
 
 if(BUILD_DOCS)
   find_program(QDOC_EXECUTABLE qdoc
-    HINTS
-      "${Qt6_DIR}/../../../bin"
-      "$ENV{HOME}/Qt/6.10.3/gcc_64/bin"
-      "${CMAKE_PREFIX_PATH}/bin"
+    PATHS
+      "${Qt6_DIR}/../../.."
+      "${CMAKE_PREFIX_PATH}"
+    PATH_SUFFIXES bin
   )
   if(NOT QDOC_EXECUTABLE)
     message(FATAL_ERROR "qdoc not found. Install Qt documentation tools or set Qt6_DIR correctly.")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,7 +32,8 @@
             },
             "cacheVariables": {
                 "CMAKE_PREFIX_PATH": "$env{HOME}/Qt/$env{QT_VERSION}/gcc_64;$env{HOME}/Qt/$env{QT_VERSION}/macos;$env{HOME}/.local;$env{HOME}/opt;/usr/local;/opt/local",
-                "CMAKE_C_FLAGS": "-I/usr/local/include"
+                "CMAKE_C_FLAGS": "-I/usr/local/include",
+                "BUILD_DOCS": "ON"
             }
         },
         {

--- a/docs/qml-api.qdocconf
+++ b/docs/qml-api.qdocconf
@@ -1,0 +1,48 @@
+project     = Shotcut
+description = Shotcut QML Scripting API
+version     = 26.x
+
+# Output
+outputdir       = ./qml-api
+outputformats   = HTML
+
+# Scan both .qdoc structural files and .cpp files with inline qdoc blocks.
+# Headers are NOT listed — qdoc cannot parse them without a full build tree.
+sources.fileextensions  = *.qdoc *.cpp
+
+# Structural .qdoc files (no C++ counterpart) + all inline-documented .cpp files
+sources = \
+    ./src/index.qdoc \
+    ./src/org-shotcut-qml.qdoc \
+    ./src/shotcut-controls.qdoc \
+    ./src/shotcut-controls-types.qdoc \
+    ../src/qmltypes/qmlapplication.cpp \
+    ../src/qmltypes/qmlfilter.cpp \
+    ../src/qmltypes/qmlproducer.cpp \
+    ../src/qmltypes/qmlprofile.cpp \
+    ../src/qmltypes/qmlview.cpp \
+    ../src/qmltypes/qmlextension.cpp \
+    ../src/qmltypes/qmlrichtext.cpp \
+    ../src/qmltypes/qmlmetadata.cpp \
+    ../src/qmltypes/qmlfile.cpp \
+    ../src/settings.cpp \
+    ../src/models/attachedfiltersmodel.cpp \
+    ../src/models/keyframesmodel.cpp \
+    ../src/models/markersmodel.cpp \
+    ../src/models/motiontrackermodel.cpp \
+    ../src/models/multitrackmodel.cpp \
+    ../src/models/subtitlesmodel.cpp \
+    ../src/docks/timelinedock.cpp \
+    ../src/docks/keyframesdock.cpp
+
+# Custom stylesheet for readability
+HTML.stylesheets = shotcut.css
+HTML.headerstyles = "    <link rel=\"stylesheet\" type=\"text/css\" href=\"style/shotcut.css\">\n"
+
+# Suppress warnings about undocumented symbols while docs are being built incrementally
+# (remove or lower this once all headers are annotated)
+warninglimit = 0
+
+# Do not generate a full Qt-style index; this is a standalone reference
+navigation.landingpage   = "Shotcut QML Scripting API"
+navigation.cppclassespage  = "C++ Classes"

--- a/docs/shotcut.css
+++ b/docs/shotcut.css
@@ -1,0 +1,224 @@
+/* ── Shotcut QML API docs — minimal readability stylesheet ───────────────── */
+
+/* Base layout */
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                 "Helvetica Neue", Arial, sans-serif;
+    font-size: 15px;
+    line-height: 1.6;
+    color: #1a1a1a;
+    background: #fff;
+    margin: 0;
+    padding: 2rem 2.5rem 4rem;
+    max-width: 960px;
+}
+
+/* Center the main content */
+.main-content,
+div.main,
+#main-content {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 2rem 2rem 4rem;
+}
+
+/* ── Navigation sidebar ───────────────────────────────────────────────────── */
+.sidebar,
+div.sidebar,
+#sidebar {
+    background: #f4f4f6;
+    border-right: 1px solid #d8d8de;
+    font-size: 13px;
+    padding: 1.2rem 0;
+}
+
+.sidebar a,
+div.sidebar a {
+    color: #333;
+    text-decoration: none;
+    display: block;
+    padding: 0.25rem 1.2rem;
+}
+
+.sidebar a:hover,
+div.sidebar a:hover {
+    background: #e8e8ef;
+    color: #000;
+}
+
+.sidebar .active,
+div.sidebar .active {
+    font-weight: 600;
+    background: #dde1f0;
+    border-left: 3px solid #0066cc;
+    padding-left: calc(1.2rem - 3px);
+}
+
+/* ── Headings ─────────────────────────────────────────────────────────────── */
+h1 {
+    font-size: 2rem;
+    font-weight: 700;
+    border-bottom: 2px solid #d0d0d8;
+    padding-bottom: 0.4rem;
+    margin-top: 0;
+}
+
+h2 {
+    font-size: 1.4rem;
+    font-weight: 600;
+    border-bottom: 1px solid #e0e0e8;
+    padding-bottom: 0.25rem;
+    margin-top: 2rem;
+}
+
+h3 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin-top: 1.6rem;
+    color: #222;
+}
+
+/* ── Code ─────────────────────────────────────────────────────────────────── */
+code,
+tt,
+kbd {
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.88em;
+    background: #f2f3f5;
+    border: 1px solid #dde;
+    border-radius: 3px;
+    padding: 0.1em 0.35em;
+}
+
+pre {
+    background: #f5f6f8;
+    border: 1px solid #d8dae0;
+    border-radius: 5px;
+    padding: 1rem 1.2rem;
+    overflow-x: auto;
+    font-size: 0.86em;
+    line-height: 1.5;
+}
+
+pre code {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 1em;
+}
+
+/* ── Tables ───────────────────────────────────────────────────────────────── */
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 1.2rem 0;
+    font-size: 0.93em;
+}
+
+th {
+    background: #eeeef4;
+    text-align: left;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #d0d0da;
+    font-weight: 600;
+}
+
+td {
+    padding: 0.45rem 0.75rem;
+    border: 1px solid #d8d8e2;
+    vertical-align: top;
+}
+
+tr:nth-child(even) td {
+    background: #fafafa;
+}
+
+/* ── Links ────────────────────────────────────────────────────────────────── */
+a {
+    color: #0066cc;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+    color: #004499;
+}
+
+/* ── Member docs (qdoc renders these as dl/dt/dd in some themes) ──────────── */
+dl.member-list dt {
+    font-family: "SFMono-Regular", Consolas, monospace;
+    font-size: 0.9em;
+    font-weight: 600;
+    background: #f0f1f5;
+    border-left: 4px solid #0066cc;
+    padding: 0.4rem 0.75rem;
+    margin-top: 1.2rem;
+    border-radius: 0 3px 3px 0;
+}
+
+dl.member-list dd {
+    margin: 0.3rem 0 1rem 1rem;
+}
+
+/* ── QDoc "since" / "note" / "warning" notices ───────────────────────────── */
+.since,
+p.since {
+    color: #555;
+    font-size: 0.85em;
+    font-style: italic;
+}
+
+div.note,
+p.note {
+    background: #eff7ff;
+    border-left: 4px solid #3399ff;
+    padding: 0.6rem 1rem;
+    margin: 1rem 0;
+    border-radius: 0 4px 4px 0;
+}
+
+div.warning,
+p.warning {
+    background: #fff8e1;
+    border-left: 4px solid #f5a623;
+    padding: 0.6rem 1rem;
+    margin: 1rem 0;
+    border-radius: 0 4px 4px 0;
+}
+
+/* ── Module index cards ───────────────────────────────────────────────────── */
+.tiles .tile,
+.module-box {
+    border: 1px solid #d0d0da;
+    border-radius: 6px;
+    padding: 1rem 1.2rem;
+    margin-bottom: 1rem;
+    background: #fafbff;
+    transition: box-shadow 0.15s;
+}
+
+.tiles .tile:hover,
+.module-box:hover {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* ── Top nav bar (qdoc default theme) ────────────────────────────────────── */
+.header,
+#header {
+    background: #2a2a3a;
+    color: #e8e8f0;
+    padding: 0.75rem 2rem;
+    font-size: 0.9em;
+}
+
+.header a,
+#header a {
+    color: #aabde0;
+    margin-right: 1rem;
+    text-decoration: none;
+}
+
+.header a:hover,
+#header a:hover {
+    color: #fff;
+}

--- a/docs/src/index.qdoc
+++ b/docs/src/index.qdoc
@@ -1,0 +1,119 @@
+/*!
+    \page index.html
+    \title Shotcut QML Scripting API
+
+    \brief Reference for all QML types and context properties available when
+    writing filter panels, VUIs, and timeline extensions for Shotcut.
+
+    \section1 Overview
+
+    \warning This API is subject to change and may not be stable across Shotcut versions.
+
+    Shotcut exposes its internal state to QML views through two mechanisms:
+
+    \list
+        \li \b{Registered types} — classes you can instantiate directly in QML
+            using their type name (e.g. \c Filter, \c File, \c Metadata).
+        \li \b{Context properties} — singleton objects injected into every view's
+            root context and accessed by a fixed name (e.g. \c application,
+            \c profile, \c settings).
+    \endlist
+
+    \section1 Modules
+
+    \annotatedlist qmlmodules
+
+    \section1 Context Properties (Singletons)
+
+    These objects are available in every Shotcut QML view without import statements:
+
+    \table
+        \header
+            \li Name
+            \li Type
+            \li Description
+        \row
+            \li \c application
+            \li \l{Application}
+            \li Application-wide utilities (copy/paste filters, status messages, etc.)
+        \row
+            \li \c profile
+            \li \l{Profile}
+            \li Current project video profile (width, height, fps, aspect ratio)
+        \row
+            \li \c settings
+            \li \l{Settings}
+            \li Persistent user settings (timeline options, fade durations, etc.)
+    \endtable
+
+    \section1 Per-View Context Properties
+
+    Additional context properties are injected by specific dock/view classes:
+
+    \table
+        \header
+            \li View
+            \li Name
+            \li Type
+        \row
+            \li Filter panels
+            \li \c filter
+            \li \l{Filter}
+        \row
+            \li Filter panels
+            \li \c producer
+            \li \l{Producer}
+        \row
+            \li Filter panels
+            \li \c metadata
+            \li \l{Metadata}
+        \row
+            \li Filter panels
+            \li \c motionTrackerModel
+            \li \l{MotionTrackerModel}
+        \row
+            \li Video player
+            \li \c video
+            \li VideoWidget
+        \row
+            \li HDR preview
+            \li \c hdrWindow
+            \li HdrPreviewWindow
+        \row
+            \li Keyframes dock
+            \li \c keyframes
+            \li \l{KeyframesDock}
+        \row
+            \li Keyframes dock
+            \li \c parameters
+            \li \l{KeyframesModel}
+        \row
+            \li Timeline dock
+            \li \c timeline
+            \li \l{TimelineDock}
+        \row
+            \li Timeline dock
+            \li \c multitrack
+            \li \l{MultitrackModel}
+        \row
+            \li Timeline dock
+            \li \c markers
+            \li \l{MarkersModel}
+        \row
+            \li Timeline dock
+            \li \c subtitlesModel
+            \li \l{SubtitlesModel}
+        \row
+            \li Timeline dock
+            \li \c subtitlesSelectionModel
+            \li \l{SubtitlesSelectionModel}
+        \row
+            \li Filters dock
+            \li \c attachedfiltersmodel
+            \li \l{AttachedFiltersModel}
+        \row
+            \li All docks
+            \li \c view
+            \li \l{QmlView}
+    \endtable
+*/

--- a/docs/src/org-shotcut-qml.qdoc
+++ b/docs/src/org-shotcut-qml.qdoc
@@ -1,0 +1,18 @@
+/*!
+    \qmlmodule org.shotcut.qml
+    \title org.shotcut.qml QML Module
+    \ingroup qmlmodules
+    \brief Types for filter scripting, metadata, and file access in Shotcut.
+
+    \code
+    import org.shotcut.qml
+    \endcode
+
+    This module contains the core types used when writing Shotcut filter UI panels
+    and VUI overlays. The most important type is \l Filter, which gives read/write
+    access to an MLT filter's properties and keyframes.
+
+    \section1 Types
+
+    \annotatedlist qmltypes
+*/

--- a/docs/src/shotcut-controls-types.qdoc
+++ b/docs/src/shotcut-controls-types.qdoc
@@ -1,0 +1,338 @@
+/*!
+    \qmltype ColorDialog
+    \inqmlmodule Shotcut.Controls
+    \brief A native color-chooser dialog.
+
+    \code
+    import Shotcut.Controls as Shotcut
+
+    Shotcut.ColorDialog {
+        id: colorDialog
+        title: qsTr("Choose Color")
+        onAccepted: filter.set("color", colorDialog.selectedColor)
+    }
+
+    Button {
+        onClicked: colorDialog.open()
+    }
+    \endcode
+*/
+
+/*!
+    \qmlproperty color ColorDialog::selectedColor
+    \brief The color currently selected in the dialog.
+    Set this before calling \l open() to pre-populate the dialog.
+    Read it in the \l accepted signal handler to retrieve the chosen color.
+*/
+
+/*!
+    \qmlproperty string ColorDialog::title
+    \brief The window title shown in the dialog's title bar.
+*/
+
+/*!
+    \qmlproperty bool ColorDialog::showAlpha
+    \brief Whether the alpha (opacity) slider is shown. Defaults to \c true.
+*/
+
+/*!
+    \qmlmethod ColorDialog::open()
+    \brief Opens the native color dialog modally. Emits \l accepted if the user confirms,
+    or no signal if cancelled.
+*/
+
+/*!
+    \qmlsignal ColorDialog::accepted()
+    \brief Emitted when the user clicks OK. Read \l selectedColor for the result.
+*/
+
+/*!
+    \qmlsignal ColorDialog::selectedColorChanged(color color)
+    \brief Emitted whenever \l selectedColor changes. \a color is the new value.
+*/
+
+// ── FontDialog ───────────────────────────────────────────────────────────────
+
+/*!
+    \qmltype FontDialog
+    \inqmlmodule Shotcut.Controls
+    \brief A native font-chooser dialog.
+
+    \code
+    import Shotcut.Controls as Shotcut
+
+    Shotcut.FontDialog {
+        id: fontDialog
+        onAccepted: document.setFontFamily(fontDialog.selectedFont.family)
+    }
+    \endcode
+*/
+
+/*!
+    \qmlproperty font FontDialog::selectedFont
+    \brief The font currently selected in the dialog.
+    Set before \l open() to pre-populate; read in \l accepted to retrieve the choice.
+*/
+
+/*!
+    \qmlmethod FontDialog::open()
+    \brief Opens the native font dialog modally.
+*/
+
+/*!
+    \qmlsignal FontDialog::accepted()
+    \brief Emitted when the user confirms the font selection.
+*/
+
+/*!
+    \qmlsignal FontDialog::rejected()
+    \brief Emitted when the user dismisses the dialog without selecting a font.
+*/
+
+// ── MessageDialog ─────────────────────────────────────────────────────────────
+
+/*!
+    \qmltype MessageDialog
+    \inqmlmodule Shotcut.Controls
+    \brief A native message/confirmation dialog with configurable buttons.
+
+    \section2 StandardButtons enum
+
+    \table
+    \header \li Value \li Button shown
+    \row \li \c MessageDialog.Ok \li OK
+    \row \li \c MessageDialog.Yes \li Yes
+    \row \li \c MessageDialog.No \li No
+    \row \li \c MessageDialog.Cancel \li Cancel
+    \endtable
+
+    Combine values with \c | to show multiple buttons.
+
+    \code
+    import Shotcut.Controls as Shotcut
+
+    Shotcut.MessageDialog {
+        title: qsTr("Confirm")
+        text: qsTr("Are you sure?")
+        buttons: MessageDialog.Yes | MessageDialog.No
+        onAccepted: doSomething()
+    }
+    \endcode
+*/
+
+/*!
+    \qmlproperty string MessageDialog::title
+    \brief The dialog window title.
+*/
+
+/*!
+    \qmlproperty string MessageDialog::text
+    \brief The message text displayed inside the dialog.
+*/
+
+/*!
+    \qmlproperty int MessageDialog::buttons
+    \brief A bitwise OR of \c StandardButtons values controlling which buttons appear.
+*/
+
+/*!
+    \qmlmethod MessageDialog::open()
+    \brief Opens the dialog modally. Emits \l accepted or \l rejected depending on
+    which button the user clicks.
+*/
+
+/*!
+    \qmlsignal MessageDialog::accepted()
+    \brief Emitted when the user clicks an affirmative button (OK or Yes).
+*/
+
+/*!
+    \qmlsignal MessageDialog::rejected()
+    \brief Emitted when the user clicks a negative button (No or Cancel) or closes the dialog.
+*/
+
+// ── FileDialog ────────────────────────────────────────────────────────────────
+
+/*!
+    \qmltype FileDialog
+    \inqmlmodule Shotcut.Controls
+    \brief A native file open/save dialog.
+
+    \section2 FileMode enum
+
+    \table
+    \header \li Value \li Description
+    \row \li \c FileDialog.OpenFile \li Select an existing file to open (default)
+    \row \li \c FileDialog.SaveFile \li Choose a filename to save
+    \endtable
+
+    \code
+    import Shotcut.Controls as Shotcut
+
+    Shotcut.FileDialog {
+        id: fileDialog
+        title: qsTr("Open File")
+        fileMode: Shotcut.FileDialog.OpenFile
+        nameFilters: ["GPS files (*.gpx *.kml)", "All files (*)"]
+        onFileSelected: myFile.url = file
+    }
+    \endcode
+*/
+
+/*!
+    \qmlproperty int FileDialog::fileMode
+    \brief Whether the dialog is for opening or saving. One of \c FileDialog.OpenFile or
+    \c FileDialog.SaveFile.
+*/
+
+/*!
+    \qmlproperty string FileDialog::title
+    \brief The dialog window title.
+*/
+
+/*!
+    \qmlproperty list<string> FileDialog::nameFilters
+    \brief The list of file type filters shown in the dialog
+    (e.g. \c {["Images (*.png *.jpg)", "All files (*)"]} ).
+*/
+
+/*!
+    \qmlproperty string FileDialog::selectedFile
+    \brief The full file path of the last selected file (read-only).
+    Available after \l fileSelected is emitted.
+*/
+
+/*!
+    \qmlmethod FileDialog::open()
+    \brief Opens the native file dialog modally.
+*/
+
+/*!
+    \qmlsignal FileDialog::fileSelected(string file)
+    \brief Emitted when the user confirms a selection. \a file is the full path.
+*/
+
+/*!
+    \qmlsignal FileDialog::accepted()
+    \brief Emitted when the user confirms the dialog.
+*/
+
+/*!
+    \qmlsignal FileDialog::rejected()
+    \brief Emitted when the user cancels or closes the dialog.
+*/
+
+// ── ColorPickerItem ──────────────────────────────────────────────────────────
+
+/*!
+    \qmltype ColorPickerItem
+    \inqmlmodule Shotcut.Controls
+    \brief An eyedropper tool that picks a color by sampling any pixel on screen.
+
+    When \l pickColor is emitted (typically by clicking a button), the user can
+    drag a crosshair over any part of the screen; releasing emits \l colorPicked
+    with the sampled color.
+
+    \code
+    import Shotcut.Controls as Shotcut
+
+    Shotcut.ColorPickerItem {
+        id: eyedropper
+        onColorPicked: filter.set("color", color)
+    }
+
+    Button {
+        text: qsTr("Pick")
+        onClicked: eyedropper.pickColor()
+    }
+    \endcode
+*/
+
+/*!
+    \qmlsignal ColorPickerItem::pickColor(point initialPos)
+    \brief Invoke this signal (emit via \c eyedropper.pickColor()) to start the
+    screen-sampling mode. \a initialPos is the initial crosshair position;
+    pass no argument to use the current cursor position.
+*/
+
+/*!
+    \qmlsignal ColorPickerItem::colorPicked(color color)
+    \brief Emitted when the user releases the mouse after picking. \a color is the
+    sampled screen color.
+*/
+
+/*!
+    \qmlsignal ColorPickerItem::cancelled()
+    \brief Emitted when the user cancels the pick without selecting a color
+    (e.g. by pressing Escape).
+*/
+
+// ── ColorWheelItem ────────────────────────────────────────────────────────────
+
+/*!
+    \qmltype ColorWheelItem
+    \inqmlmodule Shotcut.Controls
+    \brief An interactive hue/saturation color wheel with a brightness slider.
+
+    Renders a circular color wheel (hue + saturation) with an integrated
+    brightness slider. The user can click and drag inside the wheel or slider
+    to change the color interactively.
+
+    \code
+    import Shotcut.Controls as Shotcut
+
+    Shotcut.ColorWheelItem {
+        id: wheel
+        color: filter.getColor("color")
+        onColorChanged: filter.set("color", color)
+    }
+    \endcode
+*/
+
+/*!
+    \qmlproperty color ColorWheelItem::color
+    \brief The currently selected color. Settable to programmatically position the
+    wheel marker and slider.
+*/
+
+/*!
+    \qmlproperty int ColorWheelItem::red
+    \brief The red channel (0–255) of the selected color.
+*/
+
+/*!
+    \qmlproperty int ColorWheelItem::green
+    \brief The green channel (0–255) of the selected color.
+*/
+
+/*!
+    \qmlproperty int ColorWheelItem::blue
+    \brief The blue channel (0–255) of the selected color.
+*/
+
+/*!
+    \qmlproperty real ColorWheelItem::redF
+    \brief The red channel as a normalized floating-point value (0.0–1.0).
+*/
+
+/*!
+    \qmlproperty real ColorWheelItem::greenF
+    \brief The green channel as a normalized floating-point value (0.0–1.0).
+*/
+
+/*!
+    \qmlproperty real ColorWheelItem::blueF
+    \brief The blue channel as a normalized floating-point value (0.0–1.0).
+*/
+
+/*!
+    \qmlproperty real ColorWheelItem::step
+    \brief The increment applied per mouse-wheel tick or arrow-key press when
+    adjusting the brightness slider. Defaults to a small fractional value.
+*/
+
+/*!
+    \qmlsignal ColorWheelItem::colorChanged(color color)
+    \brief Emitted whenever the selected \a color changes due to user interaction
+    or a property assignment.
+*/

--- a/docs/src/shotcut-controls.qdoc
+++ b/docs/src/shotcut-controls.qdoc
@@ -1,0 +1,14 @@
+/*!
+    \qmlmodule Shotcut.Controls
+    \title Shotcut.Controls QML Module
+    \ingroup qmlmodules
+    \brief C++-backed UI controls and dialogs for Shotcut QML views.
+
+    \code
+    import Shotcut.Controls
+    \endcode
+
+    This module provides the C++-backed types registered for use in the
+    \c Shotcut.Controls import. These are native dialogs and canvas items
+    that cannot be replicated purely in QML.
+*/

--- a/src/docks/keyframesdock.cpp
+++ b/src/docks/keyframesdock.cpp
@@ -44,6 +44,65 @@
 static QmlMetadata m_emptyQmlMetadata;
 static QmlFilter m_emptyQmlFilter;
 
+/*!
+    \qmltype KeyframesDock
+    \inqmlmodule org.shotcut.qml
+    \brief The Keyframes panel controller, available as the \c keyframes context property.
+
+    \c keyframes is injected into the Keyframes QML view and exposes navigation
+    methods and the time-scale zoom state.
+*/
+
+/*!
+    \qmlsignal KeyframesDock::changed()
+    \brief Emitted when a filter parameter value changes from within the Keyframes panel.
+*/
+
+/*!
+    \qmlsignal KeyframesDock::newFilter()
+    \brief Emitted when the filter itself (not just a parameter) has been changed.
+*/
+
+/*!
+    \qmlsignal KeyframesDock::timeScaleChanged()
+    \brief Emitted when \l timeScale changes.
+*/
+
+/*!
+    \qmlsignal KeyframesDock::seekPreviousSimple()
+    \brief Emitted to request seeking to the previous simple-keyframe boundary.
+*/
+
+/*!
+    \qmlsignal KeyframesDock::seekNextSimple()
+    \brief Emitted to request seeking to the next simple-keyframe boundary.
+*/
+
+/*!
+    \qmlsignal KeyframesDock::zoomIn()
+    \brief Emitted to request zooming in on the keyframes ruler.
+*/
+
+/*!
+    \qmlsignal KeyframesDock::zoomOut()
+    \brief Emitted to request zooming out on the keyframes ruler.
+*/
+
+/*!
+    \qmlsignal KeyframesDock::zoomToFit()
+    \brief Emitted to request resetting zoom to show all keyframes.
+*/
+
+/*!
+    \qmlsignal KeyframesDock::dockClicked()
+    \brief Emitted when the user clicks inside the Keyframes dock area.
+*/
+
+/*!
+    \qmlproperty double KeyframesDock::timeScale
+    \brief The horizontal zoom factor of the Keyframes ruler. Settable.
+*/
+
 KeyframesDock::KeyframesDock(QmlProducer *qmlProducer, QWidget *parent)
     : QDockWidget(tr("Keyframes"), parent)
     , m_qview(QmlUtilities::sharedEngine(), this)
@@ -1080,6 +1139,12 @@ void KeyframesDock::setupActions()
     Actions.add("keyframesToggleKeyframeAction", action);
 }
 
+/*!
+    \qmlmethod int KeyframesDock::seekPrevious()
+    \brief Seeks the playhead to the previous keyframe position.
+    Returns the new playhead position in frames.
+*/
+
 int KeyframesDock::seekPrevious()
 {
     if (m_qmlProducer) {
@@ -1093,6 +1158,12 @@ int KeyframesDock::seekPrevious()
     }
     return 0;
 }
+
+/*!
+    \qmlmethod int KeyframesDock::seekNext()
+    \brief Seeks the playhead to the next keyframe position.
+    Returns the new playhead position in frames.
+*/
 
 int KeyframesDock::seekNext()
 {
@@ -1164,6 +1235,11 @@ void KeyframesDock::setTimeScale(double value)
     emit timeScaleChanged();
 }
 
+/*!
+    \qmlmethod void KeyframesDock::load(bool force)
+    \brief Loads (or reloads if \a force is \c true) the Keyframes panel for the current filter.
+*/
+
 void KeyframesDock::load(bool force)
 {
     LOG_DEBUG() << "begin" << m_qview.source().isEmpty() << force;
@@ -1191,6 +1267,11 @@ void KeyframesDock::load(bool force)
         emit timeScaleChanged();
     }
 }
+
+/*!
+    \qmlmethod void KeyframesDock::reload()
+    \brief Reloads the keyframes model for the current filter without resetting the view.
+*/
 
 void KeyframesDock::reload()
 {

--- a/src/docks/keyframesdock.cpp
+++ b/src/docks/keyframesdock.cpp
@@ -99,7 +99,7 @@ static QmlFilter m_emptyQmlFilter;
 */
 
 /*!
-    \qmlproperty double KeyframesDock::timeScale
+    \qmlproperty real KeyframesDock::timeScale
     \brief The horizontal zoom factor of the Keyframes ruler. Settable.
 */
 

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -69,6 +69,92 @@ static const char *kFileUrlProtocol = "file://";
 static const char *kFilesUrlDelimiter = ",file://";
 static const int kRecordingTimerIntervalMs = 1000;
 
+/*!
+    \qmltype TimelineDock
+    \inqmlmodule org.shotcut.qml
+    \brief The timeline dock controller, available as the \c timeline context property.
+
+    \c timeline is injected into the Timeline QML view and exposes properties and
+    methods for querying and controlling clip selection, the playhead position,
+    the current track, and audio recording.
+*/
+
+/*!
+    \qmlsignal TimelineDock::currentTrackChanged()
+    \brief Emitted when \l currentTrack changes.
+*/
+
+/*!
+    \qmlsignal TimelineDock::selectionChanged()
+    \brief Emitted when the clip \l selection changes.
+*/
+
+/*!
+    \qmlsignal TimelineDock::positionChanged(int position)
+    \brief Emitted when the playhead time \a position changes.
+*/
+
+/*!
+    \qmlsignal TimelineDock::loopChanged()
+    \brief Emitted when the loop region start or end time changes.
+*/
+
+/*!
+    \qmlsignal TimelineDock::clipOpened(var producer)
+    \brief Emitted when a clip is opened for source preview. \a producer is the opened clip's producer.
+*/
+
+/*!
+    \qmlsignal TimelineDock::showStatusMessage(string message)
+    \brief Emitted to request a \a message be shown in the status bar.
+*/
+
+/*!
+    \qmlsignal TimelineDock::durationChanged()
+    \brief Emitted when the total timeline duration changes.
+*/
+
+/*!
+    \qmlsignal TimelineDock::isRecordingChanged(bool recording)
+    \brief Emitted when recording starts or stops. \a recording is \c true when recording begins.
+*/
+
+/*!
+    \qmlproperty int TimelineDock::position
+    \brief The current playhead position in frames. Settable — setting this seeks the player.
+*/
+
+/*!
+    \qmlproperty bool TimelineDock::isRecording
+    \brief \c true when audio recording is in progress. Read-only.
+*/
+
+/*!
+    \qmlproperty int TimelineDock::loopStart
+    \brief The start frame of the current loop region, or \c -1 if no loop is set. Read-only.
+*/
+
+/*!
+    \qmlproperty int TimelineDock::loopEnd
+    \brief The end frame of the current loop region, or \c -1 if no loop is set. Read-only.
+*/
+
+/*!
+    \qmlmethod bool TimelineDock::isMultitrackSelected()
+    \brief Returns \c true if the timeline output is currently selected.
+*/
+
+/*!
+    \qmlmethod int TimelineDock::selectedTrack()
+    \brief Returns the index of the selected track when a single track is selected,
+    or \c -1 otherwise.
+*/
+
+/*!
+    \qmlmethod bool TimelineDock::isFloating()
+    \brief Returns \c true if the timeline dock is currently floating (undocked).
+*/
+
 TimelineDock::TimelineDock(QWidget *parent)
     : QDockWidget(parent)
     , m_quickView(QmlUtilities::sharedEngine(), this)
@@ -1877,6 +1963,11 @@ void TimelineDock::setCurrentTrack(int currentTrack)
     }
 }
 
+/*!
+    \qmlproperty int TimelineDock::currentTrack
+    \brief The zero-based index of the currently focused timeline track. Settable.
+*/
+
 int TimelineDock::currentTrack() const
 {
     return qBound(0,
@@ -1907,6 +1998,12 @@ void TimelineDock::setSelection(QList<QPoint> newSelection, int trackIndex, bool
         m_selectionSignalTimer.start();
     }
 }
+
+/*!
+    \qmlproperty list<var> TimelineDock::selection
+    \brief The current clip selection as a list of \c {point} values where \c x is the
+    track index and \c y is the clip index. Settable.
+*/
 
 QVariantList TimelineDock::selectionForJS() const
 {
@@ -1976,11 +2073,22 @@ void TimelineDock::saveAndClearSelection()
     emit selectionChanged();
 }
 
+/*!
+    \qmlmethod void TimelineDock::restoreSelection()
+    \brief Restores the previously saved clip selection.
+*/
+
 void TimelineDock::restoreSelection()
 {
     QList<QPoint> restoredSelection = uuidsToSelection(m_savedSelectionUuids);
     setSelection(restoredSelection, m_savedSelectedTrack, m_savedIsMultitrackSelected);
 }
+
+/*!
+    \qmlmethod list<var> TimelineDock::getGroupForClip(int trackIndex, int clipIndex)
+    \brief Returns the list of all clip coordinates (\c {point} values) in the same group
+    as the clip at (\a trackIndex, \a clipIndex).
+*/
 
 QVariantList TimelineDock::getGroupForClip(int trackIndex, int clipIndex)
 {
@@ -2098,6 +2206,11 @@ void TimelineDock::trimClipAtPlayhead(TrimLocation location, bool ripple)
     }
 }
 
+/*!
+    \qmlmethod void TimelineDock::openProperties()
+    \brief Opens the Properties panel for the currently selected clip. Static method.
+*/
+
 void TimelineDock::openProperties()
 {
     MAIN.onPropertiesDockTriggered(true);
@@ -2124,12 +2237,22 @@ void TimelineDock::clearSelectionIfInvalid()
     setSelection(newSelection);
 }
 
+/*!
+    \qmlmethod void TimelineDock::insertTrack()
+    \brief Inserts a new track of the same type as the current track above it.
+*/
+
 void TimelineDock::insertTrack()
 {
     if (m_selection.selectedTrack != -1)
         setSelection();
     MAIN.undoStack()->push(new Timeline::InsertTrackCommand(m_model, currentTrack()));
 }
+
+/*!
+    \qmlmethod void TimelineDock::insertAudioTrack()
+    \brief Inserts a new audio track above the current track.
+*/
 
 void TimelineDock::insertAudioTrack()
 {
@@ -2139,6 +2262,11 @@ void TimelineDock::insertAudioTrack()
         new Timeline::InsertTrackCommand(m_model, currentTrack(), AudioTrackType));
 }
 
+/*!
+    \qmlmethod void TimelineDock::insertVideoTrack()
+    \brief Inserts a new video track above the current track.
+*/
+
 void TimelineDock::insertVideoTrack()
 {
     if (m_selection.selectedTrack != -1)
@@ -2146,6 +2274,11 @@ void TimelineDock::insertVideoTrack()
     MAIN.undoStack()->push(
         new Timeline::InsertTrackCommand(m_model, currentTrack(), VideoTrackType));
 }
+
+/*!
+    \qmlmethod void TimelineDock::removeTrack()
+    \brief Removes the current track (and all its clips) from the timeline.
+*/
 
 void TimelineDock::removeTrack()
 {
@@ -2156,6 +2289,11 @@ void TimelineDock::removeTrack()
             setCurrentTrack(m_model.trackList().count() - 1);
     }
 }
+
+/*!
+    \qmlmethod void TimelineDock::moveTrack(int fromTrackIndex, int toTrackIndex)
+    \brief Moves the track at \a fromTrackIndex to \a toTrackIndex.
+*/
 
 void TimelineDock::moveTrack(int fromTrackIndex, int toTrackIndex)
 {
@@ -2175,6 +2313,11 @@ void TimelineDock::moveTrack(int fromTrackIndex, int toTrackIndex)
     MAIN.undoStack()->push(new Timeline::MoveTrackCommand(m_model, fromTrackIndex, toTrackIndex));
     setCurrentTrack(toTrackIndex);
 }
+
+/*!
+    \qmlmethod void TimelineDock::moveTrackUp()
+    \brief Moves the current track one position upward.
+*/
 
 void TimelineDock::moveTrackUp()
 {
@@ -2206,6 +2349,11 @@ void TimelineDock::moveTrackUp()
     setCurrentTrack(trackIndex - 1);
 }
 
+/*!
+    \qmlmethod void TimelineDock::moveTrackDown()
+    \brief Moves the current track one position downward.
+*/
+
 void TimelineDock::moveTrackDown()
 {
     int trackIndex = currentTrack();
@@ -2235,6 +2383,12 @@ void TimelineDock::moveTrackDown()
     MAIN.undoStack()->push(new Timeline::MoveTrackCommand(m_model, trackIndex, trackIndex + 1));
     setCurrentTrack(trackIndex + 1);
 }
+
+/*!
+    \qmlmethod bool TimelineDock::mergeClipWithNext(int trackIndex, int clipIndex, bool dryrun)
+    \brief Merges the clip at \a clipIndex with the following clip on \a trackIndex.
+    If \a dryrun is \c true the merge is validated but not applied; returns \c true when valid.
+*/
 
 bool TimelineDock::mergeClipWithNext(int trackIndex, int clipIndex, bool dryrun)
 {
@@ -2353,6 +2507,11 @@ void TimelineDock::onProducerChanged(Mlt::Producer *after)
     MAIN.undoStack()->push(m_updateCommand.release());
 }
 
+/*!
+    \qmlmethod int TimelineDock::addAudioTrack()
+    \brief Appends a new audio track and returns its track index.
+*/
+
 int TimelineDock::addAudioTrack()
 {
     if (m_selection.selectedTrack != -1)
@@ -2361,6 +2520,11 @@ int TimelineDock::addAudioTrack()
     return m_model.trackList().size() - 1;
 }
 
+/*!
+    \qmlmethod int TimelineDock::addVideoTrack()
+    \brief Appends a new video track and returns its track index.
+*/
+
 int TimelineDock::addVideoTrack()
 {
     if (m_selection.selectedTrack != -1)
@@ -2368,6 +2532,11 @@ int TimelineDock::addVideoTrack()
     MAIN.undoStack()->push(new Timeline::AddTrackCommand(m_model, true));
     return 0;
 }
+
+/*!
+    \qmlmethod void TimelineDock::alignSelectedClips()
+    \brief Aligns selected clips to a common track using audio analysis.
+*/
 
 void TimelineDock::alignSelectedClips()
 {
@@ -2420,6 +2589,11 @@ static bool isSystemClipboardValid(const QString &xml)
 {
     return MLT.isMltXml(xml) && MAIN.isClipboardNewer() && !xml.contains(kShotcutFiltersClipboard);
 }
+
+/*!
+    \qmlmethod void TimelineDock::append(int trackIndex)
+    \brief Appends the current source clip to the track at \a trackIndex.
+*/
 
 void TimelineDock::append(int trackIndex)
 {
@@ -2544,6 +2718,12 @@ void TimelineDock::append(int trackIndex)
     }
 }
 
+/*!
+    \qmlmethod void TimelineDock::remove(int trackIndex, int clipIndex, bool ignoreTransition)
+    \brief Removes the clip at (\a trackIndex, \a clipIndex), replacing it with a blank.
+    If \a ignoreTransition is \c true, adjacent transitions are not affected.
+*/
+
 void TimelineDock::remove(int trackIndex, int clipIndex, bool ignoreTransition)
 {
     if (!m_model.trackList().count())
@@ -2592,6 +2772,13 @@ void TimelineDock::remove(int trackIndex, int clipIndex, bool ignoreTransition)
         }
     }
 }
+
+/*!
+    \qmlmethod void TimelineDock::lift(int trackIndex, int clipIndex, bool ignoreTransition)
+    \brief Lifts (removes content from) the clip at (\a trackIndex, \a clipIndex),
+    leaving a blank of the same duration. If \a ignoreTransition is \c true, adjacent
+    transitions are not affected.
+*/
 
 void TimelineDock::lift(int trackIndex, int clipIndex, bool ignoreTransition)
 {
@@ -2655,6 +2842,12 @@ void TimelineDock::lift(int trackIndex, int clipIndex, bool ignoreTransition)
     }
 }
 
+/*!
+    \qmlmethod void TimelineDock::removeSelection(bool withCopy)
+    \brief Removes all selected clips. If \a withCopy is \c true, the clips are
+    copied to the clipboard before removal (cut).
+*/
+
 void TimelineDock::removeSelection(bool withCopy)
 {
     if (isTrackLocked(currentTrack())) {
@@ -2693,6 +2886,11 @@ void TimelineDock::removeSelection(bool withCopy)
         MAIN.undoStack()->endMacro();
 }
 
+/*!
+    \qmlmethod void TimelineDock::liftSelection()
+    \brief Removes all selected clips, replacing them with blanks.
+*/
+
 void TimelineDock::liftSelection()
 {
     if (isTrackLocked(currentTrack())) {
@@ -2715,6 +2913,11 @@ void TimelineDock::liftSelection()
         MAIN.undoStack()->endMacro();
 }
 
+/*!
+    \qmlmethod void TimelineDock::incrementCurrentTrack(int by)
+    \brief Moves the current track focus up or down by \a by tracks.
+*/
+
 void TimelineDock::incrementCurrentTrack(int by)
 {
     int newTrack = currentTrack();
@@ -2725,12 +2928,22 @@ void TimelineDock::incrementCurrentTrack(int by)
     setCurrentTrack(newTrack);
 }
 
+/*!
+    \qmlmethod void TimelineDock::selectTrackHead(int trackIndex)
+    \brief Selects the track and its header of the track at \a trackIndex.
+*/
+
 void TimelineDock::selectTrackHead(int trackIndex)
 {
     if (trackIndex >= 0) {
         setSelection(QList<QPoint>(), trackIndex);
     }
 }
+
+/*!
+    \qmlmethod void TimelineDock::selectMultitrack()
+    \brief Selects the timeline output, deselecting any clips.
+*/
 
 void TimelineDock::selectMultitrack()
 {
@@ -2742,6 +2955,11 @@ static void insertSorted(std::vector<T> &vec, T const &item)
 {
     vec.insert(std::upper_bound(vec.begin(), vec.end(), item), item);
 }
+
+/*!
+    \qmlmethod void TimelineDock::copy(int trackIndex, int clipIndex)
+    \brief Copies the clip at (\a trackIndex, \a clipIndex) to the clipboard.
+*/
 
 void TimelineDock::copy(int trackIndex, int clipIndex)
 {
@@ -3019,6 +3237,11 @@ void TimelineDock::onRowsMoved(
     model()->reload(true);
 }
 
+/*!
+    \qmlmethod void TimelineDock::detachAudio(int trackIndex, int clipIndex)
+    \brief Detaches the audio of the clip at (\a trackIndex, \a clipIndex) to an audio track.
+*/
+
 void TimelineDock::detachAudio(int trackIndex, int clipIndex)
 {
     if (!m_model.trackList().count())
@@ -3042,6 +3265,11 @@ void TimelineDock::detachAudio(int trackIndex, int clipIndex)
     }
 }
 
+/*!
+    \qmlmethod void TimelineDock::selectAll()
+    \brief Selects all clips on all tracks.
+*/
+
 void TimelineDock::selectAll()
 {
     QList<QPoint> selection;
@@ -3053,6 +3281,11 @@ void TimelineDock::selectAll()
     }
     setSelection(selection);
 }
+
+/*!
+    \qmlmethod void TimelineDock::selectAllOnCurrentTrack()
+    \brief Selects all clips on the current track.
+*/
 
 void TimelineDock::selectAllOnCurrentTrack()
 {
@@ -3072,6 +3305,12 @@ void TimelineDock::onProducerModified()
     // The clip name may have changed.
     emitSelectedChanged(QVector<int>() << MultitrackModel::NameRole << MultitrackModel::CommentRole);
 }
+
+/*!
+    \qmlmethod void TimelineDock::replace(int trackIndex, int clipIndex, string xml)
+    \brief Replaces the clip at (\a trackIndex, \a clipIndex) with the producer described by \a xml.
+    If \a xml is empty, uses the current source clip.
+*/
 
 void TimelineDock::replace(int trackIndex, int clipIndex, const QString &xml)
 {
@@ -3105,6 +3344,11 @@ void TimelineDock::replace(int trackIndex, int clipIndex, const QString &xml)
     }
 }
 
+/*!
+    \qmlmethod void TimelineDock::createOrEditMarker()
+    \brief Creates a new marker at the playhead, or opens the edit dialog if one already exists there.
+*/
+
 void TimelineDock::createOrEditMarker()
 {
     if (!m_model.trackList().count() || MLT.producer()->get_length() <= 1)
@@ -3116,6 +3360,11 @@ void TimelineDock::createOrEditMarker()
     }
     createMarker();
 }
+
+/*!
+    \qmlmethod void TimelineDock::createOrEditSelectionMarker()
+    \brief Creates a range marker spanning the current clip selection, or edits the existing one.
+*/
 
 void TimelineDock::createOrEditSelectionMarker()
 {
@@ -3148,6 +3397,11 @@ void TimelineDock::createOrEditSelectionMarker()
     }
 }
 
+/*!
+    \qmlmethod void TimelineDock::createMarker()
+    \brief Creates a new marker at the current playhead position.
+*/
+
 void TimelineDock::createMarker()
 {
     if (!m_model.trackList().count() || MLT.producer()->get_length() <= 1)
@@ -3165,6 +3419,11 @@ void TimelineDock::createMarker()
     emit showStatusMessage(tr("Added marker: \"%1\". Hold %2 and drag to create a range")
                                .arg(marker.text, QmlApplication::OS() == "macOS" ? "⌘" : "Ctrl"));
 }
+
+/*!
+    \qmlmethod void TimelineDock::editMarker(int markerIndex)
+    \brief Opens the edit dialog for the marker at \a markerIndex.
+*/
 
 void TimelineDock::editMarker(int markerIndex)
 {
@@ -3185,6 +3444,11 @@ void TimelineDock::editMarker(int markerIndex)
     }
 }
 
+/*!
+    \qmlmethod void TimelineDock::deleteMarker(int markerIndex)
+    \brief Deletes the marker at \a markerIndex, or the marker at the playhead if \a markerIndex is \c -1.
+*/
+
 void TimelineDock::deleteMarker(int markerIndex)
 {
     if (markerIndex < 0) {
@@ -3195,6 +3459,11 @@ void TimelineDock::deleteMarker(int markerIndex)
     }
 }
 
+/*!
+    \qmlmethod void TimelineDock::seekNextMarker()
+    \brief Seeks the playhead to the next marker after the current position.
+*/
+
 void TimelineDock::seekNextMarker()
 {
     int nextPos = m_markersModel.nextMarkerPosition(m_position);
@@ -3203,6 +3472,11 @@ void TimelineDock::seekNextMarker()
         emit markerSeeked(m_markersModel.markerIndexForPosition(nextPos));
     }
 }
+
+/*!
+    \qmlmethod void TimelineDock::seekPrevMarker()
+    \brief Seeks the playhead to the previous marker before the current position.
+*/
 
 void TimelineDock::seekPrevMarker()
 {
@@ -3220,10 +3494,22 @@ void TimelineDock::onFilterModelChanged()
     }
 }
 
+/*!
+    \qmlmethod void TimelineDock::trimClipIn(bool ripple)
+    \brief Trims the in-point of the clip under the playhead to the current time position.
+    If \a ripple is \c true, downstream clips shift accordingly.
+*/
+
 void TimelineDock::trimClipIn(bool ripple)
 {
     trimClipAtPlayhead(TimelineDock::TrimInPoint, ripple);
 }
+
+/*!
+    \qmlmethod void TimelineDock::trimClipOut(bool ripple)
+    \brief Trims the out-point of the clip under the playhead to the current time position.
+    If \a ripple is \c true, downstream clips shift accordingly.
+*/
 
 void TimelineDock::trimClipOut(bool ripple)
 {
@@ -3435,15 +3721,30 @@ void TimelineDock::onLoopChanged(int start, int end)
     emit loopChanged();
 }
 
+/*!
+    \qmlmethod void TimelineDock::setTrackName(int trackIndex, string value)
+    \brief Renames the track at \a trackIndex to \a value.
+*/
+
 void TimelineDock::setTrackName(int trackIndex, const QString &value)
 {
     MAIN.undoStack()->push(new Timeline::NameTrackCommand(m_model, trackIndex, value));
 }
 
+/*!
+    \qmlmethod void TimelineDock::toggleTrackMute(int trackIndex)
+    \brief Toggles mute on the track at \a trackIndex.
+*/
+
 void TimelineDock::toggleTrackMute(int trackIndex)
 {
     MAIN.undoStack()->push(new Timeline::MuteTrackCommand(m_model, trackIndex));
 }
+
+/*!
+    \qmlmethod void TimelineDock::toggleOtherTracksMute(int trackIndex)
+    \brief Mutes all tracks except \a trackIndex (solo), or unmutes all if already soloed.
+*/
 
 void TimelineDock::toggleOtherTracksMute(int trackIndex)
 {
@@ -3460,10 +3761,20 @@ void TimelineDock::toggleOtherTracksMute(int trackIndex)
     MAIN.undoStack()->endMacro();
 }
 
+/*!
+    \qmlmethod void TimelineDock::toggleTrackHidden(int trackIndex)
+    \brief Toggles visibility of the video track at \a trackIndex.
+*/
+
 void TimelineDock::toggleTrackHidden(int trackIndex)
 {
     MAIN.undoStack()->push(new Timeline::HideTrackCommand(m_model, trackIndex));
 }
+
+/*!
+    \qmlmethod void TimelineDock::toggleOtherTracksHidden(int trackIndex)
+    \brief Hides all video tracks except \a trackIndex, or shows all if already in that state.
+*/
 
 void TimelineDock::toggleOtherTracksHidden(int trackIndex)
 {
@@ -3480,15 +3791,31 @@ void TimelineDock::toggleOtherTracksHidden(int trackIndex)
     MAIN.undoStack()->endMacro();
 }
 
+/*!
+    \qmlmethod void TimelineDock::setTrackComposite(int trackIndex, bool composite)
+    \brief Sets whether the video track at \a trackIndex composites (\a composite) over lower tracks.
+*/
+
 void TimelineDock::setTrackComposite(int trackIndex, bool composite)
 {
     MAIN.undoStack()->push(new Timeline::CompositeTrackCommand(m_model, trackIndex, composite));
 }
 
+/*!
+    \qmlmethod void TimelineDock::setTrackLock(int trackIndex, bool lock)
+    \brief Locks (\a lock = \c true) or unlocks the track at \a trackIndex.
+*/
+
 void TimelineDock::setTrackLock(int trackIndex, bool lock)
 {
     MAIN.undoStack()->push(new Timeline::LockTrackCommand(m_model, trackIndex, lock));
 }
+
+/*!
+    \qmlmethod bool TimelineDock::moveClip(int fromTrack, int toTrack, int clipIndex, int position, bool ripple)
+    \brief Moves the clip at (\a fromTrack, \a clipIndex) to \a position on \a toTrack.
+    If \a ripple is \c true, downstream clips shift to fill the gap. Returns \c true on success.
+*/
 
 bool TimelineDock::moveClip(int fromTrack, int toTrack, int clipIndex, int position, bool ripple)
 {
@@ -3799,6 +4126,13 @@ bool TimelineDock::resizeTransition(int trackIndex, int clipIndex, int delta)
     return false;
 }
 
+/*!
+    \qmlmethod void TimelineDock::insert(int trackIndex, int position, string xml, bool seek)
+    \brief Inserts the producer described by \a xml at time \a position on \a trackIndex,
+    rippling downstream clips. Pass \c -1 for \a position to use the playhead.
+    If \a seek is \c true, moves the playhead to the end of the inserted clip.
+*/
+
 void TimelineDock::insert(int trackIndex, int position, const QString &xml, bool seek)
 {
     // Validations
@@ -3967,6 +4301,13 @@ void TimelineDock::reloadTimelineModels()
     m_markersModel.load(m_model.tractor());
     m_subtitlesModel.load(m_model.tractor());
 }
+
+/*!
+    \qmlmethod void TimelineDock::overwrite(int trackIndex, int position, string xml, bool seek)
+    \brief Overwrites at time \a position on \a trackIndex with the producer described by \a xml.
+    Pass \c -1 for \a position to use the playhead.
+    If \a seek is \c true, moves the playhead to the end of the overwritten region.
+*/
 
 void TimelineDock::overwrite(int trackIndex, int position, const QString &xml, bool seek)
 {
@@ -4166,6 +4507,12 @@ void TimelineDock::appendFromPlaylist(Mlt::Playlist *playlist, bool skipProxy, b
     m_model.checkForEmptyTracks(trackIndex);
 }
 
+/*!
+    \qmlmethod bool TimelineDock::changeGain(int trackIndex, int clipIndex, double gain)
+    \brief Sets the audio \a gain of the clip at (\a trackIndex, \a clipIndex).
+    Returns \c true on success.
+*/
+
 bool TimelineDock::changeGain(int trackIndex, int clipIndex, double gain)
 {
     if (isTrackLocked(trackIndex)) {
@@ -4188,6 +4535,12 @@ bool TimelineDock::changeGain(int trackIndex, int clipIndex, double gain)
     return true;
 }
 
+/*!
+    \qmlmethod void TimelineDock::fadeIn(int trackIndex, int clipIndex, int duration)
+    \brief Sets the fade-in \a duration (frames) for the clip at (\a trackIndex, \a clipIndex).
+    Pass \c -1 for \a clipIndex to use the clip under the playhead.
+*/
+
 void TimelineDock::fadeIn(int trackIndex, int clipIndex, int duration)
 {
     if (isTrackLocked(trackIndex)) {
@@ -4201,6 +4554,12 @@ void TimelineDock::fadeIn(int trackIndex, int clipIndex, int duration)
     emit fadeInChanged(duration);
 }
 
+/*!
+    \qmlmethod void TimelineDock::fadeOut(int trackIndex, int clipIndex, int duration)
+    \brief Sets the fade-out \a duration (frames) for the clip at (\a trackIndex, \a clipIndex).
+    Pass \c -1 for \a clipIndex to use the clip under the playhead.
+*/
+
 void TimelineDock::fadeOut(int trackIndex, int clipIndex, int duration)
 {
     if (isTrackLocked(trackIndex)) {
@@ -4213,6 +4572,11 @@ void TimelineDock::fadeOut(int trackIndex, int clipIndex, int duration)
     MAIN.undoStack()->push(new Timeline::FadeOutCommand(m_model, trackIndex, clipIndex, duration));
     emit fadeOutChanged(duration);
 }
+
+/*!
+    \qmlmethod void TimelineDock::seekPreviousEdit()
+    \brief Seeks the playhead to the nearest edit point (clip boundary) before the current position.
+*/
 
 void TimelineDock::seekPreviousEdit()
 {
@@ -4241,6 +4605,11 @@ void TimelineDock::seekPreviousEdit()
         setPosition(newPosition);
 }
 
+/*!
+    \qmlmethod void TimelineDock::seekNextEdit()
+    \brief Seeks the playhead to the nearest edit point (clip boundary) after the current position.
+*/
+
 void TimelineDock::seekNextEdit()
 {
     if (!MLT.isMultitrack())
@@ -4268,6 +4637,11 @@ void TimelineDock::seekNextEdit()
     if (newPosition != m_position)
         setPosition(newPosition);
 }
+
+/*!
+    \qmlmethod void TimelineDock::seekInPoint(int clipIndex)
+    \brief Seeks the playhead to the in-point of the clip at \a clipIndex on the current track.
+*/
 
 void TimelineDock::seekInPoint(int clipIndex)
 {
@@ -4565,6 +4939,11 @@ void TimelineDock::replaceClipsWithHash(const QString &hash, Mlt::Producer &prod
         MAIN.undoStack()->endMacro();
 }
 
+/*!
+    \qmlmethod void TimelineDock::recordAudio()
+    \brief Starts audio recording into the current track at the playhead position.
+*/
+
 void TimelineDock::recordAudio()
 {
     // Get the file name.
@@ -4674,6 +5053,11 @@ void TimelineDock::onRecordFinished(AbstractJob *, bool success)
 #endif
     }
 }
+
+/*!
+    \qmlmethod void TimelineDock::stopRecording()
+    \brief Stops an in-progress audio recording.
+*/
 
 void TimelineDock::stopRecording()
 {

--- a/src/models/attachedfiltersmodel.cpp
+++ b/src/models/attachedfiltersmodel.cpp
@@ -122,6 +122,26 @@ static int mltLinkIndex(Mlt::Producer *producer, int row)
     return -1;
 }
 
+/*!
+    \qmltype AttachedFiltersModel
+    \inqmlmodule org.shotcut.qml
+    \brief A list model of filters attached to the currently selected clip or track.
+
+    \c AttachedFiltersModel is available as the \c attachedfiltersmodel context property
+    in the Filters dock. Each row represents one attached filter service.
+*/
+
+/*!
+    \qmlsignal AttachedFiltersModel::changed()
+    \brief Emitted when any filter in the list is added, removed, reordered, or toggled.
+*/
+
+/*!
+    \qmlsignal AttachedFiltersModel::duplicateAddFailed(int index)
+    \brief Emitted when adding a filter would create a duplicate that is not allowed.
+    \a index is the row of the conflicting filter.
+*/
+
 AttachedFiltersModel::AttachedFiltersModel(QObject *parent)
     : QAbstractListModel(parent)
     , m_dropRow(-1)
@@ -160,6 +180,11 @@ void AttachedFiltersModel::setProducer(Mlt::Producer *producer)
     }
 }
 
+/*!
+    \qmlproperty string AttachedFiltersModel::producerTitle
+    \brief The display name of the producer (clip or track) the filters are attached to.
+*/
+
 QString AttachedFiltersModel::producerTitle() const
 {
     if (m_producer)
@@ -168,11 +193,21 @@ QString AttachedFiltersModel::producerTitle() const
         return QString();
 }
 
+/*!
+    \qmlproperty bool AttachedFiltersModel::isProducerSelected
+    \brief \c true when a producer is currently selected and filters can be inspected.
+*/
+
 bool AttachedFiltersModel::isProducerSelected() const
 {
     return !m_producer.isNull() && m_producer->is_valid() && !m_producer->is_blank()
            && MLT.isSeekable(m_producer.get());
 }
+
+/*!
+    \qmlproperty bool AttachedFiltersModel::supportsLinks
+    \brief \c true when the current producer supports \b Time filters (i.e. MLT link chains).
+*/
 
 bool AttachedFiltersModel::supportsLinks() const
 {
@@ -440,6 +475,12 @@ void AttachedFiltersModel::doMoveService(Mlt::Producer &producer, int fromRow, i
     }
 }
 
+/*!
+    \qmlmethod int AttachedFiltersModel::add(Metadata meta)
+    \brief Adds the filter described by \a meta to the attached filters list.
+    Returns the row index of the newly added filter.
+*/
+
 int AttachedFiltersModel::add(QmlMetadata *meta)
 {
     int insertRow = -1;
@@ -667,6 +708,11 @@ void AttachedFiltersModel::doAddService(Mlt::Producer &producer, Mlt::Service &s
     emit addedOrRemoved(&producer);
 }
 
+/*!
+    \qmlmethod void AttachedFiltersModel::remove(int row)
+    \brief Removes the filter at \a row from the attached filters list.
+*/
+
 void AttachedFiltersModel::remove(int row)
 {
     LOG_DEBUG() << row;
@@ -730,6 +776,12 @@ void AttachedFiltersModel::doRemoveService(Mlt::Producer &producer, int row)
     emit addedOrRemoved(&producer);
 }
 
+/*!
+    \qmlmethod bool AttachedFiltersModel::move(int fromRow, int toRow)
+    \brief Moves the filter from \a fromRow to \a toRow.
+    Returns \c true on success.
+*/
+
 bool AttachedFiltersModel::move(int fromRow, int toRow)
 {
     QModelIndex parent = QModelIndex();
@@ -738,6 +790,11 @@ bool AttachedFiltersModel::move(int fromRow, int toRow)
     }
     return moveRows(parent, fromRow, 1, parent, toRow);
 }
+
+/*!
+    \qmlmethod void AttachedFiltersModel::pasteFilters()
+    \brief Pastes any filters stored on the clipboard onto the current producer.
+*/
 
 void AttachedFiltersModel::pasteFilters()
 {

--- a/src/models/keyframesmodel.cpp
+++ b/src/models/keyframesmodel.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2024 Meltytech, LLC
+ * Copyright (c) 2018-2026 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,6 +27,50 @@
 #include <QTimer>
 
 static const quintptr NO_PARENT_ID = quintptr(-1);
+
+/*!
+    \qmltype KeyframesModel
+    \inqmlmodule org.shotcut.qml
+    \brief A two-level item model describing a filter's keyframeable parameters and their keyframes.
+
+    \c KeyframesModel is available as the \c parameters context property in the Keyframes panel.
+    The top level contains one row per keyframeable parameter; each parameter row contains
+    one child row per keyframe.
+
+    \section2 InterpolationType enum
+
+    Passed to \l setInterpolation() and \l addKeyframe():
+
+    \table
+    \header \li Value \li Name
+    \row \li 0 \li DiscreteInterpolation
+    \row \li 1 \li LinearInterpolation
+    \row \li 2 \li SmoothLooseInterpolation
+    \row \li 3 \li SmoothNaturalInterpolation
+    \row \li 4 \li SmoothTightInterpolation
+    \row \li 5–7 \li EaseInSinusoidal / EaseOutSinusoidal / EaseInOutSinusoidal
+    \row \li 8–10 \li EaseIn/Out/InOutQuadratic
+    \row \li 11–13 \li EaseIn/Out/InOutCubic
+    \row \li 14–16 \li EaseIn/Out/InOutQuartic
+    \row \li 17–19 \li EaseIn/Out/InOutQuintic
+    \row \li 20–22 \li EaseIn/Out/InOutExponential
+    \row \li 23–25 \li EaseIn/Out/InOutCircular
+    \row \li 26–28 \li EaseIn/Out/InOutBack
+    \row \li 29–31 \li EaseIn/Out/InOutElastic
+    \row \li 32–34 \li EaseIn/Out/InOutBounce
+    \endtable
+*/
+
+/*!
+    \qmlsignal KeyframesModel::loaded()
+    \brief Emitted after the model has been populated for a new filter.
+*/
+
+/*!
+    \qmlsignal KeyframesModel::keyframeAdded(string parameter, int position)
+    \brief Emitted when a keyframe is added. \a parameter is the MLT property name;
+    \a position is the frame number.
+*/
 
 KeyframesModel::KeyframesModel(QObject *parent)
     : QAbstractItemModel(parent)
@@ -363,6 +407,12 @@ void KeyframesModel::load(QmlFilter *filter, QmlMetadata *meta)
     emit loaded();
 }
 
+/*!
+    \qmlmethod bool KeyframesModel::remove(int parameterIndex, int keyframeIndex)
+    \brief Removes the keyframe at \a keyframeIndex on parameter \a parameterIndex.
+    Returns \c true on success.
+*/
+
 bool KeyframesModel::remove(int parameterIndex, int keyframeIndex)
 {
     bool error = true;
@@ -447,6 +497,12 @@ int KeyframesModel::nextKeyframePosition(int parameterIndex, int currentPosition
     return result;
 }
 
+/*!
+    \qmlmethod int KeyframesModel::keyframeIndex(int parameterIndex, int currentPosition)
+    \brief Returns the keyframe index at time \a currentPosition for the given \a parameterIndex,
+    or \c -1 if no keyframe exists at that position.
+*/
+
 int KeyframesModel::keyframeIndex(int parameterIndex, int currentPosition)
 {
     int result = -1;
@@ -466,10 +522,22 @@ int KeyframesModel::keyframeIndex(int parameterIndex, int currentPosition)
     return result;
 }
 
+/*!
+    \qmlmethod int KeyframesModel::parameterIndex(string propertyName)
+    \brief Returns the row index of the parameter identified by \a propertyName, or \c -1.
+*/
+
 int KeyframesModel::parameterIndex(const QString &propertyName) const
 {
     return m_propertyNames.indexOf(propertyName);
 }
+
+/*!
+    \qmlmethod bool KeyframesModel::setInterpolation(int parameterIndex, int keyframeIndex, int type)
+    \brief Sets the interpolation \a type for the keyframe at \a keyframeIndex on \a parameterIndex.
+    \a type is a value from the \c InterpolationType enum.
+    Returns \c true on success.
+*/
 
 bool KeyframesModel::setInterpolation(int parameterIndex, int keyframeIndex, InterpolationType type)
 {
@@ -512,6 +580,11 @@ bool KeyframesModel::setInterpolation(int parameterIndex, int keyframeIndex, Int
                     << "to type" << type;
     return error;
 }
+
+/*!
+    \qmlmethod void KeyframesModel::setKeyframePosition(int parameterIndex, int keyframeIndex, int position)
+    \brief Moves the keyframe at \a keyframeIndex on \a parameterIndex to \a position (in frames).
+*/
 
 void KeyframesModel::setKeyframePosition(int parameterIndex, int keyframeIndex, int position)
 {
@@ -571,6 +644,17 @@ void KeyframesModel::setKeyframePosition(int parameterIndex, int keyframeIndex, 
     emit m_filter->propertyChanged(name.toUtf8().constData());
     m_filter->endUndoCommand();
 }
+
+/*!
+    \qmlmethod void KeyframesModel::addKeyframe(int parameterIndex, double value, int position, int type)
+    \brief Adds a keyframe at time \a position for \a parameterIndex with numeric \a value and
+    interpolation \a type.
+*/
+
+/*!
+    \qmlmethod void KeyframesModel::addKeyframe(int parameterIndex, int position)
+    \brief Adds a keyframe at time \a position for \a parameterIndex using the current filter value.
+*/
 
 void KeyframesModel::addKeyframe(int parameterIndex,
                                  double value,
@@ -665,6 +749,12 @@ void KeyframesModel::addKeyframe(int parameterIndex, int position)
     }
 }
 
+/*!
+    \qmlmethod void KeyframesModel::setKeyframeValue(int parameterIndex, int keyframeIndex, double value)
+    \brief Sets the numeric \a value of an existing keyframe on parameter \a parameterIndex
+    at \a keyframeIndex.
+*/
+
 void KeyframesModel::setKeyframeValue(int parameterIndex, int keyframeIndex, double value)
 {
     if (!m_filter) {
@@ -719,6 +809,12 @@ void KeyframesModel::setKeyframeValue(int parameterIndex, int keyframeIndex, dou
                      QVector<int>() << LowestValueRole << HighestValueRole);
     m_filter->endUndoCommand();
 }
+
+/*!
+    \qmlmethod void KeyframesModel::setKeyframeValuePosition(int parameterIndex, int keyframeIndex, double value, int position)
+    \brief Sets both the \a value and time \a position of keyframe \a keyframeIndex on
+    parameter \a parameterIndex in one operation.
+*/
 
 void KeyframesModel::setKeyframeValuePosition(int parameterIndex,
                                               int keyframeIndex,
@@ -795,6 +891,11 @@ void KeyframesModel::setKeyframeValuePosition(int parameterIndex,
     m_filter->endUndoCommand();
 }
 
+/*!
+    \qmlmethod bool KeyframesModel::isKeyframe(int parameterIndex, int position)
+    \brief Returns \c true if a keyframe exists at time \a position for \a parameterIndex.
+*/
+
 bool KeyframesModel::isKeyframe(int parameterIndex, int position)
 {
     if (m_filter && parameterIndex < m_propertyNames.count()) {
@@ -804,6 +905,11 @@ bool KeyframesModel::isKeyframe(int parameterIndex, int position)
     }
     return false;
 }
+
+/*!
+    \qmlmethod bool KeyframesModel::advancedKeyframesInUse()
+    \brief Returns \c true if the filter is currently using advanced (per-keyframe) interpolation.
+*/
 
 bool KeyframesModel::advancedKeyframesInUse()
 {
@@ -815,6 +921,11 @@ bool KeyframesModel::advancedKeyframesInUse()
         }
     return false;
 }
+
+/*!
+    \qmlmethod void KeyframesModel::removeAdvancedKeyframes()
+    \brief Converts all advanced keyframes to simple (linear) keyframes.
+*/
 
 void KeyframesModel::removeAdvancedKeyframes()
 {
@@ -834,10 +945,20 @@ void KeyframesModel::removeAdvancedKeyframes()
     }
 }
 
+/*!
+    \qmlmethod bool KeyframesModel::simpleKeyframesInUse()
+    \brief Returns \c true if the filter is currently using simple (two-keyframe) animation.
+*/
+
 bool KeyframesModel::simpleKeyframesInUse()
 {
     return m_filter && m_metadata && (m_filter->animateIn() > 0 || m_filter->animateOut() > 0);
 }
+
+/*!
+    \qmlmethod void KeyframesModel::removeSimpleKeyframes()
+    \brief Removes the simple keyframe animation, returning the filter to a static state.
+*/
 
 void KeyframesModel::removeSimpleKeyframes()
 {
@@ -918,6 +1039,11 @@ void KeyframesModel::removeSimpleKeyframes()
         m_filter->clearAnimateInOut();
     }
 }
+
+/*!
+    \qmlmethod void KeyframesModel::reload()
+    \brief Reloads the model from the current filter, refreshing all parameter and keyframe rows.
+*/
 
 void KeyframesModel::reload()
 {

--- a/src/models/markersmodel.cpp
+++ b/src/models/markersmodel.cpp
@@ -59,6 +59,40 @@ static void propertiesToMarker(Mlt::Properties *properties,
     }
 }
 
+/*!
+    \qmltype MarkersModel
+    \inqmlmodule org.shotcut.qml
+    \brief A model of timeline markers (cue points with optional range spans and colors).
+
+    \c MarkersModel is available as the \c markers context property in the Timeline dock.
+    Each row represents one marker.
+
+    \section2 Roles
+
+    \table
+    \header \li Role name \li Description
+    \row \li \c text \li Marker label text
+    \row \li \c start \li Start position in frames
+    \row \li \c end \li End position in frames (\c == \c start for point markers)
+    \row \li \c color \li Marker color (\c color type)
+    \endtable
+*/
+
+/*!
+    \qmlsignal MarkersModel::rangesChanged()
+    \brief Emitted when any marker's start/end range changes.
+*/
+
+/*!
+    \qmlsignal MarkersModel::modified()
+    \brief Emitted whenever any marker is added, removed, or edited.
+*/
+
+/*!
+    \qmlsignal MarkersModel::recentColorsChanged()
+    \brief Emitted when the recent-colors list is updated.
+*/
+
 MarkersModel::MarkersModel(QObject *parent)
     : QAbstractItemModel(parent)
     , m_producer(nullptr)
@@ -105,6 +139,11 @@ Markers::Marker MarkersModel::getMarker(int markerIndex)
     }
     return retMarker;
 }
+
+/*!
+    \qmlmethod void MarkersModel::remove(int markerIndex)
+    \brief Removes the marker at \a markerIndex.
+*/
 
 void MarkersModel::remove(int markerIndex)
 {
@@ -367,6 +406,12 @@ void MarkersModel::doShift(int shiftPosition, int shiftAmount)
     }
 }
 
+/*!
+    \qmlmethod void MarkersModel::move(int markerIndex, int start, int end)
+    \brief Moves the marker at \a markerIndex so it spans \a start to \a end (in frames).
+    For a point marker set \a end equal to \a start.
+*/
+
 void MarkersModel::move(int markerIndex, int start, int end)
 {
     Mlt::Properties *markerProperties = getMarkerProperties(markerIndex);
@@ -386,6 +431,11 @@ void MarkersModel::move(int markerIndex, int start, int end)
     MAIN.undoStack()->push(command);
 }
 
+/*!
+    \qmlmethod void MarkersModel::setColor(int markerIndex, color color)
+    \brief Sets the display \a color of the marker at \a markerIndex.
+*/
+
 void MarkersModel::setColor(int markerIndex, const QColor &color)
 {
     Mlt::Properties *markerProperties = getMarkerProperties(markerIndex);
@@ -403,6 +453,11 @@ void MarkersModel::setColor(int markerIndex, const QColor &color)
         = new Markers::UpdateCommand(*this, newMarker, oldMarker, markerIndex);
     MAIN.undoStack()->push(command);
 }
+
+/*!
+    \qmlmethod void MarkersModel::clear()
+    \brief Removes all markers from the timeline.
+*/
 
 void MarkersModel::clear()
 {
@@ -529,6 +584,12 @@ int MarkersModel::rangeMarkerIndexForPosition(int position)
     return -1;
 }
 
+/*!
+    \qmlmethod int MarkersModel::nextMarkerPosition(int position)
+    \brief Returns the start frame of the nearest marker after \a position,
+    or \c -1 if no marker exists after that position.
+*/
+
 int MarkersModel::nextMarkerPosition(int position)
 {
     int nextPosition = -1;
@@ -557,6 +618,12 @@ int MarkersModel::nextMarkerPosition(int position)
     }
     return nextPosition;
 }
+
+/*!
+    \qmlmethod int MarkersModel::prevMarkerPosition(int position)
+    \brief Returns the start frame of the nearest marker before time \a position,
+    or \c -1 if no marker exists before that position.
+*/
 
 int MarkersModel::prevMarkerPosition(int position)
 {
@@ -613,6 +680,11 @@ QMap<int, QString> MarkersModel::ranges()
     }
     return result;
 }
+
+/*!
+    \qmlproperty list<string> MarkersModel::recentColors
+    \brief The list of recently used marker color strings, most-recent first.
+*/
 
 QStringList MarkersModel::recentColors()
 {

--- a/src/models/motiontrackermodel.cpp
+++ b/src/models/motiontrackermodel.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Meltytech, LLC
+ * Copyright (c) 2023-2026 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -75,6 +75,28 @@ public:
     int on_start_link(Mlt::Link *) { return 0; }
     int on_end_link(Mlt::Link *) { return 0; }
 };
+
+/*!
+    \qmltype MotionTrackerModel
+    \inqmlmodule org.shotcut.qml
+    \brief A list model of motion tracker entries attached to the current producer.
+
+    \c MotionTrackerModel is available as the \c motionTrackerModel context property
+    in the Filters panel. Each row represents one stored motion tracker (a named bounding-box
+    trajectory recorded against the clip).
+*/
+
+/*!
+    \qmlproperty string MotionTrackerModel::nameProperty
+    \brief The MLT property name used to store the tracker's display name on a filter
+    (value: \c "shotcut:motionTracker.name"). CONSTANT.
+*/
+
+/*!
+    \qmlproperty string MotionTrackerModel::operationProperty
+    \brief The MLT property name used to store the tracker's link operation on a filter
+    (value: \c "shotcut:motionTracker.operation"). CONSTANT.
+*/
 
 MotionTrackerModel::MotionTrackerModel(QObject *parent)
     : QAbstractListModel(parent)
@@ -165,6 +187,11 @@ void MotionTrackerModel::removeFromService(Mlt::Service *service)
     }
 }
 
+/*!
+    \qmlmethod void MotionTrackerModel::setName(Filter filter, string name)
+    \brief Sets the display \a name for the tracker linked to \a filter.
+*/
+
 void MotionTrackerModel::setName(QmlFilter *filter, const QString &name)
 {
     if (filter && filter->service().is_valid()) {
@@ -174,6 +201,11 @@ void MotionTrackerModel::setName(QmlFilter *filter, const QString &name)
         }
     }
 }
+
+/*!
+    \qmlmethod string MotionTrackerModel::nextName()
+    \brief Returns an auto-generated unique name for a new tracker (e.g. \c "Tracker 2").
+*/
 
 QString MotionTrackerModel::nextName() const
 {
@@ -198,6 +230,12 @@ QString MotionTrackerModel::keyForFilter(Mlt::Service *service)
     return key;
 }
 
+/*!
+    \qmlmethod void MotionTrackerModel::reset(Filter filter, string property, int row)
+    \brief Clears the keyframes for \a property on \a filter that were written by the tracker
+    at model row \a row.
+*/
+
 void MotionTrackerModel::reset(QmlFilter *filter, const QString &property, int row)
 {
     auto key = keyForRow(row);
@@ -214,6 +252,12 @@ void MotionTrackerModel::reset(QmlFilter *filter, const QString &property, int r
         }
     }
 }
+
+/*!
+    \qmlmethod list<rect> MotionTrackerModel::trackingData(int row)
+    \brief Returns the list of bounding-box rectangles recorded by the tracker at \a row,
+    one entry per keyframe interval frame.
+*/
 
 QList<MotionTrackerModel::TrackingItem> MotionTrackerModel::trackingData(const QString &key) const
 {
@@ -248,6 +292,11 @@ QList<QRectF> MotionTrackerModel::trackingData(int row) const
     }
     return result;
 }
+
+/*!
+    \qmlmethod int MotionTrackerModel::keyframeIntervalFrames(int row)
+    \brief Returns the keyframe interval in frames for the tracker at \a row.
+*/
 
 int MotionTrackerModel::keyframeIntervalFrames(int row) const
 {
@@ -316,6 +365,12 @@ Qt::ItemFlags MotionTrackerModel::flags(const QModelIndex &index) const
 
     return QAbstractItemModel::flags(index) | Qt::ItemIsEditable;
 }
+
+/*!
+    \qmlmethod void MotionTrackerModel::undo(Filter filter, string propertyName)
+    \brief Static helper that removes motion-tracker–written keyframes for \a propertyName
+    on \a filter, typically called before re-applying a tracker.
+*/
 
 void MotionTrackerModel::undo(QmlFilter *filter, const QString &propertyName)
 {

--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -94,7 +94,7 @@ static const char *kShotcutDefaultTransition = "lumaMix";
 
 /*!
     \qmlsignal MultitrackModel::seeked(int position)
-    \brief Emitted when the playhead is moved to \time \a position.
+    \brief Emitted when the playhead is moved to time \a position.
 */
 
 /*!
@@ -800,7 +800,7 @@ void MultitrackModel::setTrackHeaderWidth(int width)
 }
 
 /*!
-    \qmlproperty double MultitrackModel::scaleFactor
+    \qmlproperty real MultitrackModel::scaleFactor
     \brief The horizontal zoom/scale factor of the timeline. Settable.
 */
 

--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -39,6 +39,89 @@
 static const quintptr NO_PARENT_ID = quintptr(-1);
 static const char *kShotcutDefaultTransition = "lumaMix";
 
+/*!
+    \qmltype MultitrackModel
+    \inqmlmodule org.shotcut.qml
+    \brief A two-level item model representing the timeline: tracks at the top level, clips within each track.
+
+    \c MultitrackModel is available as the \c multitrack context property in the Timeline dock.
+    The top level rows are tracks (video or audio); each track's children are the clips on that track.
+
+    \section2 Track/Clip Roles (partial)
+
+    \table
+    \header \li Role name \li Applies to \li Description
+    \row \li \c name \li track, clip \li Display name
+    \row \li \c comment \li clip \li Clip comment
+    \row \li \c resource \li clip \li Source file path
+    \row \li \c isBlank \li clip \li Whether this is a blank (gap)
+    \row \li \c start \li clip \li Start position in frames on the timeline
+    \row \li \c duration \li track, clip \li Duration in frames
+    \row \li \c inPoint \li clip \li In-point of the source media
+    \row \li \c outPoint \li clip \li Out-point of the source media
+    \row \li \c isMute \li track \li Whether the track is muted
+    \row \li \c isHidden \li track \li Whether the track is hidden
+    \row \li \c isAudio \li track, clip \li Whether this is an audio track/clip
+    \row \li \c isLocked \li track \li Whether the track is locked
+    \row \li \c fadeIn \li clip \li Fade-in duration in frames
+    \row \li \c fadeOut \li clip \li Fade-out duration in frames
+    \row \li \c isTransition \li clip \li Whether this clip is a transition
+    \row \li \c isFiltered \li track, clip \li Whether filters are attached
+    \row \li \c speed \li clip \li Playback speed multiplier
+    \row \li \c group \li clip \li Clip group identifier
+    \endtable
+*/
+
+/*!
+    \qmlsignal MultitrackModel::created()
+    \brief Emitted when a new tractor (timeline) is created.
+*/
+
+/*!
+    \qmlsignal MultitrackModel::aboutToClose()
+    \brief Emitted just before the timeline is closed/cleared.
+*/
+
+/*!
+    \qmlsignal MultitrackModel::closed()
+    \brief Emitted after the timeline has been closed.
+*/
+
+/*!
+    \qmlsignal MultitrackModel::modified()
+    \brief Emitted whenever timeline content changes.
+*/
+
+/*!
+    \qmlsignal MultitrackModel::seeked(int position)
+    \brief Emitted when the playhead is moved to \time \a position.
+*/
+
+/*!
+    \qmlsignal MultitrackModel::trackHeightChanged()
+    \brief Emitted when \l trackHeight changes.
+*/
+
+/*!
+    \qmlsignal MultitrackModel::scaleFactorChanged()
+    \brief Emitted when \l scaleFactor changes.
+*/
+
+/*!
+    \qmlsignal MultitrackModel::durationChanged()
+    \brief Emitted when the total timeline duration changes.
+*/
+
+/*!
+    \qmlsignal MultitrackModel::filteredChanged()
+    \brief Emitted when the \l filtered state changes.
+*/
+
+/*!
+    \qmlsignal MultitrackModel::showStatusMessage(string message)
+    \brief Emitted to display a \a message in the status bar.
+*/
+
 MultitrackModel::MultitrackModel(QObject *parent)
     : QAbstractItemModel(parent)
     , m_tractor(0)
@@ -374,6 +457,11 @@ const QByteArray *MultitrackModel::getAudioLevels(int trackIndex, int clipIndex)
     return nullptr;
 }
 
+/*!
+    \qmlmethod void MultitrackModel::setTrackName(int row, string value)
+    \brief Renames the track at \a row to \a value.
+*/
+
 void MultitrackModel::setTrackName(int row, const QString &value)
 {
     if (row < m_trackList.size()) {
@@ -390,6 +478,11 @@ void MultitrackModel::setTrackName(int row, const QString &value)
         }
     }
 }
+
+/*!
+    \qmlmethod void MultitrackModel::setTrackMute(int row, bool mute)
+    \brief Sets the mute state of the track at \a row to \a mute.
+*/
 
 void MultitrackModel::setTrackMute(int row, bool mute)
 {
@@ -412,6 +505,11 @@ void MultitrackModel::setTrackMute(int row, bool mute)
         }
     }
 }
+
+/*!
+    \qmlmethod void MultitrackModel::setTrackHidden(int row, bool hidden)
+    \brief Sets the hidden state of the video track at \a row to \a hidden.
+*/
 
 void MultitrackModel::setTrackHidden(int row, bool hidden)
 {
@@ -436,6 +534,11 @@ void MultitrackModel::setTrackHidden(int row, bool hidden)
     }
 }
 
+/*!
+    \qmlmethod void MultitrackModel::setTrackComposite(int row, bool composite)
+    \brief Sets whether the video track at \a row composites over lower tracks (\a composite).
+*/
+
 void MultitrackModel::setTrackComposite(int row, bool composite)
 {
     if (row < m_trackList.size()) {
@@ -453,6 +556,11 @@ void MultitrackModel::setTrackComposite(int row, bool composite)
         emit modified();
     }
 }
+
+/*!
+    \qmlmethod void MultitrackModel::setTrackLock(int row, bool lock)
+    \brief Locks (\a lock = \c true) or unlocks the track at \a row.
+*/
 
 void MultitrackModel::setTrackLock(int row, bool lock)
 {
@@ -489,6 +597,14 @@ bool MultitrackModel::trimClipInValid(int trackIndex, int clipIndex, int delta, 
     }
     return result;
 }
+
+/*!
+    \qmlmethod int MultitrackModel::trimClipIn(int trackIndex, int clipIndex, int delta, bool ripple, bool rippleAllTracks)
+    \brief Trims the in-point of the clip at (\a trackIndex, \a clipIndex) by \a delta frames.
+    If \a ripple is \c true, clips on \a trackIndex shift to fill the gap.
+    If \a rippleAllTracks is \c true, all tracks ripple.
+    Returns the number of frames actually trimmed.
+*/
 
 int MultitrackModel::trimClipIn(
     int trackIndex, int clipIndex, int delta, bool ripple, bool rippleAllTracks)
@@ -640,6 +756,11 @@ bool MultitrackModel::trimClipOutValid(int trackIndex, int clipIndex, int delta,
     return result;
 }
 
+/*!
+    \qmlproperty int MultitrackModel::trackHeight
+    \brief The display height of each track row in pixels. Settable.
+*/
+
 int MultitrackModel::trackHeight() const
 {
     int result = m_tractor ? m_tractor->get_int(kTrackHeightProperty)
@@ -657,6 +778,11 @@ void MultitrackModel::setTrackHeight(int height)
     }
 }
 
+/*!
+    \qmlproperty int MultitrackModel::trackHeaderWidth
+    \brief The width of the track header column in pixels. Settable.
+*/
+
 int MultitrackModel::trackHeaderWidth() const
 {
     return (m_tractor && m_tractor->property_exists(kTrackHeaderWidthProperty))
@@ -673,6 +799,11 @@ void MultitrackModel::setTrackHeaderWidth(int width)
     }
 }
 
+/*!
+    \qmlproperty double MultitrackModel::scaleFactor
+    \brief The horizontal zoom/scale factor of the timeline. Settable.
+*/
+
 double MultitrackModel::scaleFactor() const
 {
     double result = m_tractor ? m_tractor->get_double(kTimelineScaleProperty) : 0;
@@ -686,6 +817,14 @@ void MultitrackModel::setScaleFactor(double scale)
         emit scaleFactorChanged();
     }
 }
+
+/*!
+    \qmlmethod int MultitrackModel::trimClipOut(int trackIndex, int clipIndex, int delta, bool ripple, bool rippleAllTracks)
+    \brief Trims the out-point of the clip at (\a trackIndex, \a clipIndex) by \a delta frames.
+    If \a ripple is \c true, downstream clips shift.
+    If \a rippleAllTracks is \c true, all tracks ripple.
+    Returns the number of frames actually trimmed.
+*/
 
 int MultitrackModel::trimClipOut(
     int trackIndex, int clipIndex, int delta, bool ripple, bool rippleAllTracks)
@@ -802,6 +941,14 @@ void MultitrackModel::notifyClipOut(int trackIndex, int clipIndex)
     }
     m_isMakingTransition = false;
 }
+
+/*!
+    \qmlmethod bool MultitrackModel::moveClip(int fromTrack, int toTrack, int clipIndex, int position, bool ripple, bool rippleAllTracks)
+    \brief Moves the clip at (\a fromTrack, \a clipIndex) to time \a position on \a toTrack.
+    If \a ripple is \c true, clips on \a toTrack shift to close the gap.
+    If \a rippleAllTracks is \c true, all tracks ripple.
+    Returns \c true on success.
+*/
 
 bool MultitrackModel::moveClip(
     int fromTrack, int toTrack, int clipIndex, int position, bool ripple, bool rippleAllTracks)
@@ -1244,6 +1391,12 @@ int MultitrackModel::appendClip(int trackIndex, Mlt::Producer &clip, bool seek, 
     return -1;
 }
 
+/*!
+    \qmlmethod void MultitrackModel::removeClip(int trackIndex, int clipIndex, bool rippleAllTracks)
+    \brief Removes the clip at (\a trackIndex, \a clipIndex). If \a rippleAllTracks is \c true,
+    all tracks shift to close the gap.
+*/
+
 void MultitrackModel::removeClip(int trackIndex, int clipIndex, bool rippleAllTracks)
 {
     if (trackIndex >= m_trackList.size()) {
@@ -1295,6 +1448,11 @@ void MultitrackModel::removeClip(int trackIndex, int clipIndex, bool rippleAllTr
     }
 }
 
+/*!
+    \qmlmethod void MultitrackModel::liftClip(int trackIndex, int clipIndex)
+    \brief Lifts (clears) the clip at (\a trackIndex, \a clipIndex), leaving a blank.
+*/
+
 void MultitrackModel::liftClip(int trackIndex, int clipIndex)
 {
     if (trackIndex >= m_trackList.size()) {
@@ -1327,6 +1485,11 @@ void MultitrackModel::liftClip(int trackIndex, int clipIndex)
         }
     }
 }
+
+/*!
+    \qmlmethod void MultitrackModel::splitClip(int trackIndex, int clipIndex, int position)
+    \brief Splits the clip at (\a trackIndex, \a clipIndex) at time \a position (frames from timeline start).
+*/
 
 void MultitrackModel::splitClip(int trackIndex, int clipIndex, int position)
 {
@@ -1414,6 +1577,11 @@ void MultitrackModel::splitClip(int trackIndex, int clipIndex, int position)
     }
 }
 
+/*!
+    \qmlmethod void MultitrackModel::joinClips(int trackIndex, int clipIndex)
+    \brief Joins the clip at \a clipIndex with the following clip on \a trackIndex into one clip.
+*/
+
 void MultitrackModel::joinClips(int trackIndex, int clipIndex)
 {
     if (clipIndex < 0)
@@ -1462,6 +1630,11 @@ void MultitrackModel::joinClips(int trackIndex, int clipIndex)
         emit modified();
     }
 }
+
+/*!
+    \qmlmethod void MultitrackModel::changeGain(int trackIndex, int clipIndex, double gain)
+    \brief Sets the audio \a gain of the clip at (\a trackIndex, \a clipIndex).
+*/
 
 void MultitrackModel::changeGain(int trackIndex, int clipIndex, double gain)
 {
@@ -1517,6 +1690,11 @@ static void moveBeforeFirstAudioFilter(Mlt::Producer *producer)
     }
     producer->move_filter(n - 1, index);
 }
+
+/*!
+    \qmlmethod void MultitrackModel::fadeIn(int trackIndex, int clipIndex, int duration)
+    \brief Sets the fade-in \a duration (frames) of the clip at (\a trackIndex, \a clipIndex).
+*/
 
 void MultitrackModel::fadeIn(int trackIndex, int clipIndex, int duration)
 {
@@ -1639,6 +1817,11 @@ void MultitrackModel::fadeIn(int trackIndex, int clipIndex, int duration)
         }
     }
 }
+
+/*!
+    \qmlmethod void MultitrackModel::fadeOut(int trackIndex, int clipIndex, int duration)
+    \brief Sets the fade-out \a duration (frames) of the clip at (\a trackIndex, \a clipIndex).
+*/
 
 void MultitrackModel::fadeOut(int trackIndex, int clipIndex, int duration)
 {
@@ -1766,6 +1949,13 @@ void MultitrackModel::fadeOut(int trackIndex, int clipIndex, int duration)
     }
 }
 
+/*!
+    \qmlmethod bool MultitrackModel::addTransitionValid(int fromTrack, int toTrack, int clipIndex, int position, bool ripple)
+    \brief Returns \c true if adding a transition at time \a position between \a clipIndex and its
+    neighbor on \a fromTrack / \a toTrack would be valid. \a ripple indicates whether
+    ripple mode is active.
+*/
+
 bool MultitrackModel::addTransitionValid(
     int fromTrack, int toTrack, int clipIndex, int position, bool ripple)
 {
@@ -1798,6 +1988,13 @@ bool MultitrackModel::addTransitionValid(
     }
     return result;
 }
+
+/*!
+    \qmlmethod int MultitrackModel::addTransition(int trackIndex, int clipIndex, int position, bool ripple, bool rippleAllTracks)
+    \brief Adds a transition between the clip at (\a trackIndex, \a clipIndex) and its
+    neighbor at time \a position. \a ripple and \a rippleAllTracks control whether downstream
+    clips shift. Returns the clip index of the resulting transition.
+*/
 
 int MultitrackModel::addTransition(
     int trackIndex, int clipIndex, int position, bool ripple, bool rippleAllTracks)
@@ -1900,6 +2097,11 @@ void MultitrackModel::clearMixReferences(int trackIndex, int clipIndex)
         }
     }
 }
+
+/*!
+    \qmlmethod void MultitrackModel::removeTransition(int trackIndex, int clipIndex)
+    \brief Removes the transition at (\a trackIndex, \a clipIndex).
+*/
 
 void MultitrackModel::removeTransition(int trackIndex, int clipIndex)
 {
@@ -2645,6 +2847,12 @@ void MultitrackModel::consolidateBlanksAllTracks()
         ++i;
     }
 }
+
+/*!
+    \qmlmethod void MultitrackModel::audioLevelsReady(var index)
+    \brief Called by the audio waveform worker when waveform data for \a index is ready.
+    Triggers a data refresh for the corresponding clip.
+*/
 
 void MultitrackModel::audioLevelsReady(const QPersistentModelIndex &index)
 {
@@ -3550,6 +3758,11 @@ bool MultitrackModel::mergeClipWithNext(int trackIndex, int clipIndex, bool dryr
     return true;
 }
 
+/*!
+    \qmlproperty bool MultitrackModel::filtered
+    \brief \c true when timeline clips are being filtered/searched. Read-only.
+*/
+
 bool MultitrackModel::isFiltered(Mlt::Producer *producer) const
 {
     if (!producer)
@@ -3625,6 +3838,12 @@ void MultitrackModel::load()
     emit scaleFactorChanged();
     emit trackHeaderWidthChanged();
 }
+
+/*!
+    \qmlmethod void MultitrackModel::reload(bool asynchronous)
+    \brief Reloads all track and clip data. If \a asynchronous is \c true, audio levels
+    are recalculated in the background.
+*/
 
 void MultitrackModel::reload(bool asynchronous)
 {

--- a/src/models/subtitlesmodel.cpp
+++ b/src/models/subtitlesmodel.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Meltytech, LLC
+ * Copyright (c) 2024-2026 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,6 +31,40 @@
 static const quintptr NO_PARENT_ID = quintptr(-1);
 
 enum Columns { COLUMN_TEXT = 0, COLUMN_START, COLUMN_END, COLUMN_DURATION, COLUMN_COUNT };
+
+/*!
+    \qmltype SubtitlesModel
+    \inqmlmodule org.shotcut.qml
+    \brief A two-level item model for subtitle tracks and subtitle items on the timeline.
+
+    \c SubtitlesModel is available as the \c subtitlesModel context property in the Subtitles dock.
+    The top level is the list of subtitle tracks; each track row contains the subtitle item rows.
+
+    \section2 Roles
+
+    Item data roles returned by \c data():
+
+    \table
+    \header \li Role name \li Description
+    \row \li \c text \li Subtitle text
+    \row \li \c start \li Start time in milliseconds
+    \row \li \c end \li End time in milliseconds
+    \row \li \c duration \li Duration in milliseconds
+    \row \li \c startFrame \li Start position in frames
+    \row \li \c endFrame \li End position in frames
+    \row \li \c siblingCount \li Number of overlapping subtitles at this time
+    \endtable
+*/
+
+/*!
+    \qmlsignal SubtitlesModel::tracksChanged(int count)
+    \brief Emitted when the number of tracks changes. \a count is the new track count.
+*/
+
+/*!
+    \qmlsignal SubtitlesModel::modified()
+    \brief Emitted whenever any subtitle data is modified.
+*/
 
 SubtitlesModel::SubtitlesModel(QObject *parent)
     : QAbstractItemModel(parent)
@@ -102,10 +136,20 @@ int64_t SubtitlesModel::maxTime() const
     return maxTime;
 }
 
+/*!
+    \qmlproperty int SubtitlesModel::trackCount
+    \brief The number of subtitle tracks. Read-only.
+*/
+
 int SubtitlesModel::trackCount() const
 {
     return m_tracks.size();
 }
+
+/*!
+    \qmlmethod QModelIndex SubtitlesModel::trackModelIndex(int trackIndex)
+    \brief Returns the \c QModelIndex for the track row at \a trackIndex.
+*/
 
 QModelIndex SubtitlesModel::trackModelIndex(int trackIndex) const
 {
@@ -224,6 +268,11 @@ void SubtitlesModel::editTrack(int trackIndex, SubtitlesModel::SubtitleTrack &tr
     Subtitles::EditTrackCommand *command = new Subtitles::EditTrackCommand(*this, track, trackIndex);
     MAIN.undoStack()->push(command);
 }
+
+/*!
+    \qmlmethod int SubtitlesModel::itemCount(int trackIndex)
+    \brief Returns the number of subtitle items on the track at \a trackIndex.
+*/
 
 int SubtitlesModel::itemCount(int trackIndex) const
 {
@@ -442,6 +491,12 @@ void SubtitlesModel::setText(int trackIndex, int itemIndex, const QString &text)
     MAIN.undoStack()->push(command);
 }
 
+/*!
+    \qmlmethod void SubtitlesModel::moveItems(int trackIndex, int firstItemIndex, int lastItemIndex, int msTime)
+    \brief Moves the subtitle items from \a firstItemIndex to \a lastItemIndex on \a trackIndex
+    so that the first item starts at \a msTime milliseconds.
+*/
+
 void SubtitlesModel::moveItems(int trackIndex, int firstItemIndex, int lastItemIndex, int64_t msTime)
 {
     int count = m_items[trackIndex].size();
@@ -457,6 +512,11 @@ void SubtitlesModel::moveItems(int trackIndex, int firstItemIndex, int lastItemI
         = new Subtitles::MoveSubtitlesCommand(*this, trackIndex, items, msTime);
     MAIN.undoStack()->push(command);
 }
+
+/*!
+    \qmlmethod bool SubtitlesModel::validateMove(list items, int msTime)
+    \brief Returns \c true if moving the given \a items to \a msTime would not create an overlap.
+*/
 
 bool SubtitlesModel::validateMove(const QModelIndexList &items, int64_t msTime)
 {
@@ -863,3 +923,51 @@ QHash<int, QByteArray> SubtitlesModel::roleNames() const
     roles[SiblingCountRole] = "siblingCount";
     return roles;
 }
+/*!
+    \qmltype SubtitlesSelectionModel
+    \inqmlmodule org.shotcut.qml
+    \brief Tracks the selected track and selected subtitle items in the Subtitles dock.
+
+    \c SubtitlesSelectionModel is available as the \c subtitlesSelectionModel context property
+    in the Subtitles dock.
+*/
+
+/*!
+    \qmlsignal SubtitlesSelectionModel::selectedTrackModelIndexChanged(QModelIndex trackModelIndex)
+    \brief Emitted when the selected track changes. \a trackModelIndex is the new track's model index.
+*/
+
+/*!
+    \qmlsignal SubtitlesSelectionModel::selectedItemsChanged()
+    \brief Emitted when the set of selected subtitle items changes.
+*/
+
+/*!
+    \qmlproperty QModelIndex SubtitlesSelectionModel::selectedTrackModelIndex
+    \brief The model index of the currently selected track (read-only).
+*/
+
+/*!
+    \qmlproperty list<var> SubtitlesSelectionModel::selectedItems
+    \brief The list of currently selected subtitle item indices (read-only).
+*/
+
+/*!
+    \qmlmethod int SubtitlesSelectionModel::selectedTrack()
+    \brief Returns the zero-based index of the currently selected track, or \c -1 if none.
+*/
+
+/*!
+    \qmlmethod bool SubtitlesSelectionModel::isItemSelected(int itemIndex)
+    \brief Returns \c true if the subtitle item at \a itemIndex is currently selected.
+*/
+
+/*!
+    \qmlmethod void SubtitlesSelectionModel::selectItem(int itemIndex)
+    \brief Selects only the subtitle item at \a itemIndex, clearing any other selection.
+*/
+
+/*!
+    \qmlmethod void SubtitlesSelectionModel::selectRange(int itemIndex)
+    \brief Extends the selection from the last single-selection anchor to \a itemIndex.
+*/

--- a/src/qmltypes/qmlapplication.cpp
+++ b/src/qmltypes/qmlapplication.cpp
@@ -49,6 +49,41 @@ QmlApplication &QmlApplication::singleton()
     return instance;
 }
 
+/*!
+    \qmltype Application
+    \inqmlmodule org.shotcut.qml
+    \brief Application-wide utilities, accessed via the \c application context property.
+
+    \c application is set as a context property on every Shotcut QML view.
+    It cannot be instantiated from QML — use the global \c application identifier directly:
+
+    \code
+    application.showStatusMessage("Ready")
+    var t = application.clockFromFrames(150)
+    var c = application.contrastingColor("red")
+    \endcode
+*/
+
+/*!
+    \qmlsignal Application::paletteChanged()
+    \brief Emitted when the application color palette changes (e.g. dark/light mode switch).
+*/
+
+/*!
+    \qmlsignal Application::filtersCopied()
+    \brief Emitted when filters are copied to the clipboard.
+*/
+
+/*!
+    \qmlsignal Application::filtersPasted()
+    \brief Emitted when filters are pasted from the clipboard.
+*/
+
+/*!
+    \qmlproperty Qt::WindowModality Application::dialogModality
+    \brief The modality to use for dialogs launched from QML.
+*/
+
 QmlApplication::QmlApplication()
     : QObject()
 {}
@@ -62,10 +97,21 @@ Qt::WindowModality QmlApplication::dialogModality()
 #endif
 }
 
+/*!
+    \qmlproperty point Application::mousePos
+    \brief The current global cursor screen coordinates.
+*/
+
 QPoint QmlApplication::mousePos()
 {
     return QCursor::pos();
 }
+
+/*!
+    \qmlproperty color Application::toolTipBaseColor
+    \brief The background color of tooltips, derived from the current palette.
+    Notifies \l paletteChanged.
+*/
 
 QColor QmlApplication::toolTipBaseColor()
 {
@@ -76,6 +122,12 @@ QColor QmlApplication::toolTipBaseColor()
     return QApplication::palette().toolTipBase().color();
 }
 
+/*!
+    \qmlproperty color Application::toolTipTextColor
+    \brief The text color of tooltips, derived from the current palette.
+    Notifies \l paletteChanged.
+*/
+
 QColor QmlApplication::toolTipTextColor()
 {
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
@@ -84,6 +136,11 @@ QColor QmlApplication::toolTipTextColor()
 #endif
     return QApplication::palette().toolTipText().color();
 }
+
+/*!
+    \qmlproperty string Application::OS
+    \brief The operating system name: \c "Windows", \c "Linux", or \c "macOS".
+*/
 
 QString QmlApplication::OS()
 {
@@ -100,15 +157,31 @@ QString QmlApplication::OS()
 #endif
 }
 
+/*!
+    \qmlproperty rect Application::mainWinRect
+    \brief The geometry of the main application window.
+*/
+
 QRect QmlApplication::mainWinRect()
 {
     return MAIN.geometry();
 }
 
+/*!
+    \qmlproperty bool Application::hasFiltersOnClipboard
+    \brief Whether the clipboard currently contains copied filters.
+    Notifies \l filtersCopied.
+*/
+
 bool QmlApplication::hasFiltersOnClipboard()
 {
     return MLT.hasFiltersOnClipboard();
 }
+
+/*!
+    \qmlmethod Application::copyEnabledFilters()
+    \brief Copies only the checked (enabled) filters to the clipboard.
+*/
 
 void QmlApplication::copyEnabledFilters()
 {
@@ -119,6 +192,11 @@ void QmlApplication::copyEnabledFilters()
     emit QmlApplication::singleton().filtersCopied();
 }
 
+/*!
+    \qmlmethod Application::copyAllFilters()
+    \brief Copies all filters on the currently selected clip to the clipboard.
+*/
+
 void QmlApplication::copyAllFilters()
 {
     QScopedPointer<Mlt::Producer> producer(
@@ -127,6 +205,11 @@ void QmlApplication::copyAllFilters()
     QGuiApplication::clipboard()->setText(MLT.filtersClipboardXML());
     emit QmlApplication::singleton().filtersCopied();
 }
+
+/*!
+    \qmlmethod Application::copyCurrentFilter()
+    \brief Copies the currently selected filter to the clipboard.
+*/
 
 void QmlApplication::copyCurrentFilter()
 {
@@ -142,6 +225,11 @@ void QmlApplication::copyCurrentFilter()
     emit QmlApplication::singleton().filtersCopied();
 }
 
+/*!
+    \qmlmethod string Application::clockFromFrames(int frames)
+    \brief Converts a frame number \a frames to a clock string (\c HH:MM:SS.mmm or \c HH:MM:SS:FF) at the current profile fps.
+*/
+
 QString QmlApplication::clockFromFrames(int frames)
 {
     if (MLT.producer()) {
@@ -149,6 +237,11 @@ QString QmlApplication::clockFromFrames(int frames)
     }
     return QString();
 }
+
+/*!
+    \qmlmethod string Application::timeFromFrames(int frames)
+    \brief Converts a frame number \a frames to an MLT timecode string.
+*/
 
 QString QmlApplication::timeFromFrames(int frames)
 {
@@ -158,10 +251,21 @@ QString QmlApplication::timeFromFrames(int frames)
     return QString();
 }
 
+/*!
+    \qmlmethod int Application::audioChannels()
+    \brief Returns the number of audio channels in the current project.
+*/
+
 int QmlApplication::audioChannels()
 {
     return MLT.audioChannels();
 }
+
+/*!
+    \qmlmethod string Application::getNextProjectFile(string filename)
+    \brief Returns a versioned file path for saving a new project-related file
+    named \a filename (e.g. \c project-001.txt) next to the current project file.
+*/
 
 QString QmlApplication::getNextProjectFile(const QString &filename)
 {
@@ -183,21 +287,41 @@ QString QmlApplication::getNextProjectFile(const QString &filename)
     return QString();
 }
 
+/*!
+    \qmlmethod bool Application::isProjectFolder()
+    \brief Returns \c true if the current project is saved inside a project folder.
+*/
+
 bool QmlApplication::isProjectFolder()
 {
     QDir dir(MLT.projectFolder());
     return (!MLT.projectFolder().isEmpty() && dir.exists());
 }
 
+/*!
+    \qmlproperty real Application::devicePixelRatio
+    \brief The display device pixel ratio (e.g. 2.0 on HiDPI screens).
+*/
+
 qreal QmlApplication::devicePixelRatio()
 {
     return MAIN.devicePixelRatioF();
 }
 
+/*!
+    \qmlmethod Application::showStatusMessage(string message, int timeoutSeconds = 15)
+    \brief Displays \a message in the main window status bar for \a timeoutSeconds seconds.
+*/
+
 void QmlApplication::showStatusMessage(const QString &message, int timeoutSeconds)
 {
     MAIN.showStatusMessage(message, timeoutSeconds);
 }
+
+/*!
+    \qmlmethod Application::showAddOnFiltersDialog()
+    \brief Opens the Add-On Filters catalog dialog.
+*/
 
 void QmlApplication::showAddOnFiltersDialog()
 {
@@ -210,11 +334,22 @@ void QmlApplication::showAddOnFiltersDialog()
     dialog.exec();
 }
 
+/*!
+    \qmlproperty int Application::maxTextureSize
+    \brief The maximum supported GPU texture dimension in pixels.
+*/
+
 int QmlApplication::maxTextureSize()
 {
     auto *videoWidget = qobject_cast<Mlt::VideoWidget *>(MLT.videoWidget());
     return videoWidget ? videoWidget->maxTextureSize() : 0;
 }
+
+/*!
+    \qmlmethod bool Application::confirmOutputFilter()
+    \brief Prompts the user to confirm applying a filter to the timeline output.
+    Returns \c true if the user confirms.
+*/
 
 bool QmlApplication::confirmOutputFilter()
 {
@@ -256,10 +391,20 @@ QDir QmlApplication::dataDir()
     return dir;
 }
 
+/*!
+    \qmlmethod color Application::contrastingColor(string color)
+    \brief Returns black or white, whichever contrasts better against \a color.
+*/
+
 QColor QmlApplication::contrastingColor(QString color)
 {
     return Util::textColor(color);
 }
+
+/*!
+    \qmlproperty list<string> Application::wipes
+    \brief The list of available wipe transition file names.
+*/
 
 QStringList QmlApplication::wipes()
 {
@@ -277,6 +422,12 @@ QStringList QmlApplication::wipes()
     return result;
 }
 
+/*!
+    \qmlmethod bool Application::addWipe(string filePath)
+    \brief Adds a custom wipe transition image at \a filePath to the wipes list.
+    Returns \c true on success.
+*/
+
 bool QmlApplication::addWipe(const QString &filePath)
 {
     const auto transitions = QString::fromLatin1("transitions");
@@ -290,10 +441,21 @@ bool QmlApplication::addWipe(const QString &filePath)
     return false;
 }
 
+/*!
+    \qmlmethod bool Application::intersects(rect a, rect b)
+    \brief Returns \c true if rectangle \a a intersects rectangle \a b.
+*/
+
 bool QmlApplication::intersects(const QRectF &a, const QRectF &b)
 {
     return a.intersects(b);
 }
+
+/*!
+    \qmlmethod string Application::actionFirstShortcut(string actionName)
+    \brief Returns the first keyboard shortcut string for the action identified by \a actionName,
+    or an empty string if none is assigned.
+*/
 
 QString QmlApplication::actionFirstShortcut(const QString &actionName)
 {

--- a/src/qmltypes/qmlextension.cpp
+++ b/src/qmltypes/qmlextension.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meltytech, LLC
+ * Copyright (c) 2025-2026 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,6 +25,43 @@
 #include <QQmlComponent>
 
 const QString QmlExtension::WHISPER_ID = QStringLiteral("whispermodel");
+
+/*!
+    \qmltype QmlExtensionFile
+    \inqmlmodule org.shotcut.qml
+    \brief Describes a single downloadable file within an extension package.
+    \sa QmlExtension
+*/
+
+/*!
+    \qmlproperty string QmlExtensionFile::name
+    \brief The display name of the file.
+*/
+
+/*!
+    \qmlproperty string QmlExtensionFile::description
+    \brief A brief description of the file's purpose.
+*/
+
+/*!
+    \qmlproperty string QmlExtensionFile::file
+    \brief The local filename to store the downloaded file as.
+*/
+
+/*!
+    \qmlproperty string QmlExtensionFile::url
+    \brief The remote URL from which the file can be downloaded.
+*/
+
+/*!
+    \qmlproperty string QmlExtensionFile::size
+    \brief The human-readable size of the download (e.g. \c "120 MB").
+*/
+
+/*!
+    \qmlproperty bool QmlExtensionFile::standard
+    \brief Whether this file is a standard (default) file vs. an optional add-on.
+*/
 
 QmlExtensionFile::QmlExtensionFile(QObject *parent)
     : QObject(parent)
@@ -71,6 +108,41 @@ QDir QmlExtension::appDir(const QString &id)
     dir.cd(id);
     return dir;
 }
+
+/*!
+    \qmltype QmlExtension
+    \inqmlmodule org.shotcut.qml
+    \brief Represents a loadable Shotcut extension (e.g. the Whisper speech-to-text package).
+
+    Extensions are installed or downloaded as a bundle of files described by
+    \l{QmlExtensionFile} entries. Access the current extension object through the
+    \c extension context property in extension-related QML views.
+
+    \code
+    Text { text: extension.name + " v" + extension.version }
+    \endcode
+*/
+
+/*!
+    \qmlproperty string QmlExtension::id
+    \brief The unique identifier for the extension (e.g. \c "whisper").
+*/
+
+/*!
+    \qmlproperty string QmlExtension::name
+    \brief The human-readable display name of the extension.
+*/
+
+/*!
+    \qmlproperty string QmlExtension::version
+    \brief The installed version string of the extension.
+*/
+
+/*!
+    \qmlproperty list<QmlExtensionFile> QmlExtension::files
+    \brief The list of files that make up this extension.
+    \sa QmlExtensionFile
+*/
 
 QmlExtension::QmlExtension(QObject *parent)
     : QObject(parent)

--- a/src/qmltypes/qmlfile.cpp
+++ b/src/qmltypes/qmlfile.cpp
@@ -23,10 +23,45 @@
 #include <QFile>
 #include <QFileInfo>
 
+/*!
+    \qmltype File
+    \inqmlmodule org.shotcut.qml
+    \brief A file URL wrapper with optional filesystem change watching.
+
+    Use \c File in filter panels to manage paths to auxiliary files
+    (e.g. LUT files, preset data files). Set \l url and call \l{File::watch()}{watch()}
+    to receive \l fileChanged notifications when the file is modified externally.
+
+    \code
+    File {
+        id: lutFile
+        url: filter.get("av.file")
+        onFileChanged: filter.set("av.file", path)
+    }
+    \endcode
+*/
+
+/*!
+    \qmlsignal File::urlChanged(url url)
+    \brief Emitted when \l url changes. \a url is the new URL value.
+*/
+
+/*!
+    \qmlsignal File::fileChanged(string path)
+    \brief Emitted when the watched file is modified or deleted externally.
+    \a path is the full file system path. Connect a file watcher by calling \l{File::watch()}{watch()} first.
+*/
+
 QmlFile::QmlFile(QObject *parent)
     : QObject(parent)
     , m_url()
 {}
+
+/*!
+    \qmlproperty string File::url
+    \brief The file URL as a string (e.g. \c "file:///home/user/lut.cube").
+    Setting this property stops watching any previously watched file.
+*/
 
 QString QmlFile::getUrl()
 {
@@ -94,20 +129,40 @@ void QmlFile::setUrl(QString text)
     }
 }
 
+/*!
+    \qmlproperty string File::fileName
+    \brief The base file name without the directory path (e.g. \c "lut.cube").
+*/
+
 QString QmlFile::getFileName()
 {
     return QFileInfo(getUrl()).fileName();
 }
+
+/*!
+    \qmlproperty string File::path
+    \brief The directory path portion of the URL (without the file name).
+*/
 
 QString QmlFile::getPath()
 {
     return QDir::toNativeSeparators(QFileInfo(getUrl()).path());
 }
 
+/*!
+    \qmlproperty string File::filePath
+    \brief The full local filesystem path (e.g. \c "/home/user/lut.cube").
+*/
+
 QString QmlFile::getFilePath()
 {
     return QDir::toNativeSeparators(getUrl());
 }
+
+/*!
+    \qmlmethod File::copyFromFile(string source)
+    \brief Copies the file at \a source to the path described by \l url.
+*/
 
 void QmlFile::copyFromFile(QString source)
 {
@@ -130,16 +185,31 @@ void QmlFile::copyFromFile(QString source)
     outfile.close();
 }
 
+/*!
+    \qmlmethod bool File::exists()
+    \brief Returns \c true if the file at \l url exists on the filesystem.
+*/
+
 bool QmlFile::exists()
 {
     return QFileInfo(m_url.toString()).exists();
 }
+
+/*!
+    \qmlmethod string File::suffix()
+    \brief Returns the file extension without the leading dot (e.g. \c "cube").
+*/
 
 QString QmlFile::suffix()
 {
     return QFileInfo(m_url.toString()).suffix();
 }
 
+/*!
+    \qmlmethod File::watch()
+    \brief Begins watching the file at \l url for external changes.
+    When the file is modified or deleted, \l fileChanged is emitted.
+*/
 void QmlFile::watch()
 {
     m_watcher.reset(new QFileSystemWatcher({getUrl()}));

--- a/src/qmltypes/qmlfilter.cpp
+++ b/src/qmltypes/qmlfilter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2025 Meltytech, LLC
+ * Copyright (c) 2013-2026 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,6 +38,102 @@
 #include <QTemporaryFile>
 #include <QtXml>
 
+/*!
+    \qmltype Filter
+    \inqmlmodule org.shotcut.qml
+    \brief Provides access to the current filter's properties, keyframes, and presets.
+
+    \c Filter is the primary scripting interface for filter UI panels and VUI overlays.
+    Each filter's QML file receives a \c filter context property of this type.
+    Use it to read and write MLT service properties, manage keyframes,
+    load/save presets, and trigger analysis jobs.
+
+    \code
+    // Inside a filter's QML panel:
+    filter.set("level", slider.value)
+    var current = filter.getDouble("level")
+    filter.startUndoParameterCommand("Change Level")
+    filter.set("level", newValue)
+    filter.endUndoCommand()
+    \endcode
+*/
+
+/*!
+    \qmlsignal Filter::presetsChanged()
+    \brief Emitted when the list of saved presets changes.
+*/
+
+/*!
+    \qmlsignal Filter::analyzeFinished(bool isSuccess)
+    \brief Emitted when an analysis job completes. \a isSuccess is \c true on success.
+*/
+
+/*!
+    \qmlsignal Filter::changed(string name)
+    \brief Emitted when any filter property changes. \a name is the property name,
+    or empty if multiple properties changed.
+*/
+
+/*!
+    \qmlsignal Filter::inChanged(int delta)
+    \brief Emitted when the filter's in-point changes. \a delta is the frame offset.
+*/
+
+/*!
+    \qmlsignal Filter::outChanged(int delta)
+    \brief Emitted when the filter's out-point changes. \a delta is the frame offset.
+*/
+
+/*!
+    \qmlsignal Filter::animateInChanged()
+    \brief Emitted when \l animateIn changes.
+*/
+
+/*!
+    \qmlsignal Filter::animateOutChanged()
+    \brief Emitted when \l animateOut changes.
+*/
+
+/*!
+    \qmlsignal Filter::animateInOutChanged()
+    \brief Emitted when either \l animateIn or \l animateOut changes.
+*/
+
+/*!
+    \qmlsignal Filter::durationChanged()
+    \brief Emitted when the filter's \l duration changes.
+*/
+
+/*!
+    \qmlsignal Filter::propertyChanged(string name)
+    \brief Emitted when a specific named property \a name changes. Use in bindings that
+    need to react to individual property updates.
+*/
+
+/*!
+    \qmlproperty bool Filter::isNew
+    \brief Whether this filter was just added or its UI is simply being reloaded.
+    Use this to set sensible initial property values on first load.
+*/
+
+/*!
+    \qmlproperty string Filter::path
+    \brief Absolute path to the directory containing this filter's QML files.
+    Use to load auxiliary QML files relative to the filter.
+*/
+
+/*!
+    \qmlproperty list<string> Filter::presets
+    \brief The list of saved preset names for this filter.
+    Notifies \l presetsChanged when the list changes.
+*/
+
+/*!
+    \qmlproperty bool Filter::blockSignals
+    \brief When \c true, suppresses all QML signals from this object.
+    Set while performing bulk property updates to avoid redundant UI refreshes.
+*/
+
 QmlFilter::QmlFilter()
     : QObject(nullptr)
     , m_metadata(nullptr)
@@ -72,6 +168,14 @@ QmlFilter::QmlFilter(Mlt::Service &mltService, const QmlMetadata *metadata, QObj
 
 QmlFilter::~QmlFilter() {}
 
+/*!
+    \qmlmethod string Filter::get(string name, int position = -1)
+    \brief Returns the value of MLT property \a name as a string.
+    If time \a position is \c -1 (default), returns the current value;
+    otherwise returns the interpolated value at that frame position.
+    To get an integer value, convert the result using \c parseInt(), e.g. \c parseInt(filter.get("someProperty")).
+*/
+
 QString QmlFilter::get(QString name, int position)
 {
     if (m_service.is_valid()) {
@@ -83,6 +187,12 @@ QString QmlFilter::get(QString name, int position)
         return QString();
     }
 }
+
+/*!
+    \qmlmethod color Filter::getColor(string name, int position = -1)
+    \brief Returns the value of MLT property \a name as a \c color.
+    \a position defaults to \c -1 (current value).
+*/
 
 QColor QmlFilter::getColor(QString name, int position)
 {
@@ -96,6 +206,12 @@ QColor QmlFilter::getColor(QString name, int position)
     return QColor(color.r, color.g, color.b, color.a);
 }
 
+/*!
+    \qmlmethod real Filter::getDouble(string name, int position = -1)
+    \brief Returns the value of MLT property \a name as a floating-point number.
+    \a position defaults to \c -1 (current value).
+*/
+
 double QmlFilter::getDouble(QString name, int position)
 {
     if (m_service.is_valid()) {
@@ -107,6 +223,13 @@ double QmlFilter::getDouble(QString name, int position)
         return 0.0;
     }
 }
+
+/*!
+    \qmlmethod rect Filter::getRect(string name, int position = -1)
+    \brief Returns the value of MLT property \a name as a \c rect.
+    The rectangle values are in the project coordinate space.
+    \a position defaults to \c -1 (current value).
+*/
 
 QRectF QmlFilter::getRect(QString name, int position)
 {
@@ -132,6 +255,12 @@ QRectF QmlFilter::getRect(QString name, int position)
         return QRectF(0.0, 0.0, 0.0, 0.0);
     }
 }
+
+/*!
+    \qmlmethod Filter::removeRectPercents(string name)
+    \brief Converts a rect property stored as percentages to absolute pixel values.
+    \a name is the MLT property to convert in-place.
+*/
 
 void QmlFilter::removeRectPercents(QString name)
 {
@@ -161,6 +290,11 @@ void QmlFilter::removeRectPercents(QString name)
     }
 }
 
+/*!
+    \qmlmethod list<string> Filter::getGradient(string name)
+    \brief Returns the gradient stop colors for property \a name as a list of color strings.
+*/
+
 QStringList QmlFilter::getGradient(QString name)
 {
     QStringList list;
@@ -175,6 +309,44 @@ QStringList QmlFilter::getGradient(QString name)
     }
     return list;
 }
+
+/*!
+    \qmlmethod Filter::set(string name, string value, int position = -1)
+    \brief Sets MLT property \a name to the string \a value.
+    If time \a position is given, sets a keyframe at that position.
+*/
+
+/*!
+    \qmlmethod Filter::set(string name, color value, int position = -1, int keyframeType = -1)
+    \brief Sets MLT property \a name to the color \a value, optionally at time \a position.
+    \a keyframeType is one of the \c mlt_keyframe_type enum values; use \c -1 for the default.
+*/
+
+/*!
+    \qmlmethod Filter::set(string name, real value, int position = -1, int keyframeType = -1)
+    \brief Sets MLT property \a name to the floating-point \a value, optionally at time \a position.
+*/
+
+/*!
+    \qmlmethod Filter::set(string name, int value, int position = -1, int keyframeType = -1)
+    \brief Sets MLT property \a name to the integer \a value, optionally at time \a position.
+*/
+
+/*!
+    \qmlmethod Filter::set(string name, bool value, int position = -1, int keyframeType = -1)
+    \brief Sets MLT property \a name to the boolean \a value, optionally at time \a position.
+*/
+
+/*!
+    \qmlmethod Filter::set(string name, real x, real y, real width, real height, real opacity = 1.0, int position = -1, int keyframeType = -1)
+    \brief Sets MLT property \a name to a rect specified by components, optionally at time \a position.
+    \a opacity is clamped to [0.0, 1.0].
+*/
+
+/*!
+    \qmlmethod Filter::set(string name, rect value, int position = -1, int keyframeType = -1)
+    \brief Sets MLT property \a name to the \a value rect, optionally at time \a position.
+*/
 
 void QmlFilter::set(QString name, QString value, int position)
 {
@@ -333,6 +505,11 @@ void QmlFilter::set(QString name,
     }
 }
 
+/*!
+    \qmlmethod Filter::setGradient(string name, list<string> colors)
+    \brief Sets the gradient stops for property \a name from a list of \a colors strings.
+*/
+
 void QmlFilter::setGradient(QString name, const QStringList &gradient)
 {
     for (int i = 1; i <= 10; i++) {
@@ -351,6 +528,11 @@ void QmlFilter::set(QString name, const QRectF &rect, int position, mlt_keyframe
 {
     set(name, rect.x(), rect.y(), rect.width(), rect.height(), 1.0, position, keyframeType);
 }
+
+/*!
+    \qmlmethod Filter::loadPresets()
+    \brief Reloads the list of saved presets from disk and emits \l presetsChanged.
+*/
 
 void QmlFilter::loadPresets()
 {
@@ -373,6 +555,12 @@ void QmlFilter::loadPresets()
     }
     emit presetsChanged();
 }
+
+/*!
+    \qmlmethod int Filter::savePreset(list<string> propertyNames, string name = "")
+    \brief Saves the current values of \a propertyNames as a preset named \a name.
+    Returns the index of the new preset in \l presets.
+*/
 
 int QmlFilter::savePreset(const QStringList &propertyNames, const QString &name)
 {
@@ -408,6 +596,11 @@ int QmlFilter::savePreset(const QStringList &propertyNames, const QString &name)
     return m_presets.indexOf(name);
 }
 
+/*!
+    \qmlmethod Filter::deletePreset(string name)
+    \brief Deletes the saved preset named \a name.
+*/
+
 void QmlFilter::deletePreset(const QString &name)
 {
     QDir dir(Settings.appDataLocation());
@@ -418,6 +611,13 @@ void QmlFilter::deletePreset(const QString &name)
     m_presets.removeOne(name);
     emit presetsChanged();
 }
+
+/*!
+    \qmlmethod Filter::analyze(bool isAudio = false, bool deferJob = true)
+    \brief Starts an analysis job for this filter.
+    Set \a isAudio to \c true for audio filters. When \a deferJob is \c true
+    the job is queued rather than run immediately. Emits \l analyzeFinished when done.
+*/
 
 void QmlFilter::analyze(bool isAudio, bool deferJob)
 {
@@ -543,6 +743,11 @@ void QmlFilter::analyze(bool isAudio, bool deferJob)
     }
 }
 
+/*!
+    \qmlmethod int Filter::framesFromTime(string time)
+    \brief Converts a timecode \a time string (HH:MM:SS.ms or MLT time format) to a frame number.
+*/
+
 int QmlFilter::framesFromTime(const QString &time)
 {
     if (MLT.producer()) {
@@ -551,11 +756,22 @@ int QmlFilter::framesFromTime(const QString &time)
     return 0;
 }
 
+/*!
+    \qmlmethod Filter::getHash()
+    \brief Computes a hash of the filter's input producer and stores it as the
+    \c shotcut:hash property. Used internally by analysis jobs.
+*/
+
 void QmlFilter::getHash()
 {
     if (m_service.is_valid())
         Util::getHash(m_service);
 }
+
+/*!
+    \qmlproperty int Filter::in
+    \brief The filter's in-point in frames, relative to the clip start.
+*/
 
 int QmlFilter::in()
 {
@@ -581,6 +797,11 @@ int QmlFilter::in()
     return result;
 }
 
+/*!
+    \qmlproperty int Filter::out
+    \brief The filter's out-point in frames, relative to the clip start.
+*/
+
 int QmlFilter::out()
 {
     int result = 0;
@@ -604,6 +825,12 @@ int QmlFilter::out()
     }
     return result;
 }
+
+/*!
+    \qmlproperty int Filter::animateIn
+    \brief Number of frames over which the "animate in" simple keyframe ramp runs.
+    Set to 0 to disable. Writing this triggers the \l animateInChanged signal.
+*/
 
 int QmlFilter::animateIn()
 {
@@ -638,6 +865,12 @@ void QmlFilter::setAnimateIn(int value)
         emit animateInChanged();
     }
 }
+
+/*!
+    \qmlproperty int Filter::animateOut
+    \brief Number of frames over which the "animate out" simple keyframe ramp runs.
+    Set to 0 to disable. Writing this triggers the \l animateOutChanged signal.
+*/
 
 int QmlFilter::animateOut()
 {
@@ -686,6 +919,11 @@ void QmlFilter::clearAnimateInOut()
         emit animateOutChanged();
 }
 
+/*!
+    \qmlproperty int Filter::duration
+    \brief Total duration of the filter in frames (\c out - \c in + 1).
+*/
+
 int QmlFilter::duration()
 {
     return out() - in() + 1;
@@ -703,16 +941,32 @@ Mlt::Animation QmlFilter::getAnimation(const QString &name)
     return Mlt::Animation();
 }
 
+/*!
+    \qmlmethod int Filter::keyframeCount(string name)
+    \brief Returns the number of keyframes set on property \a name.
+*/
+
 int QmlFilter::keyframeCount(const QString &name)
 {
     return getAnimation(name).key_count();
 }
+
+/*!
+    \qmlmethod Filter::resetProperty(string name)
+    \brief Removes all keyframes for property \a name and resets it to its default value.
+*/
 
 void QmlFilter::resetProperty(const QString &name)
 {
     m_service.clear(qUtf8Printable(name));
     emit changed(name.toUtf8().constData());
 }
+
+/*!
+    \qmlmethod Filter::clearSimpleAnimation(string name)
+    \brief Clears the "animate in/out" simple keyframe mode for property \a name,
+    leaving only the static value at the current time position.
+*/
 
 void QmlFilter::clearSimpleAnimation(const QString &name)
 {
@@ -820,6 +1074,13 @@ void QmlFilter::stopUndoTracking()
     m_previousState = Mlt::Properties();
 }
 
+/*!
+    \qmlmethod Filter::startUndoParameterCommand(string description = "")
+    \brief Begins an undo/redo command group for parameter changes.
+    All \l set() calls until \l endUndoCommand() are grouped as one undoable step.
+    \a description appears in the Edit > Undo menu.
+*/
+
 void QmlFilter::startUndoParameterCommand(const QString &desc)
 {
     if (!m_previousState.count()) {
@@ -918,6 +1179,11 @@ void QmlFilter::updateUndoCommand(const QString &name)
     m_previousState.pass_property(m_service, name.toUtf8().constData());
 }
 
+/*!
+    \qmlmethod Filter::endUndoCommand()
+    \brief Ends the undo/redo command group started by \l startUndoParameterCommand().
+*/
+
 void QmlFilter::endUndoCommand()
 {
     if (!m_previousState.count()) {
@@ -952,17 +1218,34 @@ mlt_keyframe_type QmlFilter::getKeyframeType(Mlt::Animation &animation,
     return result;
 }
 
+/*!
+    \qmlmethod int Filter::getKeyFrameType(string name, int keyIndex)
+    \brief Returns the interpolation type (\c mlt_keyframe_type) of keyframe \a keyIndex
+    for property \a name.
+*/
+
 int QmlFilter::getKeyFrameType(const QString &name, int keyIndex)
 {
     Mlt::Animation animation = getAnimation(name);
     return (int) animation.key_get_type(keyIndex);
 }
 
+/*!
+    \qmlmethod Filter::setKeyFrameType(string name, int keyIndex, int type)
+    \brief Sets the interpolation \a type of keyframe \a keyIndex for property \a name.
+*/
+
 void QmlFilter::setKeyFrameType(const QString &name, int keyIndex, int type)
 {
     Mlt::Animation animation = getAnimation(name);
     animation.key_set_type(keyIndex, (mlt_keyframe_type) type);
 }
+
+/*!
+    \qmlmethod int Filter::getNextKeyframePosition(string name, int position)
+    \brief Returns the position of the next keyframe for property \a name
+    after time \a position, or \c -1 if none.
+*/
 
 int QmlFilter::getNextKeyframePosition(const QString &name, int position)
 {
@@ -974,6 +1257,12 @@ int QmlFilter::getNextKeyframePosition(const QString &name, int position)
     return result;
 }
 
+/*!
+    \qmlmethod int Filter::getPrevKeyframePosition(string name, int position)
+    \brief Returns the position of the previous keyframe for property \a name
+    before time \a position, or \c -1 if none.
+*/
+
 int QmlFilter::getPrevKeyframePosition(const QString &name, int position)
 {
     int result = -1;
@@ -984,12 +1273,23 @@ int QmlFilter::getPrevKeyframePosition(const QString &name, int position)
     return result;
 }
 
+/*!
+    \qmlmethod bool Filter::isAtLeastVersion(string version)
+    \brief Returns \c true if Shotcut's version is greater than or equal to \a version.
+    Use to guard features introduced in specific releases.
+*/
+
 bool QmlFilter::isAtLeastVersion(const QString &version)
 {
     QVersionNumber v1 = QVersionNumber::fromString(version);
     QVersionNumber v2 = QVersionNumber::fromString(m_metadata->property("version").toString());
     return v2 >= v1;
 }
+
+/*!
+    \qmlmethod Filter::deselect()
+    \brief Deselects the current filter in the Filters panel.
+*/
 
 void QmlFilter::deselect()
 {
@@ -1017,6 +1317,11 @@ bool QmlFilter::allowAnimateOut() const
     return false;
 }
 
+/*!
+    \qmlmethod Filter::copyParameters()
+    \brief Copies this filter's current parameters to the clipboard.
+*/
+
 void QmlFilter::copyParameters()
 {
     auto name = "color";
@@ -1025,6 +1330,12 @@ void QmlFilter::copyParameters()
     dummy.set("mlt_service", name);
     QGuiApplication::clipboard()->setText(MLT.XML(&dummy));
 }
+
+/*!
+    \qmlmethod Filter::pasteParameters(list<string> propertyNames)
+    \brief Pastes parameters from the clipboard into this filter,
+    restricted to the properties listed in \a propertyNames.
+*/
 
 void QmlFilter::pasteParameters(const QStringList &propertyNames)
 {
@@ -1046,6 +1357,11 @@ void QmlFilter::pasteParameters(const QStringList &propertyNames)
     if (isChanged)
         emit changed();
 }
+
+/*!
+    \qmlmethod Filter::crop(rect r)
+    \brief Applies a crop rectangle \a r to the filter's producer source.
+*/
 
 void QmlFilter::crop(const QRectF &rect)
 {

--- a/src/qmltypes/qmlmetadata.cpp
+++ b/src/qmltypes/qmlmetadata.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2024 Meltytech, LLC
+ * Copyright (c) 2013-2026 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,6 +21,113 @@
 #include "settings.h"
 
 #include <QVersionNumber>
+
+/*!
+    \qmltype Metadata
+    \inqmlmodule org.shotcut.qml
+    \brief Describes a filter's identity, capabilities, and keyframe configuration.
+
+    \c Metadata is the read-only descriptor for a filter service. It is available
+    in \b Filters panels as the \c metadata context property. Use it to inspect
+    the filter type, supported capabilities, and keyframe parameters.
+*/
+
+/*!
+    \qmlproperty int Metadata::type
+    \brief The plugin type.
+    One of \c Filter (0), \c Producer (1), \c Transition (2), \c Link (3), or \c FilterSet (4).
+*/
+
+/*!
+    \qmlproperty string Metadata::name
+    \brief The human-readable display name of the filter (e.g. \c "Blur").
+*/
+
+/*!
+    \qmlproperty string Metadata::mlt_service
+    \brief The MLT service identifier (e.g. \c "avfilter.boxblur").
+*/
+
+/*!
+    \qmlproperty bool Metadata::needsGPU
+    \brief Whether this filter requires GPU (GLSL) processing.
+*/
+
+/*!
+    \qmlproperty string Metadata::qml
+    \brief The file name of the filter's User Interface (UI) parameter panel (relative to the filter directory).
+*/
+
+/*!
+    \qmlproperty string Metadata::vui
+    \brief The file name of the filter's VUI overlay QML file (relative to the filter directory).
+*/
+
+/*!
+    \qmlproperty bool Metadata::isAudio
+    \brief Whether this filter operates on audio rather than video.
+*/
+
+/*!
+    \qmlproperty bool Metadata::isHidden
+    \brief Whether this filter is hidden from the filter list UI.
+*/
+
+/*!
+    \qmlproperty bool Metadata::isFavorite
+    \brief Whether the user has marked this filter as a favorite.
+*/
+
+/*!
+    \qmlproperty bool Metadata::allowMultiple
+    \brief Whether multiple instances of this filter can be applied to the same clip.
+*/
+
+/*!
+    \qmlproperty bool Metadata::isClipOnly
+    \brief Whether this filter can only be applied to clips (not tracks or timeline output).
+*/
+
+/*!
+    \qmlproperty bool Metadata::isTrackOnly
+    \brief Whether this filter can only be applied to tracks.
+*/
+
+/*!
+    \qmlproperty bool Metadata::isOutputOnly
+    \brief Whether this filter can only be applied to the timeline output.
+*/
+
+/*!
+    \qmlproperty bool Metadata::isDeprecated
+    \brief Whether this filter has been deprecated and should not be used in new projects.
+*/
+
+/*!
+    \qmlproperty string Metadata::minimumVersion
+    \brief The minimum MLT metadata version required for this filter.
+*/
+
+/*!
+    \qmlproperty string Metadata::keywords
+    \brief Space-separated keywords for searching this filter in the filter list.
+*/
+
+/*!
+    \qmlproperty string Metadata::help
+    \brief A link to the documentation page for this filter.
+*/
+
+/*!
+    \qmlproperty bool Metadata::seekReverse
+    \brief Whether this filter may need to repeatedly perform reverse seeking for certain \b Time filters.
+*/
+
+/*!
+    \qmlproperty KeyframesMetadata Metadata::keyframes
+    \brief The keyframes configuration object for this filter.
+    \sa KeyframesMetadata
+*/
 
 QmlMetadata::QmlMetadata(QObject *parent)
     : QObject(parent)
@@ -100,6 +207,11 @@ void QmlMetadata::setPath(const QDir &path)
     m_path = path;
 }
 
+/*!
+    \qmlproperty url Metadata::qmlFilePath
+    \brief The full URL to the filter's QML parameter panel file.
+*/
+
 QUrl QmlMetadata::qmlFilePath() const
 {
     QUrl retVal = QUrl();
@@ -108,6 +220,11 @@ QUrl QmlMetadata::qmlFilePath() const
     }
     return retVal;
 }
+
+/*!
+    \qmlproperty url Metadata::vuiFilePath
+    \brief The full URL to the filter's VUI overlay file.
+*/
 
 QUrl QmlMetadata::vuiFilePath() const
 {
@@ -185,6 +302,56 @@ bool QmlMetadata::isMltVersion(const QString &version)
     return true;
 }
 
+/*!
+    \qmltype KeyframesMetadata
+    \inqmlmodule org.shotcut.qml
+    \brief Describes the keyframe capabilities of a filter.
+
+    Accessed via \l{Metadata::keyframes}. Describes whether the filter supports
+    trim keyframes, animate-in/out ramps, and which parameters are keyframeable.
+*/
+
+/*!
+    \qmlproperty bool KeyframesMetadata::allowTrim
+    \brief Whether the filter's in/out points can be trimmed to control when it is active.
+*/
+
+/*!
+    \qmlproperty bool KeyframesMetadata::allowAnimateIn
+    \brief Whether the filter supports an "animate in" simple keyframe ramp.
+*/
+
+/*!
+    \qmlproperty bool KeyframesMetadata::allowAnimateOut
+    \brief Whether the filter supports an "animate out" simple keyframe ramp.
+*/
+
+/*!
+    \qmlproperty list<Parameter> KeyframesMetadata::parameters
+    \brief The list of keyframeable parameters for this filter.
+    \sa Parameter
+*/
+
+/*!
+    \qmlproperty list<string> KeyframesMetadata::simpleProperties
+    \brief The list of MLT property names that use the simple (two-keyframe) animation mode.
+*/
+
+/*!
+    \qmlproperty string KeyframesMetadata::minimumVersion
+    \brief The minimum MLT metadata version required for full keyframe support of this filter.
+*/
+
+/*!
+    \qmlproperty bool KeyframesMetadata::enabled
+    \brief Whether keyframe support is enabled for this filter at all.
+*/
+
+/*!
+    \qmlproperty bool KeyframesMetadata::allowOvershoot
+    \brief Whether keyframe interpolation is allowed to overshoot the min/max parameter range.
+*/
+
 QmlKeyframesMetadata::QmlKeyframesMetadata(QObject *parent)
     : QObject(parent)
     , m_allowTrim(true)
@@ -216,6 +383,71 @@ void QmlKeyframesMetadata::setDisabled()
 {
     m_enabled = m_allowAnimateIn = m_allowAnimateOut = false;
 }
+
+/*!
+    \qmltype Parameter
+    \inqmlmodule org.shotcut.qml
+    \brief Describes a single keyframeable parameter within a filter's keyframes metadata.
+
+    Accessed from \l{KeyframesMetadata::parameters}.
+*/
+
+/*!
+    \qmlproperty int Parameter::rangeType
+    \brief The range constraint type. \c 0 = MinMax (clamped to \l minimum / \l maximum),
+    \c 1 = ClipLength (range is 0 to clip duration in frames).
+*/
+
+/*!
+    \qmlproperty string Parameter::name
+    \brief The human-readable display name of the parameter.
+*/
+
+/*!
+    \qmlproperty string Parameter::property
+    \brief The MLT property name this parameter maps to (used with \l{Filter::get()} and \l{Filter::set()}).
+*/
+
+/*!
+    \qmlproperty list<string> Parameter::gangedProperties
+    \brief Additional MLT property names that must be adjusted together with \l property
+    (e.g. linked x/y coordinates).
+*/
+
+/*!
+    \qmlproperty list<string> Parameter::gangedRectProperties
+    \brief Additional rect-type MLT property names that must be adjusted together with \l property.
+*/
+
+/*!
+    \qmlproperty bool Parameter::isCurve
+    \brief Whether this parameter can display a curve editor in the \b Keyframes panel.
+*/
+
+/*!
+    \qmlproperty real Parameter::minimum
+    \brief The minimum allowed value when \l rangeType is \c MinMax.
+*/
+
+/*!
+    \qmlproperty real Parameter::maximum
+    \brief The maximum allowed value when \l rangeType is \c MinMax.
+*/
+
+/*!
+    \qmlproperty string Parameter::units
+    \brief The display units string shown next to the parameter value (e.g. \c "px", \c "%").
+*/
+
+/*!
+    \qmlproperty bool Parameter::isRectangle
+    \brief Whether this parameter represents a rectangle (uses \l{Filter::getRect()} / \l{Filter::set()}).
+*/
+
+/*!
+    \qmlproperty bool Parameter::isColor
+    \brief Whether this parameter represents a color (uses \l{Filter::getColor()} / \l{Filter::set()}).
+*/
 
 QmlKeyframesParameter::QmlKeyframesParameter(QObject *parent)
     : QObject(parent)

--- a/src/qmltypes/qmlproducer.cpp
+++ b/src/qmltypes/qmlproducer.cpp
@@ -30,12 +30,93 @@ static const char *kHeightProperty = "meta.media.height";
 static const char *kAspectNumProperty = "meta.media.sample_aspect_num";
 static const char *kAspectDenProperty = "meta.media.sample_aspect_den";
 
+/*!
+    \qmltype Producer
+    \inqmlmodule org.shotcut.qml
+    \brief Represents the clip currently loaded in the \b Filters panel, accessed via the \c producer context property.
+
+    \c producer describes the clip that the currently displayed filter is attached to.
+    It is available in the Filters panel as the \c producer context property.
+
+    \code
+    var startFrame = producer.in
+    var endFrame   = producer.out
+    var fps        = profile.fps
+    \endcode
+*/
+
+/*!
+    \qmlsignal Producer::producerChanged()
+    \brief Emitted when the underlying producer or its properties change.
+*/
+
+/*!
+    \qmlsignal Producer::positionChanged(int position)
+    \brief Emitted when the playhead \a position within the clip changes.
+*/
+
+/*!
+    \qmlsignal Producer::seeked(int position)
+    \brief Emitted when the clip is seeked to time \a position.
+*/
+
+/*!
+    \qmlsignal Producer::inChanged(int delta)
+    \brief Emitted when the clip's in-point changes. \a delta is the frame offset.
+*/
+
+/*!
+    \qmlsignal Producer::outChanged(int delta)
+    \brief Emitted when the clip's out-point changes. \a delta is the frame offset.
+*/
+
+/*!
+    \qmlsignal Producer::durationChanged()
+    \brief Emitted when the clip's duration changes.
+*/
+
+/*!
+    \qmlsignal Producer::lengthChanged()
+    \brief Emitted when the source media length changes.
+*/
+
+/*!
+    \qmlproperty int Producer::duration
+    \brief The duration of the clip in frames (\c out - \c in + 1).
+*/
+
+/*!
+    \qmlproperty int Producer::length
+    \brief The total length of the underlying source media in frames.
+*/
+
+/*!
+    \qmlproperty string Producer::mlt_service
+    \brief The MLT service name of the producer (e.g. \c "avformat", \c "color").
+*/
+
+/*!
+    \qmlproperty string Producer::hash
+    \brief A content-based hash of the producer's media, used for caching.
+*/
+
+/*!
+    \qmlproperty int Producer::position
+    \brief The current playhead position within the clip, in frames relative to \l in.
+    Setting this seeks the preview to that position.
+*/
+
 QmlProducer::QmlProducer(QObject *parent)
     : QObject(parent)
 {
     connect(this, SIGNAL(inChanged(int)), this, SIGNAL(durationChanged()));
     connect(this, SIGNAL(outChanged(int)), this, SIGNAL(durationChanged()));
 }
+
+/*!
+    \qmlproperty int Producer::in
+    \brief The in-point of the clip in frames (absolute timeline position).
+*/
 
 int QmlProducer::in()
 {
@@ -50,6 +131,11 @@ int QmlProducer::in()
         return m_producer.get_in();
 }
 
+/*!
+    \qmlproperty int Producer::out
+    \brief The out-point of the clip in frames (absolute timeline position).
+*/
+
 int QmlProducer::out()
 {
     if (!m_producer.is_valid())
@@ -62,6 +148,11 @@ int QmlProducer::out()
     else
         return m_producer.get_out();
 }
+
+/*!
+    \qmlproperty int Producer::aspectRatio
+    \brief The pixel aspect ratio of the producer's media.
+*/
 
 double QmlProducer::aspectRatio()
 {
@@ -78,6 +169,11 @@ double QmlProducer::aspectRatio()
     return MLT.profile().dar();
 }
 
+/*!
+    \qmlproperty string Producer::resource
+    \brief The file path or resource string of the underlying media.
+*/
+
 QString QmlProducer::resource()
 {
     if (!m_producer.is_valid())
@@ -87,6 +183,11 @@ QString QmlProducer::resource()
         result = QString::fromUtf8(m_producer.get("mlt_service"));
     return result;
 }
+
+/*!
+    \qmlproperty string Producer::name
+    \brief The display name of the clip as shown in the timeline.
+*/
 
 QString QmlProducer::name()
 {
@@ -100,6 +201,11 @@ const QByteArray *QmlProducer::audioLevels()
     return static_cast<const QByteArray *>(m_producer.get_data(kAudioLevelsProperty));
 }
 
+/*!
+    \qmlproperty int Producer::fadeIn
+    \brief Duration in frames of the clip's fade-in, or 0 if none.
+*/
+
 int QmlProducer::fadeIn()
 {
     if (!m_producer.is_valid())
@@ -112,6 +218,11 @@ int QmlProducer::fadeIn()
     return (filter && filter->is_valid()) ? filter->get_length() : 0;
 }
 
+/*!
+    \qmlproperty int Producer::fadeOut
+    \brief Duration in frames of the clip's fade-out, or 0 if none.
+*/
+
 int QmlProducer::fadeOut()
 {
     if (!m_producer.is_valid())
@@ -123,6 +234,11 @@ int QmlProducer::fadeOut()
         filter.reset(MLT.getFilter("fadeOutMovit", &m_producer));
     return (filter && filter->is_valid()) ? filter->get_length() : 0;
 }
+
+/*!
+    \qmlproperty real Producer::speed
+    \brief The playback speed multiplier of the clip (1.0 = normal speed).
+*/
 
 double QmlProducer::speed()
 {
@@ -160,6 +276,12 @@ void QmlProducer::seek(int position)
     }
 }
 
+/*!
+    \qmlmethod bool Producer::outOfBounds()
+    \brief Returns \c true if the clip's in/out points fall outside the media's
+    available length.
+*/
+
 Q_INVOKABLE bool QmlProducer::outOfBounds()
 {
     return m_position < 0 || m_position > duration();
@@ -188,6 +310,11 @@ void QmlProducer::remakeAudioLevels(bool isKeyframesVisible)
         AudioLevelsTask::start(m_producer, this, QModelIndex());
 }
 
+/*!
+    \qmlproperty real Producer::displayAspectRatio
+    \brief The display aspect ratio (DAR) of the producer's media.
+*/
+
 double QmlProducer::displayAspectRatio()
 {
     if (m_producer.is_valid() && m_producer.get(kHeightProperty)) {
@@ -200,6 +327,12 @@ double QmlProducer::displayAspectRatio()
     }
     return MLT.profile().dar();
 }
+
+/*!
+    \qmlmethod string Producer::get(string name, int position = -1)
+    \brief Returns the value of MLT property \a name as a string.
+    If time \a position is \c -1, returns the current value.
+*/
 
 QString QmlProducer::get(QString name, int position)
 {
@@ -214,6 +347,12 @@ QString QmlProducer::get(QString name, int position)
     }
 }
 
+/*!
+    \qmlmethod real Producer::getDouble(string name, int position = -1)
+    \brief Returns the value of MLT property \a name as a floating-point number.
+    If time \a position is \c -1, returns the current value.
+*/
+
 double QmlProducer::getDouble(QString name, int position)
 {
     if (m_producer.is_valid()) {
@@ -225,6 +364,12 @@ double QmlProducer::getDouble(QString name, int position)
         return 0.0;
     }
 }
+
+/*!
+    \qmlmethod rect Producer::getRect(string name, int position = -1)
+    \brief Returns the value of MLT property \a name as a \c rect.
+    If time \a position is \c -1, returns the current value.
+*/
 
 QRectF QmlProducer::getRect(QString name, int position)
 {

--- a/src/qmltypes/qmlproducer.cpp
+++ b/src/qmltypes/qmlproducer.cpp
@@ -150,7 +150,7 @@ int QmlProducer::out()
 }
 
 /*!
-    \qmlproperty int Producer::aspectRatio
+    \qmlproperty real Producer::aspectRatio
     \brief The pixel aspect ratio of the producer's media.
 */
 

--- a/src/qmltypes/qmlprofile.cpp
+++ b/src/qmltypes/qmlprofile.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Meltytech, LLC
+ * Copyright (c) 2014-2026 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,29 +25,78 @@ QmlProfile &QmlProfile::singleton()
     return instance;
 }
 
+/*!
+    \qmltype Profile
+    \inqmlmodule org.shotcut.qml
+    \brief Describes the current project's \b Video \b Mode, accessed via the \c profile context property.
+
+    All properties reflect the active project profile.
+    A \l profileChanged signal is emitted when the profile switches
+    (e.g. when a new project is opened or the profile is explicitly changed).
+    After receiving \l profileChanged, re-read all properties since they may have new values.
+
+    \code
+    var w = profile.width
+    var h = profile.height
+    var scale = profile.width / profile.height * profile.sar
+    \endcode
+*/
+
+/*!
+    \qmlsignal Profile::profileChanged()
+    \brief Emitted when the project profile changes.
+    Re-read all properties after receiving this signal.
+*/
+
 QmlProfile::QmlProfile()
     : QObject()
 {}
+
+/*!
+    \qmlproperty int Profile::width
+    \brief The frame width of the current video profile in pixels.
+*/
 
 int QmlProfile::width() const
 {
     return MLT.profile().width();
 }
 
+/*!
+    \qmlproperty int Profile::height
+    \brief The frame height of the current video profile in pixels.
+*/
+
 int QmlProfile::height() const
 {
     return MLT.profile().height();
 }
+
+/*!
+    \qmlproperty real Profile::aspectRatio
+    \brief The display aspect ratio (DAR = width / height × SAR) of the current video profile.
+*/
 
 double QmlProfile::aspectRatio() const
 {
     return MLT.profile().dar();
 }
 
+/*!
+    \qmlproperty real Profile::fps
+    \brief The frames per second of the current video profile.
+*/
+
 double QmlProfile::fps() const
 {
     return MLT.profile().fps();
 }
+
+/*!
+    \qmlproperty real Profile::sar
+    \brief The sample (pixel) aspect ratio of the current video profile.
+    A value of 1.0 means square pixels.
+*/
 
 double QmlProfile::sar() const
 {

--- a/src/qmltypes/qmlrichtext.cpp
+++ b/src/qmltypes/qmlrichtext.cpp
@@ -44,6 +44,54 @@
 #include <QtGui/QTextCursor>
 #include <QtGui/QTextDocument>
 
+/*!
+    \qmltype RichText
+    \inqmlmodule org.shotcut.qml
+    \brief Provides rich-text editing helpers for the Text: Rich filter panel.
+
+    \c RichText is available as a context property in the Text: Rich filter QML panel.
+    It bridges the QML \c TextEdit item to the underlying \c QTextDocument, enabling
+    character-level formatting, cursor management, and file persistence.
+
+    \code
+    RichText {
+        id: richText
+        target: textEditItem
+        onTextChanged: filter.set("argument", text)
+    }
+    \endcode
+*/
+
+/*!
+    \qmlsignal RichText::error(string message)
+    \brief Emitted when a file load or save operation fails. \a message describes the error.
+*/
+
+/*!
+    \qmlproperty Item RichText::target
+    \brief The QML \c TextEdit item whose document this object manages.
+*/
+
+/*!
+    \qmlproperty int RichText::cursorPosition
+    \brief The cursor position within the document.
+*/
+
+/*!
+    \qmlproperty int RichText::selectionStart
+    \brief The start of the current text selection.
+*/
+
+/*!
+    \qmlproperty int RichText::selectionEnd
+    \brief The end of the current text selection.
+*/
+
+/*!
+    \qmlproperty size RichText::size
+    \brief The natural rendered size of the document (read-only).
+*/
+
 QmlRichText::QmlRichText()
     : m_target(0)
     , m_doc(0)
@@ -127,6 +175,11 @@ void QmlRichText::setText(const QString &arg)
     }
 }
 
+/*!
+    \qmlmethod RichText::saveAs(url fileUrl, string fileType)
+    \brief Saves the document to \a fileUrl. \a fileType may be \c "html" or \c "txt".
+*/
+
 void QmlRichText::saveAs(const QUrl &arg, QString fileType)
 {
     if (fileType.isEmpty())
@@ -146,6 +199,11 @@ void QmlRichText::saveAs(const QUrl &arg, QString fileType)
     f.close();
     setFileUrl(QUrl::fromLocalFile(localPath));
 }
+
+/*!
+    \qmlmethod RichText::insertTable(int rows, int columns, int border)
+    \brief Inserts a table at the cursor with \a rows rows, \a columns columns, and \a border width.
+*/
 
 void QmlRichText::insertTable(int rows, int columns, int border)
 {
@@ -183,6 +241,11 @@ void QmlRichText::insertTable(int rows, int columns, int border)
     cursor.insertHtml(html);
 }
 
+/*!
+    \qmlmethod RichText::indentLess()
+    \brief Decreases the indentation level of the current paragraph.
+*/
+
 void QmlRichText::indentLess()
 {
     QTextCursor cursor = textCursor();
@@ -193,6 +256,11 @@ void QmlRichText::indentLess()
     format.setIndent(qMax(indent - 1, 0));
     cursor.mergeBlockFormat(format);
 }
+
+/*!
+    \qmlmethod RichText::indentMore()
+    \brief Increases the indentation level of the current paragraph.
+*/
 
 void QmlRichText::indentMore()
 {
@@ -205,6 +273,11 @@ void QmlRichText::indentMore()
     cursor.mergeBlockFormat(format);
 }
 
+/*!
+    \qmlmethod RichText::pastePlain()
+    \brief Pastes clipboard text as plain text, stripping any formatting.
+*/
+
 void QmlRichText::pastePlain()
 {
     QTextCursor cursor = textCursor();
@@ -213,10 +286,20 @@ void QmlRichText::pastePlain()
     cursor.insertText(QGuiApplication::clipboard()->text());
 }
 
+/*!
+    \qmlproperty url RichText::fileUrl
+    \brief The URL of the HTML file backing the document. Setting this loads the file.
+*/
+
 QUrl QmlRichText::fileUrl() const
 {
     return m_fileUrl;
 }
+
+/*!
+    \qmlproperty string RichText::text
+    \brief The full HTML content of the document.
+*/
 
 QString QmlRichText::text() const
 {
@@ -232,6 +315,11 @@ void QmlRichText::setCursorPosition(int position)
 
     reset();
 }
+
+/*!
+    \qmlmethod RichText::reset()
+    \brief Clears the document content.
+*/
 
 void QmlRichText::reset()
 {
@@ -293,6 +381,11 @@ void QmlRichText::setAlignment(Qt::Alignment a)
     emit alignmentChanged();
 }
 
+/*!
+    \qmlproperty int RichText::alignment
+    \brief The paragraph alignment (\c Qt.AlignLeft, \c Qt.AlignCenter, etc.) at the cursor.
+*/
+
 Qt::Alignment QmlRichText::alignment() const
 {
     QTextCursor cursor = textCursor();
@@ -300,6 +393,11 @@ Qt::Alignment QmlRichText::alignment() const
         return Qt::AlignLeft;
     return textCursor().blockFormat().alignment();
 }
+
+/*!
+    \qmlproperty bool RichText::bold
+    \brief Whether the text at the cursor/selection is bold.
+*/
 
 bool QmlRichText::bold() const
 {
@@ -309,6 +407,11 @@ bool QmlRichText::bold() const
     return textCursor().charFormat().fontWeight() == QFont::Bold;
 }
 
+/*!
+    \qmlproperty bool RichText::italic
+    \brief Whether the text at the cursor/selection is italic.
+*/
+
 bool QmlRichText::italic() const
 {
     QTextCursor cursor = textCursor();
@@ -317,6 +420,11 @@ bool QmlRichText::italic() const
     return textCursor().charFormat().fontItalic();
 }
 
+/*!
+    \qmlproperty bool RichText::underline
+    \brief Whether the text at the cursor/selection is underlined.
+*/
+
 bool QmlRichText::underline() const
 {
     QTextCursor cursor = textCursor();
@@ -324,6 +432,11 @@ bool QmlRichText::underline() const
         return false;
     return textCursor().charFormat().fontUnderline();
 }
+
+/*!
+    \qmlproperty bool RichText::strikeout
+    \brief Whether the text at the cursor/selection has strikethrough.
+*/
 
 bool QmlRichText::strikeout() const
 {
@@ -365,6 +478,11 @@ void QmlRichText::setStrikeout(bool arg)
     emit strikeoutChanged();
 }
 
+/*!
+    \qmlproperty int RichText::fontSize
+    \brief The font size in points at the cursor or selection.
+*/
+
 int QmlRichText::fontSize() const
 {
     QTextCursor cursor = textCursor();
@@ -384,6 +502,11 @@ void QmlRichText::setFontSize(int arg)
     mergeFormatOnWordOrSelection(format);
     emit fontSizeChanged();
 }
+
+/*!
+    \qmlproperty color RichText::textColor
+    \brief The foreground color of the text at (or to be applied to) the selection.
+*/
 
 QColor QmlRichText::textColor() const
 {
@@ -405,6 +528,11 @@ void QmlRichText::setTextColor(const QColor &c)
     emit textColorChanged();
 }
 
+/*!
+    \qmlproperty string RichText::fontFamily
+    \brief The font family of the text at the cursor or selection.
+*/
+
 QString QmlRichText::fontFamily() const
 {
     QTextCursor cursor = textCursor();
@@ -424,6 +552,11 @@ void QmlRichText::setFontFamily(const QString &arg)
     mergeFormatOnWordOrSelection(format);
     emit fontFamilyChanged();
 }
+
+/*!
+    \qmlproperty string RichText::fontStyleName
+    \brief The font style name (e.g. \c "Bold Italic") at the cursor or selection.
+*/
 
 QString QmlRichText::fontStyleName() const
 {

--- a/src/qmltypes/qmlview.cpp
+++ b/src/qmltypes/qmlview.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 Meltytech, LLC
+ * Copyright (c) 2014-2026 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,10 +21,29 @@
 
 #include <QWidget>
 
+/*!
+    \qmltype QmlView
+    \inqmlmodule org.shotcut.qml
+    \brief Provides access to the host widget geometry, available via the \c view context property.
+
+    \c view is injected as a context property into every dock's QML view.
+    Use it when you need the screen coordinates of the host widget
+    (e.g. to position pop-up elements absolutely on screen).
+
+    \code
+    var widgetPos = view.pos()
+    \endcode
+*/
+
 QmlView::QmlView(QWidget *qview)
     : QObject(qview)
     , m_qview(qview)
 {}
+
+/*!
+    \qmlmethod point QmlView::pos()
+    \brief Returns the top-left position of the host QWidget in screen coordinates.
+*/
 
 QPoint QmlView::pos()
 {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1404,7 +1404,7 @@ void ShotcutSettings::setVideoOutDuration(double d)
 }
 
 /*!
-    \qmlproperty real Settings::audioInCurve
+    \qmlproperty int Settings::audioInCurve
     \brief The curve type for audio fade-in (0 = linear, higher = more exponential).
 */
 
@@ -1420,7 +1420,7 @@ void ShotcutSettings::setAudioInCurve(int c)
 }
 
 /*!
-    \qmlproperty real Settings::audioOutCurve
+    \qmlproperty int Settings::audioOutCurve
     \brief The curve type for audio fade-out (0 = linear, higher = more exponential).
 */
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -74,6 +74,27 @@ ShotcutSettings &ShotcutSettings::singleton()
     return *instance;
 }
 
+/*!
+    \qmltype Settings
+    \inqmlmodule org.shotcut.qml
+    \brief Persistent application settings, accessed via the \c settings context property.
+
+    \c settings is an uncreatable QML type — use the global \c settings identifier
+    available in every Shotcut QML view. Settings are backed by QSettings and persist
+    across sessions.
+
+    \code
+    if (settings.timelineSnap) { ... }
+    settings.timelineSnap = true
+    \endcode
+*/
+
+/*!
+    \qmlproperty Settings::TimelineScrolling Settings::timelineScrolling
+    \brief The timeline auto-scroll mode.
+    One of \c NoScrolling, \c CenterPlayhead, \c PageScrolling, or \c SmoothScrolling.
+*/
+
 ShotcutSettings::ShotcutSettings()
     : QObject()
     , m_recent(QDir(appDataLocation()).filePath(RECENT_INI_FILENAME), QSettings::IniFormat)
@@ -167,6 +188,11 @@ void ShotcutSettings::setImageDuration(double d)
     settings.setValue("imageDuration", d);
 }
 
+/*!
+    \qmlproperty string Settings::openPath
+    \brief The last directory used for opening files.
+*/
+
 QString ShotcutSettings::openPath() const
 {
     return settings
@@ -179,6 +205,11 @@ void ShotcutSettings::setOpenPath(const QString &s)
     settings.setValue("openPath", s);
     emit savePathChanged();
 }
+
+/*!
+    \qmlproperty string Settings::savePath
+    \brief The last directory used for saving files.
+*/
 
 QString ShotcutSettings::savePath() const
 {
@@ -284,6 +315,11 @@ void ShotcutSettings::setTextUnderIcons(bool b)
     settings.setValue("textUnderIcons", b);
 }
 
+/*!
+    \qmlproperty bool Settings::smallIcons
+    \brief Whether the toolbar uses small icons.
+*/
+
 bool ShotcutSettings::smallIcons() const
 {
     return settings.value("smallIcons", false).toBool();
@@ -334,6 +370,11 @@ void ShotcutSettings::setWindowStateDefault(const QByteArray &a)
 {
     settings.setValue("windowStateDefault", a);
 }
+
+/*!
+    \qmlproperty string Settings::viewMode
+    \brief The current view mode of the Playlist panel (e.g. \c "details", \c "icons").
+*/
 
 QString ShotcutSettings::viewMode() const
 {
@@ -616,6 +657,11 @@ void ShotcutSettings::setEncodeParallelProcessing(bool b)
     settings.setValue("encode/parallelProcessing", b);
 }
 
+/*!
+    \qmlproperty int Settings::playerAudioChannels
+    \brief The number of audio channels used by the player (e.g. 2 or 6).
+*/
+
 int ShotcutSettings::playerAudioChannels() const
 {
     return settings.value("player/audioChannels", 2).toInt();
@@ -667,6 +713,11 @@ void ShotcutSettings::setPlayerInterpolation(const QString &s)
 {
     settings.setValue("player/interpolation", s);
 }
+
+/*!
+    \qmlproperty bool Settings::playerGPU
+    \brief Whether GPU processing (GLSL) is enabled for the video player.
+*/
 
 bool ShotcutSettings::playerGPU() const
 {
@@ -970,6 +1021,11 @@ void ShotcutSettings::setPlayerHdrToneMapping(bool b)
     settings.setValue("player/hdrToneMapping", b);
 }
 
+/*!
+    \qmlproperty string Settings::playlistThumbnails
+    \brief The thumbnail display mode for the Playlist panel.
+*/
+
 QString ShotcutSettings::playlistThumbnails() const
 {
     return settings.value("playlist/thumbnails", "small").toString();
@@ -1001,6 +1057,11 @@ void ShotcutSettings::setPlaylistShowColumn(const QString &column, bool b)
     settings.setValue("playlist/columns/" + column, b);
 }
 
+/*!
+    \qmlproperty bool Settings::timelineDragScrub
+    \brief Whether scrubbing occurs while dragging clips on the timeline.
+*/
+
 bool ShotcutSettings::timelineDragScrub() const
 {
     return settings.value("timeline/dragScrub", false).toBool();
@@ -1011,6 +1072,11 @@ void ShotcutSettings::setTimelineDragScrub(bool b)
     settings.setValue("timeline/dragScrub", b);
     emit timelineDragScrubChanged();
 }
+
+/*!
+    \qmlproperty bool Settings::timelineShowWaveforms
+    \brief Whether audio waveforms are shown on timeline clips.
+*/
 
 bool ShotcutSettings::timelineShowWaveforms() const
 {
@@ -1023,6 +1089,11 @@ void ShotcutSettings::setTimelineShowWaveforms(bool b)
     emit timelineShowWaveformsChanged();
 }
 
+/*!
+    \qmlproperty bool Settings::timelineShowThumbnails
+    \brief Whether video thumbnails are shown on timeline clips.
+*/
+
 bool ShotcutSettings::timelineShowThumbnails() const
 {
     return settings.value("timeline/thumbnails", true).toBool();
@@ -1033,6 +1104,11 @@ void ShotcutSettings::setTimelineShowThumbnails(bool b)
     settings.setValue("timeline/thumbnails", b);
     emit timelineShowThumbnailsChanged();
 }
+
+/*!
+    \qmlproperty bool Settings::timelineRipple
+    \brief Whether ripple editing is enabled on the timeline.
+*/
 
 bool ShotcutSettings::timelineRipple() const
 {
@@ -1045,6 +1121,11 @@ void ShotcutSettings::setTimelineRipple(bool b)
     emit timelineRippleChanged();
 }
 
+/*!
+    \qmlproperty bool Settings::timelineRippleAllTracks
+    \brief Whether ripple editing affects all tracks simultaneously.
+*/
+
 bool ShotcutSettings::timelineRippleAllTracks() const
 {
     return settings.value("timeline/rippleAllTracks", false).toBool();
@@ -1056,6 +1137,11 @@ void ShotcutSettings::setTimelineRippleAllTracks(bool b)
     emit timelineRippleAllTracksChanged();
 }
 
+/*!
+    \qmlproperty bool Settings::timelineRippleMarkers
+    \brief Whether markers are moved along with ripple edits.
+*/
+
 bool ShotcutSettings::timelineRippleMarkers() const
 {
     return settings.value("timeline/rippleMarkers", false).toBool();
@@ -1066,6 +1152,11 @@ void ShotcutSettings::setTimelineRippleMarkers(bool b)
     settings.setValue("timeline/rippleMarkers", b);
     emit timelineRippleMarkersChanged();
 }
+
+/*!
+    \qmlproperty bool Settings::timelineSnap
+    \brief Whether clip snapping is enabled on the timeline.
+*/
 
 bool ShotcutSettings::timelineSnap() const
 {
@@ -1088,6 +1179,11 @@ void ShotcutSettings::setTimelineTrackHeight(int n)
     settings.setValue("timeline/trackHeight", qMin(n, kMaximumTrackHeight));
 }
 
+/*!
+    \qmlproperty bool Settings::timelineScrollZoom
+    \brief Whether the scroll wheel zooms the timeline (instead of scrolling).
+*/
+
 bool ShotcutSettings::timelineScrollZoom() const
 {
     return settings.value("timeline/scrollZoom", true).toBool();
@@ -1098,6 +1194,11 @@ void ShotcutSettings::setTimelineScrollZoom(bool b)
     settings.setValue("timeline/scrollZoom", b);
     emit timelineScrollZoomChanged();
 }
+
+/*!
+    \qmlproperty bool Settings::timelineFramebufferWaveform
+    \brief Whether waveforms are rendered using a framebuffer (GPU) path.
+*/
 
 bool ShotcutSettings::timelineFramebufferWaveform() const
 {
@@ -1168,6 +1269,11 @@ void ShotcutSettings::setTimelineAutoAddTracks(bool b)
     }
 }
 
+/*!
+    \qmlproperty bool Settings::timelineRectangleSelect
+    \brief Whether rectangle (rubber-band) selection is enabled on the timeline.
+*/
+
 bool ShotcutSettings::timelineRectangleSelect() const
 {
     return settings.value("timeline/rectangleSelect", true).toBool();
@@ -1179,6 +1285,11 @@ void ShotcutSettings::setTimelineRectangleSelect(bool b)
     emit timelineRectangleSelectChanged();
 }
 
+/*!
+    \qmlproperty bool Settings::timelineAdjustGain
+    \brief Whether dragging the gain handle on audio clips adjusts volume inline.
+*/
+
 bool ShotcutSettings::timelineAdjustGain() const
 {
     return settings.value("timeline/adjustGain", false).toBool();
@@ -1189,6 +1300,11 @@ void ShotcutSettings::setTimelineAdjustGain(bool b)
     settings.setValue("timeline/adjustGain", b);
     emit timelineAdjustGainChanged();
 }
+
+/*!
+    \qmlproperty bool Settings::timelineAllowTransitions
+    \brief Whether overlapping clips on the timeline automatically create transitions.
+*/
 
 bool ShotcutSettings::timelineAllowTransitions() const
 {
@@ -1223,6 +1339,11 @@ void ShotcutSettings::setAddOnFilterServices(const QStringList &services)
     settings.setValue("filter/addOnServices", services);
 }
 
+/*!
+    \qmlproperty real Settings::audioInDuration
+    \brief The default duration in seconds for audio fade-in transitions.
+*/
+
 double ShotcutSettings::audioInDuration() const
 {
     return settings.value("filter/audioInDuration", 1.0).toDouble();
@@ -1233,6 +1354,11 @@ void ShotcutSettings::setAudioInDuration(double d)
     settings.setValue("filter/audioInDuration", d);
     emit audioInDurationChanged();
 }
+
+/*!
+    \qmlproperty real Settings::audioOutDuration
+    \brief The default duration in seconds for audio fade-out transitions.
+*/
 
 double ShotcutSettings::audioOutDuration() const
 {
@@ -1245,6 +1371,11 @@ void ShotcutSettings::setAudioOutDuration(double d)
     emit audioOutDurationChanged();
 }
 
+/*!
+    \qmlproperty real Settings::videoInDuration
+    \brief The default duration in seconds for video fade-in transitions.
+*/
+
 double ShotcutSettings::videoInDuration() const
 {
     return settings.value("filter/videoInDuration", 1.0).toDouble();
@@ -1255,6 +1386,11 @@ void ShotcutSettings::setVideoInDuration(double d)
     settings.setValue("filter/videoInDuration", d);
     emit videoInDurationChanged();
 }
+
+/*!
+    \qmlproperty real Settings::videoOutDuration
+    \brief The default duration in seconds for video fade-out transitions.
+*/
 
 double ShotcutSettings::videoOutDuration() const
 {
@@ -1267,6 +1403,11 @@ void ShotcutSettings::setVideoOutDuration(double d)
     emit videoOutDurationChanged();
 }
 
+/*!
+    \qmlproperty real Settings::audioInCurve
+    \brief The curve type for audio fade-in (0 = linear, higher = more exponential).
+*/
+
 int ShotcutSettings::audioInCurve() const
 {
     return settings.value("filter/audioInCurve", mlt_keyframe_linear).toInt();
@@ -1278,6 +1419,11 @@ void ShotcutSettings::setAudioInCurve(int c)
     emit audioInCurveChanged();
 }
 
+/*!
+    \qmlproperty real Settings::audioOutCurve
+    \brief The curve type for audio fade-out (0 = linear, higher = more exponential).
+*/
+
 int ShotcutSettings::audioOutCurve() const
 {
     return settings.value("filter/audioOutCurve", mlt_keyframe_linear).toInt();
@@ -1288,6 +1434,11 @@ void ShotcutSettings::setAudioOutCurve(int c)
     settings.setValue("filter/audioOutCurve", c);
     emit audioOutCurveChanged();
 }
+
+/*!
+    \qmlproperty bool Settings::askOutputFilter
+    \brief Whether Shotcut should prompt before applying a filter to the output node.
+*/
 
 bool ShotcutSettings::askOutputFilter() const
 {
@@ -1414,6 +1565,11 @@ void ShotcutSettings::sync()
 {
     settings.sync();
 }
+
+/*!
+    \qmlproperty string Settings::appDataLocation
+    \brief The path to the application data directory (read-only).
+*/
 
 QString ShotcutSettings::appDataLocation() const
 {
@@ -1735,6 +1891,11 @@ void ShotcutSettings::setSlideshowTransitionSoftness(int transitionSoftness)
 {
     settings.setValue("slideshow/transitionSoftness", transitionSoftness);
 }
+
+/*!
+    \qmlproperty bool Settings::keyframesDragScrub
+    \brief Whether scrubbing occurs while dragging keyframes.
+*/
 
 bool ShotcutSettings::keyframesDragScrub() const
 {


### PR DESCRIPTION
Adds a QDoc-generated reference for Shotcut’s QML scripting surface by annotating existing C++ QML-facing classes/models/docks with `\qmltype`, `\qmlproperty` and `\qmlmethod` blocks; and wiring a CMake option/target to generate HTML docs.

**Changes:**
- Added extensive inline QDoc for `org.shotcut.qml` context properties/types (Filter/Producer/Profile/Application/Settings/etc.) and key models/docks used by QML views.
- Added new QDoc structure files for `org.shotcut.qml` and `Shotcut.Controls`, plus a minimal CSS for readability.
- Added `BUILD_DOCS` option + `docs` custom target and updated build/preset/gitignore for generated output.