### PR TITLE
Add Timeline > Generate > Adjustment Clip

### DIFF
--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -1484,6 +1484,13 @@ void TimelineDock::setupActions()
         if (mltProducers->get_data("blipflash")) {
             menu->addAction(tr("Blip Flash"), this, SLOT(addGenerator()))->setObjectName("blipflash");
         }
+#if LIBMLT_VERSION_INT >= ((7 << 16) + (41 << 8))
+        if (mltProducers->get_data("color")) {
+            menu->addSeparator();
+            menu->addAction(tr("Adjustment Clip"), this, SLOT(addGenerator()))
+                ->setObjectName("adjustment");
+        }
+#endif
         action->setMenu(menu);
     }
     Actions.add("timelineNewGenerator", action, windowTitle());
@@ -4848,6 +4855,23 @@ void TimelineDock::addGenerator()
         addGenerator(new CountProducerWidget(this));
     else if (sender()->objectName() == "blipflash")
         addGenerator(new BlipProducerWidget(this));
+    else if (sender()->objectName() == "adjustment")
+        addAdjustmentClip();
+}
+
+void TimelineDock::addAdjustmentClip()
+{
+    auto &profile = MLT.profile();
+    Mlt::Producer producer(profile, "color:0");
+    if (!producer.is_valid())
+        return;
+    producer.set("mlt_image_format", "rgba");
+    producer.set("meta.fx_cut", 1);
+    producer.set(kShotcutProducerProperty, "adjustment");
+    producer.set(kShotcutCaptionProperty, tr("Adjustment Clip").toUtf8().constData());
+    MLT.setDurationFromDefault(&producer);
+    auto trackIndex = addTrackIfNeeded(VideoTrackType);
+    overwrite(trackIndex, -1, MLT.XML(&producer), false);
 }
 
 class FindProducersByHashParser : public Mlt::Parser

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -286,9 +286,7 @@ private slots:
     void onClipRightClicked();
     void onNoMoreEmptyTracks(bool isAudio);
     void addGenerator();
-#if LIBMLT_VERSION_INT >= ((7 << 16) + (41 << 8))
     void addAdjustmentClip();
-#endif
 };
 
 #endif // TIMELINEDOCK_H

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -286,6 +286,9 @@ private slots:
     void onClipRightClicked();
     void onNoMoreEmptyTracks(bool isAudio);
     void addGenerator();
+#if LIBMLT_VERSION_INT >= ((7 << 16) + (41 << 8))
+    void addAdjustmentClip();
+#endif
 };
 
 #endif // TIMELINEDOCK_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4354,8 +4354,13 @@ QWidget *MainWindow::loadProducerWidget(Mlt::Producer *producer)
     QString resource = QString::fromUtf8(producer->get("resource"));
     QString shotcutProducer(producer->get(kShotcutProducerProperty));
 
-    if (resource.startsWith("video4linux2:")
-        || QString::fromUtf8(producer->get("resource1")).startsWith("video4linux2:"))
+    if (shotcutProducer == QLatin1String("adjustment")) {
+        w = new QWidget(this);
+        scrollArea->setWidget(w);
+        m_filterController->setProducer(producer);
+        return w;
+    } else if (resource.startsWith("video4linux2:")
+               || QString::fromUtf8(producer->get("resource1")).startsWith("video4linux2:"))
         w = new Video4LinuxWidget(this);
     else if (resource.startsWith("pulse:"))
         w = new PulseAudioWidget(this);


### PR DESCRIPTION
This pull request adds support for "Adjustment Clips" to the timeline, allowing users to add a special type of clip that applies effects to everything below it. The feature is only available when using libmlt version 7.41.0 or newer. The implementation includes UI changes to add the new generator, logic to create and insert the adjustment clip, and support for displaying it in the main window.

**Adjustment Clip Feature:**

* Added a menu option to insert an "Adjustment Clip" in the timeline when libmlt >= 7.41.0. (`src/docks/timelinedock.cpp`, `src/docks/timelinedock.h`) [[1]](diffhunk://#diff-f68df8db1fd177eef1313a1db87917a1f55cca11cd7d8474f227a25162845a18R1487-R1493) [[2]](diffhunk://#diff-ddb896addd53739957e7ec6971138cc519b45acb3cfb84ca42cbdda5192e2085R289-R291)
* Implemented the `addAdjustmentClip()` method to create and insert a color producer configured as an adjustment clip. (`src/docks/timelinedock.cpp`)
* Updated `loadProducerWidget()` to recognize adjustment clips and set up the filter controller appropriately. (`src/mainwindow.cpp`)