### PR TITLE
Update Convert for 10-bit and HDR

### DIFF
--- a/src/dialogs/transcodedialog.cpp
+++ b/src/dialogs/transcodedialog.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2024 Meltytech, LLC
+ * Copyright (c) 2017-2026 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -149,9 +149,12 @@ void TranscodeDialog::on_horizontalSlider_valueChanged(int position)
         ui->formatLabel->setText(
             tr("Intermediate: %1").arg(m_isProgressive ? "DNxHR/PCM MOV" : "ProRes/PCM MOV"));
         break;
-    case 2:
-        ui->formatLabel->setText(tr("Lossless: %1").arg("Ut Video/PCM MKV"));
+    case 2: {
+        const bool is8bit = !Settings.isHdrCompatibleProcessingMode();
+        ui->formatLabel->setText(
+            tr("Lossless: %1").arg(is8bit ? "Ut Video/PCM MKV" : "H.264/PCM MKV"));
         break;
+    }
     }
     m_format = position;
 }

--- a/src/jobs/ffmpegjob.cpp
+++ b/src/jobs/ffmpegjob.cpp
@@ -44,6 +44,7 @@ FfmpegJob::FfmpegJob(const QString &name,
     action->setData("Open");
     connect(action, SIGNAL(triggered()), this, SLOT(onOpenTriggered()));
     m_successActions << action;
+    m_args.append("-hide_banner");
     m_args.append(args);
     setLabel(tr("Check %1").arg(Util::baseName(name)));
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -627,6 +627,12 @@ ShotcutSettings::ProcessingMode ShotcutSettings::processingModeId(const QString 
     return Native8Cpu;
 }
 
+bool ShotcutSettings::isHdrCompatibleProcessingMode()
+{
+    const auto mode = processingMode();
+    return mode == Native10Cpu || mode == Linear10GpuCpu;
+}
+
 bool ShotcutSettings::showConvertClipDialog() const
 {
     return settings.value("showConvertClipDialog", true).toBool();

--- a/src/settings.h
+++ b/src/settings.h
@@ -132,6 +132,7 @@ public:
     void setProcessingMode(ProcessingMode mode);
     QString processingModeStr(ProcessingMode mode);
     ProcessingMode processingModeId(const QString &mode);
+    bool isHdrCompatibleProcessingMode();
 
     // encode
     QString encodePath() const;

--- a/src/transcoder.cpp
+++ b/src/transcoder.cpp
@@ -329,9 +329,8 @@ void Transcoder::convertProducer(Mlt::Producer *producer, TranscodeDialog &dialo
         if (dialog.deinterlace() || progressive) {
             args << "-codec:v"
                  << "dnxhd"
-                 << "-profile:v"
-                 << (is10bit ? "dnxhr_hqx" : "dnxhr_hq")
-                 << "-pix_fmt" << (is10bit ? "yuv422p10le" : "yuv422p");
+                 << "-profile:v" << (is10bit ? "dnxhr_hqx" : "dnxhr_hq") << "-pix_fmt"
+                 << (is10bit ? "yuv422p10le" : "yuv422p");
         } else { // interlaced
             args << "-codec:v"
                  << "prores_ks"

--- a/src/transcoder.cpp
+++ b/src/transcoder.cpp
@@ -273,7 +273,10 @@ void Transcoder::convertProducer(Mlt::Producer *producer, TranscodeDialog &dialo
         filterString += minterpFilter;
     }
     if (is10bit) {
-        filterString += QStringLiteral(",format=yuv420p10le");
+        // Intermediate (format 1) encodes to yuv422p10le (DNxHR HQX); preserve chroma.
+        const auto pixFmt = dialog.format() == 1 ? QStringLiteral("yuv422p10le")
+                                                  : QStringLiteral("yuv420p10le");
+        filterString += QStringLiteral(",format=") + pixFmt;
     }
     args << filterString;
     args << "-fps_mode"

--- a/src/transcoder.cpp
+++ b/src/transcoder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Meltytech, LLC
+ * Copyright (c) 2023-2026 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -150,6 +150,7 @@ void Transcoder::convertProducer(Mlt::Producer *producer, TranscodeDialog &dialo
     QString resource = Util::GetFilenameFromProducer(producer);
     QStringList args;
     int in = -1;
+    const bool is10bit = Settings.isHdrCompatibleProcessingMode();
 
     args << "-loglevel"
          << "verbose";
@@ -264,11 +265,20 @@ void Transcoder::convertProducer(Mlt::Producer *producer, TranscodeDialog &dialo
     if (denominator == 1001) {
         fpsStr = QStringLiteral("%1/%2").arg(numerator).arg(denominator);
     }
-    QString minterpFilter
-        = QStringLiteral(",minterpolate='mi_mode=%1:mc_mode=aobmc:me_mode=bidir:vsbmc=1:fps=%2'")
-              .arg(dialog.frc(), fpsStr);
-    filterString = filterString + minterpFilter;
+    if (dialog.fpsOverride()) {
+        QString minterpFilter
+            = QStringLiteral(
+                  ",minterpolate='mi_mode=%1:mc_mode=aobmc:me_mode=bidir:vsbmc=1:fps=%2'")
+                  .arg(dialog.frc(), fpsStr);
+        filterString += minterpFilter;
+    }
+    if (is10bit) {
+        filterString += QStringLiteral(",format=yuv420p10le");
+    }
     args << filterString;
+    args << "-fps_mode"
+         << "cfr"
+         << "-r" << fpsStr;
 
     // Specify color range
     if (color_range == "full") {
@@ -298,6 +308,12 @@ void Transcoder::convertProducer(Mlt::Producer *producer, TranscodeDialog &dialo
              << "512k"
              << "-codec:v"
              << "libx264";
+        if (is10bit) {
+            args << "-profile:v"
+                 << "high10"
+                 << "-pix_fmt"
+                 << "yuv420p10le";
+        }
         args << "-preset"
              << "medium"
              << "-g"
@@ -314,9 +330,8 @@ void Transcoder::convertProducer(Mlt::Producer *producer, TranscodeDialog &dialo
             args << "-codec:v"
                  << "dnxhd"
                  << "-profile:v"
-                 << "dnxhr_hq"
-                 << "-pix_fmt"
-                 << "yuv422p";
+                 << (is10bit ? "dnxhr_hqx" : "dnxhr_hq")
+                 << "-pix_fmt" << (is10bit ? "yuv422p10le" : "yuv422p");
         } else { // interlaced
             args << "-codec:v"
                  << "prores_ks"
@@ -328,11 +343,22 @@ void Transcoder::convertProducer(Mlt::Producer *producer, TranscodeDialog &dialo
         args << "-f"
              << "matroska"
              << "-codec:a"
-             << "pcm_f32le"
-             << "-codec:v"
-             << "utvideo";
-        args << "-pix_fmt"
-             << "yuv422p";
+             << "pcm_f32le";
+        if (is10bit) {
+            args << "-codec:v"
+                 << "libx264"
+                 << "-profile:v"
+                 << "high10"
+                 << "-pix_fmt"
+                 << "yuv420p10le"
+                 << "-crf"
+                 << "0";
+        } else {
+            args << "-codec:v"
+                 << "utvideo"
+                 << "-pix_fmt"
+                 << "yuv422p";
+        }
         break;
     }
     if (dialog.get709Convert()) {
@@ -342,7 +368,8 @@ void Transcoder::convertProducer(Mlt::Producer *producer, TranscodeDialog &dialo
              << "bt709"
              << "-color_trc"
              << "bt709";
-    } else if (dialog.format() == 2 && producer->get_int("meta.media.colorspace") == 709) {
+    } else if (dialog.format() == 2 && !is10bit
+               && producer->get_int("meta.media.colorspace") == 709) {
         // Work around a limitation that FFMpeg does not pass colorspace for utvideo
         args << "-colorspace"
              << "bt709";

--- a/src/transcoder.cpp
+++ b/src/transcoder.cpp
@@ -275,7 +275,7 @@ void Transcoder::convertProducer(Mlt::Producer *producer, TranscodeDialog &dialo
     if (is10bit) {
         // Intermediate (format 1) encodes to yuv422p10le (DNxHR HQX); preserve chroma.
         const auto pixFmt = dialog.format() == 1 ? QStringLiteral("yuv422p10le")
-                                                  : QStringLiteral("yuv420p10le");
+                                                 : QStringLiteral("yuv420p10le");
         filterString += QStringLiteral(",format=") + pixFmt;
     }
     args << filterString;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -812,7 +812,7 @@ QString Util::trcString(int trc)
     return trcString;
 }
 
-bool Util::trcIsCompatible(int trc)
+bool Util::trcIsSdrCompatible(int trc)
 {
     // Transfer characteristics > SMPTE240M Probably need conversion except IEC61966-2-4 is OK
     return trc <= 7 || trc == 11 || trc == 13 || trc == 14 || trc == 15 || trc == 18;
@@ -824,7 +824,7 @@ QString Util::getConversionAdvice(Mlt::Producer *producer)
     producer->probe();
     QString resource = Util::GetFilenameFromProducer(producer);
     int trc = producer->get_int("meta.media.color_trc");
-    if (!Util::trcIsCompatible(trc)) {
+    if (!Settings.isHdrCompatibleProcessingMode() && !Util::trcIsSdrCompatible(trc)) {
         QString trcString = Util::trcString(trc);
         LOG_INFO() << resource << "Probable HDR" << trcString;
         advice = QObject::tr("This file uses color transfer characteristics %1, which may result "
@@ -865,7 +865,8 @@ void Util::offerSingleFileConversion(QString &message, Mlt::Producer *producer, 
                parent);
     dialog.setWindowModality(QmlApplication::dialogModality());
     dialog.showCheckBox();
-    dialog.set709Convert(!Util::trcIsCompatible(producer->get_int("meta.media.color_trc")));
+    dialog.set709Convert(!Settings.isHdrCompatibleProcessingMode()
+                         && !Util::trcIsSdrCompatible(producer->get_int("meta.media.color_trc")));
     dialog.showSubClipCheckBox();
     LOG_DEBUG() << "in" << producer->get_in() << "out" << producer->get_out() << "length"
                 << producer->get_length() - 1;

--- a/src/util.h
+++ b/src/util.h
@@ -84,7 +84,7 @@ public:
     static bool isFpsDifferent(double a, double b);
     static QString getNextFile(const QString &filePath);
     static QString trcString(int trc);
-    static bool trcIsCompatible(int trc);
+    static bool trcIsSdrCompatible(int trc);
     static QString getConversionAdvice(Mlt::Producer *producer);
     static mlt_color mltColorFromQColor(const QColor &color);
     static void offerSingleFileConversion(QString &message,

--- a/src/widgets/avformatproducerwidget.cpp
+++ b/src/widgets/avformatproducerwidget.cpp
@@ -853,7 +853,8 @@ void AvformatProducerWidget::on_actionFFmpegConvert_triggered()
                ui->scanComboBox->currentIndex(),
                this);
     dialog.setWindowModality(QmlApplication::dialogModality());
-    dialog.set709Convert(ui->videoTableWidget->item(5, 1)->data(Qt::UserRole).toInt() > 7);
+    dialog.set709Convert(!Settings.isHdrCompatibleProcessingMode()
+                         && ui->videoTableWidget->item(5, 1)->data(Qt::UserRole).toInt() > 7);
     dialog.showSubClipCheckBox();
     auto fps = Util::getAndroidFrameRate(m_producer.get());
     if (fps > 0.0)


### PR DESCRIPTION
This pull request introduces improved support for HDR (High Dynamic Range) workflows by making the application's transcoding and conversion logic aware of the current processing mode's HDR compatibility. The main changes ensure that lossless transcodes use a 10-bit H.264 codec when HDR-compatible processing is enabled, and that color space conversions and user prompts are more accurate for HDR content. Several utility and dialog functions have been updated to reflect this logic, and some code has been refactored for clarity.

**HDR-aware transcoding and conversion:**

* Added `ShotcutSettings::isHdrCompatibleProcessingMode()` to determine if the current processing mode supports HDR, and updated relevant dialogs and conversion logic to use this check. (`src/settings.h`, `src/settings.cpp`, `src/dialogs/transcodedialog.cpp`, `src/transcoder.cpp`, `src/util.cpp`, `src/widgets/avformatproducerwidget.cpp`) [[1]](diffhunk://#diff-c044ba02ccf7862f1e2f56436d5b92baa7bb35601791846655fb07ac253a8697R630-R635) [[2]](diffhunk://#diff-e43eb64bdd9061c058d0e50763df67fe62bf719f55bcff809d1eadda8eb67513R135) [[3]](diffhunk://#diff-07030df8aa32460a382b281c186787dad56e981576adc3064720ca348728681bL152-R158) [[4]](diffhunk://#diff-7b909efef9eee1ead1de95a6acf4b3f0ef45a27a25d59ac494e04f86dcd2f4b4R153) [[5]](diffhunk://#diff-71add9df638df1a7aa8cc927c71965c319c6cf6c9290ecb5b90436820d4e1884L856-R857)

* Lossless transcode mode now uses 10-bit H.264 when HDR-compatible processing is enabled, instead of Ut Video, and sets appropriate ffmpeg arguments for 10-bit output. (`src/dialogs/transcodedialog.cpp`, `src/transcoder.cpp`) [[1]](diffhunk://#diff-07030df8aa32460a382b281c186787dad56e981576adc3064720ca348728681bL152-R158) [[2]](diffhunk://#diff-7b909efef9eee1ead1de95a6acf4b3f0ef45a27a25d59ac494e04f86dcd2f4b4L331-R361) [[3]](diffhunk://#diff-7b909efef9eee1ead1de95a6acf4b3f0ef45a27a25d59ac494e04f86dcd2f4b4R311-R316) [[4]](diffhunk://#diff-7b909efef9eee1ead1de95a6acf4b3f0ef45a27a25d59ac494e04f86dcd2f4b4L317-R334)

**Color space and conversion improvements:**

* Updated logic for when to offer BT.709 color conversion and when to prompt users about probable HDR content, making it conditional on both the processing mode and color transfer characteristics. (`src/util.cpp`, `src/widgets/avformatproducerwidget.cpp`) [[1]](diffhunk://#diff-449acf764318b0ca96972daf8d28a28af79ad2c3381044851f2953792fcd8eefL827-R827) [[2]](diffhunk://#diff-449acf764318b0ca96972daf8d28a28af79ad2c3381044851f2953792fcd8eefL868-R869) [[3]](diffhunk://#diff-71add9df638df1a7aa8cc927c71965c319c6cf6c9290ecb5b90436820d4e1884L856-R857)

* Renamed `Util::trcIsCompatible` to `Util::trcIsSdrCompatible` for clarity and updated all references. (`src/util.h`, `src/util.cpp`) [[1]](diffhunk://#diff-40ab92941994ec9418dbb76ae46d5aef0e4cb8b034f2be2b31562bb9aca8070fL87-R87) [[2]](diffhunk://#diff-449acf764318b0ca96972daf8d28a28af79ad2c3381044851f2953792fcd8eefL815-R815)

**Other improvements:**

* Added `-hide_banner` to ffmpeg job arguments to reduce log clutter. (`src/jobs/ffmpegjob.cpp`)

* Updated copyright years in relevant files. (`src/dialogs/transcodedialog.cpp`, `src/transcoder.cpp`) [[1]](diffhunk://#diff-07030df8aa32460a382b281c186787dad56e981576adc3064720ca348728681bL2-R2) [[2]](diffhunk://#diff-7b909efef9eee1ead1de95a6acf4b3f0ef45a27a25d59ac494e04f86dcd2f4b4L2-R2)