### PR TITLE
Fix Motion Tracker keyframes not applying after save/reload

### DIFF
--- a/src/models/motiontrackermodel.cpp
+++ b/src/models/motiontrackermodel.cpp
@@ -270,12 +270,18 @@ QList<MotionTrackerModel::TrackingItem> MotionTrackerModel::trackingData(const Q
     for (const auto &i : l) {
         auto pair = i.split("~=");
         if (pair.size() == 2) {
-            auto frame = pair.at(0).toInt(&ok);
+            // The keyframe time may be serialized either as a frame number
+            // ("5") or as a clock value ("00:00:00.167"), depending on the MLT
+            // time format used when the project was written. toInt() only
+            // parses the frame-number form; for the clock form it fails, so we
+            // fall back to the running index. Only the rectangles are consumed
+            // downstream, so the exact frame value is not significant here.
+            int frame = pair.at(0).toInt(&ok);
+            if (!ok)
+                frame = int(result.size());
             props.set("", pair.at(1).toLatin1().constData());
             auto rect = props.get_rect("");
-            if (ok) {
-                result << TrackingItem{frame, QRectF(rect.x, rect.y, rect.w, rect.h)};
-            }
+            result << TrackingItem{frame, QRectF(rect.x, rect.y, rect.w, rect.h)};
         }
     }
     return result;

--- a/src/models/motiontrackermodel.cpp
+++ b/src/models/motiontrackermodel.cpp
@@ -264,21 +264,19 @@ QList<MotionTrackerModel::TrackingItem> MotionTrackerModel::trackingData(const Q
     QList<TrackingItem> result;
     auto s = m_data.value(key, {}).trackingData;
     auto l = s.split(';');
-    bool ok{false};
     Mlt::Properties props;
+    auto consumer = MLT.consumer();
 
     for (const auto &i : l) {
         auto pair = i.split("~=");
         if (pair.size() == 2) {
-            // The keyframe time may be serialized either as a frame number
-            // ("5") or as a clock value ("00:00:00.167"), depending on the MLT
-            // time format used when the project was written. toInt() only
-            // parses the frame-number form; for the clock form it fails, so we
-            // fall back to the running index. Only the rectangles are consumed
-            // downstream, so the exact frame value is not significant here.
-            int frame = pair.at(0).toInt(&ok);
-            if (!ok)
-                frame = int(result.size());
+            // The keyframe time is serialized either as a frame number ("5") or
+            // as a clock value ("00:00:00.167"), depending on the time format
+            // MLT used when the project was written (animated properties are
+            // saved as time so they adapt to a frame-rate change). time_to_frames()
+            // parses both forms to the correct frame using the project frame rate.
+            int frame = consumer ? consumer->time_to_frames(pair.at(0).toUtf8().constData())
+                                 : pair.at(0).toInt();
             props.set("", pair.at(1).toLatin1().constData());
             auto rect = props.get_rect("");
             result << TrackingItem{frame, QRectF(rect.x, rect.y, rect.w, rect.h)};


### PR DESCRIPTION
## Problem
After saving and reopening a project, **Load Keyframes from Motion Tracker** silently applies zero keyframes — the masked rectangle stays static instead of following the tracked motion.

## Root cause
`MotionTrackerModel::trackingData()` parses each keyframe's time key with `QString::toInt`, which only accepts integer frame numbers (e.g. `5`). When a project is saved, Shotcut serializes animated properties — including the `opencv.tracker` `results` — in clock time format (e.g. `00:00:00.167`). After a save + reload, `toInt` then fails on every entry, so `trackingData` returns an empty list and `applyTracking` lays down no keyframes.

This is why tracking "works" right after Analyze (in-memory `results` are frame-numbered) but stops working once the project has been saved and reopened.

## Fix
Accept both frame-number and clock/timecode time keys. The parsed frame value is not used downstream (only the rectangles are consumed by `applyTracking`/`reset`), so fall back to the running index when `toInt` fails.

## Verification
On a real project whose tracker `results` were stored as clock timecodes, the parser yielded **0** rectangles before the change and all **46** after, and the masked filter's keyframes are applied across the whole clip as expected.

