### PR TITLE
Add visible, keyframeable track volume filters

### DIFF
--- a/src/commands/filtercommands.cpp
+++ b/src/commands/filtercommands.cpp
@@ -331,7 +331,7 @@ void PasteCommand::undo()
     // Remove all filters
     for (int i = 0; i < producer.filter_count(); i++) {
         Mlt::Filter *filter = producer.filter(i);
-        if (Util::isUserFilter(filter)) {
+        if (Util::isUserFilter(filter) && !filter->get(kShotcutTrackVolumeProperty)) {
             producer.detach(*filter);
             i--;
         }

--- a/src/commands/filtercommands.cpp
+++ b/src/commands/filtercommands.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025 Meltytech, LLC
+ * Copyright (c) 2021-2026 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,7 +22,10 @@
 #include "mainwindow.h"
 #include "mltcontroller.h"
 #include "qmltypes/qmlapplication.h"
+#include "shotcut_mlt_properties.h"
 #include "util.h"
+
+#include <QScopedPointer>
 
 class FindProducerParser : public Mlt::Parser
 {
@@ -337,6 +340,13 @@ void PasteCommand::undo()
     // Restore the "before" filters
     Mlt::Profile profile(kDefaultMltProfile);
     Mlt::Producer filtersProducer(profile, "xml-string", m_beforeXml.toUtf8().constData());
+    for (int i = 0; i < filtersProducer.filter_count(); i++) {
+        QScopedPointer<Mlt::Filter> filter(filtersProducer.filter(i));
+        if (filter && filter->get(kShotcutTrackVolumeProperty)) {
+            filtersProducer.detach(*filter);
+            i--;
+        }
+    }
     if (filtersProducer.is_valid() && filtersProducer.filter_count() > 0) {
         MLT.pasteFilters(&producer, &filtersProducer);
     }

--- a/src/controllers/filtercontroller.cpp
+++ b/src/controllers/filtercontroller.cpp
@@ -540,7 +540,7 @@ void FilterController::onGainChanged()
     if (m_currentFilter) {
         QString name = m_currentFilter->objectNameOrService();
         if (name == QStringLiteral("audioGain")) {
-            emit m_currentFilter->changed();
+            emit m_currentFilter->changed(QStringLiteral("level"));
         }
     }
 }

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -2657,6 +2657,7 @@ void TimelineDock::onSeeked(int position)
 {
     if (MLT.isMultitrack() && m_position != position) {
         m_position = qMin(position, m_model.tractor()->get_length());
+        m_model.updateTrackGains(m_position);
         m_model.clearTrackAudioLevels();
         emit positionChanged(m_position);
     }

--- a/src/docks/timelinedock.cpp
+++ b/src/docks/timelinedock.cpp
@@ -2306,7 +2306,7 @@ void TimelineDock::clearSelectionIfInvalid()
 
         newSelection << QPoint(clip.x(), clip.y());
     }
-    setSelection(newSelection);
+    setSelection(newSelection, m_selection.selectedTrack, m_selection.isMultitrackSelected);
 }
 
 /*!
@@ -2642,6 +2642,7 @@ void TimelineDock::applyCopiedFiltersToSelectdClips()
 void TimelineDock::onShowFrame(const SharedFrame &frame)
 {
     if (MLT.isMultitrack() && m_model.tractor()) {
+        m_model.updateTrackGains(frame.get_position());
         m_model.updateTrackAudioLevels(frame);
         if (m_ignoreNextPositionChange) {
             m_ignoreNextPositionChange = false;

--- a/src/mltcontroller.cpp
+++ b/src/mltcontroller.cpp
@@ -1177,6 +1177,23 @@ static int indexOfFirstNonGpu(Producer &toProducer)
     return -1;
 }
 
+static void moveTrackVolumeFilterToEnd(Producer &producer)
+{
+    int trackVolumeIndex = -1;
+    int firstPostUserFilterIndex = producer.filter_count();
+    for (int i = 0; i < producer.filter_count(); i++) {
+        QScopedPointer<Mlt::Filter> filter(producer.filter(i));
+        if (filter && filter->get(kShotcutTrackVolumeProperty))
+            trackVolumeIndex = i;
+        else if (Util::isPostUserFilter(filter.data())) {
+            firstPostUserFilterIndex = i;
+            break;
+        }
+    }
+    if (trackVolumeIndex >= 0 && trackVolumeIndex != firstPostUserFilterIndex - 1)
+        producer.move_filter(trackVolumeIndex, firstPostUserFilterIndex);
+}
+
 void Controller::copyFilters(Producer &fromProducer,
                              Producer &toProducer,
                              bool fromClipboard,
@@ -1194,7 +1211,8 @@ void Controller::copyFilters(Producer &fromProducer,
 
     for (int i = 0; i < count; i++) {
         QScopedPointer<Mlt::Filter> fromFilter(fromProducer.filter(i));
-        if (Util::isUserFilter(fromFilter.data()) && fromFilter->get("mlt_service")) {
+        if ((Util::isUserFilter(fromFilter.data()) || fromFilter->get(kShotcutTrackVolumeProperty))
+            && fromFilter->get("mlt_service")) {
             filterCount++;
             if (filterIndex >= 0 && filterIndex != (filterCount - 1)) {
                 continue;
@@ -1223,6 +1241,7 @@ void Controller::copyFilters(Producer &fromProducer,
             Mlt::Filter toFilter(MLT.profile(), fromFilter->get("mlt_service"));
             if (toFilter.is_valid()) {
                 toFilter.inherit(*fromFilter);
+                toFilter.clear(kShotcutTrackVolumeProperty);
                 if (filterIndex != FILTER_INDEX_ALL)
                     toFilter.clear("disable");
                 // Force any 2-pass filters to require re-analysis
@@ -1296,6 +1315,7 @@ void Controller::pasteFilters(Mlt::Producer *producer, Producer *fromProducer)
             copyFilters(*m_filtersClipboard, *targetProducer, true, FILTER_INDEX_ALL);
         }
         adjustFilters(*targetProducer, j);
+        moveTrackVolumeFilterToEnd(*targetProducer);
     }
 }
 

--- a/src/models/attachedfiltersmodel.cpp
+++ b/src/models/attachedfiltersmodel.cpp
@@ -58,9 +58,8 @@ static int firstUserFilterIndex(Mlt::Producer *producer)
 {
     if (producer && producer->is_valid()) {
         for (int i = 0; i < producer->filter_count(); i++) {
-            Mlt::Filter *filter = producer->filter(i);
-            bool preUser = Util::isPreUserFilter(filter);
-            delete filter;
+            QScopedPointer<Mlt::Filter> filter(producer->filter(i));
+            bool preUser = Util::isPreUserFilter(filter.data());
             if (!preUser)
                 return i;
         }
@@ -74,13 +73,17 @@ static int userFilterCount(Mlt::Producer *producer)
     int count = 0;
     if (producer && producer->is_valid()) {
         for (int i = 0; i < producer->filter_count(); i++) {
-            Mlt::Filter *filter = producer->filter(i);
-            if (Util::isUserFilter(filter))
+            QScopedPointer<Mlt::Filter> filter(producer->filter(i));
+            if (Util::isUserFilter(filter.data()))
                 count++;
-            delete filter;
         }
     }
     return count;
+}
+
+static bool isTrackVolumeFilterService(Mlt::Filter *filter)
+{
+    return filter && filter->is_valid() && filter->get(kShotcutTrackVolumeProperty);
 }
 
 static int firstUserLinkIndex(Mlt::Producer *producer)
@@ -257,6 +260,25 @@ QString AttachedFiltersModel::name(int row) const
     return name;
 }
 
+bool AttachedFiltersModel::isTrackVolumeFilter(int row) const
+{
+    if (row < 0 || !m_producer || !m_producer->is_valid())
+        return false;
+
+    const int mltIndex = mltFilterIndex(m_producer.data(), row);
+    QScopedPointer<Mlt::Filter> filter(mltIndex >= 0 ? m_producer->filter(mltIndex) : nullptr);
+    return filter.data() && isTrackVolumeFilterService(filter.data());
+}
+
+int AttachedFiltersModel::trackVolumeFilterIndex() const
+{
+    for (int row = 0; row < m_metaList.count(); row++) {
+        if (isTrackVolumeFilter(row))
+            return row;
+    }
+    return -1;
+}
+
 int AttachedFiltersModel::rowCount(const QModelIndex &) const
 {
     if (m_producer && m_producer->is_valid())
@@ -410,7 +432,12 @@ bool AttachedFiltersModel::insertRows(int row, int, const QModelIndex &)
 
 bool AttachedFiltersModel::removeRows(int row, int, const QModelIndex &parent)
 {
-    if (m_producer && m_producer->is_valid() && m_dropRow >= 0 && row != m_dropRow) {
+    if (!m_producer || !m_producer->is_valid())
+        return false;
+
+    int mltIndex = mltFilterIndex(m_producer.data(), row);
+    QScopedPointer<Mlt::Filter> filter(mltIndex >= 0 ? m_producer->filter(mltIndex) : nullptr);
+    if (m_dropRow >= 0 && row != m_dropRow) {
         bool result = moveRows(parent, row, 1, parent, m_dropRow);
         m_dropRow = -1;
         return result;
@@ -432,6 +459,18 @@ bool AttachedFiltersModel::moveRows(const QModelIndex &sourceParent,
     if (destinationRow == sourceRow) {
         return false;
     }
+
+    int mltSourceIndex = mltFilterIndex(m_producer.data(), sourceRow);
+    QScopedPointer<Mlt::Filter> sourceFilter(
+        mltSourceIndex >= 0 ? m_producer->filter(mltSourceIndex) : nullptr);
+    if (sourceFilter.data() && isTrackVolumeFilterService(sourceFilter.data()))
+        return false;
+
+    int mltDestinationIndex = mltFilterIndex(m_producer.data(), destinationRow);
+    QScopedPointer<Mlt::Filter> destinationFilter(
+        mltDestinationIndex >= 0 ? m_producer->filter(mltDestinationIndex) : nullptr);
+    if (destinationFilter.data() && isTrackVolumeFilterService(destinationFilter.data()))
+        return false;
 
     if (isSourceClip()) {
         doMoveService(*m_producer, sourceRow, destinationRow);
@@ -736,22 +775,23 @@ void AttachedFiltersModel::doAddService(Mlt::Producer &producer, Mlt::Service &s
 void AttachedFiltersModel::remove(int row)
 {
     LOG_DEBUG() << row;
+    if (row < 0 || row >= m_metaList.count())
+        return;
+
+    int mltIndex = mltFilterIndex(m_producer.get(), row);
+    QScopedPointer<Mlt::Filter> filter(mltIndex >= 0 ? m_producer->filter(mltIndex) : nullptr);
     if (isSourceClip()) {
         doRemoveService(*m_producer, row);
     } else {
-        int mltIndex = mltLinkIndex(m_producer.get(), row);
-        if (mltIndex >= 0) {
+        int linkIndex = mltLinkIndex(m_producer.get(), row);
+        if (linkIndex >= 0) {
             Mlt::Chain chain(*(m_producer.get()));
-            Mlt::Link *link = chain.link(mltIndex);
+            Mlt::Link *link = chain.link(linkIndex);
             MAIN.undoStack()->push(new Filter::RemoveCommand(*this, name(row), *link, row));
             delete link;
-        } else {
-            mltIndex = mltFilterIndex(m_producer.get(), row);
-            if (mltIndex >= 0) {
-                Mlt::Filter *filter = m_producer->filter(mltIndex);
-                MAIN.undoStack()->push(new Filter::RemoveCommand(*this, name(row), *filter, row));
-                delete filter;
-            }
+        } else if (mltIndex >= 0) {
+            QScopedPointer<Mlt::Filter> removeFilter(m_producer->filter(mltIndex));
+            MAIN.undoStack()->push(new Filter::RemoveCommand(*this, name(row), *removeFilter, row));
         }
     }
 }
@@ -805,9 +845,15 @@ void AttachedFiltersModel::doRemoveService(Mlt::Producer &producer, int row)
 bool AttachedFiltersModel::move(int fromRow, int toRow)
 {
     QModelIndex parent = QModelIndex();
-    if (fromRow < 0 || toRow < 0) {
+    if (fromRow < 0 || toRow < 0 || fromRow >= m_metaList.count() || toRow >= m_metaList.count()) {
         return false;
     }
+
+    int mltIndex = mltFilterIndex(m_producer.get(), fromRow);
+    QScopedPointer<Mlt::Filter> filter(mltIndex >= 0 ? m_producer->filter(mltIndex) : nullptr);
+    if (filter.data() && isTrackVolumeFilterService(filter.data()))
+        return false;
+
     return moveRows(parent, fromRow, 1, parent, toRow);
 }
 
@@ -860,12 +906,11 @@ void AttachedFiltersModel::reset(Mlt::Producer *producer)
         }
         count = m_producer->filter_count();
         for (int i = 0; i < count; i++) {
-            Mlt::Filter *filter = m_producer->filter(i);
-            if (Util::isUserFilter(filter)) {
-                QmlMetadata *newMeta = MAIN.filterController()->metadataForService(filter);
+            QScopedPointer<Mlt::Filter> filter(m_producer->filter(i));
+            if (Util::isUserFilter(filter.data())) {
+                QmlMetadata *newMeta = MAIN.filterController()->metadataForService(filter.data());
                 m_metaList.append(newMeta);
             }
-            delete filter;
         }
     }
 
@@ -910,6 +955,8 @@ int AttachedFiltersModel::findInsertRow(QmlMetadata *meta)
     // Put the filter after the last filter that is less than or equal in sort order.
     int insertRow = 0;
     for (int i = m_metaList.count() - 1; i >= 0; i--) {
+        if (isTrackVolumeFilter(i))
+            continue;
         if (sortOrder(m_metaList[i]) <= sortOrder(meta)) {
             insertRow = i + 1;
             break;

--- a/src/models/attachedfiltersmodel.cpp
+++ b/src/models/attachedfiltersmodel.cpp
@@ -435,8 +435,6 @@ bool AttachedFiltersModel::removeRows(int row, int, const QModelIndex &parent)
     if (!m_producer || !m_producer->is_valid())
         return false;
 
-    int mltIndex = mltFilterIndex(m_producer.data(), row);
-    QScopedPointer<Mlt::Filter> filter(mltIndex >= 0 ? m_producer->filter(mltIndex) : nullptr);
     if (m_dropRow >= 0 && row != m_dropRow) {
         bool result = moveRows(parent, row, 1, parent, m_dropRow);
         m_dropRow = -1;
@@ -779,7 +777,6 @@ void AttachedFiltersModel::remove(int row)
         return;
 
     int mltIndex = mltFilterIndex(m_producer.get(), row);
-    QScopedPointer<Mlt::Filter> filter(mltIndex >= 0 ? m_producer->filter(mltIndex) : nullptr);
     if (isSourceClip()) {
         doRemoveService(*m_producer, row);
     } else {

--- a/src/models/attachedfiltersmodel.h
+++ b/src/models/attachedfiltersmodel.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2023 Meltytech, LLC
+ * Copyright (c) 2013-2026 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -48,6 +48,8 @@ public:
     bool supportsLinks() const;
     Mlt::Producer *producer() const { return m_producer.data(); }
     QString name(int row) const;
+    Q_INVOKABLE bool isTrackVolumeFilter(int row) const;
+    int trackVolumeFilterIndex() const;
 
     // The below are used by QUndoCommands
     void doAddService(Mlt::Producer &producer, Mlt::Service &service, int row);

--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -462,9 +462,8 @@ QVariant MultitrackModel::data(const QModelIndex &index, int role) const
                         return enabled;
                     if (enabled)
                         return filter->get_double("level");
-                    return filter->anim_get_double("level",
-                                                   m_trackGainPosition,
-                                                   filter->get_length());
+                    const int position = qMax(m_trackGainPosition - filter->get_in(), 0);
+                    return filter->anim_get_double("level", position, filter->get_length());
                 } else if (GainEnabledRole == role) {
                     return true;
                 }
@@ -729,7 +728,7 @@ void MultitrackModel::setTrackGain(int row, double gain)
         return;
     }
     if (!filter && !qFuzzyIsNull(gain)) {
-        filter.reset(ensureTrackVolumeFilter(track.data(), row));
+        filter.reset(ensureTrackVolumeFilter(track.data()));
         if (!filter) {
             LOG_ERROR() << "Failed to create or get track volume filter";
             return;
@@ -924,7 +923,7 @@ void MultitrackModel::setTrackAudioLevel(int row, double audioLevel)
     emit dataChanged(modelIndex, modelIndex, {AudioLevelRole});
 }
 
-Mlt::Filter *MultitrackModel::ensureTrackVolumeFilter(Mlt::Producer *track, int trackIndex)
+Mlt::Filter *MultitrackModel::ensureTrackVolumeFilter(Mlt::Producer *track)
 {
     if (!track || !track->is_valid())
         return nullptr;

--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -857,7 +857,6 @@ Mlt::Filter *MultitrackModel::ensureTrackAudioLevelFilter(Mlt::Producer *track,
         newFilter.set(kShotcutHiddenProperty, 1);
         newFilter.set(kShotcutHiddenPositionProperty, kShotcutHiddenPositionPost);
         newFilter.set("prefix", prefix.constData());
-        newFilter.set_in_and_out(0, qMax(track->get_length() - 1, 0));
         track->attach(newFilter);
         int target = firstPostUserHiddenFilterIndex(track);
         const int gainIndex = filterIndexByShotcutName(track, "audioGain");
@@ -943,7 +942,7 @@ Mlt::Filter *MultitrackModel::ensureTrackVolumeFilter(Mlt::Producer *track)
     newFilter.set(kShotcutTrackVolumeProperty, "Volume"); // Mark as track volume filter
     newFilter.set(kShotcutTrackVolumeNameProperty, track->get(kTrackNameProperty));
     newFilter.set("level", 0); // 0 dB = linear gain of 1.0 (no-op)
-    newFilter.set_in_and_out(0, qMax(track->get_length() - 1, 0));
+    newFilter.set_in_and_out(0, qMax(m_tractor->get_length() - 1, 0));
     AttachedFiltersModel *attachedModel = MAIN.filterController()->attachedModel();
     if (attachedModel->producer()
         && attachedModel->producer()->get_service() == track->get_service()) {

--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -98,6 +98,19 @@ static int filterIndexByShotcutName(Mlt::Service *service, const char *name)
     return -1;
 }
 
+static Mlt::Filter *trackVolumeFilter(Mlt::Service *service)
+{
+    if (!service || !service->is_valid())
+        return nullptr;
+    const int count = service->filter_count();
+    for (int i = 0; i < count; i++) {
+        std::unique_ptr<Mlt::Filter> filter(service->filter(i));
+        if (filter && filter->is_valid() && filter->get(kShotcutTrackVolumeProperty))
+            return filter.release();
+    }
+    return nullptr;
+}
+
 static double audioLevelDbFromLinear(double left, double right)
 {
     double linear = qMax(left, right);
@@ -213,6 +226,7 @@ MultitrackModel::MultitrackModel(QObject *parent)
     , m_isMakingTransition(false)
     , m_trackLevelIndicatorSupported(hasTrackLevelIndicatorSupport())
     , m_hasAudioTracks(false)
+    , m_trackGainPosition(0)
 {
     connect(this, SIGNAL(modified()), SLOT(adjustBackgroundDuration()));
     connect(this, SIGNAL(modified()), SLOT(adjustTrackFilters()));
@@ -440,7 +454,7 @@ QVariant MultitrackModel::data(const QModelIndex &index, int role) const
                 return isFiltered(track.data());
             case GainEnabledRole:
             case GainRole: {
-                QScopedPointer<Mlt::Filter> filter(getFilter("audioGain", track.data()));
+                QScopedPointer<Mlt::Filter> filter(trackVolumeFilter(track.data()));
                 if (filter && filter->is_valid()) {
                     Mlt::Animation anim = filter->get_animation("level");
                     bool enabled = anim.key_count() < 2;
@@ -448,6 +462,9 @@ QVariant MultitrackModel::data(const QModelIndex &index, int role) const
                         return enabled;
                     if (enabled)
                         return filter->get_double("level");
+                    return filter->anim_get_double("level",
+                                                   m_trackGainPosition,
+                                                   filter->get_length());
                 } else if (GainEnabledRole == role) {
                     return true;
                 }
@@ -593,6 +610,7 @@ void MultitrackModel::setTrackName(int row, const QString &value)
             QVector<int> roles;
             roles << NameRole;
             emit dataChanged(modelIndex, modelIndex, roles);
+            syncTrackAudioLevelFilterPrefixes();
             emit modified();
         }
     }
@@ -706,18 +724,48 @@ void MultitrackModel::setTrackGain(int row, double gain)
     if (!track)
         return;
 
-    std::unique_ptr<Mlt::Filter> filter(getFilter("audioGain", track.data()));
-    if (!filter) {
-        Mlt::Filter newFilter(MLT.profile(), "volume");
-        if (!newFilter.is_valid())
+    QScopedPointer<Mlt::Filter> filter(trackVolumeFilter(track.data()));
+    if (!filter && qFuzzyIsNull(gain)) {
+        return;
+    }
+    if (!filter && !qFuzzyIsNull(gain)) {
+        filter.reset(ensureTrackVolumeFilter(track.data(), row));
+        if (!filter) {
+            LOG_ERROR() << "Failed to create or get track volume filter";
             return;
-        newFilter.set(kShotcutFilterProperty, "audioGain");
-        newFilter.set(kShotcutHiddenProperty, 1);
-        newFilter.set(kShotcutHiddenPositionProperty, kShotcutHiddenPositionPost);
-        newFilter.set_in_and_out(0, qMax(track->get_length() - 1, 0));
-        track->attach(newFilter);
-        track->move_filter(track->filter_count() - 1, firstPostUserHiddenFilterIndex(track.data()));
-        filter.reset(new Mlt::Filter(newFilter));
+        }
+    }
+
+    Mlt::Animation animation = filter->get_animation("level");
+    const bool hasExtraKeyframes = animation.is_valid() && animation.key_count() > 1;
+    if (qFuzzyIsNull(gain) && !hasExtraKeyframes) {
+        AttachedFiltersModel *attachedModel = MAIN.filterController()->attachedModel();
+        bool removedByAttachedModel = false;
+        if (attachedModel->producer()
+            && attachedModel->producer()->get_service() == track->get_service()) {
+            const int filterRow = attachedModel->trackVolumeFilterIndex();
+            if (filterRow >= 0) {
+                attachedModel->doRemoveService(*track, filterRow);
+                removedByAttachedModel = true;
+            } else {
+                track->detach(*filter);
+            }
+        } else {
+            track->detach(*filter);
+        }
+        if (!removedByAttachedModel)
+            filterAddedOrRemoved(track.data());
+        std::unique_ptr<Mlt::Filter> levelFilter(ensureTrackAudioLevelFilter(track.data(), i));
+        Q_UNUSED(levelFilter)
+        MLT.refreshConsumer();
+
+        QModelIndex modelIndex = index(row, 0);
+        QVector<int> roles;
+        roles << GainRole;
+        roles << GainEnabledRole;
+        emit dataChanged(modelIndex, modelIndex, roles);
+        emit modified();
+        return;
     }
 
     filter->clear("level");
@@ -757,6 +805,23 @@ void MultitrackModel::updateTrackAudioLevels(const SharedFrame &frame)
             audioLevel = qMax(audioLevel - duckReduction, -100.0);
 
         setTrackAudioLevel(row, audioLevel);
+    }
+}
+
+void MultitrackModel::updateTrackGains(int position)
+{
+    if (!m_tractor)
+        return;
+
+    m_trackGainPosition = position;
+    for (int row = 0; row < m_trackList.size(); ++row) {
+        QScopedPointer<Mlt::Producer> track(m_tractor->track(m_trackList[row].mlt_index));
+        QScopedPointer<Mlt::Filter> filter(trackVolumeFilter(track.data()));
+        Mlt::Animation animation(filter ? filter->get_animation("level") : nullptr);
+        if (animation.is_valid() && animation.key_count() > 1) {
+            QModelIndex modelIndex = index(row, 0);
+            emit dataChanged(modelIndex, modelIndex, {GainRole});
+        }
     }
 }
 
@@ -813,19 +878,29 @@ Mlt::Filter *MultitrackModel::ensureTrackAudioLevelFilter(Mlt::Producer *track,
 
 void MultitrackModel::syncTrackAudioLevelFilterPrefixes()
 {
-    if (!m_trackLevelIndicatorSupported || !m_tractor)
+    if (!m_tractor)
         return;
 
     for (int row = 0; row < m_trackList.size(); ++row) {
         const int mltTrackIndex = m_trackList[row].mlt_index;
         QScopedPointer<Mlt::Producer> track(m_tractor->track(mltTrackIndex));
-        std::unique_ptr<Mlt::Filter> levelFilter(
-            ensureTrackAudioLevelFilter(track.data(), mltTrackIndex));
-        Q_UNUSED(levelFilter)
+        if (!track || !track->is_valid())
+            continue;
 
-        QScopedPointer<Mlt::Transition> mix(getTransition("mix", mltTrackIndex));
-        if (mix && mix->is_valid())
-            mix->set("prefix", trackDuckLevelPrefix(mltTrackIndex).constData());
+        std::unique_ptr<Mlt::Filter> volumeFilter(trackVolumeFilter(track.data()));
+        if (volumeFilter) {
+            volumeFilter->set(kShotcutTrackVolumeNameProperty, track->get(kTrackNameProperty));
+        }
+
+        if (m_trackLevelIndicatorSupported) {
+            std::unique_ptr<Mlt::Filter> levelFilter(
+                ensureTrackAudioLevelFilter(track.data(), mltTrackIndex));
+            Q_UNUSED(levelFilter)
+
+            QScopedPointer<Mlt::Transition> mix(getTransition("mix", mltTrackIndex));
+            if (mix && mix->is_valid())
+                mix->set("prefix", trackDuckLevelPrefix(mltTrackIndex).constData());
+        }
     }
 }
 
@@ -839,6 +914,40 @@ void MultitrackModel::setTrackAudioLevel(int row, double audioLevel)
     m_trackList[row].audioLevel = audioLevel;
     QModelIndex modelIndex = index(row, 0);
     emit dataChanged(modelIndex, modelIndex, {AudioLevelRole});
+}
+
+Mlt::Filter *MultitrackModel::ensureTrackVolumeFilter(Mlt::Producer *track, int trackIndex)
+{
+    if (!track || !track->is_valid())
+        return nullptr;
+
+    std::unique_ptr<Mlt::Filter> filter(trackVolumeFilter(track));
+    if (filter) {
+        // Filter already exists and is marked as track volume
+        return filter.release();
+    }
+
+    // Create new track volume filter (not hidden, visible in filter panel)
+    Mlt::Filter newFilter(MLT.profile(), "volume");
+    if (!newFilter.is_valid())
+        return nullptr;
+
+    newFilter.set(kShotcutFilterProperty, "audioGain");
+    newFilter.set(kShotcutTrackVolumeProperty, "Volume"); // Mark as track volume filter
+    newFilter.set(kShotcutTrackVolumeNameProperty, track->get(kTrackNameProperty));
+    newFilter.set("level", 0); // 0 dB = linear gain of 1.0 (no-op)
+    newFilter.set_in_and_out(0, qMax(track->get_length() - 1, 0));
+    AttachedFiltersModel *attachedModel = MAIN.filterController()->attachedModel();
+    if (attachedModel->producer()
+        && attachedModel->producer()->get_service() == track->get_service()) {
+        attachedModel->doAddService(*track, newFilter, attachedModel->rowCount());
+    } else {
+        track->attach(newFilter);
+        track->move_filter(track->filter_count() - 1, firstPostUserHiddenFilterIndex(track));
+        filterAddedOrRemoved(track);
+    }
+
+    return new Mlt::Filter(newFilter);
 }
 
 bool MultitrackModel::trimClipInValid(int trackIndex, int clipIndex, int delta, bool ripple)
@@ -2869,6 +2978,8 @@ void MultitrackModel::filterAddedOrRemoved(Mlt::Producer *producer)
                 QModelIndex modelIndex = index(i, 0);
                 QVector<int> roles;
                 roles << IsFilteredRole;
+                roles << GainRole;
+                roles << GainEnabledRole;
                 emit dataChanged(modelIndex, modelIndex, roles);
                 break;
             }
@@ -2896,6 +3007,15 @@ void MultitrackModel::onFilterChanged(Mlt::Service *filter)
                     roles << GainRole;
                 if (roles.length())
                     emit dataChanged(modelIndex, modelIndex, roles);
+            }
+        } else if (filter->get(kShotcutTrackVolumeProperty)) {
+            for (int i = 0; i < m_trackList.size(); i++) {
+                QScopedPointer<Mlt::Producer> track(m_tractor->track(m_trackList[i].mlt_index));
+                if (track && service.get_service() == track->get_service()) {
+                    QModelIndex modelIndex = index(i, 0);
+                    emit dataChanged(modelIndex, modelIndex, {GainRole, GainEnabledRole});
+                    break;
+                }
             }
         }
     }

--- a/src/models/multitrackmodel.cpp
+++ b/src/models/multitrackmodel.cpp
@@ -768,8 +768,16 @@ void MultitrackModel::setTrackGain(int row, double gain)
         return;
     }
 
-    filter->clear("level");
-    filter->set("level", gain);
+    if (animation.is_valid() && animation.key_count() > 0) {
+        const int position = qMax(m_trackGainPosition - filter->get_in(), 0);
+        if (!animation.is_key(position)
+            || gain != filter->anim_get_double("level", position, filter->get_length())) {
+            filter->anim_set("level", gain, position, filter->get_length());
+        }
+    } else {
+        filter->clear("level");
+        filter->set("level", gain);
+    }
 
     std::unique_ptr<Mlt::Filter> levelFilter(ensureTrackAudioLevelFilter(track.data(), i));
     Q_UNUSED(levelFilter)

--- a/src/models/multitrackmodel.h
+++ b/src/models/multitrackmodel.h
@@ -110,6 +110,7 @@ public:
     Q_INVOKABLE void audioLevelsReady(const QPersistentModelIndex &index);
     const QByteArray *getAudioLevels(int trackIndex, int clipIndex) const;
     void updateTrackAudioLevels(const SharedFrame &frame);
+    void updateTrackGains(int position);
     void clearTrackAudioLevels();
     bool createIfNeeded();
     void addBackgroundTrack();
@@ -223,6 +224,7 @@ private:
     bool m_isMakingTransition;
     bool m_trackLevelIndicatorSupported;
     bool m_hasAudioTracks;
+    int m_trackGainPosition;
 
     void moveClipToEnd(Mlt::Playlist &playlist,
                        int trackIndex,
@@ -262,6 +264,7 @@ private:
     Mlt::Filter *ensureTrackAudioLevelFilter(Mlt::Producer *track, int mltTrackIndex) const;
     void syncTrackAudioLevelFilterPrefixes();
     void setTrackAudioLevel(int row, double audioLevel);
+    Mlt::Filter *ensureTrackVolumeFilter(Mlt::Producer *track, int trackIndex);
 
     friend class UndoHelper;
 

--- a/src/models/multitrackmodel.h
+++ b/src/models/multitrackmodel.h
@@ -264,7 +264,7 @@ private:
     Mlt::Filter *ensureTrackAudioLevelFilter(Mlt::Producer *track, int mltTrackIndex) const;
     void syncTrackAudioLevelFilterPrefixes();
     void setTrackAudioLevel(int row, double audioLevel);
-    Mlt::Filter *ensureTrackVolumeFilter(Mlt::Producer *track, int trackIndex);
+    Mlt::Filter *ensureTrackVolumeFilter(Mlt::Producer *track);
 
     friend class UndoHelper;
 

--- a/src/qml/filters/audio_gain/ui.qml
+++ b/src/qml/filters/audio_gain/ui.qml
@@ -141,7 +141,7 @@ Item {
 
         Label {
             visible: filter.get('shotcut:trackVolume')
-            text: filter.get('shotcut:trackVolumeName') + qsTr(' Track Volume')
+            text: qsTr('%1 Track Volume').arg(filter.get('shotcut:trackVolumeName'))
             Layout.columnSpan: parent.columns
             Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
             font.bold: true

--- a/src/qml/filters/audio_gain/ui.qml
+++ b/src/qml/filters/audio_gain/ui.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2025 Meltytech, LLC
+ * Copyright (c) 2013-2026 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -138,6 +138,18 @@ Item {
         columns: 4
         anchors.fill: parent
         anchors.margins: 8
+
+        Label {
+            visible: filter.get('shotcut:trackVolume')
+            text: filter.get('shotcut:trackVolumeName') + qsTr(' Track Volume')
+            Layout.columnSpan: parent.columns
+            Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+            font.bold: true
+
+            Shotcut.HoverTip {
+                text: qsTr('Track master volume')
+            }
+        }
 
         Label {
             text: qsTr('Preset')

--- a/src/qml/views/filter/AttachedFilters.qml
+++ b/src/qml/views/filter/AttachedFilters.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Meltytech, LLC
+ * Copyright (c) 2014-2026 Meltytech, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -214,9 +214,12 @@ Rectangle {
                 property string grabSection: ""
 
                 function beginDrag() {
+                    var clickedIndex = attachedFiltersView.indexAt(mouseX, mouseY);
+                    if (clickedIndex < 0 || attachedfiltersmodel.isTrackVolumeFilter(clickedIndex))
+                        return;
                     preventStealing = true;
                     var grabbedItem = attachedFiltersView.itemAt(mouseX, mouseY);
-                    oldIndex = attachedFiltersView.indexAt(mouseX, mouseY);
+                    oldIndex = clickedIndex;
                     grabPos = Qt.point(mouseX - grabbedItem.x, mouseY - grabbedItem.y);
                     grabSection = grabbedItem.viewData.section;
                     dragItem.model = grabbedItem.modelData;

--- a/src/qml/views/filter/AttachedFilters.qml
+++ b/src/qml/views/filter/AttachedFilters.qml
@@ -214,7 +214,7 @@ Rectangle {
                 property string grabSection: ""
 
                 function beginDrag() {
-                    var clickedIndex = attachedFiltersView.indexAt(mouseX, mouseY);
+                    const clickedIndex = attachedFiltersView.indexAt(mouseX, mouseY);
                     if (clickedIndex < 0 || attachedfiltersmodel.isTrackVolumeFilter(clickedIndex))
                         return;
                     preventStealing = true;

--- a/src/qml/views/filter/filterview.qml
+++ b/src/qml/views/filter/filterview.qml
@@ -276,6 +276,7 @@ Rectangle {
 
             implicitWidth: height
             enabled: attachedFilters.selectedCanMoveUp
+                     && !attachedfiltersmodel.isTrackVolumeFilter(selectedIndex)
             opacity: enabled ? 1 : 0.5
             icon.name: 'lift'
             icon.source: 'qrc:///icons/oxygen/32x32/actions/lift.png'
@@ -296,6 +297,7 @@ Rectangle {
 
             implicitWidth: height
             enabled: attachedFilters.selectedCanMoveDown
+                     && !attachedfiltersmodel.isTrackVolumeFilter(selectedIndex)
             opacity: enabled ? 1 : 0.5
             icon.name: 'overwrite'
             icon.source: 'qrc:///icons/oxygen/32x32/actions/overwrite.png'

--- a/src/shotcut_mlt_properties.h
+++ b/src/shotcut_mlt_properties.h
@@ -48,6 +48,8 @@
 #define kShotcutHiddenProperty "shotcut:hidden"
 #define kShotcutHiddenPositionProperty "shotcut:hiddenPosition"
 #define kShotcutHiddenPositionPost "post"
+#define kShotcutTrackVolumeProperty "shotcut:trackVolume"
+#define kShotcutTrackVolumeNameProperty "shotcut:trackVolumeName"
 #define kShotcutSkipConvertProperty "shotcut:skipConvert"
 #define kShotcutAnimInProperty "shotcut:animIn"
 #define kShotcutAnimOutProperty "shotcut:animOut"


### PR DESCRIPTION
Create a Track Volume Audio Gain filter on demand when a track gain changes. Expose it in Filters with a track-specific heading, synchronize its name after track renames and moves, and keep timeline/header/filter-panel gain controls in sync, including animated values during playback.

Keep the filter last among visible track filters and prevent reordering it. It remains deletable; deleting it resets the track gain to 0 dB. Copying it creates a normal Audio Gain filter without the Track Volume marker.

I'm posting this for consideration and discussion. The current track volume sliders create a hidden gain filter that can not be manipulated by the user and does not support keyframes. This changes it so the filter is visible and the user can add keyframes. The track volume sliders move back and forth as the keyframes animate the volume. 