### PR TITLE
Add track volume control and audio level indicator in timeline

### DIFF
--- a/src/commands/filtercommands.cpp
+++ b/src/commands/filtercommands.cpp
@@ -22,6 +22,7 @@
 #include "mainwindow.h"
 #include "mltcontroller.h"
 #include "qmltypes/qmlapplication.h"
+#include "util.h"
 
 class FindProducerParser : public Mlt::Parser
 {
@@ -327,8 +328,7 @@ void PasteCommand::undo()
     // Remove all filters
     for (int i = 0; i < producer.filter_count(); i++) {
         Mlt::Filter *filter = producer.filter(i);
-        if (filter && filter->is_valid() && !filter->get_int("_loader")
-            && !filter->get_int(kShotcutHiddenProperty)) {
+        if (Util::isUserFilter(filter)) {
             producer.detach(*filter);
             i--;
         }

--- a/src/commands/timelinecommands.cpp
+++ b/src/commands/timelinecommands.cpp
@@ -2125,8 +2125,7 @@ void DetachAudioCommand::redo()
         // Remove audio filters from the video clip.
         for (int i = 0; i < videoClip.filter_count(); i++) {
             Mlt::Filter *filter = videoClip.filter(i);
-            if (filter && filter->is_valid() && !filter->get_int("_loader")
-                && !filter->get_int(kShotcutHiddenProperty)) {
+            if (Util::isUserFilter(filter)) {
                 QmlMetadata *newMeta = MAIN.filterController()->metadataForService(filter);
                 if (newMeta && newMeta->isAudio()) {
                     videoClip.detach(*filter);
@@ -2142,8 +2141,7 @@ void DetachAudioCommand::redo()
         // Remove video filters from the audio clip.
         for (int i = 0; i < audioClip.filter_count(); i++) {
             Mlt::Filter *filter = audioClip.filter(i);
-            if (filter && filter->is_valid() && !filter->get_int("_loader")
-                && !filter->get_int(kShotcutHiddenProperty)) {
+            if (Util::isUserFilter(filter)) {
                 QmlMetadata *newMeta = MAIN.filterController()->metadataForService(filter);
                 if (newMeta && !newMeta->isAudio()) {
                     audioClip.detach(*filter);
@@ -2385,8 +2383,7 @@ void ApplyFiltersCommand::redo()
     QList<QmlMetadata *> m_applyMeta;
     for (int i = 0; i < filtersProducer.filter_count(); i++) {
         Mlt::Filter *filter = filtersProducer.filter(i);
-        if (filter && filter->is_valid() && !filter->get_int("_loader")
-            && !filter->get_int(kShotcutHiddenProperty)) {
+        if (Util::isUserFilter(filter)) {
             m_applyMeta.append(MAIN.filterController()->metadataForService(filter));
         }
         delete filter;
@@ -2398,8 +2395,7 @@ void ApplyFiltersCommand::redo()
             // Remove any filters that would be duplicated by the new filters
             for (int i = 0; i < clipInfo->producer->filter_count(); i++) {
                 Mlt::Filter *filter = clipInfo->producer->filter(i);
-                if (filter && filter->is_valid() && !filter->get_int("_loader")
-                    && !filter->get_int(kShotcutHiddenProperty)) {
+                if (Util::isUserFilter(filter)) {
                     QmlMetadata *currentMeta = MAIN.filterController()->metadataForService(filter);
                     for (int j = 0; j < m_applyMeta.size(); j++) {
                         if (m_applyMeta[j] == currentMeta) {
@@ -2430,8 +2426,7 @@ void ApplyFiltersCommand::undo()
             // Remove existing filters
             for (int i = 0; i < clipInfo->producer->filter_count(); i++) {
                 Mlt::Filter *filter = clipInfo->producer->filter(i);
-                if (filter && filter->is_valid() && !filter->get_int("_loader")
-                    && !filter->get_int(kShotcutHiddenProperty)) {
+                if (Util::isUserFilter(filter)) {
                     clipInfo->producer->detach(*filter);
                     i--;
                 }
@@ -2486,6 +2481,40 @@ bool ChangeGainCommand::mergeWith(const QUndoCommand *other)
         || (!that->m_gain && m_gain != that->m_gain))
         return false;
     m_gain = static_cast<const ChangeGainCommand *>(other)->m_gain;
+    return true;
+}
+
+ChangeTrackGainCommand::ChangeTrackGainCommand(MultitrackModel &model,
+                                               int trackIndex,
+                                               double gain,
+                                               QUndoCommand *parent)
+    : QUndoCommand(parent)
+    , m_model(model)
+    , m_trackIndex(qBound(0, trackIndex, qMax(model.rowCount() - 1, 0)))
+    , m_gain(gain)
+    , m_previous(model.data(model.index(trackIndex), MultitrackModel::GainRole).toDouble())
+{
+    setText(QObject::tr("Adjust track gain/volume"));
+}
+
+void ChangeTrackGainCommand::redo()
+{
+    LOG_DEBUG() << "trackIndex" << m_trackIndex << "gain" << m_gain;
+    m_model.setTrackGain(m_trackIndex, m_gain);
+}
+
+void ChangeTrackGainCommand::undo()
+{
+    LOG_DEBUG() << "trackIndex" << m_trackIndex << "gain" << m_previous;
+    m_model.setTrackGain(m_trackIndex, m_previous);
+}
+
+bool ChangeTrackGainCommand::mergeWith(const QUndoCommand *other)
+{
+    const ChangeTrackGainCommand *that = static_cast<const ChangeTrackGainCommand *>(other);
+    if (that->id() != id() || that->m_trackIndex != m_trackIndex)
+        return false;
+    m_gain = that->m_gain;
     return true;
 }
 

--- a/src/commands/timelinecommands.h
+++ b/src/commands/timelinecommands.h
@@ -48,6 +48,7 @@ enum {
     UndoIdMoveClip,
     UndoIdChangeGain,
     UndoIdChangeTransitionProperty,
+    UndoIdChangeTrackGain,
 };
 
 struct ClipPosition
@@ -936,6 +937,27 @@ private:
     MultitrackModel &m_model;
     int m_trackIndex;
     int m_clipIndex;
+    double m_gain;
+    double m_previous;
+};
+
+class ChangeTrackGainCommand : public QUndoCommand
+{
+public:
+    ChangeTrackGainCommand(MultitrackModel &model,
+                           int trackIndex,
+                           double gain,
+                           QUndoCommand *parent = 0);
+    void redo();
+    void undo();
+
+protected:
+    int id() const { return UndoIdChangeTrackGain; }
+    bool mergeWith(const QUndoCommand *other);
+
+private:
+    MultitrackModel &m_model;
+    int m_trackIndex;
     double m_gain;
     double m_previous;
 };

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -691,7 +691,7 @@ void TimelineDock::setupActions()
     connect(action, &QAction::triggered, this, [&]() {
         if (!isMultitrackValid() || !isVisible())
             return;
-        m_model.setTrackHeight(50);
+        m_model.setTrackHeight(60);
     });
     Actions.add("timelineResetTrackHeightAction", action);
 

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -2641,11 +2641,14 @@ void TimelineDock::applyCopiedFiltersToSelectdClips()
 
 void TimelineDock::onShowFrame(const SharedFrame &frame)
 {
-    if (m_ignoreNextPositionChange) {
-        m_ignoreNextPositionChange = false;
-    } else if (MLT.isMultitrack() && m_position != frame.get_position() && m_model.tractor()) {
-        m_position = qMin(frame.get_position(), m_model.tractor()->get_length());
-        emit positionChanged(m_position);
+    if (MLT.isMultitrack() && m_model.tractor()) {
+        m_model.updateTrackAudioLevels(frame);
+        if (m_ignoreNextPositionChange) {
+            m_ignoreNextPositionChange = false;
+        } else if (m_position != frame.get_position()) {
+            m_position = qMin(frame.get_position(), m_model.tractor()->get_length());
+            emit positionChanged(m_position);
+        }
     }
 }
 
@@ -2653,6 +2656,7 @@ void TimelineDock::onSeeked(int position)
 {
     if (MLT.isMultitrack() && m_position != position) {
         m_position = qMin(position, m_model.tractor()->get_length());
+        m_model.clearTrackAudioLevels();
         emit positionChanged(m_position);
     }
 }
@@ -3864,6 +3868,20 @@ void TimelineDock::toggleOtherTracksMute(int trackIndex)
         }
     }
     MAIN.undoStack()->endMacro();
+}
+
+bool TimelineDock::setTrackGain(int trackIndex, double gain)
+{
+    if (isTrackLocked(trackIndex)) {
+        emit warnTrackLocked(trackIndex);
+        return false;
+    }
+    if (trackIndex < 0 || trackIndex >= m_model.rowCount())
+        return false;
+
+    MAIN.undoStack()->push(new Timeline::ChangeTrackGainCommand(m_model, trackIndex, gain));
+    emit gainChanged(gain);
+    return true;
 }
 
 /*!

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -691,7 +691,7 @@ void TimelineDock::setupActions()
     connect(action, &QAction::triggered, this, [&]() {
         if (!isMultitrackValid() || !isVisible())
             return;
-        m_model.setTrackHeight(60);
+        m_model.setTrackHeight(50);
     });
     Actions.add("timelineResetTrackHeightAction", action);
 

--- a/src/docks/timelinedock.h
+++ b/src/docks/timelinedock.h
@@ -155,6 +155,7 @@ public slots:
     void toggleOtherTracksHidden(int trackIndex);
     void setTrackComposite(int trackIndex, bool composite);
     void setTrackLock(int trackIndex, bool lock);
+    bool setTrackGain(int trackIndex, double gain);
     bool moveClip(int fromTrack, int toTrack, int clipIndex, int position, bool ripple);
     void onClipMoved(int fromTrack, int toTrack, int clipIndex, int position, bool ripple);
     bool trimClipIn(

--- a/src/mltcontroller.cpp
+++ b/src/mltcontroller.cpp
@@ -1129,7 +1129,7 @@ Producer *Controller::setupNewProducer(Producer *newProducer) const
             int i = 0;
             QScopedPointer<Mlt::Filter> filter(newProducer->filter(i));
             while (filter && filter->is_valid()) {
-                if (!filter->get_int("_loader") && !filter->get_int(kShotcutHiddenProperty)) {
+                if (Util::isUserFilter(filter.data())) {
                     newProducer->detach(*filter);
                     chain->Service::attach(*filter);
                 } else {
@@ -1167,8 +1167,7 @@ static int indexOfFirstNonGpu(Producer &toProducer)
 {
     for (int i = 0; i < toProducer.filter_count(); i++) {
         QScopedPointer<Mlt::Filter> filter(toProducer.filter(i));
-        if (filter && filter->is_valid() && !filter->get_int("_loader")
-            && !filter->get_int(kShotcutHiddenProperty) && filter->get("mlt_service")) {
+        if (Util::isUserFilter(filter.data()) && filter->get("mlt_service")) {
             if (!QString::fromLatin1(filter->get("mlt_service")).startsWith("movit."))
                 return i;
         }
@@ -1176,8 +1175,7 @@ static int indexOfFirstNonGpu(Producer &toProducer)
     Mlt::Chain toChain(toProducer);
     for (int i = 0; i < toChain.link_count(); i++) {
         QScopedPointer<Mlt::Link> link(toChain.link(i));
-        if (link && link->is_valid() && !link->get_int("_loader")
-            && !link->get_int(kShotcutHiddenProperty) && link->get("mlt_service")) {
+        if (Util::isUserLink(link.data()) && link->get("mlt_service")) {
             if (!QString::fromLatin1(link->get("mlt_service")).startsWith("movit."))
                 return i;
         }
@@ -1202,8 +1200,7 @@ void Controller::copyFilters(Producer &fromProducer,
 
     for (int i = 0; i < count; i++) {
         QScopedPointer<Mlt::Filter> fromFilter(fromProducer.filter(i));
-        if (fromFilter && fromFilter->is_valid() && !fromFilter->get_int("_loader")
-            && !fromFilter->get_int(kShotcutHiddenProperty) && fromFilter->get("mlt_service")) {
+        if (Util::isUserFilter(fromFilter.data()) && fromFilter->get("mlt_service")) {
             filterCount++;
             if (filterIndex >= 0 && filterIndex != (filterCount - 1)) {
                 continue;
@@ -1222,7 +1219,7 @@ void Controller::copyFilters(Producer &fromProducer,
                 if (!metadata->allowMultiple()) {
                     std::unique_ptr<Mlt::Filter> existing(
                         getFilter(metadata->uniqueId(), &toProducer));
-                    if (existing && !existing->get_int("_loader")) {
+                    if (Util::isUserFilter(existing.get())) {
                         continue;
                     }
                 }
@@ -1259,7 +1256,7 @@ void Controller::copyFilters(Producer &fromProducer,
         for (int i = 0; i < count; i++) {
             QScopedPointer<Mlt::Link> fromLink(fromChain.link(i));
             if (fromLink && fromLink->is_valid() && fromLink->get("mlt_service")
-                && !fromLink->get_int("_loader")) {
+                && Util::isUserLink(fromLink.data())) {
                 filterCount++;
                 if (filterIndex >= 0 && filterIndex != (filterCount - 1)) {
                     continue;
@@ -1329,7 +1326,7 @@ void Controller::adjustFilters(Producer &producer, int index)
                 // Convert legacy fadeIn filters.
                 filter->set(kShotcutAnimOutProperty, filter->get_length());
             }
-            if (!filter->get_int("_loader") && !filter->get_int(kShotcutHiddenProperty)) {
+            if (Util::isUserFilter(filter.data())) {
                 int filterIn = in;
                 int filterOut = out;
                 if (filter->get(kFilterInProperty))
@@ -1536,8 +1533,7 @@ void Controller::adjustFilter(
                 filter->anim_set("level", -60, filter->get_length() - 1);
             }
             emit MAIN.serviceInChanged(inDelta, filter);
-        } else if (!filter->get_int("_loader") && !filter->get_int(kShotcutHiddenProperty)
-                   && filter->get_in() <= in) {
+        } else if (Util::isUserFilter(filter) && filter->get_in() <= in) {
             filter->set_in_and_out(in + inDelta, filter->get_out());
             emit MAIN.serviceInChanged(inDelta, filter);
         }
@@ -1576,8 +1572,7 @@ void Controller::adjustFilter(
                 filter->anim_set("level", -60, filter->get_length() - 1);
             }
             emit MAIN.serviceOutChanged(outDelta, filter);
-        } else if (!filter->get_int("_loader") && !filter->get_int(kShotcutHiddenProperty)
-                   && filter->get_out() >= out) {
+        } else if (Util::isUserFilter(filter) && filter->get_out() >= out) {
             filter->set_in_and_out(filter->get_in(), out - outDelta);
             emit MAIN.serviceOutChanged(outDelta, filter);
 

--- a/src/models/attachedfiltersmodel.cpp
+++ b/src/models/attachedfiltersmodel.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2025 Meltytech, LLC
+ * Copyright (c) 2013-2026 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -54,36 +54,60 @@ static int sortOrder(const QmlMetadata *meta)
     return 2;
 }
 
-static int normalFilterCount(Mlt::Producer *producer)
+static int firstUserFilterIndex(Mlt::Producer *producer)
+{
+    if (producer && producer->is_valid()) {
+        for (int i = 0; i < producer->filter_count(); i++) {
+            Mlt::Filter *filter = producer->filter(i);
+            bool preUser = Util::isPreUserFilter(filter);
+            delete filter;
+            if (!preUser)
+                return i;
+        }
+        return producer->filter_count();
+    }
+    return 0;
+}
+
+static int userFilterCount(Mlt::Producer *producer)
 {
     int count = 0;
     if (producer && producer->is_valid()) {
         for (int i = 0; i < producer->filter_count(); i++) {
             Mlt::Filter *filter = producer->filter(i);
-            if (filter->is_valid()
-                && (filter->get_int("_loader") || filter->get_int(kShotcutHiddenProperty))) {
+            if (Util::isUserFilter(filter))
                 count++;
-            } else {
-                i = producer->filter_count();
-            }
             delete filter;
         }
     }
     return count;
 }
 
-static int normalLinkCount(Mlt::Producer *producer)
+static int firstUserLinkIndex(Mlt::Producer *producer)
+{
+    if (producer && producer->is_valid() && producer->type() == mlt_service_chain_type) {
+        Mlt::Chain chain(*producer);
+        for (int i = 0; i < chain.link_count(); i++) {
+            Mlt::Link *link = chain.link(i);
+            bool userLink = Util::isUserLink(link);
+            delete link;
+            if (userLink)
+                return i;
+        }
+        return chain.link_count();
+    }
+    return 0;
+}
+
+static int userLinkCount(Mlt::Producer *producer)
 {
     int count = 0;
     if (producer && producer->is_valid() && producer->type() == mlt_service_chain_type) {
         Mlt::Chain chain(*producer);
         for (int i = 0; i < chain.link_count(); i++) {
             Mlt::Link *link = chain.link(i);
-            if (link->is_valid() && link->get_int("_loader")) {
+            if (Util::isUserLink(link))
                 count++;
-            } else {
-                i = chain.link_count();
-            }
             delete link;
         }
     }
@@ -95,15 +119,16 @@ static int mltFilterIndex(Mlt::Producer *producer, int row)
     if (row >= 0 && producer && producer->is_valid()) {
         int linkCount = 0;
         if (producer->type() == mlt_service_chain_type) {
-            Mlt::Chain chain(*producer);
-            linkCount = chain.link_count() - normalLinkCount(producer);
+            linkCount = userLinkCount(producer);
             if (row < linkCount) {
                 // This row refers to an MLT link, not a filter
                 return -1;
             }
         }
-        int mltIndex = normalFilterCount(producer) + row - linkCount;
-        if (mltIndex >= 0 && mltIndex < producer->filter_count()) {
+        int userRow = row - linkCount;
+        int mltIndex = firstUserFilterIndex(producer) + userRow;
+        if (userRow >= 0 && userRow < userFilterCount(producer) && mltIndex >= 0
+            && mltIndex < producer->filter_count()) {
             return mltIndex;
         }
     }
@@ -113,9 +138,8 @@ static int mltFilterIndex(Mlt::Producer *producer, int row)
 static int mltLinkIndex(Mlt::Producer *producer, int row)
 {
     if (row >= 0 && producer && producer->is_valid() && producer->type() == mlt_service_chain_type) {
-        Mlt::Chain chain(*producer);
-        int mltIndex = normalLinkCount(producer) + row;
-        if (mltIndex >= 0 && mltIndex < chain.link_count()) {
+        int mltIndex = firstUserLinkIndex(producer) + row;
+        if (row >= 0 && row < userLinkCount(producer) && mltIndex >= 0) {
             return mltIndex;
         }
     }
@@ -563,8 +587,7 @@ int AttachedFiltersModel::add(QmlMetadata *meta)
         int adjustFrom = m_producer->filter_count();
         for (int i = 0; i < filterSetProducer.filter_count(); i++) {
             Mlt::Filter *filter = filterSetProducer.filter(i);
-            if (filter->is_valid() && !filter->get_int("_loader")
-                && !filter->get_int(kShotcutHiddenProperty)) {
+            if (Util::isUserFilter(filter)) {
                 QmlMetadata *tmpMeta = MAIN.filterController()->metadataForService(filter);
                 insertRow = findInsertRow(tmpMeta);
                 if (!meta->objectName().isEmpty())
@@ -648,11 +671,9 @@ void AttachedFiltersModel::doAddService(Mlt::Producer &producer, Mlt::Service &s
     case mlt_service_filter_type: {
         int linkRows = 0;
         if (producer.type() == mlt_service_chain_type) {
-            Mlt::Chain chain(producer);
-            linkRows = chain.link_count() - normalLinkCount(&producer);
+            linkRows = userLinkCount(&producer);
         }
-        int normFilterCount = normalFilterCount(&producer);
-        int mltIndex = normFilterCount + row - linkRows;
+        int mltIndex = firstUserFilterIndex(&producer) + row - linkRows;
         if (mltIndex < 0) {
             LOG_ERROR() << "Invalid MLT index" << row;
             return;
@@ -681,8 +702,7 @@ void AttachedFiltersModel::doAddService(Mlt::Producer &producer, Mlt::Service &s
             return;
         }
         Mlt::Chain chain(producer);
-        int normLinkCount = normalLinkCount(&producer);
-        int mltIndex = normLinkCount + row;
+        int mltIndex = firstUserLinkIndex(&producer) + row;
         Mlt::Link link(service);
         if (isProducerLoaded(producer)) {
             beginInsertRows(QModelIndex(), row, row);
@@ -830,7 +850,7 @@ void AttachedFiltersModel::reset(Mlt::Producer *producer)
             for (int i = 0; i < count; i++) {
                 Mlt::Link *link = chain.link(i);
                 if (link && link->is_valid()) {
-                    if (!link->get_int("_loader")) {
+                    if (Util::isUserLink(link)) {
                         QmlMetadata *newMeta = MAIN.filterController()->metadataForService(link);
                         m_metaList.append(newMeta);
                     }
@@ -841,8 +861,7 @@ void AttachedFiltersModel::reset(Mlt::Producer *producer)
         count = m_producer->filter_count();
         for (int i = 0; i < count; i++) {
             Mlt::Filter *filter = m_producer->filter(i);
-            if (filter && filter->is_valid() && !filter->get_int("_loader")
-                && !filter->get_int(kShotcutHiddenProperty)) {
+            if (Util::isUserFilter(filter)) {
                 QmlMetadata *newMeta = MAIN.filterController()->metadataForService(filter);
                 m_metaList.append(newMeta);
             }

--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -1013,8 +1013,9 @@ bool MultitrackModel::trimClipOutValid(int trackIndex, int clipIndex, int delta,
 
 int MultitrackModel::trackHeight() const
 {
-    int result = m_tractor ? m_tractor->get_int(kTrackHeightProperty)
-                           : Settings.timelineTrackHeight();
+    int result = (m_tractor && m_tractor->property_exists(kTrackHeightProperty))
+                     ? m_tractor->get_int(kTrackHeightProperty)
+                     : Settings.timelineTrackHeight();
     return qBound(10, result ? result : Settings.timelineTrackHeight(), 150);
 }
 

--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -28,6 +28,7 @@
 #include "proxymanager.h"
 #include "qmltypes/qmlmetadata.h"
 #include "settings.h"
+#include "sharedframe.h"
 #include "shotcut_mlt_properties.h"
 #include "util.h"
 
@@ -37,8 +38,86 @@
 #include <QTimer>
 #include <qmath.h>
 
+#include <cmath>
+
 static const quintptr NO_PARENT_ID = quintptr(-1);
 static const char *kShotcutDefaultTransition = "lumaMix";
+
+static QByteArray trackAudioLevelPrefix(int mltTrackIndex)
+{
+    return QStringLiteral("meta.track.%1.audio_level.").arg(mltTrackIndex).toLatin1();
+}
+
+static double audioLevelDbFromFilter(Mlt::Filter *filter)
+{
+    static const char *kAudioLevelLeft = "_audio_level.0";
+    static const char *kAudioLevelRight = "_audio_level.1";
+
+    if (!filter || !filter->is_valid())
+        return -100.0;
+
+    double left = filter->get_double(kAudioLevelLeft);
+    double right = filter->get_double(kAudioLevelRight);
+
+    double linear = qMax(left, right);
+    if (linear <= 0.0)
+        return -100.0;
+
+    double level = 20.0 * log10(qMin(linear, 1.0));
+    return qRound(level * 10.0) / 10.0;
+}
+
+static int firstPostUserHiddenFilterIndex(Mlt::Service *service)
+{
+    if (!service || !service->is_valid())
+        return 0;
+    const int count = service->filter_count();
+    for (int i = 0; i < count; i++) {
+        QScopedPointer<Mlt::Filter> filter(service->filter(i));
+        if (Util::isPostUserFilter(filter.data()))
+            return i;
+    }
+    return count;
+}
+
+static int filterIndexByShotcutName(Mlt::Service *service, const char *name)
+{
+    if (!service || !service->is_valid() || !name)
+        return -1;
+    const int count = service->filter_count();
+    for (int i = 0; i < count; i++) {
+        QScopedPointer<Mlt::Filter> filter(service->filter(i));
+        if (filter && filter->is_valid() && !qstrcmp(filter->get(kShotcutFilterProperty), name))
+            return i;
+    }
+    return -1;
+}
+
+static double audioLevelDbFromLinear(double left, double right)
+{
+    double linear = qMax(left, right);
+    if (linear <= 0.0)
+        return -100.0;
+
+    double level = 20.0 * log10(qMin(linear, 1.0));
+    return qRound(level * 10.0) / 10.0;
+}
+
+static bool hasTrackLevelIndicatorSupport()
+{
+    if (LIBMLT_VERSION_INT >= ((7 << 16) + (41 << 8)))
+        return true;
+
+    QScopedPointer<Mlt::Properties> audioLevelMetadata(
+        MLT.repository()->metadata(mlt_service_filter_type, "audiolevel"));
+    if (!audioLevelMetadata || !audioLevelMetadata->is_valid()
+        || !audioLevelMetadata->get("version"))
+        return false;
+
+    bool ok = false;
+    int version = QString::fromLatin1(audioLevelMetadata->get("version")).toInt(&ok);
+    return ok && version >= 4;
+}
 
 /*!
     \qmltype MultitrackModel
@@ -127,11 +206,17 @@ MultitrackModel::MultitrackModel(QObject *parent)
     : QAbstractItemModel(parent)
     , m_tractor(0)
     , m_isMakingTransition(false)
+    , m_trackLevelIndicatorSupported(hasTrackLevelIndicatorSupport())
 {
     connect(this, SIGNAL(modified()), SLOT(adjustBackgroundDuration()));
     connect(this, SIGNAL(modified()), SLOT(adjustTrackFilters()));
     connect(this, SIGNAL(reloadRequested()), SLOT(reload()), Qt::QueuedConnection);
     connect(this, &MultitrackModel::created, this, &MultitrackModel::scaleFactorChanged);
+}
+
+bool MultitrackModel::trackLevelIndicatorSupported() const
+{
+    return m_trackLevelIndicatorSupported;
 }
 
 MultitrackModel::~MultitrackModel()
@@ -328,6 +413,8 @@ QVariant MultitrackModel::data(const QModelIndex &index, int role) const
                 return playlist.get_int("hide") & 1;
             case IsAudioRole:
                 return m_trackList[index.row()].type == AudioTrackType;
+            case AudioLevelRole:
+                return m_trackList[index.row()].audioLevel;
             case IsLockedRole:
                 return track->get_int(kTrackLockProperty);
             case IsCompositeRole: {
@@ -340,6 +427,21 @@ QVariant MultitrackModel::data(const QModelIndex &index, int role) const
             }
             case IsFilteredRole:
                 return isFiltered(track.data());
+            case GainEnabledRole:
+            case GainRole: {
+                QScopedPointer<Mlt::Filter> filter(getFilter("audioGain", track.data()));
+                if (filter && filter->is_valid()) {
+                    Mlt::Animation anim = filter->get_animation("level");
+                    bool enabled = anim.key_count() < 2;
+                    if (GainEnabledRole == role)
+                        return enabled;
+                    if (enabled)
+                        return filter->get_double("level");
+                } else if (GainEnabledRole == role) {
+                    return true;
+                }
+                return 0.0;
+            }
             case IsTopVideoRole:
                 if (m_trackList[index.row()].type == AudioTrackType)
                     return false;
@@ -422,6 +524,7 @@ QHash<int, QByteArray> MultitrackModel::roleNames() const
     roles[IsMuteRole] = "mute";
     roles[IsHiddenRole] = "hidden";
     roles[IsAudioRole] = "audio";
+    roles[AudioLevelRole] = "audioLevel";
     roles[AudioLevelsRole] = "audioLevels";
     roles[IsCompositeRole] = "composite";
     roles[IsLockedRole] = "locked";
@@ -580,6 +683,142 @@ void MultitrackModel::setTrackLock(int row, bool lock)
         emit dataChanged(modelIndex, modelIndex, roles);
         emit modified();
     }
+}
+
+void MultitrackModel::setTrackGain(int row, double gain)
+{
+    if (row < 0 || row >= m_trackList.size())
+        return;
+
+    int i = m_trackList.at(row).mlt_index;
+    QScopedPointer<Mlt::Producer> track(m_tractor->track(i));
+    if (!track)
+        return;
+
+    std::unique_ptr<Mlt::Filter> filter(getFilter("audioGain", track.data()));
+    if (!filter) {
+        Mlt::Filter newFilter(MLT.profile(), "volume");
+        if (!newFilter.is_valid())
+            return;
+        newFilter.set(kShotcutFilterProperty, "audioGain");
+        newFilter.set(kShotcutHiddenProperty, 1);
+        newFilter.set(kShotcutHiddenPositionProperty, kShotcutHiddenPositionPost);
+        newFilter.set_in_and_out(0, qMax(track->get_length() - 1, 0));
+        track->attach(newFilter);
+        track->move_filter(track->filter_count() - 1, firstPostUserHiddenFilterIndex(track.data()));
+        filter.reset(new Mlt::Filter(newFilter));
+    }
+
+    filter->clear("level");
+    filter->set("level", gain);
+
+    std::unique_ptr<Mlt::Filter> levelFilter(ensureTrackAudioLevelFilter(track.data(), i));
+    Q_UNUSED(levelFilter)
+
+    MLT.refreshConsumer();
+
+    QModelIndex modelIndex = index(row, 0);
+    QVector<int> roles;
+    roles << GainRole;
+    roles << GainEnabledRole;
+    emit dataChanged(modelIndex, modelIndex, roles);
+    emit modified();
+}
+
+void MultitrackModel::updateTrackAudioLevels(const SharedFrame &frame)
+{
+    if (!m_trackLevelIndicatorSupported || !m_tractor || !frame.is_valid())
+        return;
+
+    for (int row = 0; row < m_trackList.size(); ++row) {
+        const int mltTrackIndex = m_trackList[row].mlt_index;
+        const QByteArray leftKey
+            = QStringLiteral("meta.track.%1.audio_level.0").arg(mltTrackIndex).toLatin1();
+        const QByteArray rightKey
+            = QStringLiteral("meta.track.%1.audio_level.1").arg(mltTrackIndex).toLatin1();
+        const double left = frame.get_double(leftKey.constData());
+        const double right = frame.get_double(rightKey.constData());
+        const double audioLevel = audioLevelDbFromLinear(left, right);
+
+        setTrackAudioLevel(row, audioLevel);
+    }
+}
+
+void MultitrackModel::clearTrackAudioLevels()
+{
+    if (!m_trackLevelIndicatorSupported)
+        return;
+
+    for (int row = 0; row < m_trackList.size(); ++row)
+        setTrackAudioLevel(row, -100.0);
+}
+
+Mlt::Filter *MultitrackModel::ensureTrackAudioLevelFilter(Mlt::Producer *track,
+                                                          int mltTrackIndex) const
+{
+    if (!track || !track->is_valid())
+        return nullptr;
+
+    std::unique_ptr<Mlt::Filter> levelFilter(getFilter("audioLevel", track));
+    const QByteArray prefix = trackAudioLevelPrefix(mltTrackIndex);
+    if (!levelFilter) {
+        Mlt::Filter newFilter(MLT.profile(), "audiolevel");
+        if (!newFilter.is_valid())
+            return nullptr;
+        newFilter.set(kShotcutFilterProperty, "audioLevel");
+        newFilter.set(kShotcutHiddenProperty, 1);
+        newFilter.set(kShotcutHiddenPositionProperty, kShotcutHiddenPositionPost);
+        newFilter.set("prefix", prefix.constData());
+        newFilter.set_in_and_out(0, qMax(track->get_length() - 1, 0));
+        track->attach(newFilter);
+        int target = firstPostUserHiddenFilterIndex(track);
+        const int gainIndex = filterIndexByShotcutName(track, "audioGain");
+        if (gainIndex >= target)
+            target = gainIndex + 1;
+        target = qBound(0, target, qMax(track->filter_count() - 1, 0));
+        track->move_filter(track->filter_count() - 1, target);
+
+        levelFilter.reset(getFilter("audioLevel", track));
+    }
+    if (levelFilter && levelFilter->is_valid()) {
+        levelFilter->set("prefix", prefix.constData());
+
+        // Keep audio level metering after gain so indicator reflects the track volume slider.
+        const int gainIndex = filterIndexByShotcutName(track, "audioGain");
+        const int levelIndex = filterIndexByShotcutName(track, "audioLevel");
+        if (gainIndex >= 0 && levelIndex >= 0 && levelIndex < gainIndex) {
+            int target = qBound(0, gainIndex + 1, qMax(track->filter_count() - 1, 0));
+            track->move_filter(levelIndex, target);
+        }
+    }
+
+    return levelFilter.release();
+}
+
+void MultitrackModel::syncTrackAudioLevelFilterPrefixes()
+{
+    if (!m_trackLevelIndicatorSupported || !m_tractor)
+        return;
+
+    for (int row = 0; row < m_trackList.size(); ++row) {
+        const int mltTrackIndex = m_trackList[row].mlt_index;
+        QScopedPointer<Mlt::Producer> track(m_tractor->track(mltTrackIndex));
+        std::unique_ptr<Mlt::Filter> levelFilter(
+            ensureTrackAudioLevelFilter(track.data(), mltTrackIndex));
+        Q_UNUSED(levelFilter)
+    }
+}
+
+void MultitrackModel::setTrackAudioLevel(int row, double audioLevel)
+{
+    if (row < 0 || row >= m_trackList.size())
+        return;
+    if (qFuzzyCompare(m_trackList[row].audioLevel + 1.0, audioLevel + 1.0))
+        return;
+
+    m_trackList[row].audioLevel = audioLevel;
+    QModelIndex modelIndex = index(row, 0);
+    emit dataChanged(modelIndex, modelIndex, {AudioLevelRole});
 }
 
 bool MultitrackModel::trimClipInValid(int trackIndex, int clipIndex, int delta, bool ripple)
@@ -1685,8 +1924,7 @@ static void moveBeforeFirstAudioFilter(Mlt::Producer *producer)
     int index = 0;
     for (; index < n; index++) {
         QScopedPointer<Mlt::Filter> filter(producer->filter(index));
-        if (filter && filter->is_valid() && !filter->get_int("_loader")
-            && !filter->get_int(kShotcutHiddenProperty)) {
+        if (Util::isUserFilter(filter.data())) {
             QmlMetadata *meta = MAIN.filterController()->metadataForService(filter.data());
             if (meta && meta->isAudio()) {
                 break;
@@ -2930,8 +3168,7 @@ void MultitrackModel::adjustServiceFilterDurations(Mlt::Service &service, int du
         int n = service.filter_count();
         for (int i = 0; i < n; i++) {
             QScopedPointer<Mlt::Filter> filter(service.filter(i));
-            if (filter && filter->is_valid() && !filter->get_int("_loader")
-                && !filter->get_int(kShotcutHiddenProperty)) {
+            if (Util::isUserFilter(filter.data())) {
                 int in = filter->get_in();
                 int out = filter->get_out();
                 // Only change out if it is pinned (same as old track duration)
@@ -3201,6 +3438,7 @@ int MultitrackModel::addAudioTrack()
     m_trackList.append(t);
     reorderMixTransitions();
     endInsertRows();
+    syncTrackAudioLevelFilterPrefixes();
     emit modified();
     return m_trackList.count() - 1;
 }
@@ -3266,6 +3504,7 @@ int MultitrackModel::addVideoTrack()
     m_trackList.prepend(t);
     reorderMixTransitions();
     endInsertRows();
+    syncTrackAudioLevelFilterPrefixes();
     emit modified();
     return 0;
 }
@@ -3339,6 +3578,7 @@ void MultitrackModel::removeTrack(int trackIndex)
         reorderMixTransitions();
         endRemoveRows();
         MLT.updateAvformatCaching(m_tractor->count());
+        syncTrackAudioLevelFilterPrefixes();
         //        foreach (Track t, m_trackList) LOG_DEBUG() << (t.type == VideoTrackType?"Video":"Audio") << "track number" << t.number << "mlt_index" << t.mlt_index;
     }
     emit modified();
@@ -3580,6 +3820,7 @@ void MultitrackModel::insertTrack(int trackIndex, TrackType type)
     refreshVideoBlendTransitions();
     reorderMixTransitions();
     endInsertRows();
+    syncTrackAudioLevelFilterPrefixes();
     emit modified();
     //    foreach (Track t, m_trackList) LOG_DEBUG() << (t.type == VideoTrackType?"Video":"Audio") << "track number" << t.number << "mlt_index" << t.mlt_index;
 }
@@ -3697,6 +3938,7 @@ void MultitrackModel::moveTrack(int fromTrackIndex, int toTrackIndex)
     m_trackList.clear();
     refreshTrackList();
     reorderMixTransitions();
+    syncTrackAudioLevelFilterPrefixes();
 
     endMoveRows();
     emit dataChanged(index(0),
@@ -3794,8 +4036,7 @@ bool MultitrackModel::isFiltered(Mlt::Producer *producer) const
         int count = producer->filter_count();
         for (int i = 0; i < count; i++) {
             QScopedPointer<Mlt::Filter> filter(producer->filter(i));
-            if (filter && filter->is_valid() && !filter->get_int("_loader")
-                && !filter->get_int(kShotcutHiddenProperty))
+            if (Util::isUserFilter(filter.data()))
                 return true;
         }
     }
@@ -4054,6 +4295,8 @@ void MultitrackModel::refreshTrackList()
             }
         }
     }
+
+    syncTrackAudioLevelFilterPrefixes();
 }
 
 void MultitrackModel::getAudioLevels()

--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -207,6 +207,7 @@ MultitrackModel::MultitrackModel(QObject *parent)
     , m_tractor(0)
     , m_isMakingTransition(false)
     , m_trackLevelIndicatorSupported(hasTrackLevelIndicatorSupport())
+    , m_hasAudioTracks(false)
 {
     connect(this, SIGNAL(modified()), SLOT(adjustBackgroundDuration()));
     connect(this, SIGNAL(modified()), SLOT(adjustTrackFilters()));
@@ -217,6 +218,11 @@ MultitrackModel::MultitrackModel(QObject *parent)
 bool MultitrackModel::trackLevelIndicatorSupported() const
 {
     return m_trackLevelIndicatorSupported;
+}
+
+bool MultitrackModel::hasAudioTracks() const
+{
+    return m_hasAudioTracks;
 }
 
 MultitrackModel::~MultitrackModel()
@@ -1031,7 +1037,7 @@ int MultitrackModel::trackHeaderWidth() const
 {
     return (m_tractor && m_tractor->property_exists(kTrackHeaderWidthProperty))
                ? m_tractor->get_int(kTrackHeaderWidthProperty)
-               : 150;
+               : 165;
 }
 
 void MultitrackModel::setTrackHeaderWidth(int width)
@@ -4230,6 +4236,7 @@ void MultitrackModel::refreshTrackList()
     int a = 0;
     int v = 0;
     bool isKdenlive = false;
+    bool hasAudioTracks = false;
 
     // Add video tracks in reverse order.
     for (int i = 0; i < n; ++i) {
@@ -4286,6 +4293,7 @@ void MultitrackModel::refreshTrackList()
                 t.mlt_index = i;
                 t.type = AudioTrackType;
                 t.number = a++;
+                hasAudioTracks = true;
                 QString trackName = track->get(kTrackNameProperty);
                 if (trackName.isEmpty())
                     trackName = QStringLiteral("A%1").arg(a);
@@ -4294,6 +4302,11 @@ void MultitrackModel::refreshTrackList()
                 //                LOG_DEBUG() << __FUNCTION__ << QString(track->get("id")) << i;
             }
         }
+    }
+
+    if (m_hasAudioTracks != hasAudioTracks) {
+        m_hasAudioTracks = hasAudioTracks;
+        emit hasAudioTracksChanged();
     }
 
     syncTrackAudioLevelFilterPrefixes();

--- a/src/models/multitrackmodel.h
+++ b/src/models/multitrackmodel.h
@@ -56,6 +56,7 @@ class MultitrackModel : public QAbstractItemModel
     Q_PROPERTY(double scaleFactor READ scaleFactor WRITE setScaleFactor NOTIFY scaleFactorChanged)
     Q_PROPERTY(bool filtered READ isFiltered NOTIFY filteredChanged)
     Q_PROPERTY(bool trackLevelIndicatorSupported READ trackLevelIndicatorSupported CONSTANT)
+    Q_PROPERTY(bool hasAudioTracks READ hasAudioTracks NOTIFY hasAudioTracksChanged)
 
 public:
     /// Two level model: tracks and clips on track
@@ -141,6 +142,7 @@ public:
     bool checkForEmptyTracks(int trackIndex);
     QString trackTransitionService();
     bool trackLevelIndicatorSupported() const;
+    bool hasAudioTracks() const;
 
 signals:
     void created();
@@ -154,6 +156,7 @@ signals:
     void showStatusMessage(QString);
     void durationChanged();
     void filteredChanged();
+    void hasAudioTracksChanged();
     void reloadRequested();
     void appended(int trackIndex, int clipIndex);
     void inserted(int trackIndex, int clipIndex);
@@ -218,6 +221,7 @@ private:
     TrackList m_trackList;
     bool m_isMakingTransition;
     bool m_trackLevelIndicatorSupported;
+    bool m_hasAudioTracks;
 
     void moveClipToEnd(Mlt::Playlist &playlist,
                        int trackIndex,

--- a/src/models/multitrackmodel.h
+++ b/src/models/multitrackmodel.h
@@ -27,6 +27,8 @@
 
 #include <memory>
 
+class SharedFrame;
+
 typedef enum {
     PlaylistTrackType = 0,
     BlackTrackType,
@@ -40,6 +42,7 @@ typedef struct
     TrackType type;
     int number;
     int mlt_index;
+    double audioLevel = -100.0;
 } Track;
 
 typedef QList<Track> TrackList;
@@ -52,6 +55,7 @@ class MultitrackModel : public QAbstractItemModel
                    trackHeaderWidthChanged FINAL)
     Q_PROPERTY(double scaleFactor READ scaleFactor WRITE setScaleFactor NOTIFY scaleFactorChanged)
     Q_PROPERTY(bool filtered READ isFiltered NOTIFY filteredChanged)
+    Q_PROPERTY(bool trackLevelIndicatorSupported READ trackLevelIndicatorSupported CONSTANT)
 
 public:
     /// Two level model: tracks and clips on track
@@ -69,6 +73,7 @@ public:
         IsMuteRole,    /// track only
         IsHiddenRole,  /// track only
         IsAudioRole,
+        AudioLevelRole,   /// track only
         AudioLevelsRole,  /// clip only
         IsCompositeRole,  /// track only
         IsLockedRole,     /// track only
@@ -84,8 +89,8 @@ public:
         IsBottomAudioRole, /// track only
         AudioIndexRole,    /// clip only
         GroupRole,         /// clip only
-        GainRole,          /// clip only
-        GainEnabledRole,   /// clip only
+        GainRole,          /// track, clip
+        GainEnabledRole,   /// track, clip
     };
 
     explicit MultitrackModel(QObject *parent = 0);
@@ -103,6 +108,8 @@ public:
     QHash<int, QByteArray> roleNames() const;
     Q_INVOKABLE void audioLevelsReady(const QPersistentModelIndex &index);
     const QByteArray *getAudioLevels(int trackIndex, int clipIndex) const;
+    void updateTrackAudioLevels(const SharedFrame &frame);
+    void clearTrackAudioLevels();
     bool createIfNeeded();
     void addBackgroundTrack();
     int addAudioTrack();
@@ -133,6 +140,7 @@ public:
     int mltIndexForTrack(int trackIndex) const;
     bool checkForEmptyTracks(int trackIndex);
     QString trackTransitionService();
+    bool trackLevelIndicatorSupported() const;
 
 signals:
     void created();
@@ -160,6 +168,7 @@ public slots:
     void setTrackHidden(int row, bool hidden);
     void setTrackComposite(int row, bool composite);
     void setTrackLock(int row, bool lock);
+    void setTrackGain(int row, double gain);
     int trimClipIn(int trackIndex, int clipIndex, int delta, bool ripple, bool rippleAllTracks);
     void notifyClipIn(int trackIndex, int clipIndex);
     int trimClipOut(int trackIndex, int clipIndex, int delta, bool ripple, bool rippleAllTracks);
@@ -208,6 +217,7 @@ private:
     Mlt::Tractor *m_tractor;
     TrackList m_trackList;
     bool m_isMakingTransition;
+    bool m_trackLevelIndicatorSupported;
 
     void moveClipToEnd(Mlt::Playlist &playlist,
                        int trackIndex,
@@ -244,6 +254,9 @@ private:
     void refreshVideoBlendTransitions();
     int bottomVideoTrackMltIndex() const;
     bool hasEmptyTrack(TrackType trackType) const;
+    Mlt::Filter *ensureTrackAudioLevelFilter(Mlt::Producer *track, int mltTrackIndex) const;
+    void syncTrackAudioLevelFilterPrefixes();
+    void setTrackAudioLevel(int row, double audioLevel);
 
     friend class UndoHelper;
 

--- a/src/models/subtitlesmodel.cpp
+++ b/src/models/subtitlesmodel.cpp
@@ -573,7 +573,7 @@ void SubtitlesModel::doInsertTrack(const SubtitlesModel::SubtitleTrack &track, i
         if (!filter || !filter->is_valid()) {
             continue;
         }
-        if (!filter->get_int("_loader") && !filter->get_int(kShotcutHiddenProperty)) {
+        if (Util::isUserFilter(filter.data()) || Util::isPostUserFilter(filter.data())) {
             filterIndex = i;
             break;
         }

--- a/src/qml/views/timeline/Timeline.js
+++ b/src/qml/views/timeline/Timeline.js
@@ -112,8 +112,8 @@ function acceptDrop(xml) {
     timeline.handleDrop(timeline.currentTrack, position, xml)
 }
 
-function trackHeight(isAudio) {
-    return isAudio? Math.max(20, multitrack.trackHeight) : multitrack.trackHeight * 2
+function trackHeight() {
+    return multitrack.trackHeight * 2;
 }
 
 function clamp(x, minimum, maximum) {

--- a/src/qml/views/timeline/TrackHead.qml
+++ b/src/qml/views/timeline/TrackHead.qml
@@ -23,6 +23,7 @@ Rectangle {
     id: trackHeadRoot
 
     property string trackName: ''
+    property real trackGain: 0
     property bool isMute
     property bool isHidden
     property bool isComposite
@@ -35,12 +36,133 @@ Rectangle {
     property bool isBottomAudio
     property bool selected: false
     property bool current: false
+    property real trackAudioLevel: -100
+    property bool trackAudioLevelSupported: false
+    property bool _blockTrackGainUpdate: true
+    property real _maximumGainDb: 10
+    property real _minimumGainDb: -70
 
     signal clicked
 
     function pulseLockButton() {
         lockButtonAnim.restart();
     }
+
+    function _iecScale(dB) {
+        if (dB < -70.0)
+            return 0.0;
+        if (dB < -60.0)
+            return (dB + 70.0) * 0.0025;
+        if (dB < -50.0)
+            return (dB + 60.0) * 0.005 + 0.025;
+        if (dB < -40.0)
+            return (dB + 50.0) * 0.0075 + 0.075;
+        if (dB < -30.0)
+            return (dB + 40.0) * 0.015 + 0.15;
+        if (dB < -20.0)
+            return (dB + 30.0) * 0.02 + 0.3;
+        if (dB < -0.001 || dB > 0.001)
+            return (dB + 20.0) * 0.025 + 0.5;
+        return 1.0;
+    }
+
+    function _iecScaleMax(dB, maxDb) {
+        return _iecScale(dB) / _iecScale(maxDb);
+    }
+
+    function _mixColor(a, b, t) {
+        return Qt.rgba(a.r + (b.r - a.r) * t,
+                       a.g + (b.g - a.g) * t,
+                       a.b + (b.b - a.b) * t,
+                       a.a + (b.a - a.a) * t);
+    }
+
+    function _audioLevelColor(level) {
+        if (level <= -70.0)
+            return Qt.rgba(0.0, 0.0, 0.0, 1.0);
+
+        const darkGreen = Qt.color('darkgreen');
+        const green = Qt.color('green');
+        const yellow = Qt.color('yellow');
+        const red = Qt.color('red');
+        const darkRed = Qt.color('darkred');
+        const brightness = Math.max(0.0, Math.min(1.0, _iecScaleMax(level, 0.0)));
+        const shapedBrightness = Math.pow(brightness, 1.35);
+        const levelPos = Math.max(0.0, Math.min(1.0, _iecScaleMax(level, 0.0)));
+        const pDarkGreen = _iecScaleMax(-90.0, 0.0);
+        const pGreen = _iecScaleMax(-12.0, 0.0);
+        const pYellow = _iecScaleMax(-6.0, 0.0);
+        const pRed = _iecScaleMax(0.0, 0.0);
+        let color = darkGreen;
+
+        if (level > 0.0) {
+            const over = Math.max(0.0, Math.min(1.0, level / _maximumGainDb));
+            color = _mixColor(red, darkRed, over);
+        } else if (levelPos <= pGreen) {
+            color = _mixColor(darkGreen, green, (levelPos - pDarkGreen) / (pGreen - pDarkGreen));
+        } else if (levelPos <= pYellow) {
+            color = _mixColor(green, yellow, (levelPos - pGreen) / (pYellow - pGreen));
+        } else {
+            color = _mixColor(yellow, red, (levelPos - pYellow) / (pRed - pYellow));
+        }
+
+        return Qt.rgba(color.r * shapedBrightness,
+                       color.g * shapedBrightness,
+                       color.b * shapedBrightness,
+                       1.0);
+    }
+
+    function _indicatorAudioLevel() {
+        return isMute ? -100.0 : trackAudioLevel;
+    }
+
+    function _indicatorAudioLevelText() {
+        if (isMute)
+            return qsTr('Track muted');
+        if (trackAudioLevel <= -70.0)
+            return qsTr('-inf dB');
+        return trackAudioLevel.toFixed(1) + qsTr(' dB');
+    }
+
+    function _setTrackGain(value) {
+        if (_blockTrackGainUpdate)
+            return;
+        const gain = Math.round(Math.max(_minimumGainDb, Math.min(_maximumGainDb, value)) * 10) / 10;
+        if (!timeline.setTrackGain(index, gain)) {
+            _syncTrackGain();
+            return;
+        }
+        if (gain <= volumeSlider.from && !isMute) {
+            timeline.toggleTrackMute(index);
+        } else if (gain > volumeSlider.from && isMute) {
+            timeline.toggleTrackMute(index);
+        }
+    }
+
+    function _syncTrackGain() {
+        _blockTrackGainUpdate = true;
+        volumeSlider.value = Math.max(volumeSlider.from,
+                                      Math.min(volumeSlider.to,
+                                               Math.round(trackGain * 10) / 10));
+        _blockTrackGainUpdate = false;
+    }
+
+    function _toggleMuteWithPopupState(modifiers) {
+        if (modifiers & Qt.AltModifier) {
+            timeline.toggleOtherTracksMute(index);
+            return;
+        }
+        if (volumePopup.opened) {
+            timeline.toggleTrackMute(index);
+        } else {
+            _syncTrackGain();
+            volumePopup.open();
+        }
+    }
+
+    onTrackGainChanged: _syncTrackGain()
+
+    Component.onCompleted: _syncTrackGain()
 
     color: selected ? selectedTrackColor : (index % 2) ? activePalette.alternateBase : activePalette.base
     border.color: selected ? 'red' : 'transparent'
@@ -167,6 +289,40 @@ Rectangle {
         RowLayout {
             spacing: 8
 
+            Item {
+                Layout.alignment: Qt.AlignVCenter
+                width: 14
+                height: 14
+                visible: trackHeadRoot.trackAudioLevelSupported
+
+                Rectangle {
+                    anchors.centerIn: parent
+                    width: 10
+                    height: 10
+                    radius: 5
+                    antialiasing: true
+                    color: trackHeadRoot._audioLevelColor(trackHeadRoot._indicatorAudioLevel())
+                    border.color: activePalette.shadow
+                    border.width: 1
+                }
+
+                MouseArea {
+                    id: audioLevelIndicatorMouseArea
+
+                    anchors.fill: parent
+                    acceptedButtons: Qt.NoButton
+                    hoverEnabled: true
+
+                    ToolTip {
+                        parent: audioLevelIndicatorMouseArea
+                        visible: audioLevelIndicatorMouseArea.containsMouse
+                        delay: 0
+                        timeout: -1
+                        text: trackHeadRoot._indicatorAudioLevelText()
+                    }
+                }
+            }
+
             ToolButton {
                 id: lockButton
 
@@ -205,10 +361,10 @@ Rectangle {
             }
 
             ToolButton {
-                id: muteButton
+                id: volumeButton
 
-                icon.name: isMute ? 'audio-volume-muted' : 'audio-volume-high'
-                icon.source: isMute ? 'qrc:///icons/oxygen/32x32/status/audio-volume-muted.png' : 'qrc:///icons/oxygen/32x32/status/audio-volume-high.png'
+                icon.name: isMute ? 'audio-volume-muted' : 'player-volume'
+                icon.source: isMute ? 'qrc:///icons/oxygen/32x32/status/audio-volume-muted.png' : 'qrc:///icons/oxygen/32x32/actions/player-volume.png'
                 icon.width: 16
                 icon.height: 16
                 padding: 1
@@ -216,17 +372,91 @@ Rectangle {
 
                 MouseArea {
                     anchors.fill: parent
-                    onClicked: mouse => {
-                        if (mouse.modifiers & Qt.AltModifier) {
-                            timeline.toggleOtherTracksMute(index);
-                        } else {
-                            timeline.toggleTrackMute(index);
-                        }
-                    }
+                    acceptedButtons: Qt.LeftButton
+                    onClicked: mouse => trackHeadRoot._toggleMuteWithPopupState(mouse.modifiers)
                 }
 
                 Shotcut.HoverTip {
-                    text: qsTr('Mute/Unmute - Alt+Click to toggle mute of other tracks') + application.actionFirstShortcut('timelineToggleTrackMuteAction')
+                    text: volumePopup.opened ? qsTr('Mute/Unmute - Alt+Click to toggle mute of other tracks') + application.actionFirstShortcut('timelineToggleTrackMuteAction') : qsTr('Adjust track volume - Alt+Click to toggle mute of other tracks') + application.actionFirstShortcut('timelineToggleTrackMuteAction')
+                }
+
+                Popup {
+                    id: volumePopup
+
+                    parent: trackHeadRoot
+                    x: Math.max(0, volumeButton.x - width + volumeButton.width)
+                    y: Math.min(trackHeadRoot.height - 4, volumeButton.y + volumeButton.height)
+                    width: 220
+                    height: 36
+                    padding: 6
+                    modal: false
+                    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+                    background: Rectangle {
+                        radius: 3
+                        color: activePalette.base
+                        border.color: activePalette.mid
+                    }
+
+                    contentItem: RowLayout {
+                        spacing: 6
+
+                        ToolButton {
+                            id: popupMuteButton
+
+                            Layout.alignment: Qt.AlignVCenter
+                            icon.name: isMute ? 'audio-volume-muted' : 'audio-volume-high'
+                            icon.source: isMute ? 'qrc:///icons/oxygen/32x32/status/audio-volume-muted.png' : 'qrc:///icons/oxygen/32x32/status/audio-volume-high.png'
+                            icon.width: 16
+                            icon.height: 16
+                            padding: 1
+                            focusPolicy: Qt.NoFocus
+                            onClicked: timeline.toggleTrackMute(index)
+
+                            Shotcut.HoverTip {
+                                text: isMute ? qsTr('Unmute') : qsTr('Mute')
+                            }
+                        }
+
+                        Slider {
+                            id: volumeSlider
+
+                            Layout.fillWidth: true
+                            Layout.alignment: Qt.AlignVCenter
+                            from: _minimumGainDb
+                            to: _maximumGainDb
+                            stepSize: 0.1
+                            snapMode: Slider.SnapAlways
+                            live: true
+                            value: 0
+                            implicitHeight: 24
+                            implicitWidth: 120
+                            onValueChanged: trackHeadRoot._setTrackGain(value)
+
+                            MouseArea {
+                                anchors.fill: parent
+                                acceptedButtons: Qt.NoButton
+                                hoverEnabled: true
+                                onWheel: wheel => {
+                                    const step = 0.1;
+                                    const delta = wheel.angleDelta.y > 0 ? step : -step;
+                                    volumeSlider.value = Math.max(volumeSlider.from,
+                                                                  Math.min(volumeSlider.to,
+                                                                           Math.round((volumeSlider.value + delta) * 10) / 10));
+                                    wheel.accepted = true;
+                                }
+                            }
+                        }
+
+                        Label {
+                            Layout.alignment: Qt.AlignVCenter
+                            Layout.preferredWidth: 52
+                            horizontalAlignment: Text.AlignRight
+                            text: (Math.abs(trackGain) < 0.05) ? '0 dB' : ((trackGain > 0 ? '+' : '') + (Math.round(trackGain * 10) / 10).toFixed(1) + ' dB')
+                            color: activePalette.windowText
+                            font.pixelSize: 10
+                        }
+                    }
                 }
             }
 

--- a/src/qml/views/timeline/TrackHead.qml
+++ b/src/qml/views/timeline/TrackHead.qml
@@ -38,13 +38,12 @@ Rectangle {
     property bool current: false
     property real trackAudioLevel: -100
     property bool trackAudioLevelSupported: false
+    property bool inlineAudioControlsEnabled: false
+    property bool stackedHeaderLayout: false
     property int _pendingVolumeClickModifiers: Qt.NoModifier
     property bool _blockTrackGainUpdate: true
     property real _maximumGainDb: 10
     property real _minimumGainDb: -70
-    property bool _showInlineAudioControls: trackHeadRoot.height >= 92
-    property var _inlineScaleTicks: [_minimumGainDb, -60, -50, -40, -30, -20, -12, -6, 0, _maximumGainDb]
-    property var _inlineScaleLabels: [_minimumGainDb, -30, -12, -6, 0, _maximumGainDb]
 
     signal clicked
 
@@ -83,13 +82,6 @@ Rectangle {
     function _formatDb(value) {
         const v = Math.round(value * 10) / 10;
         return (Math.abs(v) < 0.05) ? '0.0 dB' : ((v > 0 ? '+' : '') + v.toFixed(1) + ' dB');
-    }
-
-    function _inlineScaleX(width, dB) {
-        const handleHalf = Math.max(6, inlineVolumeSlider.implicitHandleWidth / 2);
-        const left = handleHalf;
-        const right = Math.max(left, width - handleHalf);
-        return left + trackHeadRoot._gainScalePosition(dB) * (right - left);
     }
 
     function _inlineMeterScalePosition(dB) {
@@ -185,7 +177,7 @@ Rectangle {
             return;
         }
 
-        if (_showInlineAudioControls) {
+        if (inlineAudioControlsEnabled) {
             if (volumePopup.opened)
                 volumePopup.close();
             timeline.toggleTrackMute(index);
@@ -299,24 +291,31 @@ Rectangle {
         }
     }
 
-    Flow {
+    Column {
         id: trackHeadColumn
 
-        flow: (trackHeadRoot.height < 50) ? Flow.LeftToRight : Flow.TopToBottom
-        spacing: (trackHeadRoot.height < 50) ? 0 : 6
+        spacing: trackHeadRoot.stackedHeaderLayout ? 1 : 2
 
         anchors {
             top: parent.top
             left: parent.left
+            right: parent.right
             leftMargin: 8
-            rightMargin: (trackHeadRoot.height < 50) ? 0 : 4
-            topMargin: (trackHeadRoot.height < 50) ? 0 : 4
-            bottomMargin: (trackHeadRoot.height < 50) ? 0 : 4
+            rightMargin: trackHeadRoot.stackedHeaderLayout ? 4 : 0
+            topMargin: trackHeadRoot.stackedHeaderLayout ? 2 : 0
+            bottomMargin: trackHeadRoot.stackedHeaderLayout ? 4 : 0
         }
 
-        Rectangle {
+        Flow {
+            id: trackHeadHeaderFlow
+
+            width: parent.width
+            flow: trackHeadRoot.stackedHeaderLayout ? Flow.TopToBottom : Flow.LeftToRight
+            spacing: trackHeadRoot.stackedHeaderLayout ? 4 : 0
+
+            Rectangle {
             color: 'transparent'
-            width: trackHeadRoot.width - trackHeadColumn.anchors.margins * 2 - (trackHeadRoot.height < 50 ? 120 : 0)
+            width: trackHeadHeaderFlow.width - (trackHeadRoot.stackedHeaderLayout ? 0 : trackHeadButtons.implicitWidth)
             radius: 2
             border.color: (!timeline.isFloating() && trackNameMouseArea.containsMouse) ? activePalette.shadow : 'transparent'
             height: nameEdit.height
@@ -365,14 +364,15 @@ Rectangle {
             }
         }
 
-        RowLayout {
+            RowLayout {
+            id: trackHeadButtons
             spacing: 8
 
             Item {
                 Layout.alignment: Qt.AlignVCenter
                 width: 14
                 height: 14
-                visible: trackHeadRoot.trackAudioLevelSupported && !trackHeadRoot._showInlineAudioControls
+                visible: trackHeadRoot.trackAudioLevelSupported && !trackHeadRoot.inlineAudioControlsEnabled
 
                 Rectangle {
                     anchors.centerIn: parent
@@ -463,7 +463,7 @@ Rectangle {
                 }
 
                 Shotcut.HoverTip {
-                    text: trackHeadRoot._showInlineAudioControls ? (qsTr('Mute/Unmute - Alt+Click to toggle mute of other tracks') + application.actionFirstShortcut('timelineToggleTrackMuteAction')) : (volumePopup.opened ? qsTr('Mute/Unmute - Alt+Click to toggle mute of other tracks') + application.actionFirstShortcut('timelineToggleTrackMuteAction') : qsTr('Adjust track volume - Alt+Click to toggle mute of other tracks') + application.actionFirstShortcut('timelineToggleTrackMuteAction'))
+                    text: trackHeadRoot.inlineAudioControlsEnabled ? (qsTr('Mute/Unmute - Alt+Click to toggle mute of other tracks') + application.actionFirstShortcut('timelineToggleTrackMuteAction')) : (volumePopup.opened ? qsTr('Mute/Unmute - Alt+Click to toggle mute of other tracks') + application.actionFirstShortcut('timelineToggleTrackMuteAction') : qsTr('Adjust track volume - Alt+Click to toggle mute of other tracks') + application.actionFirstShortcut('timelineToggleTrackMuteAction'))
                 }
 
                 Popup {
@@ -553,77 +553,105 @@ Rectangle {
                 }
             }
 
-            ToolButton {
-                id: hideButton
+            Item {
+                width: 20
+                height: 20
 
-                visible: isVideo
-                icon.name: isHidden ? 'layer-visible-off' : 'layer-visible-on'
-                icon.source: isHidden ? 'qrc:///icons/oxygen/32x32/actions/layer-visible-off.png' : 'qrc:///icons/oxygen/32x32/actions/layer-visible-on.png'
-                icon.width: 16
-                icon.height: 16
-                padding: 1
-                focusPolicy: Qt.NoFocus
+                ToolButton {
+                    id: hideButton
 
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: mouse => {
-                        if (mouse.modifiers & Qt.AltModifier) {
-                            timeline.toggleOtherTracksHidden(index);
-                        } else {
-                            timeline.toggleTrackHidden(index);
+                    anchors.centerIn: parent
+                    visible: isVideo
+                    icon.name: isHidden ? 'layer-visible-off' : 'layer-visible-on'
+                    icon.source: isHidden ? 'qrc:///icons/oxygen/32x32/actions/layer-visible-off.png' : 'qrc:///icons/oxygen/32x32/actions/layer-visible-on.png'
+                    icon.width: 16
+                    icon.height: 16
+                    padding: 1
+                    focusPolicy: Qt.NoFocus
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: mouse => {
+                            if (mouse.modifiers & Qt.AltModifier) {
+                                timeline.toggleOtherTracksHidden(index);
+                            } else {
+                                timeline.toggleTrackHidden(index);
+                            }
                         }
                     }
-                }
 
-                Shotcut.HoverTip {
-                    text: qsTr('Show/Hide - Alt+Click to toggle visibility of other tracks') + application.actionFirstShortcut('timelineToggleTrackHiddenAction')
+                    Shotcut.HoverTip {
+                        text: qsTr('Show/Hide - Alt+Click to toggle visibility of other tracks') + application.actionFirstShortcut('timelineToggleTrackHiddenAction')
+                    }
                 }
             }
 
-            ToolButton {
-                visible: isFiltered
-                icon.name: 'view-filter'
-                icon.source: 'qrc:///icons/oxygen/32x32/status/view-filter.png'
-                icon.width: 16
-                icon.height: 16
-                padding: 1
-                focusPolicy: Qt.NoFocus
-                onClicked: {
-                    trackHeadRoot.clicked();
-                    nameEdit.focus = false;
-                    timeline.filteredClicked();
-                }
+            Item {
+                width: 20
+                height: 20
 
-                Shotcut.HoverTip {
-                    text: qsTr('Filters')
+                ToolButton {
+                    id: filterButton
+
+                    anchors.centerIn: parent
+                    visible: isFiltered
+                    icon.name: 'view-filter'
+                    icon.source: 'qrc:///icons/oxygen/32x32/status/view-filter.png'
+                    icon.width: 16
+                    icon.height: 16
+                    padding: 1
+                    focusPolicy: Qt.NoFocus
+                    onClicked: {
+                        trackHeadRoot.clicked();
+                        nameEdit.focus = false;
+                        timeline.filteredClicked();
+                    }
+
+                    Shotcut.HoverTip {
+                        text: qsTr('Filters')
+                    }
                 }
+            }
             }
         }
 
         Rectangle {
-            visible: trackHeadRoot._showInlineAudioControls
-            width: trackHeadRoot.width - trackHeadColumn.anchors.leftMargin - trackHeadColumn.anchors.rightMargin
-            height: 40
+            visible: trackHeadRoot.inlineAudioControlsEnabled
+            width: parent.width
+            height: trackHeadRoot.stackedHeaderLayout ? 28 : 30
             color: 'transparent'
             border.color: 'transparent'
 
             Column {
                 anchors.fill: parent
-                spacing: 1
+                spacing: 2
 
                 Rectangle {
                     id: inlineMeter
 
-                    x: Math.round(trackHeadRoot._inlineScaleX(parent.width,
-                                                              trackHeadRoot._minimumGainDb))
-                    width: Math.max(1,
-                                    Math.round(trackHeadRoot._inlineScaleX(parent.width, 0.0)) - x)
-                    height: 8
+                    width: parent.width
+                    height: trackHeadRoot.stackedHeaderLayout ? 9 : 10
                     radius: 2
                     color: Qt.darker(activePalette.mid, 1.35)
                     border.color: activePalette.shadow
                     border.width: 1
                     clip: true
+
+                    MouseArea {
+                        id: inlineMeterMouseArea
+
+                        anchors.fill: parent
+                        acceptedButtons: Qt.NoButton
+                        hoverEnabled: true
+
+                        ToolTip {
+                            parent: inlineMeterMouseArea
+                            visible: inlineMeterMouseArea.containsMouse
+                            delay: 0
+                            timeout: -1
+                            text: trackHeadRoot._indicatorAudioLevelText()
+                        }
+                    }
 
                     Item {
                         id: inlineMeterFill
@@ -669,46 +697,11 @@ Rectangle {
                     }
                 }
 
-                Item {
-                    id: inlineScale
-
-                    width: parent.width
-                    height: 10
-
-                    Repeater {
-                        model: trackHeadRoot._inlineScaleTicks
-
-                        delegate: Rectangle {
-                            width: 1
-                            height: 4
-                            color: activePalette.mid
-                            x: Math.round(trackHeadRoot._inlineScaleX(inlineScale.width, modelData) - width / 2)
-                            y: 0
-                        }
-                    }
-
-                    Repeater {
-                        model: trackHeadRoot._inlineScaleLabels
-
-                        delegate: Label {
-                            text: modelData > 0 ? ('+' + modelData) : ('' + modelData)
-                            color: activePalette.text
-                            font.pixelSize: 8
-                            x: Math.max(0,
-                                        Math.min(inlineScale.width - width,
-                                                 Math.round(trackHeadRoot._inlineScaleX(inlineScale.width,
-                                                                                        modelData)
-                                                            - width / 2)))
-                            y: 2
-                        }
-                    }
-                }
-
                 Slider {
                     id: inlineVolumeSlider
 
                     width: parent.width
-                    height: 20
+                    height: trackHeadRoot.stackedHeaderLayout ? 16 : 18
                     from: _minimumGainDb
                     to: _maximumGainDb
                     stepSize: 0.1

--- a/src/qml/views/timeline/TrackHead.qml
+++ b/src/qml/views/timeline/TrackHead.qml
@@ -38,6 +38,7 @@ Rectangle {
     property bool current: false
     property real trackAudioLevel: -100
     property bool trackAudioLevelSupported: false
+    property int _pendingVolumeClickModifiers: Qt.NoModifier
     property bool _blockTrackGainUpdate: true
     property real _maximumGainDb: 10
     property real _minimumGainDb: -70
@@ -147,20 +148,48 @@ Rectangle {
         _blockTrackGainUpdate = false;
     }
 
-    function _toggleMuteWithPopupState(modifiers) {
+    function _handleVolumeButtonSingleClick(modifiers) {
         if (modifiers & Qt.AltModifier) {
+            if (volumePopup.opened)
+                volumePopup.close();
             timeline.toggleOtherTracksMute(index);
             return;
         }
-        if (volumePopup.opened) {
-            timeline.toggleTrackMute(index);
-        } else {
-            _syncTrackGain();
+
+        _syncTrackGain();
+        if (!volumePopup.opened)
             volumePopup.open();
-        }
+    }
+
+    function _handleVolumeButtonDoubleClick() {
+        if (volumePopup.opened)
+            volumePopup.close();
+        timeline.toggleTrackMute(index);
+    }
+
+    function _positionVolumePopupOverVolumeButton() {
+        if (!volumePopup.opened)
+            return;
+
+        const buttonCenter = volumeButton.mapToItem(trackHeadRoot,
+                                                    volumeButton.width / 2,
+                                                    volumeButton.height / 2);
+        const popupButtonCenter = popupMuteButton.mapToItem(trackHeadRoot,
+                                                            popupMuteButton.width / 2,
+                                                            popupMuteButton.height / 2);
+        volumePopup.x += Math.round(buttonCenter.x - popupButtonCenter.x);
+        volumePopup.y += Math.round(buttonCenter.y - popupButtonCenter.y);
     }
 
     onTrackGainChanged: _syncTrackGain()
+
+    Timer {
+        id: volumeButtonSingleClickTimer
+
+        interval: Qt.styleHints.mouseDoubleClickInterval
+        repeat: false
+        onTriggered: trackHeadRoot._handleVolumeButtonSingleClick(trackHeadRoot._pendingVolumeClickModifiers)
+    }
 
     Component.onCompleted: _syncTrackGain()
 
@@ -373,7 +402,14 @@ Rectangle {
                 MouseArea {
                     anchors.fill: parent
                     acceptedButtons: Qt.LeftButton
-                    onClicked: mouse => trackHeadRoot._toggleMuteWithPopupState(mouse.modifiers)
+                    onClicked: mouse => {
+                        trackHeadRoot._pendingVolumeClickModifiers = mouse.modifiers;
+                        volumeButtonSingleClickTimer.restart();
+                    }
+                    onDoubleClicked: mouse => {
+                        volumeButtonSingleClickTimer.stop();
+                        trackHeadRoot._handleVolumeButtonDoubleClick();
+                    }
                 }
 
                 Shotcut.HoverTip {
@@ -384,13 +420,14 @@ Rectangle {
                     id: volumePopup
 
                     parent: trackHeadRoot
-                    x: Math.max(0, volumeButton.x - width + volumeButton.width)
-                    y: Math.min(trackHeadRoot.height - 4, volumeButton.y + volumeButton.height)
+                    x: Math.round(volumeButton.mapToItem(trackHeadRoot, 0, 0).x - padding)
+                    y: Math.round(volumeButton.mapToItem(trackHeadRoot, 0, 0).y - padding)
                     width: 220
                     height: 36
                     padding: 6
                     modal: false
                     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+                    onOpened: trackHeadRoot._positionVolumePopupOverVolumeButton()
 
                     background: Rectangle {
                         radius: 3
@@ -409,9 +446,14 @@ Rectangle {
                             icon.source: isMute ? 'qrc:///icons/oxygen/32x32/status/audio-volume-muted.png' : 'qrc:///icons/oxygen/32x32/status/audio-volume-high.png'
                             icon.width: 16
                             icon.height: 16
-                            padding: 1
+                            width: volumeButton.width
+                            height: volumeButton.height
+                            padding: volumeButton.padding
                             focusPolicy: Qt.NoFocus
-                            onClicked: timeline.toggleTrackMute(index)
+                            onClicked: {
+                                timeline.toggleTrackMute(index);
+                                volumePopup.close();
+                            }
 
                             Shotcut.HoverTip {
                                 text: isMute ? qsTr('Unmute') : qsTr('Mute')

--- a/src/qml/views/timeline/TrackHead.qml
+++ b/src/qml/views/timeline/TrackHead.qml
@@ -617,6 +617,7 @@ Rectangle {
 
         Rectangle {
             visible: trackHeadRoot.inlineAudioControlsEnabled
+                     && trackHeadRoot.trackAudioLevelSupported
             width: parent.width
             height: trackHeadRoot.stackedHeaderLayout ? 28 : 30
             color: 'transparent'

--- a/src/qml/views/timeline/TrackHead.qml
+++ b/src/qml/views/timeline/TrackHead.qml
@@ -42,6 +42,9 @@ Rectangle {
     property bool _blockTrackGainUpdate: true
     property real _maximumGainDb: 10
     property real _minimumGainDb: -70
+    property bool _showInlineAudioControls: trackHeadRoot.height >= 92
+    property var _inlineScaleTicks: [_minimumGainDb, -60, -50, -40, -30, -20, -12, -6, 0, _maximumGainDb]
+    property var _inlineScaleLabels: [_minimumGainDb, -30, -12, -6, 0, _maximumGainDb]
 
     signal clicked
 
@@ -69,6 +72,30 @@ Rectangle {
 
     function _iecScaleMax(dB, maxDb) {
         return _iecScale(dB) / _iecScale(maxDb);
+    }
+
+    function _gainScalePosition(dB) {
+        return Math.max(0.0,
+                        Math.min(1.0,
+                                 (dB - _minimumGainDb) / (_maximumGainDb - _minimumGainDb)));
+    }
+
+    function _formatDb(value) {
+        const v = Math.round(value * 10) / 10;
+        return (Math.abs(v) < 0.05) ? '0.0 dB' : ((v > 0 ? '+' : '') + v.toFixed(1) + ' dB');
+    }
+
+    function _inlineScaleX(width, dB) {
+        const handleHalf = Math.max(6, inlineVolumeSlider.implicitHandleWidth / 2);
+        const left = handleHalf;
+        const right = Math.max(left, width - handleHalf);
+        return left + trackHeadRoot._gainScalePosition(dB) * (right - left);
+    }
+
+    function _inlineMeterScalePosition(dB) {
+        return Math.max(0.0,
+                        Math.min(1.0,
+                                 (dB - _minimumGainDb) / (0.0 - _minimumGainDb)));
     }
 
     function _mixColor(a, b, t) {
@@ -133,18 +160,20 @@ Rectangle {
             _syncTrackGain();
             return;
         }
-        if (gain <= volumeSlider.from && !isMute) {
+        if (gain <= _minimumGainDb && !isMute) {
             timeline.toggleTrackMute(index);
-        } else if (gain > volumeSlider.from && isMute) {
+        } else if (gain > _minimumGainDb && isMute) {
             timeline.toggleTrackMute(index);
         }
     }
 
     function _syncTrackGain() {
+        const gain = Math.max(_minimumGainDb,
+                              Math.min(_maximumGainDb,
+                                       Math.round(trackGain * 10) / 10));
         _blockTrackGainUpdate = true;
-        volumeSlider.value = Math.max(volumeSlider.from,
-                                      Math.min(volumeSlider.to,
-                                               Math.round(trackGain * 10) / 10));
+        volumeSlider.value = gain;
+        inlineVolumeSlider.value = gain;
         _blockTrackGainUpdate = false;
     }
 
@@ -153,6 +182,13 @@ Rectangle {
             if (volumePopup.opened)
                 volumePopup.close();
             timeline.toggleOtherTracksMute(index);
+            return;
+        }
+
+        if (_showInlineAudioControls) {
+            if (volumePopup.opened)
+                volumePopup.close();
+            timeline.toggleTrackMute(index);
             return;
         }
 
@@ -189,6 +225,20 @@ Rectangle {
         interval: Qt.styleHints.mouseDoubleClickInterval
         repeat: false
         onTriggered: trackHeadRoot._handleVolumeButtonSingleClick(trackHeadRoot._pendingVolumeClickModifiers)
+    }
+
+    Timer {
+        id: volumeSliderWheelTipTimer
+
+        interval: 800
+        repeat: false
+    }
+
+    Timer {
+        id: inlineSliderWheelTipTimer
+
+        interval: 800
+        repeat: false
     }
 
     Component.onCompleted: _syncTrackGain()
@@ -322,7 +372,7 @@ Rectangle {
                 Layout.alignment: Qt.AlignVCenter
                 width: 14
                 height: 14
-                visible: trackHeadRoot.trackAudioLevelSupported
+                visible: trackHeadRoot.trackAudioLevelSupported && !trackHeadRoot._showInlineAudioControls
 
                 Rectangle {
                     anchors.centerIn: parent
@@ -413,7 +463,7 @@ Rectangle {
                 }
 
                 Shotcut.HoverTip {
-                    text: volumePopup.opened ? qsTr('Mute/Unmute - Alt+Click to toggle mute of other tracks') + application.actionFirstShortcut('timelineToggleTrackMuteAction') : qsTr('Adjust track volume - Alt+Click to toggle mute of other tracks') + application.actionFirstShortcut('timelineToggleTrackMuteAction')
+                    text: trackHeadRoot._showInlineAudioControls ? (qsTr('Mute/Unmute - Alt+Click to toggle mute of other tracks') + application.actionFirstShortcut('timelineToggleTrackMuteAction')) : (volumePopup.opened ? qsTr('Mute/Unmute - Alt+Click to toggle mute of other tracks') + application.actionFirstShortcut('timelineToggleTrackMuteAction') : qsTr('Adjust track volume - Alt+Click to toggle mute of other tracks') + application.actionFirstShortcut('timelineToggleTrackMuteAction'))
                 }
 
                 Popup {
@@ -474,6 +524,7 @@ Rectangle {
                             implicitHeight: 24
                             implicitWidth: 120
                             onValueChanged: trackHeadRoot._setTrackGain(value)
+                            ToolTip.visible: false
 
                             MouseArea {
                                 anchors.fill: parent
@@ -545,6 +596,146 @@ Rectangle {
 
                 Shotcut.HoverTip {
                     text: qsTr('Filters')
+                }
+            }
+        }
+
+        Rectangle {
+            visible: trackHeadRoot._showInlineAudioControls
+            width: trackHeadRoot.width - trackHeadColumn.anchors.leftMargin - trackHeadColumn.anchors.rightMargin
+            height: 40
+            color: 'transparent'
+            border.color: 'transparent'
+
+            Column {
+                anchors.fill: parent
+                spacing: 1
+
+                Rectangle {
+                    id: inlineMeter
+
+                    x: Math.round(trackHeadRoot._inlineScaleX(parent.width,
+                                                              trackHeadRoot._minimumGainDb))
+                    width: Math.max(1,
+                                    Math.round(trackHeadRoot._inlineScaleX(parent.width, 0.0)) - x)
+                    height: 8
+                    radius: 2
+                    color: Qt.darker(activePalette.mid, 1.35)
+                    border.color: activePalette.shadow
+                    border.width: 1
+                    clip: true
+
+                    Item {
+                        id: inlineMeterFill
+
+                        anchors.left: parent.left
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: Math.max(0,
+                                        Math.round(parent.width * trackHeadRoot._inlineMeterScalePosition(Math.max(trackHeadRoot._minimumGainDb,
+                                                                                                            Math.min(0.0,
+                                                                                                              trackHeadRoot._indicatorAudioLevel())))))
+                        height: parent.height - 2
+                        clip: true
+
+                        Rectangle {
+                            anchors.left: parent.left
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: inlineMeter.width
+                            height: parent.height
+                            radius: 1
+                            gradient: Gradient {
+                                orientation: Gradient.Horizontal
+                                GradientStop {
+                                    position: 0.0
+                                    color: 'darkgreen'
+                                }
+
+                                GradientStop {
+                                    position: trackHeadRoot._inlineMeterScalePosition(-12.0)
+                                    color: 'green'
+                                }
+
+                                GradientStop {
+                                    position: trackHeadRoot._inlineMeterScalePosition(-6.0)
+                                    color: 'yellow'
+                                }
+
+                                GradientStop {
+                                    position: 1.0
+                                    color: 'red'
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Item {
+                    id: inlineScale
+
+                    width: parent.width
+                    height: 10
+
+                    Repeater {
+                        model: trackHeadRoot._inlineScaleTicks
+
+                        delegate: Rectangle {
+                            width: 1
+                            height: 4
+                            color: activePalette.mid
+                            x: Math.round(trackHeadRoot._inlineScaleX(inlineScale.width, modelData) - width / 2)
+                            y: 0
+                        }
+                    }
+
+                    Repeater {
+                        model: trackHeadRoot._inlineScaleLabels
+
+                        delegate: Label {
+                            text: modelData > 0 ? ('+' + modelData) : ('' + modelData)
+                            color: activePalette.text
+                            font.pixelSize: 8
+                            x: Math.max(0,
+                                        Math.min(inlineScale.width - width,
+                                                 Math.round(trackHeadRoot._inlineScaleX(inlineScale.width,
+                                                                                        modelData)
+                                                            - width / 2)))
+                            y: 2
+                        }
+                    }
+                }
+
+                Slider {
+                    id: inlineVolumeSlider
+
+                    width: parent.width
+                    height: 20
+                    from: _minimumGainDb
+                    to: _maximumGainDb
+                    stepSize: 0.1
+                    snapMode: Slider.SnapAlways
+                    live: true
+                    value: 0
+                    onValueChanged: trackHeadRoot._setTrackGain(value)
+                    ToolTip.visible: pressed || inlineSliderWheelTipTimer.running || inlineVolumeSliderMouseArea.containsMouse
+                    ToolTip.text: trackHeadRoot._formatDb(value)
+
+                    MouseArea {
+                        id: inlineVolumeSliderMouseArea
+
+                        anchors.fill: parent
+                        acceptedButtons: Qt.NoButton
+                        hoverEnabled: true
+                        onWheel: wheel => {
+                            const step = 0.1;
+                            const delta = wheel.angleDelta.y > 0 ? step : -step;
+                            inlineVolumeSlider.value = Math.max(inlineVolumeSlider.from,
+                                                                Math.min(inlineVolumeSlider.to,
+                                                                         Math.round((inlineVolumeSlider.value + delta) * 10)
+                                                                         / 10));
+                            inlineSliderWheelTipTimer.restart();
+                            wheel.accepted = true;
+                        }
+                    }
                 }
             }
         }

--- a/src/qml/views/timeline/TrackHead.qml
+++ b/src/qml/views/timeline/TrackHead.qml
@@ -169,6 +169,16 @@ Rectangle {
         _blockTrackGainUpdate = false;
     }
 
+    function _resetTrackGain() {
+        _setTrackGain(0);
+    }
+
+    function _setTrackGainFromMouse(slider, mouseX) {
+        const width = Math.max(1, slider.width);
+        const position = Math.max(0.0, Math.min(1.0, mouseX / width));
+        _setTrackGain(slider.from + (slider.to - slider.from) * position);
+    }
+
     function _handleVolumeButtonSingleClick(modifiers) {
         if (modifiers & Qt.AltModifier) {
             if (volumePopup.opened)
@@ -527,9 +537,39 @@ Rectangle {
                             ToolTip.visible: false
 
                             MouseArea {
+                                id: volumeSliderMouseArea
+
                                 anchors.fill: parent
-                                acceptedButtons: Qt.NoButton
+                                acceptedButtons: Qt.LeftButton
                                 hoverEnabled: true
+                                property bool _dragging: false
+                                property real _pressX: 0
+                                property real _pressY: 0
+
+                                onPressed: mouse => {
+                                        _dragging = false;
+                                        _pressX = mouse.x;
+                                        _pressY = mouse.y;
+                                        mouse.accepted = true;
+                                }
+
+                                onDoubleClicked: mouse => {
+                                        _dragging = false;
+                                        trackHeadRoot._resetTrackGain();
+                                        mouse.accepted = true;
+                                }
+
+                                onPositionChanged: mouse => {
+                                    if (!(mouse.buttons & Qt.LeftButton))
+                                        return;
+                                    if (!_dragging) {
+                                        if (Math.abs(mouse.x - _pressX) < 3 && Math.abs(mouse.y - _pressY) < 3)
+                                            return;
+                                        _dragging = true;
+                                    }
+                                    trackHeadRoot._setTrackGainFromMouse(volumeSlider, mouse.x);
+                                }
+
                                 onWheel: wheel => {
                                     const step = 0.1;
                                     const delta = wheel.angleDelta.y > 0 ? step : -step;
@@ -717,8 +757,36 @@ Rectangle {
                         id: inlineVolumeSliderMouseArea
 
                         anchors.fill: parent
-                        acceptedButtons: Qt.NoButton
+                        acceptedButtons: Qt.LeftButton
                         hoverEnabled: true
+                        property bool _dragging: false
+                        property real _pressX: 0
+                        property real _pressY: 0
+
+                        onPressed: mouse => {
+                            _dragging = false;
+                            _pressX = mouse.x;
+                            _pressY = mouse.y;
+                            mouse.accepted = true;
+                        }
+
+                        onDoubleClicked: mouse => {
+                            _dragging = false;
+                            trackHeadRoot._resetTrackGain();
+                            mouse.accepted = true;
+                        }
+
+                        onPositionChanged: mouse => {
+                            if (!(mouse.buttons & Qt.LeftButton))
+                                return;
+                            if (!_dragging) {
+                                if (Math.abs(mouse.x - _pressX) < 3 && Math.abs(mouse.y - _pressY) < 3)
+                                    return;
+                                _dragging = true;
+                            }
+                            trackHeadRoot._setTrackGainFromMouse(inlineVolumeSlider, mouse.x);
+                        }
+
                         onWheel: wheel => {
                             const step = 0.1;
                             const delta = wheel.angleDelta.y > 0 ? step : -step;

--- a/src/qml/views/timeline/timeline.qml
+++ b/src/qml/views/timeline/timeline.qml
@@ -251,6 +251,9 @@ Rectangle {
                             property var trackIndex: index
 
                             trackName: model.name
+                            trackGain: typeof model.gain !== 'undefined' ? model.gain : 0
+                            trackAudioLevel: typeof model.audioLevel !== 'undefined' ? model.audioLevel : -100
+                            trackAudioLevelSupported: multitrack.trackLevelIndicatorSupported
                             isMute: model.mute
                             isHidden: model.hidden
                             isComposite: model.composite

--- a/src/qml/views/timeline/timeline.qml
+++ b/src/qml/views/timeline/timeline.qml
@@ -35,7 +35,7 @@ Rectangle {
     property var dragDelta
     property int inlineAudioControlsThreshold: 60
     property int separateTrackHeaderRowsThreshold: 80
-    property int shortestTrackHeight: multitrack.hasAudioTracks ? Logic.trackHeight(true) : Logic.trackHeight(false)
+    property int shortestTrackHeight: Logic.trackHeight()
     property bool inlineAudioControlsEnabled: shortestTrackHeight >= inlineAudioControlsThreshold
     property bool separateTrackHeaderRows: shortestTrackHeight >= separateTrackHeaderRowsThreshold
 
@@ -272,7 +272,7 @@ Rectangle {
                             isTopAudio: model.isTopAudio
                             isBottomAudio: model.isBottomAudio
                             width: headerWidth
-                            height: Logic.trackHeight(model.audio)
+                            height: Logic.trackHeight()
                             current: index === timeline.currentTrack
                             onIsLockedChanged: tracksRepeater.itemAt(index).isLocked = isLocked
                             onClicked: {
@@ -587,7 +587,7 @@ Rectangle {
                                 delegate: Rectangle {
                                     width: tracksContainer.width
                                     color: (index === timeline.currentTrack) ? selectedTrackColor : (index % 2) ? activePalette.alternateBase : activePalette.base
-                                    height: Logic.trackHeight(audio)
+                                    height: Logic.trackHeight()
                                 }
                             }
                         }
@@ -823,7 +823,7 @@ Rectangle {
             //  Clear previous blank selection
             model: multitrack
             rootIndex: trackDelegateModel.modelIndex(index)
-            height: Logic.trackHeight(audio)
+            height: Logic.trackHeight()
             isAudio: audio
             isMute: mute
             isCurrentTrack: timeline.currentTrack === index

--- a/src/qml/views/timeline/timeline.qml
+++ b/src/qml/views/timeline/timeline.qml
@@ -33,6 +33,11 @@ Rectangle {
     property bool stopScrolling: false
     property color shotcutBlue: Qt.rgba(23 / 255, 92 / 255, 118 / 255, 1)
     property var dragDelta
+    property int inlineAudioControlsThreshold: 60
+    property int separateTrackHeaderRowsThreshold: 80
+    property int shortestTrackHeight: multitrack.hasAudioTracks ? Logic.trackHeight(true) : Logic.trackHeight(false)
+    property bool inlineAudioControlsEnabled: shortestTrackHeight >= inlineAudioControlsThreshold
+    property bool separateTrackHeaderRows: shortestTrackHeight >= separateTrackHeaderRowsThreshold
 
     signal clipClicked
     signal timelineRightClicked
@@ -254,6 +259,8 @@ Rectangle {
                             trackGain: typeof model.gain !== 'undefined' ? model.gain : 0
                             trackAudioLevel: typeof model.audioLevel !== 'undefined' ? model.audioLevel : -100
                             trackAudioLevelSupported: multitrack.trackLevelIndicatorSupported
+                            inlineAudioControlsEnabled: root.inlineAudioControlsEnabled
+                            stackedHeaderLayout: root.separateTrackHeaderRows
                             isMute: model.mute
                             isHidden: model.hidden
                             isComposite: model.composite

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1182,7 +1182,7 @@ void ShotcutSettings::setTimelineSnap(bool b)
 
 int ShotcutSettings::timelineTrackHeight() const
 {
-    return qMin(settings.value("timeline/trackHeight", 60).toInt(), kMaximumTrackHeight);
+    return qMin(settings.value("timeline/trackHeight", 50).toInt(), kMaximumTrackHeight);
 }
 
 void ShotcutSettings::setTimelineTrackHeight(int n)

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1182,7 +1182,7 @@ void ShotcutSettings::setTimelineSnap(bool b)
 
 int ShotcutSettings::timelineTrackHeight() const
 {
-    return qMin(settings.value("timeline/trackHeight", 50).toInt(), kMaximumTrackHeight);
+    return qMin(settings.value("timeline/trackHeight", 60).toInt(), kMaximumTrackHeight);
 }
 
 void ShotcutSettings::setTimelineTrackHeight(int n)

--- a/src/shotcut_mlt_properties.h
+++ b/src/shotcut_mlt_properties.h
@@ -46,6 +46,8 @@
 #define kShotcutDetailProperty "shotcut:detail"
 #define kShotcutHashProperty "shotcut:hash"
 #define kShotcutHiddenProperty "shotcut:hidden"
+#define kShotcutHiddenPositionProperty "shotcut:hiddenPosition"
+#define kShotcutHiddenPositionPost "post"
 #define kShotcutSkipConvertProperty "shotcut:skipConvert"
 #define kShotcutAnimInProperty "shotcut:animIn"
 #define kShotcutAnimOutProperty "shotcut:animOut"

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -27,6 +27,8 @@
 #include "shotcut_mlt_properties.h"
 #include "transcoder.h"
 #include <MltChain.h>
+#include <MltFilter.h>
+#include <MltLink.h>
 #include <MltProducer.h>
 
 #include <QApplication>
@@ -1340,4 +1342,29 @@ bool Util::cpuHasAVX2()
 int Util::msToPosition(int64_t ms)
 {
     return ms * MLT.profile().frame_rate_num() / MLT.profile().frame_rate_den() / 1000;
+}
+
+bool Util::isPostUserFilter(Mlt::Filter *filter)
+{
+    return filter && filter->is_valid() && filter->get_int(kShotcutHiddenProperty)
+           && !qstrcmp(filter->get(kShotcutHiddenPositionProperty), kShotcutHiddenPositionPost);
+}
+
+bool Util::isPreUserFilter(Mlt::Filter *filter)
+{
+    return filter && filter->is_valid()
+           && (filter->get_int("_loader")
+               || (filter->get_int(kShotcutHiddenProperty) && !isPostUserFilter(filter)));
+}
+
+bool Util::isUserFilter(Mlt::Filter *filter)
+{
+    return filter && filter->is_valid() && !filter->get_int("_loader")
+           && !filter->get_int(kShotcutHiddenProperty);
+}
+
+bool Util::isUserLink(Mlt::Link *link)
+{
+    return link && link->is_valid() && !link->get_int("_loader")
+           && !link->get_int(kShotcutHiddenProperty);
 }

--- a/src/util.h
+++ b/src/util.h
@@ -32,8 +32,10 @@ class QDoubleSpinBox;
 class QTemporaryFile;
 
 namespace Mlt {
+class Filter;
+class Link;
 class Producer;
-}
+} // namespace Mlt
 
 class Util
 {
@@ -111,6 +113,10 @@ public:
     static bool openUrl(const QUrl &url);
     static bool cpuHasAVX2();
     static int msToPosition(int64_t ms);
+    static bool isPostUserFilter(Mlt::Filter *filter);
+    static bool isPreUserFilter(Mlt::Filter *filter);
+    static bool isUserFilter(Mlt::Filter *filter);
+    static bool isUserLink(Mlt::Link *link);
 };
 
 #endif // UTIL_H

--- a/src/widgets/avformatproducerwidget.cpp
+++ b/src/widgets/avformatproducerwidget.cpp
@@ -230,7 +230,7 @@ void AvformatProducerWidget::reopen(Mlt::Producer *p)
         int n = p->filter_count();
         for (int j = 0; j < n; j++) {
             QScopedPointer<Mlt::Filter> filter(p->filter(j));
-            if (filter && filter->is_valid() && !filter->get_int("_loader")) {
+            if (Util::isUserFilter(filter.data())) {
                 in = qMin(qRound(filter->get_in() * speedRatio), length - 1);
                 out = qMin(qRound(filter->get_out() * speedRatio), length - 1);
                 filter->set_in_and_out(in, out);


### PR DESCRIPTION
Track volume control is now available in each timeline track header and updates the track gain via a hidden volume filter.

A per-track audio level indicator shows the audio level for each track in the timeline UI. The indicator color mapping follows the audio meter gradient and updates in real time with incoming levels.

The the audiolevel and volume filters are hidden and are added after all the user filters. So some refactoring was necessary to keep track of normalizing filters (hidden), pre-user filters (subtitle feed - hidden), user filters (not hidden), and post-user filters (track volumen and level - hidden)

Depends on https://github.com/mltframework/mlt/pull/1278

Volume control:
<img width="225" height="147" alt="image" src="https://github.com/user-attachments/assets/a38a32da-9116-484c-80b3-285ca784830c" />


Level indicators:
<img width="155" height="308" alt="image" src="https://github.com/user-attachments/assets/599d5fe8-dc70-4d7c-a643-4c67dc554f4d" />

