### PR TITLE
Fix magnet snap leaving a gap at low timeline zoom

### DIFF
--- a/src/qml/views/timeline/Clip.qml
+++ b/src/qml/views/timeline/Clip.qml
@@ -259,7 +259,11 @@ Rectangle {
                 doubleClickTimer.isFirstRelease = false;
                 parent.y = 0;
                 var delta = parent.x - startX;
-                if (Math.abs(delta) >= 1 || trackIndex !== originalTrackIndex) {
+                // At low zoom, magnet snap may move by <1px while changing the
+                // frame. Commit when the frame changes, not only when abs(delta)>=1.
+                var startFrame = Math.round(startX / multitrack.scaleFactor);
+                var frame = Math.round(parent.x / multitrack.scaleFactor);
+                if (Math.abs(delta) >= 1 || frame !== startFrame || trackIndex !== originalTrackIndex) {
                     parent.moved(clipRoot);
                     originalX = parent.x;
                     originalTrackIndex = trackIndex;

--- a/src/qml/views/timeline/Track.js
+++ b/src/qml/views/timeline/Track.js
@@ -33,22 +33,23 @@ function snapClip(clip, repeater) {
                 continue
             var itemLeft = repeater.itemAt(i).x
             var itemRight = itemLeft + repeater.itemAt(i).width
-            // Snap to blank
+            // Snap to blank / neighboring clips in frame space so low zoom
+            // (small timeScale) round-trips to integer frames.
             if (right > itemLeft - SNAP && right < itemLeft + SNAP) {
                 // Snap right edge to left edge.
-                clip.x = itemLeft - clip.width
+                clip.x = Math.round(itemLeft / timeScale) * timeScale - clip.width
                 return
             } else if (left > itemRight - SNAP && left < itemRight + SNAP) {
                 // Snap left edge to right edge.
-                clip.x = itemRight
+                clip.x = Math.round(itemRight / timeScale) * timeScale
                 return
             } else if (right > itemRight - SNAP && right < itemRight + SNAP) {
                 // Snap right edge to right edge.
-                clip.x = itemRight - clip.width
+                clip.x = Math.round(itemRight / timeScale) * timeScale - clip.width
                 return
             } else if (left > itemLeft - SNAP && left < itemLeft + SNAP) {
                 // Snap left edge to left edge.
-                clip.x = itemLeft
+                clip.x = Math.round(itemLeft / timeScale) * timeScale
                 return
             }
         }


### PR DESCRIPTION
## Summary
At low timeline zoom, magnet snap can adjust a clip by less than one pixel while changing its frame. The drop path only committed moves when the pixel delta was at least 1, so a one-frame gap could remain after an apparent snap.

This snaps neighboring clip edges in frame space and commits the drop when the rounded frame changes.

## Test plan
- [x] Zoom timeline out (around `scaleFactor` 0.2), magnet on, close a one-frame gap between neighboring clips on the same track; after drop they are frame-exact contiguous (no blank).
- [ ] Magnet off: existing non-snap drag/drop behavior unchanged.
- [ ] Playhead/marker snaps still work.